### PR TITLE
ci: update publish

### DIFF
--- a/.github/workflows/typescript-publish.yml
+++ b/.github/workflows/typescript-publish.yml
@@ -28,6 +28,8 @@ jobs:
   publish:
     name: Publish @solana/keychain
     runs-on: ubuntu-latest
+    env:
+      NPM_CONFIG_PROVENANCE: true
 
     steps:
       - name: Checkout repository
@@ -45,7 +47,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 'lts/*'
-          registry-url: 'https://registry.npmjs.org'
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -92,7 +93,7 @@ jobs:
         working-directory: typescript/packages/keychain
         run: |
           echo "📦 Publishing @solana/keychain@${{ steps.version.outputs.version }} to npm..."
-          npm publish --access public --provenance
+          npm publish --access public
 
       - name: Create and push tag
         run: |


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `typescript-publish.yml` to use `npm publish`, set NPM provenance, and reorder tag creation step.
> 
>   - **Environment**:
>     - Adds `NPM_CONFIG_PROVENANCE: true` to the environment in `typescript-publish.yml`.
>   - **Publishing**:
>     - Switches from `pnpm publish` to `npm publish` in `typescript-publish.yml`.
>     - Reorders steps to create and push git tag after publishing to npm.
>   - **Misc**:
>     - Removes `registry-url` from `setup-node` in `typescript-publish.yml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=solana-foundation%2Fsolana-keychain&utm_source=github&utm_medium=referral)<sup> for a2e00522edb59f9a98b832a8c6e838b784fceb16. You can [customize](https://app.ellipsis.dev/solana-foundation/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->