### PR TITLE
ci: add registry url

### DIFF
--- a/.github/workflows/typescript-publish.yml
+++ b/.github/workflows/typescript-publish.yml
@@ -47,6 +47,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 'lts/*'
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds npm registry URL to Node.js setup in `typescript-publish.yml`.
> 
>   - **CI Configuration**:
>     - Adds `registry-url: 'https://registry.npmjs.org'` to `actions/setup-node@v4` step in `typescript-publish.yml` to specify npm registry.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=solana-foundation%2Fsolana-keychain&utm_source=github&utm_medium=referral)<sup> for bdda7965a85834812207be638a8d6a6f438a2506. You can [customize](https://app.ellipsis.dev/solana-foundation/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->