### PR TITLE
ci: add GCP KMS to TypeScript CI pipeline

### DIFF
--- a/.github/workflows/typescript-ci.yml
+++ b/.github/workflows/typescript-ci.yml
@@ -14,7 +14,7 @@ jobs:
         working-directory: typescript
     strategy:
       matrix:
-        package: [vault, privy, turnkey, fireblocks]
+        package: [vault, privy, turnkey, fireblocks, gcp-kms]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -37,7 +37,7 @@ jobs:
         working-directory: typescript
     strategy:
       matrix:
-        package: [privy, turnkey, fireblocks]
+        package: [privy, turnkey, fireblocks, gcp-kms]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -48,6 +48,11 @@ jobs:
           version: 10.14.0
       - name: Install dependencies
         run: pnpm install
+      - name: Setup GCP credentials
+        if: matrix.package == 'gcp-kms'
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}
       - name: Build packages
         run: pnpm build
       - name: Run integration tests for @solana/keychain-${{ matrix.package }}
@@ -66,6 +71,9 @@ jobs:
           FIREBLOCKS_API_KEY: ${{ secrets.FIREBLOCKS_API_KEY }}
           FIREBLOCKS_PRIVATE_KEY_PEM: ${{ secrets.FIREBLOCKS_PRIVATE_KEY_PEM }}
           FIREBLOCKS_VAULT_ACCOUNT_ID: ${{ secrets.FIREBLOCKS_VAULT_ACCOUNT_ID }}
+          # GCP KMS
+          GCP_KMS_KEY_NAME: ${{ secrets.GCP_KMS_KEY_NAME }}
+          GCP_KMS_SIGNER_PUBKEY: ${{ secrets.GCP_KMS_SIGNER_PUBKEY }}
         run: pnpm -F @solana/keychain-${{ matrix.package }} run test:integration
 
   typescript-lint:

--- a/typescript/packages/gcp-kms/src/__tests__/gcp-kms-signer.test.ts
+++ b/typescript/packages/gcp-kms/src/__tests__/gcp-kms-signer.test.ts
@@ -21,7 +21,8 @@ vi.mock('@google-cloud/kms', () => {
 });
 
 describe('GcpKmsSigner', () => {
-    const TEST_KEY_NAME = 'projects/test-project/locations/us-east1/keyRings/test-ring/cryptoKeys/test-key/cryptoKeyVersions/1';
+    const TEST_KEY_NAME =
+        'projects/test-project/locations/us-east1/keyRings/test-ring/cryptoKeys/test-key/cryptoKeyVersions/1';
     const TEST_PUBLIC_KEY = address('11111111111111111111111111111111');
 
     beforeEach(() => {
@@ -97,9 +98,11 @@ describe('GcpKmsSigner', () => {
 
     describe('signMessages', () => {
         it('should sign a message successfully', async () => {
-            mockAsymmetricSign.mockResolvedValue([{
-                signature: new Uint8Array(64).fill(0x42),
-            }]);
+            mockAsymmetricSign.mockResolvedValue([
+                {
+                    signature: new Uint8Array(64).fill(0x42),
+                },
+            ]);
 
             const signer = new GcpKmsSigner({
                 keyName: TEST_KEY_NAME,
@@ -122,9 +125,11 @@ describe('GcpKmsSigner', () => {
         });
 
         it('should handle multiple messages with delay', async () => {
-            mockAsymmetricSign.mockResolvedValue([{
-                signature: new Uint8Array(64).fill(0x42),
-            }]);
+            mockAsymmetricSign.mockResolvedValue([
+                {
+                    signature: new Uint8Array(64).fill(0x42),
+                },
+            ]);
 
             const signer = new GcpKmsSigner({
                 keyName: TEST_KEY_NAME,
@@ -149,9 +154,11 @@ describe('GcpKmsSigner', () => {
         });
 
         it('should throw error on invalid signature length', async () => {
-            mockAsymmetricSign.mockResolvedValue([{
-                signature: new Uint8Array(32), // Wrong length
-            }]);
+            mockAsymmetricSign.mockResolvedValue([
+                {
+                    signature: new Uint8Array(32), // Wrong length
+                },
+            ]);
 
             const signer = new GcpKmsSigner({
                 keyName: TEST_KEY_NAME,
@@ -194,9 +201,11 @@ describe('GcpKmsSigner', () => {
 
     describe('signTransactions', () => {
         it('should sign a transaction successfully', async () => {
-            mockAsymmetricSign.mockResolvedValue([{
-                signature: new Uint8Array(64).fill(0x42),
-            }]);
+            mockAsymmetricSign.mockResolvedValue([
+                {
+                    signature: new Uint8Array(64).fill(0x42),
+                },
+            ]);
 
             const signer = new GcpKmsSigner({
                 keyName: TEST_KEY_NAME,
@@ -216,9 +225,11 @@ describe('GcpKmsSigner', () => {
         });
 
         it('should sign multiple transactions successfully', async () => {
-            mockAsymmetricSign.mockResolvedValue([{
-                signature: new Uint8Array(64).fill(0x42),
-            }]);
+            mockAsymmetricSign.mockResolvedValue([
+                {
+                    signature: new Uint8Array(64).fill(0x42),
+                },
+            ]);
 
             const signer = new GcpKmsSigner({
                 keyName: TEST_KEY_NAME,
@@ -237,9 +248,11 @@ describe('GcpKmsSigner', () => {
         });
 
         it('should throw error on invalid signature length', async () => {
-            mockAsymmetricSign.mockResolvedValue([{
-                signature: new Uint8Array(32),
-            }]);
+            mockAsymmetricSign.mockResolvedValue([
+                {
+                    signature: new Uint8Array(32),
+                },
+            ]);
 
             const signer = new GcpKmsSigner({
                 keyName: TEST_KEY_NAME,
@@ -276,17 +289,21 @@ describe('GcpKmsSigner', () => {
 
             const transaction = { messageBytes: new Uint8Array([1, 2, 3, 4]), signatures: {} } as any;
 
-            await expect(signer.signTransactions([transaction])).rejects.toThrow('GCP KMS Sign operation failed: GCP Error');
+            await expect(signer.signTransactions([transaction])).rejects.toThrow(
+                'GCP KMS Sign operation failed: GCP Error',
+            );
         });
     });
 
     describe('isAvailable', () => {
         it('should return true for valid Ed25519 key', async () => {
-            mockGetCryptoKeyVersion.mockResolvedValue([{
-                name: TEST_KEY_NAME,
-                algorithm: 'EC_SIGN_ED25519',
-                state: 'ENABLED',
-            }]);
+            mockGetCryptoKeyVersion.mockResolvedValue([
+                {
+                    name: TEST_KEY_NAME,
+                    algorithm: 'EC_SIGN_ED25519',
+                    state: 'ENABLED',
+                },
+            ]);
 
             const signer = new GcpKmsSigner({
                 keyName: TEST_KEY_NAME,
@@ -299,11 +316,13 @@ describe('GcpKmsSigner', () => {
         });
 
         it('should return false for wrong algorithm', async () => {
-            mockGetCryptoKeyVersion.mockResolvedValue([{
-                name: TEST_KEY_NAME,
-                algorithm: 'RSA_SIGN_PKCS1_2048_SHA256',
-                state: 'ENABLED',
-            }]);
+            mockGetCryptoKeyVersion.mockResolvedValue([
+                {
+                    name: TEST_KEY_NAME,
+                    algorithm: 'RSA_SIGN_PKCS1_2048_SHA256',
+                    state: 'ENABLED',
+                },
+            ]);
 
             const signer = new GcpKmsSigner({
                 keyName: TEST_KEY_NAME,
@@ -316,11 +335,13 @@ describe('GcpKmsSigner', () => {
         });
 
         it('should return false for disabled key', async () => {
-            mockGetCryptoKeyVersion.mockResolvedValue([{
-                name: TEST_KEY_NAME,
-                algorithm: 'EC_SIGN_ED25519',
-                state: 'DISABLED',
-            }]);
+            mockGetCryptoKeyVersion.mockResolvedValue([
+                {
+                    name: TEST_KEY_NAME,
+                    algorithm: 'EC_SIGN_ED25519',
+                    state: 'DISABLED',
+                },
+            ]);
 
             const signer = new GcpKmsSigner({
                 keyName: TEST_KEY_NAME,

--- a/typescript/packages/keychain/tsconfig.json
+++ b/typescript/packages/keychain/tsconfig.json
@@ -11,6 +11,7 @@
         { "path": "../core" },
         { "path": "../aws-kms" },
         { "path": "../fireblocks" },
+        { "path": "../gcp-kms" },
         { "path": "../privy" },
         { "path": "../turnkey" },
         { "path": "../vault" }


### PR DESCRIPTION
- Add gcp-kms to unit and integration test matrices
- Add GCP authentication step using google-github-actions/auth@v2
- Add GCP_KMS_KEY_NAME and GCP_KMS_SIGNER_PUBKEY env vars
- Fix missing gcp-kms reference in keychain tsconfig.json
- Format gcp-kms test file with prettier