### PR TITLE
Revise security policy for reporting vulnerabilities

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,11 @@
+# Security Policy
+
+## Reporting Security Problems
+
+**DO NOT CREATE A GITHUB ISSUE** to report a security problem.
+
+Instead please use this [Report a Vulnerability](https://github.com/solana-foundation/solana-keychain/security/advisories/new) link.
+
+Provide a helpful title and detailed description of the problem.
+
+Expect a response as fast as possible in the advisory, typically within 72 hours.


### PR DESCRIPTION
Updated the security policy to emphasize reporting vulnerabilities through a dedicated link and removed the supported versions section.