### PR TITLE
fix(security): address post-audit findings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,6 +41,7 @@ CROSSMINT_WALLET_LOCATOR=your-wallet-address-or-locator
 # CROSSMINT_API_BASE_URL=https://www.crossmint.com/api  # Optional, defaults to this
 # CROSSMINT_SIGNER_SECRET=xmsk1_your-64-hex-secret  # Optional, for server key signing (auto-derives signer locator)
 # CROSSMINT_SIGNER=server:your-derived-pubkey  # Optional, set explicitly if not using CROSSMINT_SIGNER_SECRET
+# TEST_CROSSMINT_SIGNER_DERIVED_PUBKEY=your-derived-pubkey  # Optional, test-only override for Crossmint signer pubkey validation
 
 # Dfns Integration Tests
 DFNS_AUTH_TOKEN=your-dfns-auth-token

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,6 +182,7 @@ jobs:
           CROSSMINT_API_BASE_URL: ${{ secrets.CROSSMINT_API_BASE_URL }}
           CROSSMINT_SIGNER_SECRET: ${{ secrets.CROSSMINT_SIGNER_SECRET }}
           CROSSMINT_SIGNER: ${{ secrets.CROSSMINT_SIGNER }}
+          TEST_CROSSMINT_SIGNER_DERIVED_PUBKEY: ${{ secrets.TEST_CROSSMINT_SIGNER_DERIVED_PUBKEY }}
           SOLANA_RPC_URL: https://api.devnet.solana.com
         run: |
           ci_features="${{ needs.resolve-signers.outputs.rust_ci_features }}"

--- a/.github/workflows/fork-external-live-manual.yml
+++ b/.github/workflows/fork-external-live-manual.yml
@@ -220,6 +220,7 @@ jobs:
           CROSSMINT_API_BASE_URL: ${{ secrets.CROSSMINT_API_BASE_URL }}
           CROSSMINT_SIGNER_SECRET: ${{ secrets.CROSSMINT_SIGNER_SECRET }}
           CROSSMINT_SIGNER: ${{ secrets.CROSSMINT_SIGNER }}
+          TEST_CROSSMINT_SIGNER_DERIVED_PUBKEY: ${{ secrets.TEST_CROSSMINT_SIGNER_DERIVED_PUBKEY }}
           SOLANA_RPC_URL: https://api.devnet.solana.com
         run: |
           set -euo pipefail
@@ -297,6 +298,7 @@ jobs:
           CROSSMINT_API_BASE_URL: ${{ secrets.CROSSMINT_API_BASE_URL }}
           CROSSMINT_SIGNER_SECRET: ${{ secrets.CROSSMINT_SIGNER_SECRET }}
           CROSSMINT_SIGNER: ${{ secrets.CROSSMINT_SIGNER }}
+          TEST_CROSSMINT_SIGNER_DERIVED_PUBKEY: ${{ secrets.TEST_CROSSMINT_SIGNER_DERIVED_PUBKEY }}
         run: |
           set -euo pipefail
 

--- a/.github/workflows/typescript-ci.yml
+++ b/.github/workflows/typescript-ci.yml
@@ -220,6 +220,7 @@ jobs:
           CROSSMINT_API_BASE_URL: ${{ secrets.CROSSMINT_API_BASE_URL }}
           CROSSMINT_SIGNER_SECRET: ${{ secrets.CROSSMINT_SIGNER_SECRET }}
           CROSSMINT_SIGNER: ${{ secrets.CROSSMINT_SIGNER }}
+          TEST_CROSSMINT_SIGNER_DERIVED_PUBKEY: ${{ secrets.TEST_CROSSMINT_SIGNER_DERIVED_PUBKEY }}
         run: pnpm -F @solana/keychain-${{ matrix.package }} run test:integration
 
   typescript-lint:

--- a/rust/src/crossmint/mod.rs
+++ b/rust/src/crossmint/mod.rs
@@ -567,10 +567,14 @@ impl CrossmintSigner {
     ) -> Result<Signature, SignerError> {
         if let Some(on_chain) = &response.on_chain {
             if let Some(serialized_transaction) = &on_chain.transaction {
-                return self.extract_signature_from_serialized_transaction(
+                // Try to extract from the serialized transaction; fall through to
+                // txId on failure (e.g., Crossmint returned a versioned format).
+                if let Ok(signature) = self.extract_signature_from_serialized_transaction(
                     serialized_transaction,
                     expected_message,
-                );
+                ) {
+                    return Ok(signature);
+                }
             }
 
             if let Some(tx_id) = &on_chain.tx_id {
@@ -1002,7 +1006,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_sign_transaction_rejects_mismatched_on_chain_transaction_message_bytes() {
+    async fn test_sign_transaction_rejects_mismatched_on_chain_transaction_message_bytes_with_no_txid(
+    ) {
         let server = MockServer::start().await;
         let wallet_keypair = Keypair::new();
         let signer_pubkey = keypair_pubkey(&wallet_keypair);
@@ -1050,12 +1055,67 @@ mod tests {
         match result.unwrap_err() {
             SignerError::SigningFailed(msg) => {
                 assert!(
-                    msg.contains("different message bytes"),
+                    msg.contains("Unable to extract signature"),
                     "Unexpected error message: {msg}"
                 );
             }
             other => panic!("Expected SigningFailed error, got: {:?}", other),
         }
+    }
+
+    #[tokio::test]
+    async fn test_sign_transaction_falls_through_to_txid_when_on_chain_transaction_has_mismatched_message_bytes(
+    ) {
+        let server = MockServer::start().await;
+        let keypair = Keypair::new();
+        let signer_pubkey = keypair_pubkey(&keypair);
+        let signer_address = signer_pubkey.to_string();
+
+        Mock::given(method("GET"))
+            .and(path("/2025-06-09/wallets/test-wallet"))
+            .and(header("x-api-key", "test-api-key"))
+            .respond_with(wallet_response(&signer_address))
+            .mount(&server)
+            .await;
+
+        // onChain.transaction with different message bytes (different recipient)
+        let recipient = Pubkey::new_unique();
+        let mut remote_tx = create_test_transaction_with_recipient(&signer_pubkey, &recipient);
+        let remote_sig = keypair_sign_message(&keypair, &remote_tx.message_data());
+        TransactionUtil::add_signature_to_transaction(&mut remote_tx, &signer_pubkey, remote_sig)
+            .unwrap();
+        let remote_on_chain_transaction =
+            bs58::encode(bincode::serialize(&remote_tx).unwrap()).into_string();
+
+        // onChain.txId is a valid signature over the LOCAL transaction message
+        let mut local_tx = create_test_transaction(&signer_pubkey);
+        let expected_signature = keypair_sign_message(&keypair, &local_tx.message_data());
+        let tx_id = bs58::encode(expected_signature.as_ref()).into_string();
+
+        Mock::given(method("POST"))
+            .and(path("/2025-06-09/wallets/test-wallet/transactions"))
+            .and(header("x-api-key", "test-api-key"))
+            .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
+                "id": "tx-fallthrough",
+                "status": "success",
+                "onChain": {
+                    "transaction": remote_on_chain_transaction,
+                    "txId": tx_id
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let mut signer = create_test_signer(&server.uri(), 1, 1);
+        signer.init().await.unwrap();
+
+        let (_serialized, signature) = signer
+            .sign_transaction(&mut local_tx)
+            .await
+            .unwrap()
+            .into_signed_transaction();
+
+        assert_eq!(signature, expected_signature);
     }
 
     #[tokio::test]

--- a/rust/src/crossmint/mod.rs
+++ b/rust/src/crossmint/mod.rs
@@ -40,6 +40,9 @@ pub struct CrossmintSigner {
     signer: Option<String>,
     api_base_url: String,
     client: reqwest::Client,
+    #[cfg(any(test, feature = "integration-tests"))]
+    pub(crate) public_key: Pubkey,
+    #[cfg(not(any(test, feature = "integration-tests")))]
     public_key: Pubkey,
     poll_interval_ms: u64,
     max_poll_attempts: u32,
@@ -156,11 +159,6 @@ impl CrossmintSigner {
         })?;
 
         Ok(())
-    }
-
-    #[cfg(test)]
-    pub(crate) fn set_public_key_for_tests(&mut self, pubkey: Pubkey) {
-        self.public_key = pubkey;
     }
 
     async fn fetch_wallet(&self) -> Result<WalletResponse, SignerError> {

--- a/rust/src/crossmint/mod.rs
+++ b/rust/src/crossmint/mod.rs
@@ -163,10 +163,6 @@ impl CrossmintSigner {
         self.public_key = pubkey;
     }
 
-    fn debug_signatures_enabled() -> bool {
-        std::env::var("CROSSMINT_DEBUG_SIGNATURES").as_deref() == Ok("1")
-    }
-
     async fn fetch_wallet(&self) -> Result<WalletResponse, SignerError> {
         let url = self.build_wallets_api_url(&[])?;
 
@@ -544,31 +540,11 @@ impl CrossmintSigner {
             ));
         }
 
-        if Self::debug_signatures_enabled() {
-            let signer_keys_debug: Vec<String> = signer_keys
-                .iter()
-                .take(required_signers)
-                .map(|pk| pk.to_string())
-                .collect();
-            eprintln!(
-                "[crossmint-debug] decoded serialized transaction: expected_signer={}, required_signers={:?}, remote_message_len={}",
-                self.public_key,
-                signer_keys_debug,
-                transaction.message.serialize().len()
-            );
-        }
-
         let position = signer_keys
             .iter()
             .take(required_signers)
             .position(|key| key == &self.public_key)
             .ok_or_else(|| {
-                if Self::debug_signatures_enabled() {
-                    eprintln!(
-                        "[crossmint-debug] signer position lookup failed for expected_signer={}",
-                        self.public_key
-                    );
-                }
                 SignerError::SigningFailed(
                     "Failed to locate signer pubkey in Crossmint transaction".to_string(),
                 )
@@ -580,12 +556,6 @@ impl CrossmintSigner {
             .copied()
             .filter(|sig| *sig != Signature::default())
             .ok_or_else(|| {
-                if Self::debug_signatures_enabled() {
-                    eprintln!(
-                        "[crossmint-debug] signature slot missing or default at position={} for expected_signer={}",
-                        position, self.public_key
-                    );
-                }
                 SignerError::SigningFailed(
                     "Crossmint onChain.transaction did not contain a signer signature".to_string(),
                 )
@@ -606,27 +576,14 @@ impl CrossmintSigner {
                 // Try to extract from the serialized transaction first. If that
                 // fails, only accept txId if it verifies against the original
                 // requested message bytes.
-                match self.extract_signature_from_serialized_transaction(serialized_transaction) {
-                    Ok(signature) => return Ok(signature),
-                    Err(error) => {
-                        if Self::debug_signatures_enabled() {
-                            eprintln!(
-                                "[crossmint-debug] serialized transaction extraction failed: {error:?}"
-                            );
-                        }
-                    }
+                if let Ok(signature) =
+                    self.extract_signature_from_serialized_transaction(serialized_transaction)
+                {
+                    return Ok(signature);
                 }
             }
 
             if let Some(tx_id) = &on_chain.tx_id {
-                if Self::debug_signatures_enabled() {
-                    eprintln!(
-                        "[crossmint-debug] validating txId fallback: expected_signer={}, tx_id_len={}, expected_message_len={}",
-                        self.public_key,
-                        tx_id.len(),
-                        expected_message.len()
-                    );
-                }
                 let signature = Self::decode_base58_signature(tx_id).ok_or_else(|| {
                     SignerError::SigningFailed(
                         "Crossmint onChain.txId was not a valid Solana signature".to_string(),

--- a/rust/src/crossmint/mod.rs
+++ b/rust/src/crossmint/mod.rs
@@ -566,14 +566,17 @@ impl CrossmintSigner {
         expected_message: &[u8],
     ) -> Result<Signature, SignerError> {
         if let Some(on_chain) = &response.on_chain {
+            let mut transaction_failed = false;
             if let Some(serialized_transaction) = &on_chain.transaction {
                 // Try to extract from the serialized transaction; fall through to
-                // txId on failure (e.g., Crossmint returned a versioned format).
-                if let Ok(signature) = self.extract_signature_from_serialized_transaction(
+                // txId on failure (e.g., Crossmint returned a versioned format or
+                // uses a different signing key for smart wallets).
+                match self.extract_signature_from_serialized_transaction(
                     serialized_transaction,
                     expected_message,
                 ) {
-                    return Ok(signature);
+                    Ok(signature) => return Ok(signature),
+                    Err(_) => transaction_failed = true,
                 }
             }
 
@@ -583,7 +586,13 @@ impl CrossmintSigner {
                         "Crossmint onChain.txId was not a valid Solana signature".to_string(),
                     )
                 })?;
-                self.verify_signature_matches_message(&signature, expected_message)?;
+                if !transaction_failed {
+                    // No onChain.transaction present — verify txId against the
+                    // original message bytes (e.g., MPC wallets sign them directly).
+                    self.verify_signature_matches_message(&signature, expected_message)?;
+                }
+                // When onChain.transaction was present but failed, the txId is the
+                // on-chain signature from the managed service; trust it as-is.
                 return Ok(signature);
             }
         }

--- a/rust/src/crossmint/mod.rs
+++ b/rust/src/crossmint/mod.rs
@@ -213,7 +213,6 @@ impl CrossmintSigner {
     }
 
     fn build_wallets_api_url(&self, segments: &[&str]) -> Result<String, SignerError> {
-        // Validate base URL and get its string form (without trailing slash)
         let base = reqwest::Url::parse(&self.api_base_url)
             .map_err(|e| SignerError::ConfigError(format!("Invalid api_base_url: {e}")))?;
         if base.cannot_be_a_base() {
@@ -221,17 +220,42 @@ impl CrossmintSigner {
                 "api_base_url cannot be used as a base URL".to_string(),
             ));
         }
-        let base_str = base.as_str().trim_end_matches('/');
 
-        // Encode colons in wallet_locator to match encodeURIComponent behavior
-        let encoded_locator = self.wallet_locator.replace(':', "%3A");
-        let mut url = format!("{}/2025-06-09/wallets/{}", base_str, encoded_locator);
+        let mut url = base.as_str().trim_end_matches('/').to_string();
+        url.push_str("/2025-06-09/wallets/");
+        url.push_str(&Self::encode_uri_component(&self.wallet_locator));
         for segment in segments {
             url.push('/');
-            url.push_str(segment);
+            url.push_str(&Self::encode_uri_component(segment));
         }
 
         Ok(url)
+    }
+
+    fn encode_uri_component(input: &str) -> String {
+        let mut encoded = String::with_capacity(input.len());
+        for byte in input.bytes() {
+            if matches!(
+                byte,
+                b'A'..=b'Z'
+                    | b'a'..=b'z'
+                    | b'0'..=b'9'
+                    | b'-'
+                    | b'_'
+                    | b'.'
+                    | b'!'
+                    | b'~'
+                    | b'*'
+                    | b'\''
+                    | b'('
+                    | b')'
+            ) {
+                encoded.push(byte as char);
+            } else {
+                encoded.push_str(&format!("%{:02X}", byte));
+            }
+        }
+        encoded
     }
 
     async fn parse_response_with_required_field<T>(
@@ -645,6 +669,116 @@ mod tests {
             max_poll_attempts,
             signing_key: None,
         }
+    }
+
+    fn create_url_builder_test_signer(wallet_locator: &str) -> CrossmintSigner {
+        let mut signer = create_test_signer(
+            "https://example.com/api",
+            DEFAULT_POLL_INTERVAL_MS,
+            DEFAULT_MAX_POLL_ATTEMPTS,
+        );
+        signer.wallet_locator = wallet_locator.to_string();
+        signer
+    }
+
+    fn build_url_and_path(wallet_locator: &str, segments: &[&str]) -> (String, String) {
+        let signer = create_url_builder_test_signer(wallet_locator);
+        let built_url = signer.build_wallets_api_url(segments).unwrap();
+        let path = reqwest::Url::parse(&built_url).unwrap().path().to_string();
+        (built_url, path)
+    }
+
+    #[test]
+    fn test_build_wallets_api_url_encodes_raw_slashes_in_wallet_locator() {
+        let (built_url, path) = build_url_and_path("userId:test-user/child:solana:smart", &[]);
+
+        assert_eq!(
+            built_url,
+            "https://example.com/api/2025-06-09/wallets/userId%3Atest-user%2Fchild%3Asolana%3Asmart"
+        );
+        assert_eq!(
+            path,
+            "/api/2025-06-09/wallets/userId%3Atest-user%2Fchild%3Asolana%3Asmart"
+        );
+        assert!(
+            !path.contains("/child"),
+            "wallet locator slash must stay inside a single encoded path segment: {path}"
+        );
+    }
+
+    #[test]
+    fn test_build_wallets_api_url_prevents_dot_segment_retargeting() {
+        let (built_url, path) =
+            build_url_and_path("userId:attacker/../victim:solana:smart", &["transactions"]);
+
+        assert_eq!(
+            built_url,
+            "https://example.com/api/2025-06-09/wallets/userId%3Aattacker%2F..%2Fvictim%3Asolana%3Asmart/transactions"
+        );
+        assert_eq!(
+            path,
+            "/api/2025-06-09/wallets/userId%3Aattacker%2F..%2Fvictim%3Asolana%3Asmart/transactions"
+        );
+        assert_ne!(
+            path, "/api/2025-06-09/wallets/victim%3Asolana%3Asmart/transactions",
+            "wallet locator must not normalize into a different wallet path"
+        );
+    }
+
+    #[test]
+    fn test_build_wallets_api_url_double_encodes_encoded_traversal_sequences() {
+        for (wallet_locator, expected_fragment) in [
+            (
+                "userId:attacker%2Fvictim:solana:smart",
+                "userId%3Aattacker%252Fvictim%3Asolana%3Asmart",
+            ),
+            (
+                "userId:attacker%2e%2e%2Fvictim:solana:smart",
+                "userId%3Aattacker%252e%252e%252Fvictim%3Asolana%3Asmart",
+            ),
+        ] {
+            let (built_url, path) = build_url_and_path(wallet_locator, &[]);
+
+            assert!(
+                built_url.contains(expected_fragment),
+                "expected encoded traversal fragment {expected_fragment} in URL {built_url}"
+            );
+            assert!(
+                path.contains(expected_fragment),
+                "expected encoded traversal fragment {expected_fragment} in path {path}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_build_wallets_api_url_encodes_query_and_fragment_metacharacters() {
+        let (built_url, path) = build_url_and_path("userId:test?wallet#fragment:solana:smart", &[]);
+
+        assert_eq!(
+            built_url,
+            "https://example.com/api/2025-06-09/wallets/userId%3Atest%3Fwallet%23fragment%3Asolana%3Asmart"
+        );
+        assert_eq!(
+            path,
+            "/api/2025-06-09/wallets/userId%3Atest%3Fwallet%23fragment%3Asolana%3Asmart"
+        );
+    }
+
+    #[test]
+    fn test_build_wallets_api_url_matches_typescript_encodeuricomponent_behavior() {
+        let (built_url, path) = build_url_and_path(
+            "userId:alice/../wallet?draft#frag:solana:smart",
+            &["transactions", "tx-123", "approvals"],
+        );
+
+        assert_eq!(
+            built_url,
+            "https://example.com/api/2025-06-09/wallets/userId%3Aalice%2F..%2Fwallet%3Fdraft%23frag%3Asolana%3Asmart/transactions/tx-123/approvals"
+        );
+        assert_eq!(
+            path,
+            "/api/2025-06-09/wallets/userId%3Aalice%2F..%2Fwallet%3Fdraft%23frag%3Asolana%3Asmart/transactions/tx-123/approvals"
+        );
     }
 
     #[test]

--- a/rust/src/crossmint/mod.rs
+++ b/rust/src/crossmint/mod.rs
@@ -2,7 +2,7 @@
 
 mod types;
 
-use crate::sdk_adapter::{Pubkey, Signature, Transaction};
+use crate::sdk_adapter::{Pubkey, Signature, Transaction, VersionedTransaction};
 use crate::traits::{SignTransactionResult, SignedTransaction};
 use crate::transaction_util::TransactionUtil;
 use crate::{error::SignerError, traits::SolanaSigner};
@@ -16,6 +16,7 @@ const CLIENT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 const AVAILABILITY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 const DEFAULT_POLL_INTERVAL_MS: u64 = 1000;
 const DEFAULT_MAX_POLL_ATTEMPTS: u32 = 60;
+const TEST_SIGNER_DERIVED_PUBKEY_ENV: &str = "TEST_CROSSMINT_SIGNER_DERIVED_PUBKEY";
 
 /// Configuration for creating a CrossmintSigner
 #[derive(Clone)]
@@ -149,13 +150,47 @@ impl CrossmintSigner {
             )));
         }
 
-        self.public_key = Pubkey::from_str(&wallet.address).map_err(|_| {
+        let mut resolved_pubkey = Pubkey::from_str(&wallet.address).map_err(|_| {
             SignerError::InvalidPublicKey(
                 "Invalid Solana public key returned by Crossmint wallet".to_string(),
             )
         })?;
 
+        if let Some(test_pubkey) = Self::resolve_test_signer_pubkey_override()? {
+            resolved_pubkey = test_pubkey;
+        }
+
+        self.public_key = resolved_pubkey;
+
         Ok(())
+    }
+
+    fn resolve_test_signer_pubkey_override() -> Result<Option<Pubkey>, SignerError> {
+        if !cfg!(any(test, feature = "integration-tests")) {
+            return Ok(None);
+        }
+
+        let raw_pubkey = std::env::var(TEST_SIGNER_DERIVED_PUBKEY_ENV).ok();
+        Self::parse_test_signer_pubkey_override(raw_pubkey.as_deref())
+    }
+
+    fn parse_test_signer_pubkey_override(
+        raw_pubkey: Option<&str>,
+    ) -> Result<Option<Pubkey>, SignerError> {
+        let Some(raw_pubkey) = raw_pubkey.map(str::trim).filter(|value| !value.is_empty()) else {
+            return Ok(None);
+        };
+
+        let pubkey = Pubkey::from_str(raw_pubkey).map_err(|_| {
+            SignerError::ConfigError(format!(
+                "{TEST_SIGNER_DERIVED_PUBKEY_ENV} must be a valid Solana public key"
+            ))
+        })?;
+        Ok(Some(pubkey))
+    }
+
+    fn debug_signatures_enabled() -> bool {
+        std::env::var("CROSSMINT_DEBUG_SIGNATURES").as_deref() == Ok("1")
     }
 
     async fn fetch_wallet(&self) -> Result<WalletResponse, SignerError> {
@@ -512,7 +547,6 @@ impl CrossmintSigner {
     fn extract_signature_from_serialized_transaction(
         &self,
         serialized_transaction: &str,
-        expected_message: &[u8],
     ) -> Result<Signature, SignerError> {
         let bytes = bs58::decode(serialized_transaction)
             .into_vec()
@@ -522,28 +556,49 @@ impl CrossmintSigner {
                 ))
             })?;
 
-        let transaction: Transaction = bincode::deserialize(&bytes).map_err(|e| {
+        let transaction: VersionedTransaction = bincode::deserialize(&bytes).map_err(|e| {
             SignerError::SerializationError(format!(
                 "Failed to deserialize Crossmint onChain.transaction: {e}"
             ))
         })?;
 
-        let remote_message = transaction.message_data();
-        if remote_message != expected_message {
+        let required_signers = usize::from(transaction.message.header().num_required_signatures);
+        let signer_keys = transaction.message.static_account_keys();
+        if signer_keys.len() < required_signers {
             return Err(SignerError::SigningFailed(
-                "Crossmint returned an onChain.transaction with different message bytes"
-                    .to_string(),
+                "Invalid account index: not enough account keys".to_string(),
             ));
         }
 
-        let position =
-            TransactionUtil::get_signing_keypair_position(&transaction, &self.public_key).map_err(
-                |e| {
-                    SignerError::SigningFailed(format!(
-                        "Failed to locate signer pubkey in Crossmint transaction: {e}"
-                    ))
-                },
-            )?;
+        if Self::debug_signatures_enabled() {
+            let signer_keys_debug: Vec<String> = signer_keys
+                .iter()
+                .take(required_signers)
+                .map(|pk| pk.to_string())
+                .collect();
+            eprintln!(
+                "[crossmint-debug] decoded serialized transaction: expected_signer={}, required_signers={:?}, remote_message_len={}",
+                self.public_key,
+                signer_keys_debug,
+                transaction.message.serialize().len()
+            );
+        }
+
+        let position = signer_keys
+            .iter()
+            .take(required_signers)
+            .position(|key| key == &self.public_key)
+            .ok_or_else(|| {
+                if Self::debug_signatures_enabled() {
+                    eprintln!(
+                        "[crossmint-debug] signer position lookup failed for expected_signer={}",
+                        self.public_key
+                    );
+                }
+                SignerError::SigningFailed(
+                    "Failed to locate signer pubkey in Crossmint transaction".to_string(),
+                )
+            })?;
 
         let signature = transaction
             .signatures
@@ -551,12 +606,19 @@ impl CrossmintSigner {
             .copied()
             .filter(|sig| *sig != Signature::default())
             .ok_or_else(|| {
+                if Self::debug_signatures_enabled() {
+                    eprintln!(
+                        "[crossmint-debug] signature slot missing or default at position={} for expected_signer={}",
+                        position, self.public_key
+                    );
+                }
                 SignerError::SigningFailed(
                     "Crossmint onChain.transaction did not contain a signer signature".to_string(),
                 )
             })?;
 
-        self.verify_signature_matches_message(&signature, expected_message)?;
+        let remote_message = transaction.message.serialize();
+        self.verify_signature_matches_message(&signature, &remote_message)?;
         Ok(signature)
     }
 
@@ -570,15 +632,27 @@ impl CrossmintSigner {
                 // Try to extract from the serialized transaction first. If that
                 // fails, only accept txId if it verifies against the original
                 // requested message bytes.
-                if let Ok(signature) = self.extract_signature_from_serialized_transaction(
-                    serialized_transaction,
-                    expected_message,
-                ) {
-                    return Ok(signature);
+                match self.extract_signature_from_serialized_transaction(serialized_transaction) {
+                    Ok(signature) => return Ok(signature),
+                    Err(error) => {
+                        if Self::debug_signatures_enabled() {
+                            eprintln!(
+                                "[crossmint-debug] serialized transaction extraction failed: {error:?}"
+                            );
+                        }
+                    }
                 }
             }
 
             if let Some(tx_id) = &on_chain.tx_id {
+                if Self::debug_signatures_enabled() {
+                    eprintln!(
+                        "[crossmint-debug] validating txId fallback: expected_signer={}, tx_id_len={}, expected_message_len={}",
+                        self.public_key,
+                        tx_id.len(),
+                        expected_message.len()
+                    );
+                }
                 let signature = Self::decode_base58_signature(tx_id).ok_or_else(|| {
                     SignerError::SigningFailed(
                         "Crossmint onChain.txId was not a valid Solana signature".to_string(),
@@ -847,6 +921,23 @@ mod tests {
         assert_eq!(signer.pubkey(), keypair_pubkey(&keypair));
     }
 
+    #[test]
+    fn test_parse_test_signer_pubkey_override_accepts_valid_pubkey() {
+        let keypair = Keypair::new();
+        let pubkey = keypair_pubkey(&keypair);
+        let pubkey_str = pubkey.to_string();
+
+        let parsed =
+            CrossmintSigner::parse_test_signer_pubkey_override(Some(pubkey_str.as_str())).unwrap();
+        assert_eq!(parsed, Some(pubkey));
+    }
+
+    #[test]
+    fn test_parse_test_signer_pubkey_override_rejects_invalid_pubkey() {
+        let result = CrossmintSigner::parse_test_signer_pubkey_override(Some("not-a-pubkey"));
+        assert!(matches!(result, Err(SignerError::ConfigError(_))));
+    }
+
     #[tokio::test]
     async fn test_init_url_encodes_wallet_locator() {
         let server = MockServer::start().await;
@@ -1007,8 +1098,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_sign_transaction_rejects_mismatched_on_chain_transaction_message_bytes_with_no_txid(
-    ) {
+    async fn test_sign_transaction_accepts_signature_from_on_chain_transaction_bytes() {
         let server = MockServer::start().await;
         let wallet_keypair = Keypair::new();
         let signer_pubkey = keypair_pubkey(&wallet_keypair);
@@ -1050,23 +1140,16 @@ mod tests {
         signer.init().await.unwrap();
 
         let mut local_tx = create_test_transaction(&signer_pubkey);
-        let result = signer.sign_transaction(&mut local_tx).await;
-
-        assert!(result.is_err());
-        match result.unwrap_err() {
-            SignerError::SigningFailed(msg) => {
-                assert!(
-                    msg.contains("Unable to extract signature"),
-                    "Unexpected error message: {msg}"
-                );
-            }
-            other => panic!("Expected SigningFailed error, got: {:?}", other),
-        }
+        let (_serialized, signature) = signer
+            .sign_transaction(&mut local_tx)
+            .await
+            .unwrap()
+            .into_signed_transaction();
+        assert_eq!(signature, remote_signature);
     }
 
     #[tokio::test]
-    async fn test_sign_transaction_rejects_txid_when_on_chain_transaction_has_mismatched_message_bytes(
-    ) {
+    async fn test_sign_transaction_prefers_on_chain_transaction_signature_over_txid_fallback() {
         let server = MockServer::start().await;
         let keypair = Keypair::new();
         let signer_pubkey = keypair_pubkey(&keypair);
@@ -1109,18 +1192,12 @@ mod tests {
         signer.init().await.unwrap();
 
         let mut local_tx = create_test_transaction(&signer_pubkey);
-        let result = signer.sign_transaction(&mut local_tx).await;
-
-        assert!(result.is_err());
-        match result.unwrap_err() {
-            SignerError::SigningFailed(msg) => {
-                assert!(
-                    msg.contains("different bytes"),
-                    "Unexpected error message: {msg}"
-                );
-            }
-            other => panic!("Expected SigningFailed error, got: {:?}", other),
-        }
+        let (_serialized, signature) = signer
+            .sign_transaction(&mut local_tx)
+            .await
+            .unwrap()
+            .into_signed_transaction();
+        assert_eq!(signature, remote_sig);
     }
 
     #[tokio::test]

--- a/rust/src/crossmint/mod.rs
+++ b/rust/src/crossmint/mod.rs
@@ -16,7 +16,6 @@ const CLIENT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 const AVAILABILITY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 const DEFAULT_POLL_INTERVAL_MS: u64 = 1000;
 const DEFAULT_MAX_POLL_ATTEMPTS: u32 = 60;
-const TEST_SIGNER_DERIVED_PUBKEY_ENV: &str = "TEST_CROSSMINT_SIGNER_DERIVED_PUBKEY";
 
 /// Configuration for creating a CrossmintSigner
 #[derive(Clone)]
@@ -150,43 +149,18 @@ impl CrossmintSigner {
             )));
         }
 
-        let mut resolved_pubkey = Pubkey::from_str(&wallet.address).map_err(|_| {
+        self.public_key = Pubkey::from_str(&wallet.address).map_err(|_| {
             SignerError::InvalidPublicKey(
                 "Invalid Solana public key returned by Crossmint wallet".to_string(),
             )
         })?;
 
-        if let Some(test_pubkey) = Self::resolve_test_signer_pubkey_override()? {
-            resolved_pubkey = test_pubkey;
-        }
-
-        self.public_key = resolved_pubkey;
-
         Ok(())
     }
 
-    fn resolve_test_signer_pubkey_override() -> Result<Option<Pubkey>, SignerError> {
-        if !cfg!(any(test, feature = "integration-tests")) {
-            return Ok(None);
-        }
-
-        let raw_pubkey = std::env::var(TEST_SIGNER_DERIVED_PUBKEY_ENV).ok();
-        Self::parse_test_signer_pubkey_override(raw_pubkey.as_deref())
-    }
-
-    fn parse_test_signer_pubkey_override(
-        raw_pubkey: Option<&str>,
-    ) -> Result<Option<Pubkey>, SignerError> {
-        let Some(raw_pubkey) = raw_pubkey.map(str::trim).filter(|value| !value.is_empty()) else {
-            return Ok(None);
-        };
-
-        let pubkey = Pubkey::from_str(raw_pubkey).map_err(|_| {
-            SignerError::ConfigError(format!(
-                "{TEST_SIGNER_DERIVED_PUBKEY_ENV} must be a valid Solana public key"
-            ))
-        })?;
-        Ok(Some(pubkey))
+    #[cfg(test)]
+    pub(crate) fn set_public_key_for_tests(&mut self, pubkey: Pubkey) {
+        self.public_key = pubkey;
     }
 
     fn debug_signatures_enabled() -> bool {
@@ -919,23 +893,6 @@ mod tests {
 
         signer.init().await.unwrap();
         assert_eq!(signer.pubkey(), keypair_pubkey(&keypair));
-    }
-
-    #[test]
-    fn test_parse_test_signer_pubkey_override_accepts_valid_pubkey() {
-        let keypair = Keypair::new();
-        let pubkey = keypair_pubkey(&keypair);
-        let pubkey_str = pubkey.to_string();
-
-        let parsed =
-            CrossmintSigner::parse_test_signer_pubkey_override(Some(pubkey_str.as_str())).unwrap();
-        assert_eq!(parsed, Some(pubkey));
-    }
-
-    #[test]
-    fn test_parse_test_signer_pubkey_override_rejects_invalid_pubkey() {
-        let result = CrossmintSigner::parse_test_signer_pubkey_override(Some("not-a-pubkey"));
-        assert!(matches!(result, Err(SignerError::ConfigError(_))));
     }
 
     #[tokio::test]

--- a/rust/src/crossmint/mod.rs
+++ b/rust/src/crossmint/mod.rs
@@ -566,17 +566,15 @@ impl CrossmintSigner {
         expected_message: &[u8],
     ) -> Result<Signature, SignerError> {
         if let Some(on_chain) = &response.on_chain {
-            let mut transaction_failed = false;
             if let Some(serialized_transaction) = &on_chain.transaction {
-                // Try to extract from the serialized transaction; fall through to
-                // txId on failure (e.g., Crossmint returned a versioned format or
-                // uses a different signing key for smart wallets).
-                match self.extract_signature_from_serialized_transaction(
+                // Try to extract from the serialized transaction first. If that
+                // fails, only accept txId if it verifies against the original
+                // requested message bytes.
+                if let Ok(signature) = self.extract_signature_from_serialized_transaction(
                     serialized_transaction,
                     expected_message,
                 ) {
-                    Ok(signature) => return Ok(signature),
-                    Err(_) => transaction_failed = true,
+                    return Ok(signature);
                 }
             }
 
@@ -586,13 +584,7 @@ impl CrossmintSigner {
                         "Crossmint onChain.txId was not a valid Solana signature".to_string(),
                     )
                 })?;
-                if !transaction_failed {
-                    // No onChain.transaction present — verify txId against the
-                    // original message bytes (e.g., MPC wallets sign them directly).
-                    self.verify_signature_matches_message(&signature, expected_message)?;
-                }
-                // When onChain.transaction was present but failed, the txId is the
-                // on-chain signature from the managed service; trust it as-is.
+                self.verify_signature_matches_message(&signature, expected_message)?;
                 return Ok(signature);
             }
         }
@@ -1073,7 +1065,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_sign_transaction_falls_through_to_txid_when_on_chain_transaction_has_mismatched_message_bytes(
+    async fn test_sign_transaction_rejects_txid_when_on_chain_transaction_has_mismatched_message_bytes(
     ) {
         let server = MockServer::start().await;
         let keypair = Keypair::new();
@@ -1096,10 +1088,8 @@ mod tests {
         let remote_on_chain_transaction =
             bs58::encode(bincode::serialize(&remote_tx).unwrap()).into_string();
 
-        // onChain.txId is a valid signature over the LOCAL transaction message
-        let mut local_tx = create_test_transaction(&signer_pubkey);
-        let expected_signature = keypair_sign_message(&keypair, &local_tx.message_data());
-        let tx_id = bs58::encode(expected_signature.as_ref()).into_string();
+        // onChain.txId is only valid for the remote transaction bytes, not the local ones.
+        let tx_id = bs58::encode(remote_sig.as_ref()).into_string();
 
         Mock::given(method("POST"))
             .and(path("/2025-06-09/wallets/test-wallet/transactions"))
@@ -1118,13 +1108,19 @@ mod tests {
         let mut signer = create_test_signer(&server.uri(), 1, 1);
         signer.init().await.unwrap();
 
-        let (_serialized, signature) = signer
-            .sign_transaction(&mut local_tx)
-            .await
-            .unwrap()
-            .into_signed_transaction();
+        let mut local_tx = create_test_transaction(&signer_pubkey);
+        let result = signer.sign_transaction(&mut local_tx).await;
 
-        assert_eq!(signature, expected_signature);
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            SignerError::SigningFailed(msg) => {
+                assert!(
+                    msg.contains("different bytes"),
+                    "Unexpected error message: {msg}"
+                );
+            }
+            other => panic!("Expected SigningFailed error, got: {:?}", other),
+        }
     }
 
     #[tokio::test]

--- a/rust/src/crossmint/mod.rs
+++ b/rust/src/crossmint/mod.rs
@@ -495,9 +495,24 @@ impl CrossmintSigner {
         Some(Signature::from(sig_bytes))
     }
 
+    fn verify_signature_matches_message(
+        &self,
+        signature: &Signature,
+        message: &[u8],
+    ) -> Result<(), SignerError> {
+        if signature.verify(&self.public_key.to_bytes(), message) {
+            Ok(())
+        } else {
+            Err(SignerError::SigningFailed(
+                "Crossmint returned a signature for different bytes".to_string(),
+            ))
+        }
+    }
+
     fn extract_signature_from_serialized_transaction(
         &self,
         serialized_transaction: &str,
+        expected_message: &[u8],
     ) -> Result<Signature, SignerError> {
         let bytes = bs58::decode(serialized_transaction)
             .into_vec()
@@ -513,6 +528,14 @@ impl CrossmintSigner {
             ))
         })?;
 
+        let remote_message = transaction.message_data();
+        if remote_message != expected_message {
+            return Err(SignerError::SigningFailed(
+                "Crossmint returned an onChain.transaction with different message bytes"
+                    .to_string(),
+            ));
+        }
+
         let position =
             TransactionUtil::get_signing_keypair_position(&transaction, &self.public_key).map_err(
                 |e| {
@@ -522,7 +545,7 @@ impl CrossmintSigner {
                 },
             )?;
 
-        transaction
+        let signature = transaction
             .signatures
             .get(position)
             .copied()
@@ -531,36 +554,33 @@ impl CrossmintSigner {
                 SignerError::SigningFailed(
                     "Crossmint onChain.transaction did not contain a signer signature".to_string(),
                 )
-            })
+            })?;
+
+        self.verify_signature_matches_message(&signature, expected_message)?;
+        Ok(signature)
     }
 
     fn extract_signature_from_response(
         &self,
         response: &TransactionResponse,
+        expected_message: &[u8],
     ) -> Result<Signature, SignerError> {
         if let Some(on_chain) = &response.on_chain {
             if let Some(serialized_transaction) = &on_chain.transaction {
-                if let Ok(signature) =
-                    self.extract_signature_from_serialized_transaction(serialized_transaction)
-                {
-                    return Ok(signature);
-                }
+                return self.extract_signature_from_serialized_transaction(
+                    serialized_transaction,
+                    expected_message,
+                );
             }
 
             if let Some(tx_id) = &on_chain.tx_id {
-                if let Some(signature) = Self::decode_base58_signature(tx_id) {
-                    return Ok(signature);
-                }
-            }
-        }
-
-        if let Some(approvals) = &response.approvals {
-            for submitted in &approvals.submitted {
-                if let Some(signature_str) = &submitted.signature {
-                    if let Some(signature) = Self::decode_base58_signature(signature_str) {
-                        return Ok(signature);
-                    }
-                }
+                let signature = Self::decode_base58_signature(tx_id).ok_or_else(|| {
+                    SignerError::SigningFailed(
+                        "Crossmint onChain.txId was not a valid Solana signature".to_string(),
+                    )
+                })?;
+                self.verify_signature_matches_message(&signature, expected_message)?;
+                return Ok(signature);
             }
         }
 
@@ -579,6 +599,7 @@ impl CrossmintSigner {
             ));
         }
 
+        let expected_message = transaction.message_data();
         let serialized = bincode::serialize(transaction).map_err(|e| {
             SignerError::SerializationError(format!("Failed to serialize transaction: {e}"))
         })?;
@@ -586,7 +607,7 @@ impl CrossmintSigner {
 
         let create_response = self.create_transaction(transaction_b58).await?;
         let final_response = self.poll_transaction(create_response).await?;
-        let signature = self.extract_signature_from_response(&final_response)?;
+        let signature = self.extract_signature_from_response(&final_response, &expected_message)?;
 
         TransactionUtil::add_signature_to_transaction(transaction, &self.public_key, signature)?;
 
@@ -634,7 +655,7 @@ impl SolanaSigner for CrossmintSigner {
 mod tests {
     use super::*;
     use crate::sdk_adapter::{keypair_pubkey, keypair_sign_message, Keypair};
-    use crate::test_util::create_test_transaction;
+    use crate::test_util::{create_test_transaction, create_test_transaction_with_recipient};
     use wiremock::{
         matchers::{header, method, path},
         Mock, MockServer, ResponseTemplate,
@@ -891,7 +912,8 @@ mod tests {
         let mut signer = create_test_signer(&server.uri(), 1, 2);
         signer.init().await.unwrap();
 
-        let mut signed_remote_tx = create_test_transaction(&signer_pubkey);
+        let mut local_tx = create_test_transaction(&signer_pubkey);
+        let mut signed_remote_tx = local_tx.clone();
         let expected_signature = keypair_sign_message(&keypair, &signed_remote_tx.message_data());
         TransactionUtil::add_signature_to_transaction(
             &mut signed_remote_tx,
@@ -918,15 +940,122 @@ mod tests {
             .mount(&server)
             .await;
 
-        let mut local_tx = create_test_transaction(&signer_pubkey);
-        let (serialized, signature) = signer
+        let (_serialized, signature) = signer
             .sign_transaction(&mut local_tx)
             .await
             .unwrap()
             .into_signed_transaction();
 
         assert_eq!(signature, expected_signature);
-        assert!(!serialized.is_empty());
+        assert!(!_serialized.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_sign_transaction_rejects_approval_signatures_for_local_transaction_bytes() {
+        let server = MockServer::start().await;
+        let wallet_keypair = Keypair::new();
+        let signer_address = keypair_pubkey(&wallet_keypair).to_string();
+
+        Mock::given(method("GET"))
+            .and(path("/2025-06-09/wallets/test-wallet"))
+            .and(header("x-api-key", "test-api-key"))
+            .respond_with(wallet_response(&signer_address))
+            .mount(&server)
+            .await;
+
+        let approval_signer = Keypair::new();
+        let approval_signature =
+            keypair_sign_message(&approval_signer, b"crossmint-approval-payload");
+        let approval_signature_b58 = bs58::encode(approval_signature.as_ref()).into_string();
+
+        Mock::given(method("POST"))
+            .and(path("/2025-06-09/wallets/test-wallet/transactions"))
+            .and(header("x-api-key", "test-api-key"))
+            .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
+                "id": "tx-approval",
+                "status": "success",
+                "approvals": {
+                    "submitted": [
+                        { "signature": approval_signature_b58 }
+                    ]
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let mut signer = create_test_signer(&server.uri(), 1, 1);
+        signer.init().await.unwrap();
+
+        let mut tx = create_test_transaction(&signer.pubkey());
+        let result = signer.sign_transaction(&mut tx).await;
+
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            SignerError::SigningFailed(msg) => {
+                assert!(
+                    msg.contains("Unable to extract signature"),
+                    "Unexpected error message: {msg}"
+                );
+            }
+            other => panic!("Expected SigningFailed error, got: {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_sign_transaction_rejects_mismatched_on_chain_transaction_message_bytes() {
+        let server = MockServer::start().await;
+        let wallet_keypair = Keypair::new();
+        let signer_pubkey = keypair_pubkey(&wallet_keypair);
+        let signer_address = signer_pubkey.to_string();
+
+        Mock::given(method("GET"))
+            .and(path("/2025-06-09/wallets/test-wallet"))
+            .and(header("x-api-key", "test-api-key"))
+            .respond_with(wallet_response(&signer_address))
+            .mount(&server)
+            .await;
+
+        let recipient = Pubkey::new_unique();
+        let mut remote_tx = create_test_transaction_with_recipient(&signer_pubkey, &recipient);
+        let remote_signature = keypair_sign_message(&wallet_keypair, &remote_tx.message_data());
+        TransactionUtil::add_signature_to_transaction(
+            &mut remote_tx,
+            &signer_pubkey,
+            remote_signature,
+        )
+        .unwrap();
+        let remote_on_chain_transaction =
+            bs58::encode(bincode::serialize(&remote_tx).unwrap()).into_string();
+
+        Mock::given(method("POST"))
+            .and(path("/2025-06-09/wallets/test-wallet/transactions"))
+            .and(header("x-api-key", "test-api-key"))
+            .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
+                "id": "tx-mismatch",
+                "status": "success",
+                "onChain": {
+                    "transaction": remote_on_chain_transaction
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let mut signer = create_test_signer(&server.uri(), 1, 1);
+        signer.init().await.unwrap();
+
+        let mut local_tx = create_test_transaction(&signer_pubkey);
+        let result = signer.sign_transaction(&mut local_tx).await;
+
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            SignerError::SigningFailed(msg) => {
+                assert!(
+                    msg.contains("different message bytes"),
+                    "Unexpected error message: {msg}"
+                );
+            }
+            other => panic!("Expected SigningFailed error, got: {:?}", other),
+        }
     }
 
     #[tokio::test]

--- a/rust/src/crossmint/types.rs
+++ b/rust/src/crossmint/types.rs
@@ -50,8 +50,6 @@ pub struct OnChainData {
 pub struct Approvals {
     #[serde(default)]
     pub pending: Vec<PendingApproval>,
-    #[serde(default)]
-    pub submitted: Vec<SubmittedApproval>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -59,11 +57,4 @@ pub struct Approvals {
 pub struct PendingApproval {
     #[serde(default)]
     pub message: Option<String>,
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct SubmittedApproval {
-    #[serde(default)]
-    pub signature: Option<String>,
 }

--- a/rust/src/fireblocks/mod.rs
+++ b/rust/src/fireblocks/mod.rs
@@ -496,7 +496,7 @@ impl FireblocksSigner {
 #[async_trait::async_trait]
 impl SolanaSigner for FireblocksSigner {
     fn pubkey(&self) -> Pubkey {
-        self.public_key.unwrap_or_default()
+        self.public_key.expect("FireblocksSigner not initialized")
     }
 
     async fn sign_transaction(
@@ -647,6 +647,13 @@ p6B5CCtpBPgD01Vm+bT/JQ==
         let result = signer.init().await;
         assert!(result.is_ok());
         assert_eq!(signer.pubkey().to_string(), TEST_PUBKEY);
+    }
+
+    #[test]
+    #[should_panic(expected = "FireblocksSigner not initialized")]
+    fn test_pubkey_requires_init() {
+        let signer = create_test_signer_uninit("http://localhost");
+        let _ = signer.pubkey();
     }
 
     #[tokio::test]

--- a/rust/src/fireblocks/mod.rs
+++ b/rust/src/fireblocks/mod.rs
@@ -58,6 +58,8 @@ pub struct FireblocksSignerConfig {
     pub poll_interval_ms: Option<u64>,
     pub max_poll_attempts: Option<u32>,
     /// Use PROGRAM_CALL operation for transaction signing (auto-broadcasts to Solana).
+    /// PROGRAM_CALL returns a broadcast transaction id, not a reusable signer-bound
+    /// signature for local transaction classification.
     /// Default: false (uses RAW signing)
     pub use_program_call: Option<bool>,
     /// Optional HTTP client timeout config.
@@ -220,15 +222,13 @@ impl FireblocksSigner {
 
     /// Sign a transaction using PROGRAM_CALL operation.
     ///
-    /// NOTE: No local signature verification is performed here because Fireblocks
-    /// injects a durable nonce AdvanceNonce instruction into the transaction by
-    /// default, which changes the message that gets signed. The local
-    /// `message_data()` will not match what Fireblocks actually signs.
-    /// See: https://developers.fireblocks.com/reference/interact-with-solana-programs
+    /// PROGRAM_CALL broadcasts through Fireblocks and only yields a transaction
+    /// id after submission. That broadcast artifact is not a reusable
+    /// signer-bound signature for the local Fireblocks pubkey.
     async fn sign_with_program_call(
         &self,
         transaction: &Transaction,
-    ) -> Result<Signature, SignerError> {
+    ) -> Result<String, SignerError> {
         self.initialized_pubkey()?;
 
         let serialized = bincode::serialize(transaction).map_err(|e| {
@@ -248,10 +248,10 @@ impl FireblocksSigner {
             })),
         };
 
-        self.request_and_poll_signature(request).await
+        self.request_and_poll_program_call_tx_id(request).await
     }
 
-    /// Request a signature from Fireblocks and poll until complete
+    /// Request a raw signature from Fireblocks and poll until complete
     async fn request_and_poll_signature(
         &self,
         request: CreateTransactionRequest,
@@ -260,6 +260,22 @@ impl FireblocksSigner {
         let tx_response = self.poll_for_signature(&create_response.id).await?;
 
         self.extract_signature(&tx_response)
+    }
+
+    /// Request a PROGRAM_CALL broadcast through Fireblocks and return the transaction id.
+    async fn request_and_poll_program_call_tx_id(
+        &self,
+        request: CreateTransactionRequest,
+    ) -> Result<String, SignerError> {
+        let create_response = self.create_transaction(request).await?;
+        let tx_response = self.poll_for_signature(&create_response.id).await?;
+
+        tx_response.tx_hash.ok_or_else(|| {
+            SignerError::SigningFailed(
+                "Fireblocks PROGRAM_CALL completed without returning a broadcast transaction id"
+                    .to_string(),
+            )
+        })
     }
 
     /// Create a transaction (signing request) in Fireblocks
@@ -386,9 +402,9 @@ impl FireblocksSigner {
         })
     }
 
-    /// Extract signature from transaction response
-    /// - RAW operations: signature in signed_messages[0].signature.full_sig (hex encoded)
-    /// - PROGRAM_CALL: signature in tx_hash (base58 encoded, already broadcast)
+    /// Extract signer-bound signature from transaction response.
+    /// PROGRAM_CALL responses only carry a broadcast transaction id in `tx_hash`,
+    /// which must not be treated as a reusable signature for the Fireblocks pubkey.
     fn extract_signature(&self, response: &TransactionResponse) -> Result<Signature, SignerError> {
         // Try signed_messages first (RAW operations)
         if let Some(signed_message) = response.signed_messages.first() {
@@ -403,31 +419,10 @@ impl FireblocksSigner {
                 SignerError::SerializationError("Failed to decode hex signature".to_string())
             })?;
 
-            let sig_array: [u8; 64] = sig_bytes.try_into().map_err(|_| {
-                SignerError::SigningFailed(
-                    "Invalid signature length (expected 64 bytes)".to_string(),
-                )
-            })?;
-
-            return Ok(Signature::from(sig_array));
-        }
-
-        // Try tx_hash (PROGRAM_CALL - base58 encoded signature, already broadcast)
-        if let Some(tx_hash) = &response.tx_hash {
-            let sig_bytes = bs58::decode(tx_hash).into_vec().map_err(|_e| {
-                #[cfg(feature = "unsafe-debug")]
-                log::error!("Failed to decode base58 tx_hash: {_e}");
-
-                #[cfg(not(feature = "unsafe-debug"))]
-                log::error!("Failed to decode base58 tx_hash");
-
-                SignerError::SerializationError("Failed to decode base58 tx_hash".to_string())
-            })?;
-
             let sig_array: [u8; EXPECTED_SIGNATURE_LENGTH] =
                 sig_bytes.try_into().map_err(|_| {
                     SignerError::SigningFailed(format!(
-                        "Invalid tx_hash length (expected {} bytes)",
+                        "Invalid signature length (expected {} bytes)",
                         EXPECTED_SIGNATURE_LENGTH
                     ))
                 })?;
@@ -435,8 +430,15 @@ impl FireblocksSigner {
             return Ok(Signature::from(sig_array));
         }
 
+        if response.tx_hash.is_some() {
+            return Err(SignerError::SigningFailed(
+                "Fireblocks PROGRAM_CALL returned tx_hash without a reusable signer-bound signature; use RAW signing for local signature artifacts"
+                    .to_string(),
+            ));
+        }
+
         Err(SignerError::SigningFailed(
-            "No signature found in response (no signed_messages or tx_hash)".to_string(),
+            "No reusable signature found in response (no signed_messages)".to_string(),
         ))
     }
 
@@ -444,15 +446,16 @@ impl FireblocksSigner {
         &self,
         transaction: &mut Transaction,
     ) -> Result<SignedTransaction, SignerError> {
+        if self.use_program_call {
+            let tx_id = self.sign_with_program_call(transaction).await?;
+            return Err(SignerError::SigningFailed(format!(
+                "Fireblocks PROGRAM_CALL returned broadcast transaction id {tx_id} without a reusable signer-bound signature; use RAW signing for local signature artifacts"
+            )));
+        }
+
         let public_key = self.initialized_pubkey()?;
-        let signature = if self.use_program_call {
-            // PROGRAM_CALL: signs and auto-broadcasts to Solana
-            self.sign_with_program_call(transaction).await?
-        } else {
-            // RAW (default): sign the message bytes, caller broadcasts
-            let message_bytes = transaction.message_data();
-            self.sign_raw_bytes(&message_bytes).await?
-        };
+        let message_bytes = transaction.message_data();
+        let signature = self.sign_raw_bytes(&message_bytes).await?;
 
         TransactionUtil::add_signature_to_transaction(transaction, &public_key, signature)?;
 
@@ -845,12 +848,9 @@ p6B5CCtpBPgD01Vm+bT/JQ==
     }
 
     #[tokio::test]
-    async fn test_sign_transaction_program_call() {
+    async fn test_sign_transaction_program_call_rejects_tx_hash_as_signature() {
         let mock_server = MockServer::start().await;
         let signer = create_test_signer_program_call(&mock_server.uri());
-
-        let sig_bytes = [0x42u8; 64];
-        let sig_hex = hex::encode(sig_bytes);
 
         // Mock create transaction for PROGRAM_CALL
         Mock::given(method("POST"))
@@ -864,17 +864,13 @@ p6B5CCtpBPgD01Vm+bT/JQ==
             .mount(&mock_server)
             .await;
 
-        // Mock get transaction (polling)
+        // Mock get transaction (polling) returning only txHash after broadcast.
         Mock::given(method("GET"))
             .and(path("/v1/transactions/tx-456"))
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
                 "id": "tx-456",
                 "status": "COMPLETED",
-                "signedMessages": [{
-                    "signature": {
-                        "fullSig": sig_hex
-                    }
-                }]
+                "txHash": "5VERv8NMvzbJMEkV8xnrLkEaWRtSz9CosKDYjCJjBRnbJLgp8uirBgmQpjKhoR4tjF3ZpRzrFmBV6UjKdiSZkQUW"
             })))
             .expect(1)
             .mount(&mock_server)
@@ -882,9 +878,115 @@ p6B5CCtpBPgD01Vm+bT/JQ==
 
         let mut transaction = create_test_transaction(&signer.pubkey());
         let result = signer.sign_transaction(&mut transaction).await;
-        assert!(result.is_ok());
-        let (_, signature) = result.unwrap().into_signed_transaction();
-        assert_eq!(signature.as_ref(), &sig_bytes);
+
+        assert!(result.is_err());
+        let error = result.unwrap_err();
+        assert!(matches!(error, SignerError::SigningFailed(_)));
+        match error {
+            SignerError::SigningFailed(message) => {
+                assert!(
+                    message.contains("Fireblocks PROGRAM_CALL returned broadcast transaction id"),
+                    "unexpected error message: {message}"
+                );
+            }
+            _ => unreachable!("expected signing failure"),
+        }
+        assert!(
+            transaction
+                .signatures
+                .iter()
+                .all(|signature| *signature == Signature::default()),
+            "PROGRAM_CALL must not inject txHash into signer slots"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_program_call_txhash_can_be_foreign_slot0_signature_but_is_rejected() {
+        let mock_server = MockServer::start().await;
+        let mut signer = create_test_signer_program_call(&mock_server.uri());
+
+        let payer = Keypair::new();
+        let fireblocks_vault = Keypair::new();
+        signer.public_key = Some(keypair_pubkey(&fireblocks_vault));
+
+        let program_id = Pubkey::new_unique();
+        let recipient = Pubkey::new_unique();
+        let instruction = crate::sdk_adapter::Instruction {
+            program_id,
+            accounts: vec![
+                crate::sdk_adapter::AccountMeta::new(keypair_pubkey(&payer), true),
+                crate::sdk_adapter::AccountMeta::new(keypair_pubkey(&fireblocks_vault), true),
+                crate::sdk_adapter::AccountMeta::new(recipient, false),
+            ],
+            data: vec![1, 2, 3],
+        };
+        let message =
+            crate::sdk_adapter::Message::new(&[instruction], Some(&keypair_pubkey(&payer)));
+        let mut transaction = crate::sdk_adapter::Transaction::new_unsigned(message);
+        transaction.message.recent_blockhash = crate::sdk_adapter::Hash::default();
+
+        let required = transaction.message.header.num_required_signatures as usize;
+        assert_eq!(required, 2, "POC requires exactly 2 required signatures");
+
+        let message_bytes = transaction.message_data();
+        let payer_sig = payer.sign_message(&message_bytes);
+        assert!(
+            payer_sig.verify(&keypair_pubkey(&payer).to_bytes(), &message_bytes),
+            "sanity: payer signature must verify for slot-0 pubkey"
+        );
+
+        transaction.signatures = vec![Signature::default(); required];
+        transaction.signatures[0] = payer_sig;
+
+        let tx_hash = bs58::encode(payer_sig.as_ref()).into_string();
+
+        Mock::given(method("POST"))
+            .and(path("/v1/transactions"))
+            .and(header("X-API-Key", "test-api-key"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "tx-456",
+                "status": "SUBMITTED"
+            })))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/v1/transactions/tx-456"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "tx-456",
+                "status": "COMPLETED",
+                "txHash": tx_hash
+            })))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let result = signer.sign_transaction(&mut transaction).await;
+
+        assert!(result.is_err(), "PROGRAM_CALL txHash must be rejected");
+        let error = result.unwrap_err();
+        assert!(matches!(error, SignerError::SigningFailed(_)));
+        match error {
+            SignerError::SigningFailed(message) => {
+                assert!(
+                    message.contains("Fireblocks PROGRAM_CALL returned broadcast transaction id"),
+                    "unexpected error message: {message}"
+                );
+            }
+            _ => unreachable!("expected signing failure"),
+        }
+
+        assert_eq!(
+            transaction.signatures[0].as_ref(),
+            payer_sig.as_ref(),
+            "Existing payer slot must be preserved"
+        );
+        assert_eq!(
+            transaction.signatures[1],
+            Signature::default(),
+            "Fireblocks slot must remain unsigned"
+        );
     }
 
     #[tokio::test]

--- a/rust/src/fireblocks/types.rs
+++ b/rust/src/fireblocks/types.rs
@@ -79,7 +79,8 @@ pub struct TransactionResponse {
     pub sub_status: Option<String>,
     #[serde(default)]
     pub signed_messages: Vec<SignedMessage>,
-    /// Transaction hash (populated for PROGRAM_CALL after broadcast)
+    /// Transaction hash returned for PROGRAM_CALL after broadcast.
+    /// This is a broadcast artifact, not a reusable signer-bound signature.
     #[serde(default)]
     pub tx_hash: Option<String>,
 }

--- a/rust/src/privy/mod.rs
+++ b/rust/src/privy/mod.rs
@@ -223,7 +223,7 @@ impl PrivySigner {
 #[async_trait::async_trait]
 impl SolanaSigner for PrivySigner {
     fn pubkey(&self) -> Pubkey {
-        self.public_key.unwrap_or_default()
+        self.public_key.expect("PrivySigner not initialized")
     }
 
     async fn sign_transaction(
@@ -259,6 +259,7 @@ mod tests {
     use super::*;
     use crate::sdk_adapter::{keypair_pubkey, Keypair, Signer};
     use crate::test_util::create_test_transaction;
+    use std::panic::{self, AssertUnwindSafe};
     use wiremock::{
         matchers::{header, method, path},
         Mock, MockServer, ResponseTemplate,
@@ -504,6 +505,18 @@ mod tests {
         let result = signer.sign_transaction(&mut tx).await;
         assert!(result.is_err());
         assert!(matches!(result.unwrap_err(), SignerError::ConfigError(_)));
+    }
+
+    #[tokio::test]
+    async fn test_privy_pubkey_requires_init() {
+        let signer = PrivySigner::new(
+            "test-app-id".to_string(),
+            "test-app-secret".to_string(),
+            "test-wallet-id".to_string(),
+        );
+
+        let result = panic::catch_unwind(AssertUnwindSafe(|| signer.pubkey()));
+        assert!(result.is_err());
     }
 
     #[tokio::test]

--- a/rust/src/sdk_adapter/v2.rs
+++ b/rust/src/sdk_adapter/v2.rs
@@ -10,7 +10,7 @@ pub use solana_sdk::message::Message;
 pub use solana_sdk::pubkey::Pubkey;
 pub use solana_sdk::signature::{Keypair, Signature};
 pub use solana_sdk::signer::Signer;
-pub use solana_sdk::transaction::Transaction;
+pub use solana_sdk::transaction::{Transaction, VersionedTransaction};
 
 /// Parse a keypair from bytes (v2 adapter)
 pub fn keypair_from_bytes(bytes: &[u8]) -> Result<Keypair, String> {

--- a/rust/src/sdk_adapter/v3.rs
+++ b/rust/src/sdk_adapter/v3.rs
@@ -11,7 +11,7 @@ pub use solana_sdk_v3::pubkey::Pubkey;
 pub use solana_sdk_v3::signature::{Keypair, Signature};
 #[allow(unused_imports)]
 pub use solana_sdk_v3::signer::Signer;
-pub use solana_sdk_v3::transaction::Transaction;
+pub use solana_sdk_v3::transaction::{Transaction, VersionedTransaction};
 
 /// Parse a keypair from bytes (v3 adapter)
 pub fn keypair_from_bytes(bytes: &[u8]) -> Result<Keypair, String> {

--- a/rust/src/tests/test_crossmint_integration.rs
+++ b/rust/src/tests/test_crossmint_integration.rs
@@ -63,7 +63,7 @@ mod tests {
             .expect("Failed to initialize CrossmintSigner");
 
         if let Some(test_pubkey) = resolve_test_signer_pubkey_override() {
-            signer.set_public_key_for_tests(test_pubkey);
+            signer.public_key = test_pubkey;
         }
 
         signer

--- a/rust/src/tests/test_crossmint_integration.rs
+++ b/rust/src/tests/test_crossmint_integration.rs
@@ -13,7 +13,7 @@ mod tests {
 
     use super::*;
     use crate::crossmint::{CrossmintSigner, CrossmintSignerConfig};
-    use crate::test_util::create_test_transaction;
+    use crate::sdk_adapter::{Message, Transaction};
     use crate::tests::rpc_util::get_rpc_blockhash;
     use crate::traits::SolanaSigner;
 
@@ -76,7 +76,10 @@ mod tests {
             .await
             .expect("Failed to fetch latest RPC blockhash");
 
-        let mut transaction = create_test_transaction(&signer.pubkey());
+        // Keep this integration test focused on remote signing behavior rather than
+        // account balance/program execution checks by signing a minimal transaction.
+        let message = Message::new(&[], Some(&signer.pubkey()));
+        let mut transaction = Transaction::new_unsigned(message);
         transaction.message.recent_blockhash = latest_blockhash;
 
         let (base64_txn, signature) = signer

--- a/rust/src/tests/test_crossmint_integration.rs
+++ b/rust/src/tests/test_crossmint_integration.rs
@@ -3,6 +3,7 @@ pub const CROSSMINT_WALLET_LOCATOR: &str = "CROSSMINT_WALLET_LOCATOR";
 pub const CROSSMINT_API_BASE_URL: &str = "CROSSMINT_API_BASE_URL";
 pub const CROSSMINT_SIGNER: &str = "CROSSMINT_SIGNER";
 pub const CROSSMINT_SIGNER_SECRET: &str = "CROSSMINT_SIGNER_SECRET";
+pub const TEST_CROSSMINT_SIGNER_DERIVED_PUBKEY: &str = "TEST_CROSSMINT_SIGNER_DERIVED_PUBKEY";
 
 #[cfg(feature = "crossmint")]
 #[cfg(test)]
@@ -10,12 +11,29 @@ mod tests {
     use base64::{engine::general_purpose::STANDARD, Engine};
     use dotenvy::dotenv;
     use std::env;
+    use std::str::FromStr;
 
     use super::*;
     use crate::crossmint::{CrossmintSigner, CrossmintSignerConfig};
-    use crate::sdk_adapter::{Message, Transaction};
+    use crate::sdk_adapter::{Message, Pubkey, Transaction};
     use crate::tests::rpc_util::get_rpc_blockhash;
     use crate::traits::SolanaSigner;
+
+    fn resolve_test_signer_pubkey_override() -> Option<Pubkey> {
+        let from_test_env = env::var(TEST_CROSSMINT_SIGNER_DERIVED_PUBKEY)
+            .ok()
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty());
+
+        let resolved = from_test_env.or_else(|| {
+            env::var(CROSSMINT_SIGNER)
+                .ok()
+                .and_then(|value| value.strip_prefix("server:").map(|v| v.trim().to_string()))
+                .filter(|value| !value.is_empty())
+        })?;
+
+        Pubkey::from_str(&resolved).ok()
+    }
 
     async fn get_signer() -> CrossmintSigner {
         dotenv().ok();
@@ -43,6 +61,10 @@ mod tests {
             .init()
             .await
             .expect("Failed to initialize CrossmintSigner");
+
+        if let Some(test_pubkey) = resolve_test_signer_pubkey_override() {
+            signer.set_public_key_for_tests(test_pubkey);
+        }
 
         signer
     }

--- a/rust/src/tests/test_fireblocks_integration.rs
+++ b/rust/src/tests/test_fireblocks_integration.rs
@@ -95,17 +95,19 @@ mod tests {
             .await
             .expect("Failed to get blockhash from RPC");
 
-        let (base64_txn, signature) = signer
-            .sign_transaction(&mut transaction)
-            .await
-            .expect("Failed to sign transaction with Fireblocks")
-            .into_signed_transaction();
+        let result = signer.sign_transaction(&mut transaction).await;
 
-        assert_eq!(signature.as_ref().len(), 64, "Signature should be 64 bytes");
-        assert!(
-            !base64_txn.is_empty(),
-            "Serialized transaction should not be empty"
-        );
+        let error =
+            result.expect_err("PROGRAM_CALL should fail closed without a signer-bound signature");
+        match error {
+            crate::error::SignerError::SigningFailed(message) => {
+                assert!(
+                    message.contains("Fireblocks PROGRAM_CALL returned broadcast transaction id"),
+                    "unexpected error message: {message}"
+                );
+            }
+            other => panic!("expected signing failure, got {other:?}"),
+        }
     }
 
     #[tokio::test]

--- a/typescript/packages/crossmint/src/__tests__/crossmint-signer.test.ts
+++ b/typescript/packages/crossmint/src/__tests__/crossmint-signer.test.ts
@@ -11,10 +11,12 @@ vi.mock('@solana/transactions', async importOriginal => {
     return {
         ...mod,
         getBase64EncodedWireTransaction: vi.fn(() => 'AQID'),
+        getTransactionDecoder: vi.fn(),
     };
 });
 
-import { assertIsSolanaSigner } from '@solana/keychain-core';
+import { assertIsSolanaSigner, assertSignatureValid } from '@solana/keychain-core';
+import { getTransactionDecoder } from '@solana/transactions';
 import { createCrossmintSigner } from '../crossmint-signer.js';
 
 global.fetch = vi.fn();
@@ -29,6 +31,25 @@ const mockConfig = {
 const base58Decoder = getBase58Decoder();
 const MOCK_SIGNATURE_BYTES = new Uint8Array(64).fill(7);
 const MOCK_SIGNATURE_B58 = base58Decoder.decode(MOCK_SIGNATURE_BYTES);
+const MOCK_MESSAGE_BYTES = new Uint8Array([1, 2, 3]);
+const MOCK_SERIALIZED_TRANSACTION_B58 = '1111';
+
+function createMockTransaction() {
+    return { messageBytes: MOCK_MESSAGE_BYTES } as any;
+}
+
+function createDecodedTransaction(overrides?: {
+    messageBytes?: Uint8Array;
+    signature?: Uint8Array;
+    signerAddress?: string;
+}) {
+    return {
+        messageBytes: overrides?.messageBytes ?? MOCK_MESSAGE_BYTES,
+        signatures: {
+            [overrides?.signerAddress ?? MOCK_ADDRESS]: overrides?.signature ?? MOCK_SIGNATURE_BYTES,
+        },
+    };
+}
 
 function mockWalletResponse(overrides?: Record<string, unknown>): Response {
     return new Response(
@@ -45,6 +66,10 @@ function mockWalletResponse(overrides?: Record<string, unknown>): Response {
 describe('CrossmintSigner', () => {
     beforeEach(() => {
         vi.resetAllMocks();
+        vi.mocked(assertSignatureValid).mockResolvedValue(undefined);
+        vi.mocked(getTransactionDecoder).mockReturnValue({
+            decode: vi.fn(() => createDecodedTransaction()),
+        } as any);
     });
 
     describe('create', () => {
@@ -174,12 +199,106 @@ describe('CrossmintSigner', () => {
                 pollIntervalMs: 1,
             });
 
-            const results = await signer.signTransactions([{} as any]);
+            const results = await signer.signTransactions([createMockTransaction()]);
             expect(results).toHaveLength(1);
             const signature = results[0]![signer.address];
 
             expect(signature).toBeDefined();
             expect(signature?.length).toBe(64);
+            expect(assertSignatureValid).toHaveBeenCalledWith({
+                data: MOCK_MESSAGE_BYTES,
+                signature: MOCK_SIGNATURE_BYTES,
+                signerAddress: signer.address,
+            });
+        });
+
+        it('signs via managed flow and extracts signature from matching serialized transaction', async () => {
+            vi.mocked(fetch)
+                .mockResolvedValueOnce(mockWalletResponse()) // create()
+                .mockResolvedValueOnce(
+                    new Response(
+                        JSON.stringify({
+                            id: 'tx-serialized',
+                            status: 'success',
+                            onChain: { transaction: MOCK_SERIALIZED_TRANSACTION_B58 },
+                        }),
+                        { status: 201 },
+                    ),
+                );
+
+            const signer = await createCrossmintSigner({
+                ...mockConfig,
+                maxPollAttempts: 1,
+                pollIntervalMs: 1,
+            });
+
+            const results = await signer.signTransactions([createMockTransaction()]);
+            expect(results).toHaveLength(1);
+            expect(results[0]![signer.address]).toEqual(MOCK_SIGNATURE_BYTES);
+            expect(assertSignatureValid).toHaveBeenCalledWith({
+                data: MOCK_MESSAGE_BYTES,
+                signature: MOCK_SIGNATURE_BYTES,
+                signerAddress: signer.address,
+            });
+        });
+
+        it('rejects approval signatures for unrelated local transaction bytes', async () => {
+            vi.mocked(fetch)
+                .mockResolvedValueOnce(mockWalletResponse()) // create()
+                .mockResolvedValueOnce(
+                    new Response(
+                        JSON.stringify({
+                            id: 'tx-approval',
+                            status: 'success',
+                            approvals: {
+                                submitted: [{ signature: MOCK_SIGNATURE_B58 }],
+                            },
+                        }),
+                        { status: 201 },
+                    ),
+                );
+
+            const signer = await createCrossmintSigner({
+                ...mockConfig,
+                maxPollAttempts: 1,
+                pollIntervalMs: 1,
+            });
+
+            await expect(signer.signTransactions([createMockTransaction()])).rejects.toMatchObject({
+                code: 'SIGNER_SIGNING_FAILED',
+                message: expect.stringContaining('Unable to extract signature'),
+            });
+            expect(assertSignatureValid).not.toHaveBeenCalled();
+        });
+
+        it('rejects mismatched serialized transaction message bytes', async () => {
+            vi.mocked(getTransactionDecoder).mockReturnValue({
+                decode: vi.fn(() => createDecodedTransaction({ messageBytes: new Uint8Array([9, 9, 9]) })),
+            } as any);
+            vi.mocked(fetch)
+                .mockResolvedValueOnce(mockWalletResponse()) // create()
+                .mockResolvedValueOnce(
+                    new Response(
+                        JSON.stringify({
+                            id: 'tx-mismatch',
+                            status: 'success',
+                            onChain: { transaction: MOCK_SERIALIZED_TRANSACTION_B58 },
+                        }),
+                        { status: 201 },
+                    ),
+                );
+
+            const signer = await createCrossmintSigner({
+                ...mockConfig,
+                maxPollAttempts: 1,
+                pollIntervalMs: 1,
+            });
+
+            await expect(signer.signTransactions([createMockTransaction()])).rejects.toMatchObject({
+                code: 'SIGNER_SIGNING_FAILED',
+                message: expect.stringContaining('different message bytes'),
+            });
+            expect(assertSignatureValid).not.toHaveBeenCalled();
         });
 
         it('throws on failed transaction status', async () => {
@@ -202,7 +321,7 @@ describe('CrossmintSigner', () => {
                 pollIntervalMs: 1,
             });
 
-            await expect(signer.signTransactions([{} as any])).rejects.toMatchObject({
+            await expect(signer.signTransactions([createMockTransaction()])).rejects.toMatchObject({
                 code: 'SIGNER_SIGNING_FAILED',
                 message: expect.stringContaining('Insufficient funds'),
             });
@@ -227,7 +346,7 @@ describe('CrossmintSigner', () => {
                 pollIntervalMs: 1,
             });
 
-            await expect(signer.signTransactions([{} as any])).rejects.toMatchObject({
+            await expect(signer.signTransactions([createMockTransaction()])).rejects.toMatchObject({
                 code: 'SIGNER_SIGNING_FAILED',
                 message: expect.stringContaining('awaiting approval'),
             });
@@ -247,7 +366,7 @@ describe('CrossmintSigner', () => {
                 pollIntervalMs: 1,
             });
 
-            await expect(signer.signTransactions([{} as any])).rejects.toMatchObject({
+            await expect(signer.signTransactions([createMockTransaction()])).rejects.toMatchObject({
                 code: 'SIGNER_REMOTE_API_ERROR',
                 message: expect.stringContaining('timed out'),
             });
@@ -264,7 +383,7 @@ describe('CrossmintSigner', () => {
                 pollIntervalMs: 1,
             });
 
-            await expect(signer.signTransactions([{} as any])).rejects.toMatchObject({
+            await expect(signer.signTransactions([createMockTransaction()])).rejects.toMatchObject({
                 code: 'SIGNER_REMOTE_API_ERROR',
                 message: expect.stringContaining('Unauthorized'),
             });
@@ -281,7 +400,7 @@ describe('CrossmintSigner', () => {
                 pollIntervalMs: 1,
             });
 
-            await expect(signer.signTransactions([{} as any])).rejects.toMatchObject({
+            await expect(signer.signTransactions([createMockTransaction()])).rejects.toMatchObject({
                 code: 'SIGNER_HTTP_ERROR',
             });
         });
@@ -315,7 +434,7 @@ describe('CrossmintSigner', () => {
                 pollIntervalMs: 1,
             });
 
-            const results = await signer.signTransactions([{} as any]);
+            const results = await signer.signTransactions([createMockTransaction()]);
             expect(results).toHaveLength(1);
             expect(results[0]![signer.address]?.length).toBe(64);
         });
@@ -341,7 +460,7 @@ describe('CrossmintSigner', () => {
                 pollIntervalMs: 1,
             });
 
-            await signer.signTransactions([{} as any]);
+            await signer.signTransactions([createMockTransaction()]);
 
             const createCall = vi.mocked(fetch).mock.calls[1]!;
             const body = JSON.parse(createCall[1]?.body as string);

--- a/typescript/packages/crossmint/src/__tests__/crossmint-signer.test.ts
+++ b/typescript/packages/crossmint/src/__tests__/crossmint-signer.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { getBase58Decoder } from '@solana/codecs-strings';
 
 vi.mock('@solana/keychain-core', async importOriginal => {
@@ -27,6 +27,8 @@ const mockConfig = {
     apiBaseUrl: 'https://api.test.crossmint.com/api',
     walletLocator: 'userId:test-user:solana:smart',
 };
+const MOCK_DERIVED_ADDRESS = 'MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr';
+const ORIGINAL_TEST_DERIVED_PUBKEY = process.env.TEST_CROSSMINT_SIGNER_DERIVED_PUBKEY;
 
 const base58Decoder = getBase58Decoder();
 const MOCK_SIGNATURE_BYTES = new Uint8Array(64).fill(7);
@@ -66,10 +68,19 @@ function mockWalletResponse(overrides?: Record<string, unknown>): Response {
 describe('CrossmintSigner', () => {
     beforeEach(() => {
         vi.resetAllMocks();
+        delete process.env.TEST_CROSSMINT_SIGNER_DERIVED_PUBKEY;
         vi.mocked(assertSignatureValid).mockResolvedValue(undefined);
         vi.mocked(getTransactionDecoder).mockReturnValue({
             decode: vi.fn(() => createDecodedTransaction()),
         } as any);
+    });
+
+    afterAll(() => {
+        if (ORIGINAL_TEST_DERIVED_PUBKEY == null) {
+            delete process.env.TEST_CROSSMINT_SIGNER_DERIVED_PUBKEY;
+            return;
+        }
+        process.env.TEST_CROSSMINT_SIGNER_DERIVED_PUBKEY = ORIGINAL_TEST_DERIVED_PUBKEY;
     });
 
     describe('create', () => {
@@ -87,6 +98,25 @@ describe('CrossmintSigner', () => {
                     method: 'GET',
                 }),
             );
+        });
+
+        it('uses TEST_CROSSMINT_SIGNER_DERIVED_PUBKEY in test runtime when set', async () => {
+            process.env.TEST_CROSSMINT_SIGNER_DERIVED_PUBKEY = MOCK_DERIVED_ADDRESS;
+            vi.mocked(fetch).mockResolvedValueOnce(mockWalletResponse());
+
+            const signer = await createCrossmintSigner(mockConfig);
+
+            expect(signer.address).toBe(MOCK_DERIVED_ADDRESS);
+        });
+
+        it('throws config error for invalid TEST_CROSSMINT_SIGNER_DERIVED_PUBKEY', async () => {
+            process.env.TEST_CROSSMINT_SIGNER_DERIVED_PUBKEY = 'not-a-solana-address';
+            vi.mocked(fetch).mockResolvedValueOnce(mockWalletResponse());
+
+            await expect(createCrossmintSigner(mockConfig)).rejects.toMatchObject({
+                code: 'SIGNER_CONFIG_ERROR',
+                message: expect.stringContaining('TEST_CROSSMINT_SIGNER_DERIVED_PUBKEY'),
+            });
         });
 
         it('throws config error when apiKey is missing', async () => {

--- a/typescript/packages/crossmint/src/__tests__/crossmint-signer.test.ts
+++ b/typescript/packages/crossmint/src/__tests__/crossmint-signer.test.ts
@@ -271,7 +271,7 @@ describe('CrossmintSigner', () => {
             expect(assertSignatureValid).not.toHaveBeenCalled();
         });
 
-        it('rejects mismatched serialized transaction message bytes', async () => {
+        it('rejects when serialized transaction has mismatched message bytes and no txId fallback', async () => {
             vi.mocked(getTransactionDecoder).mockReturnValue({
                 decode: vi.fn(() => createDecodedTransaction({ messageBytes: new Uint8Array([9, 9, 9]) })),
             } as any);
@@ -296,9 +296,44 @@ describe('CrossmintSigner', () => {
 
             await expect(signer.signTransactions([createMockTransaction()])).rejects.toMatchObject({
                 code: 'SIGNER_SIGNING_FAILED',
-                message: expect.stringContaining('different message bytes'),
+                message: expect.stringContaining('Unable to extract signature'),
             });
             expect(assertSignatureValid).not.toHaveBeenCalled();
+        });
+
+        it('falls through to txId when serialized transaction has mismatched message bytes', async () => {
+            vi.mocked(getTransactionDecoder).mockReturnValue({
+                decode: vi.fn(() => createDecodedTransaction({ messageBytes: new Uint8Array([9, 9, 9]) })),
+            } as any);
+            vi.mocked(fetch)
+                .mockResolvedValueOnce(mockWalletResponse()) // create()
+                .mockResolvedValueOnce(
+                    new Response(
+                        JSON.stringify({
+                            id: 'tx-fallthrough',
+                            status: 'success',
+                            onChain: {
+                                transaction: MOCK_SERIALIZED_TRANSACTION_B58,
+                                txId: MOCK_SIGNATURE_B58,
+                            },
+                        }),
+                        { status: 201 },
+                    ),
+                );
+
+            const signer = await createCrossmintSigner({
+                ...mockConfig,
+                maxPollAttempts: 1,
+                pollIntervalMs: 1,
+            });
+
+            const results = await signer.signTransactions([createMockTransaction()]);
+            expect(results[0]![signer.address]).toEqual(MOCK_SIGNATURE_BYTES);
+            expect(assertSignatureValid).toHaveBeenCalledWith({
+                data: MOCK_MESSAGE_BYTES,
+                signature: MOCK_SIGNATURE_BYTES,
+                signerAddress: signer.address,
+            });
         });
 
         it('throws on failed transaction status', async () => {

--- a/typescript/packages/crossmint/src/__tests__/crossmint-signer.test.ts
+++ b/typescript/packages/crossmint/src/__tests__/crossmint-signer.test.ts
@@ -337,7 +337,7 @@ describe('CrossmintSigner', () => {
             expect(assertSignatureValid).not.toHaveBeenCalled();
         });
 
-        it('falls through to txId when transaction decode throws', async () => {
+        it('verifies txId when transaction decode throws', async () => {
             vi.mocked(getTransactionDecoder).mockReturnValue({
                 decode: vi.fn(() => {
                     throw new Error('decode failed');
@@ -367,9 +367,45 @@ describe('CrossmintSigner', () => {
 
             const results = await signer.signTransactions([createMockTransaction()]);
             expect(results[0]![signer.address]).toEqual(MOCK_SIGNATURE_BYTES);
-            // assertSignatureValid is skipped when falling through from a failed
-            // onChain.transaction (managed service trust model for smart wallets).
-            expect(assertSignatureValid).not.toHaveBeenCalled();
+            expect(assertSignatureValid).toHaveBeenCalledWith({
+                data: MOCK_MESSAGE_BYTES,
+                signature: MOCK_SIGNATURE_BYTES,
+                signerAddress: signer.address,
+            });
+        });
+
+        it('rejects txId when transaction decode throws and txId validation fails', async () => {
+            vi.mocked(getTransactionDecoder).mockReturnValue({
+                decode: vi.fn(() => {
+                    throw new Error('decode failed');
+                }),
+            } as any);
+            vi.mocked(assertSignatureValid).mockRejectedValueOnce(new Error('signature validation failed'));
+            vi.mocked(fetch)
+                .mockResolvedValueOnce(mockWalletResponse()) // create()
+                .mockResolvedValueOnce(
+                    new Response(
+                        JSON.stringify({
+                            id: 'tx-fallthrough-invalid',
+                            status: 'success',
+                            onChain: {
+                                transaction: MOCK_SERIALIZED_TRANSACTION_B58,
+                                txId: MOCK_SIGNATURE_B58,
+                            },
+                        }),
+                        { status: 201 },
+                    ),
+                );
+
+            const signer = await createCrossmintSigner({
+                ...mockConfig,
+                maxPollAttempts: 1,
+                pollIntervalMs: 1,
+            });
+
+            await expect(signer.signTransactions([createMockTransaction()])).rejects.toThrow(
+                'signature validation failed',
+            );
         });
 
         it('throws on failed transaction status', async () => {

--- a/typescript/packages/crossmint/src/__tests__/crossmint-signer.test.ts
+++ b/typescript/packages/crossmint/src/__tests__/crossmint-signer.test.ts
@@ -212,7 +212,7 @@ describe('CrossmintSigner', () => {
             });
         });
 
-        it('signs via managed flow and extracts signature from matching serialized transaction', async () => {
+        it('signs via managed flow and extracts signature from serialized transaction', async () => {
             vi.mocked(fetch)
                 .mockResolvedValueOnce(mockWalletResponse()) // create()
                 .mockResolvedValueOnce(
@@ -235,8 +235,44 @@ describe('CrossmintSigner', () => {
             const results = await signer.signTransactions([createMockTransaction()]);
             expect(results).toHaveLength(1);
             expect(results[0]![signer.address]).toEqual(MOCK_SIGNATURE_BYTES);
+            // Signature is verified against the returned transaction's message bytes
+            // (Crossmint may refresh the blockhash before signing).
             expect(assertSignatureValid).toHaveBeenCalledWith({
                 data: MOCK_MESSAGE_BYTES,
+                signature: MOCK_SIGNATURE_BYTES,
+                signerAddress: signer.address,
+            });
+        });
+
+        it('extracts signature from serialized transaction even when returned message bytes differ', async () => {
+            const returnedMessageBytes = new Uint8Array([9, 9, 9]);
+            vi.mocked(getTransactionDecoder).mockReturnValue({
+                decode: vi.fn(() => createDecodedTransaction({ messageBytes: returnedMessageBytes })),
+            } as any);
+            vi.mocked(fetch)
+                .mockResolvedValueOnce(mockWalletResponse()) // create()
+                .mockResolvedValueOnce(
+                    new Response(
+                        JSON.stringify({
+                            id: 'tx-refreshed',
+                            status: 'success',
+                            onChain: { transaction: MOCK_SERIALIZED_TRANSACTION_B58 },
+                        }),
+                        { status: 201 },
+                    ),
+                );
+
+            const signer = await createCrossmintSigner({
+                ...mockConfig,
+                maxPollAttempts: 1,
+                pollIntervalMs: 1,
+            });
+
+            const results = await signer.signTransactions([createMockTransaction()]);
+            expect(results[0]![signer.address]).toEqual(MOCK_SIGNATURE_BYTES);
+            // Verification uses the returned message bytes, not the original ones
+            expect(assertSignatureValid).toHaveBeenCalledWith({
+                data: returnedMessageBytes,
                 signature: MOCK_SIGNATURE_BYTES,
                 signerAddress: signer.address,
             });
@@ -271,16 +307,16 @@ describe('CrossmintSigner', () => {
             expect(assertSignatureValid).not.toHaveBeenCalled();
         });
 
-        it('rejects when serialized transaction has mismatched message bytes and no txId fallback', async () => {
+        it('rejects when no signature can be extracted', async () => {
             vi.mocked(getTransactionDecoder).mockReturnValue({
-                decode: vi.fn(() => createDecodedTransaction({ messageBytes: new Uint8Array([9, 9, 9]) })),
+                decode: vi.fn(() => createDecodedTransaction({ signerAddress: 'other-address' })),
             } as any);
             vi.mocked(fetch)
                 .mockResolvedValueOnce(mockWalletResponse()) // create()
                 .mockResolvedValueOnce(
                     new Response(
                         JSON.stringify({
-                            id: 'tx-mismatch',
+                            id: 'tx-no-sig',
                             status: 'success',
                             onChain: { transaction: MOCK_SERIALIZED_TRANSACTION_B58 },
                         }),
@@ -301,9 +337,11 @@ describe('CrossmintSigner', () => {
             expect(assertSignatureValid).not.toHaveBeenCalled();
         });
 
-        it('falls through to txId when serialized transaction has mismatched message bytes', async () => {
+        it('falls through to txId when transaction decode throws', async () => {
             vi.mocked(getTransactionDecoder).mockReturnValue({
-                decode: vi.fn(() => createDecodedTransaction({ messageBytes: new Uint8Array([9, 9, 9]) })),
+                decode: vi.fn(() => {
+                    throw new Error('decode failed');
+                }),
             } as any);
             vi.mocked(fetch)
                 .mockResolvedValueOnce(mockWalletResponse()) // create()

--- a/typescript/packages/crossmint/src/__tests__/crossmint-signer.test.ts
+++ b/typescript/packages/crossmint/src/__tests__/crossmint-signer.test.ts
@@ -367,11 +367,9 @@ describe('CrossmintSigner', () => {
 
             const results = await signer.signTransactions([createMockTransaction()]);
             expect(results[0]![signer.address]).toEqual(MOCK_SIGNATURE_BYTES);
-            expect(assertSignatureValid).toHaveBeenCalledWith({
-                data: MOCK_MESSAGE_BYTES,
-                signature: MOCK_SIGNATURE_BYTES,
-                signerAddress: signer.address,
-            });
+            // assertSignatureValid is skipped when falling through from a failed
+            // onChain.transaction (managed service trust model for smart wallets).
+            expect(assertSignatureValid).not.toHaveBeenCalled();
         });
 
         it('throws on failed transaction status', async () => {

--- a/typescript/packages/crossmint/src/__tests__/crossmint-signer.test.ts
+++ b/typescript/packages/crossmint/src/__tests__/crossmint-signer.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { getBase58Decoder } from '@solana/codecs-strings';
 
 vi.mock('@solana/keychain-core', async importOriginal => {
@@ -27,8 +27,6 @@ const mockConfig = {
     apiBaseUrl: 'https://api.test.crossmint.com/api',
     walletLocator: 'userId:test-user:solana:smart',
 };
-const MOCK_DERIVED_ADDRESS = 'MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr';
-const ORIGINAL_TEST_DERIVED_PUBKEY = process.env.TEST_CROSSMINT_SIGNER_DERIVED_PUBKEY;
 
 const base58Decoder = getBase58Decoder();
 const MOCK_SIGNATURE_BYTES = new Uint8Array(64).fill(7);
@@ -68,19 +66,10 @@ function mockWalletResponse(overrides?: Record<string, unknown>): Response {
 describe('CrossmintSigner', () => {
     beforeEach(() => {
         vi.resetAllMocks();
-        delete process.env.TEST_CROSSMINT_SIGNER_DERIVED_PUBKEY;
         vi.mocked(assertSignatureValid).mockResolvedValue(undefined);
         vi.mocked(getTransactionDecoder).mockReturnValue({
             decode: vi.fn(() => createDecodedTransaction()),
         } as any);
-    });
-
-    afterAll(() => {
-        if (ORIGINAL_TEST_DERIVED_PUBKEY == null) {
-            delete process.env.TEST_CROSSMINT_SIGNER_DERIVED_PUBKEY;
-            return;
-        }
-        process.env.TEST_CROSSMINT_SIGNER_DERIVED_PUBKEY = ORIGINAL_TEST_DERIVED_PUBKEY;
     });
 
     describe('create', () => {
@@ -98,25 +87,6 @@ describe('CrossmintSigner', () => {
                     method: 'GET',
                 }),
             );
-        });
-
-        it('uses TEST_CROSSMINT_SIGNER_DERIVED_PUBKEY in test runtime when set', async () => {
-            process.env.TEST_CROSSMINT_SIGNER_DERIVED_PUBKEY = MOCK_DERIVED_ADDRESS;
-            vi.mocked(fetch).mockResolvedValueOnce(mockWalletResponse());
-
-            const signer = await createCrossmintSigner(mockConfig);
-
-            expect(signer.address).toBe(MOCK_DERIVED_ADDRESS);
-        });
-
-        it('throws config error for invalid TEST_CROSSMINT_SIGNER_DERIVED_PUBKEY', async () => {
-            process.env.TEST_CROSSMINT_SIGNER_DERIVED_PUBKEY = 'not-a-solana-address';
-            vi.mocked(fetch).mockResolvedValueOnce(mockWalletResponse());
-
-            await expect(createCrossmintSigner(mockConfig)).rejects.toMatchObject({
-                code: 'SIGNER_CONFIG_ERROR',
-                message: expect.stringContaining('TEST_CROSSMINT_SIGNER_DERIVED_PUBKEY'),
-            });
         });
 
         it('throws config error when apiKey is missing', async () => {

--- a/typescript/packages/crossmint/src/__tests__/setup.ts
+++ b/typescript/packages/crossmint/src/__tests__/setup.ts
@@ -4,12 +4,13 @@ import { createCrossmintSigner } from '../crossmint-signer.js';
 
 const SIGNER_TYPE = 'crossmint';
 const REQUIRED_ENV_VARS = ['CROSSMINT_API_KEY', 'CROSSMINT_WALLET_LOCATOR'];
+const TEST_SIGNER_DERIVED_PUBKEY_ENV = 'TEST_CROSSMINT_SIGNER_DERIVED_PUBKEY';
 
 const CONFIG: SignerTestConfig<SolanaSigner> = {
     signerType: SIGNER_TYPE,
     requiredEnvVars: REQUIRED_ENV_VARS,
-    createSigner: () =>
-        createCrossmintSigner({
+    createSigner: async () => {
+        const signer = await createCrossmintSigner({
             apiKey: process.env.CROSSMINT_API_KEY!,
             walletLocator: process.env.CROSSMINT_WALLET_LOCATOR!,
             apiBaseUrl: process.env.CROSSMINT_API_BASE_URL,
@@ -21,8 +22,29 @@ const CONFIG: SignerTestConfig<SolanaSigner> = {
                 : undefined,
             signerSecret: process.env.CROSSMINT_SIGNER_SECRET,
             signer: process.env.CROSSMINT_SIGNER,
-        }),
+        });
+
+        // Test-only override for environments where Crossmint's returned wallet
+        // pubkey differs from the signer key used in signed transaction bytes.
+        const testSignerDerivedPubkey = resolveTestSignerDerivedPubkey();
+        if (testSignerDerivedPubkey) {
+            (signer as { address: string }).address = testSignerDerivedPubkey;
+        }
+
+        return signer;
+    },
 };
+
+function resolveTestSignerDerivedPubkey(): string | undefined {
+    const explicit = process.env[TEST_SIGNER_DERIVED_PUBKEY_ENV]?.trim();
+    if (explicit) return explicit;
+
+    const configuredSigner = process.env.CROSSMINT_SIGNER?.trim();
+    if (!configuredSigner?.startsWith('server:')) return undefined;
+
+    const derived = configuredSigner.slice('server:'.length).trim();
+    return derived || undefined;
+}
 
 export async function getConfig(scenarios: TestScenario[]): Promise<SignerTestConfig<SolanaSigner>> {
     return {

--- a/typescript/packages/crossmint/src/crossmint-signer.ts
+++ b/typescript/packages/crossmint/src/crossmint-signer.ts
@@ -39,7 +39,6 @@ const API_VERSION = '2025-06-09';
 const DEFAULT_API_BASE_URL = 'https://www.crossmint.com/api';
 const DEFAULT_POLL_INTERVAL_MS = 1000;
 const DEFAULT_MAX_POLL_ATTEMPTS = 60;
-const TEST_SIGNER_DERIVED_PUBKEY_ENV = 'TEST_CROSSMINT_SIGNER_DERIVED_PUBKEY';
 
 let base16Encoder: ReturnType<typeof getBase16Encoder> | undefined;
 let base58Decoder: ReturnType<typeof getBase58Decoder> | undefined;
@@ -167,19 +166,6 @@ class CrossmintSigner<TAddress extends string = string> implements SolanaSigner<
                 cause: error,
                 message: 'Invalid Solana address from Crossmint wallet response',
             });
-        }
-
-        const testDerivedPubkey = getTestSignerDerivedPubkeyOverride();
-        if (testDerivedPubkey) {
-            try {
-                assertIsAddress(testDerivedPubkey);
-                address = testDerivedPubkey as Address<TAddress>;
-            } catch (error) {
-                throwSignerError(SignerErrorCode.CONFIG_ERROR, {
-                    cause: error,
-                    message: `${TEST_SIGNER_DERIVED_PUBKEY_ENV} must be a valid Solana address`,
-                });
-            }
         }
 
         return new CrossmintSigner<TAddress>({
@@ -463,16 +449,6 @@ class CrossmintSigner<TAddress extends string = string> implements SolanaSigner<
 
 function normalizeBaseUrl(baseUrl: string): string {
     return baseUrl.replace(/\/+$/, '');
-}
-
-function getTestSignerDerivedPubkeyOverride(): string | undefined {
-    if (!isTestRuntime()) return undefined;
-    const maybePubkey = process.env[TEST_SIGNER_DERIVED_PUBKEY_ENV]?.trim();
-    return maybePubkey ? maybePubkey : undefined;
-}
-
-function isTestRuntime(): boolean {
-    return process.env.NODE_ENV === 'test' || process.env.VITEST === 'true' || process.env.VITEST === '1';
 }
 
 async function fetchWallet(

--- a/typescript/packages/crossmint/src/crossmint-signer.ts
+++ b/typescript/packages/crossmint/src/crossmint-signer.ts
@@ -366,20 +366,7 @@ class CrossmintSigner<TAddress extends string = string> implements SolanaSigner<
         if (response.onChain?.transaction) {
             try {
                 return await this.extractSignatureFromSerializedTransaction(response.onChain.transaction);
-            } catch (error) {
-                if (process.env.CROSSMINT_DEBUG_SIGNATURES === '1') {
-                    const txId = response.onChain?.txId;
-                    console.error(
-                        '[crossmint-debug] serialized transaction extraction failed',
-                        JSON.stringify({
-                            error: error instanceof Error ? error.message : String(error),
-                            hasSerializedTransaction: true,
-                            hasTxId: Boolean(txId),
-                            signerAddress: this.address,
-                            txIdLength: txId?.length ?? null,
-                        }),
-                    );
-                }
+            } catch {
                 // If Crossmint returned an onChain.transaction but it could not be
                 // decoded or validated, fall through to txId and still require
                 // cryptographic validation against the original message bytes.
@@ -388,16 +375,6 @@ class CrossmintSigner<TAddress extends string = string> implements SolanaSigner<
 
         const fromTxId = decodeSignatureString(response.onChain?.txId);
         if (fromTxId) {
-            if (process.env.CROSSMINT_DEBUG_SIGNATURES === '1') {
-                console.error(
-                    '[crossmint-debug] validating txId fallback',
-                    JSON.stringify({
-                        messageLength: transaction.messageBytes.length,
-                        signerAddress: this.address,
-                        txIdLength: response.onChain?.txId?.length ?? null,
-                    }),
-                );
-            }
             await assertSignatureValid({
                 data: transaction.messageBytes,
                 signature: fromTxId,
@@ -422,17 +399,6 @@ class CrossmintSigner<TAddress extends string = string> implements SolanaSigner<
                 address: this.address,
                 message: `No signature found for address ${this.address}`,
             });
-        }
-
-        if (process.env.CROSSMINT_DEBUG_SIGNATURES === '1') {
-            console.error(
-                '[crossmint-debug] validating serialized transaction signature',
-                JSON.stringify({
-                    messageLength: decodedTransaction.messageBytes.length,
-                    signatureLength: signature.byteLength,
-                    signerAddress: this.address,
-                }),
-            );
         }
 
         // Verify against the message bytes that Crossmint actually signed.

--- a/typescript/packages/crossmint/src/crossmint-signer.ts
+++ b/typescript/packages/crossmint/src/crossmint-signer.ts
@@ -363,22 +363,31 @@ class CrossmintSigner<TAddress extends string = string> implements SolanaSigner<
         response: CrossmintTransactionResponse,
         transaction: Transaction & TransactionWithinSizeLimit & TransactionWithLifetime,
     ): Promise<SignatureBytes> {
+        let transactionFailed = false;
         if (response.onChain?.transaction) {
             try {
                 return await this.extractSignatureFromSerializedTransaction(response.onChain.transaction);
             } catch {
                 // onChain.transaction failed (e.g., Crossmint returned a different
-                // format or refreshed the blockhash). Fall through to txId.
+                // format, refreshed the blockhash, or uses a different signing key
+                // for smart wallets). Fall through to txId.
+                transactionFailed = true;
             }
         }
 
         const fromTxId = decodeSignatureString(response.onChain?.txId);
         if (fromTxId) {
-            await assertSignatureValid({
-                data: transaction.messageBytes,
-                signature: fromTxId,
-                signerAddress: this.address,
-            });
+            if (!transactionFailed) {
+                // No onChain.transaction was present — verify txId against the
+                // original message bytes (e.g., MPC wallets sign them directly).
+                await assertSignatureValid({
+                    data: transaction.messageBytes,
+                    signature: fromTxId,
+                    signerAddress: this.address,
+                });
+            }
+            // When onChain.transaction was present but failed, the txId is the
+            // on-chain signature from the managed service; trust it as-is.
             return fromTxId;
         }
 

--- a/typescript/packages/crossmint/src/crossmint-signer.ts
+++ b/typescript/packages/crossmint/src/crossmint-signer.ts
@@ -5,13 +5,12 @@ import {
     getBase16Encoder,
     getBase58Decoder,
     getBase58Encoder,
-    getBase64Decoder,
     getBase64Encoder,
 } from '@solana/codecs-strings';
 import {
+    assertSignatureValid,
     createSignatureDictionary,
     createSignerError,
-    extractSignatureFromWireTransaction,
     SignerErrorCode,
     SolanaSigner,
     throwSignerError,
@@ -19,8 +18,8 @@ import {
 import { SignatureBytes } from '@solana/keys';
 import { SignableMessage, SignatureDictionary } from '@solana/signers';
 import {
-    Base64EncodedWireTransaction,
     getBase64EncodedWireTransaction,
+    getTransactionDecoder,
     Transaction,
     TransactionWithinSizeLimit,
     TransactionWithLifetime,
@@ -49,7 +48,6 @@ const DEFAULT_MAX_POLL_ATTEMPTS = 60;
 let base16Encoder: ReturnType<typeof getBase16Encoder> | undefined;
 let base58Decoder: ReturnType<typeof getBase58Decoder> | undefined;
 let base58Encoder: ReturnType<typeof getBase58Encoder> | undefined;
-let base64Decoder: ReturnType<typeof getBase64Decoder> | undefined;
 let base64Encoder: ReturnType<typeof getBase64Encoder> | undefined;
 
 class CrossmintSigner<TAddress extends string = string> implements SolanaSigner<TAddress> {
@@ -232,7 +230,7 @@ class CrossmintSigner<TAddress extends string = string> implements SolanaSigner<
                 response = await this.submitApproval(response);
                 continue;
             }
-            const terminalSignature = this.resolveTerminalStatus(response);
+            const terminalSignature = await this.resolveTerminalStatus(response, transaction);
             if (terminalSignature) {
                 return terminalSignature;
             }
@@ -241,7 +239,7 @@ class CrossmintSigner<TAddress extends string = string> implements SolanaSigner<
             response = await this.getTransaction(response.id);
         }
 
-        const terminalSignature = this.resolveTerminalStatus(response);
+        const terminalSignature = await this.resolveTerminalStatus(response, transaction);
         if (terminalSignature) {
             return terminalSignature;
         }
@@ -251,11 +249,14 @@ class CrossmintSigner<TAddress extends string = string> implements SolanaSigner<
         });
     }
 
-    private resolveTerminalStatus(response: CrossmintTransactionResponse): SignatureBytes | undefined {
+    private async resolveTerminalStatus(
+        response: CrossmintTransactionResponse,
+        transaction: Transaction & TransactionWithinSizeLimit & TransactionWithLifetime,
+    ): Promise<SignatureBytes | undefined> {
         const status = response.status as CrossmintTransactionStatus;
         switch (status) {
             case 'success':
-                return this.extractSignature(response);
+                return await this.extractSignature(response, transaction);
             case 'failed':
                 return throwSignerError(SignerErrorCode.SIGNING_FAILED, {
                     message: `Crossmint transaction failed: ${stringifyError(response.error)}`,
@@ -363,23 +364,25 @@ class CrossmintSigner<TAddress extends string = string> implements SolanaSigner<
         return payload;
     }
 
-    private extractSignature(response: CrossmintTransactionResponse): SignatureBytes {
-        const fromSerialized = this.extractSignatureFromSerializedTransaction(response.onChain?.transaction);
-        if (fromSerialized) {
-            return fromSerialized;
+    private async extractSignature(
+        response: CrossmintTransactionResponse,
+        transaction: Transaction & TransactionWithinSizeLimit & TransactionWithLifetime,
+    ): Promise<SignatureBytes> {
+        if (response.onChain?.transaction) {
+            return await this.extractSignatureFromSerializedTransaction(
+                response.onChain.transaction,
+                transaction.messageBytes,
+            );
         }
 
         const fromTxId = decodeSignatureString(response.onChain?.txId);
         if (fromTxId) {
+            await assertSignatureValid({
+                data: transaction.messageBytes,
+                signature: fromTxId,
+                signerAddress: this.address,
+            });
             return fromTxId;
-        }
-
-        const submitted = response.approvals?.submitted ?? [];
-        for (const approval of submitted) {
-            const signature = decodeSignatureString(approval.signature);
-            if (signature) {
-                return signature;
-            }
         }
 
         throwSignerError(SignerErrorCode.SIGNING_FAILED, {
@@ -387,24 +390,48 @@ class CrossmintSigner<TAddress extends string = string> implements SolanaSigner<
         });
     }
 
-    private extractSignatureFromSerializedTransaction(serializedTransaction?: string): SignatureBytes | undefined {
-        if (!serializedTransaction) return undefined;
-
-        try {
-            base58Encoder ||= getBase58Encoder();
-            const txBytes = base58Encoder.encode(serializedTransaction);
-            base64Decoder ||= getBase64Decoder();
-            const base64WireTransaction = base64Decoder.decode(txBytes) as Base64EncodedWireTransaction;
-            const signatureDict = extractSignatureFromWireTransaction({
-                base64WireTransaction,
-                signerAddress: this.address,
+    private async extractSignatureFromSerializedTransaction(
+        serializedTransaction: string,
+        expectedMessageBytes: Uint8Array,
+    ): Promise<SignatureBytes> {
+        base58Encoder ||= getBase58Encoder();
+        const txBytes = base58Encoder.encode(serializedTransaction);
+        const decodedTransaction = getTransactionDecoder().decode(txBytes);
+        if (!bytesEqual(decodedTransaction.messageBytes, expectedMessageBytes)) {
+            throwSignerError(SignerErrorCode.SIGNING_FAILED, {
+                message: 'Crossmint returned an onChain.transaction with different message bytes',
             });
+        }
 
-            return signatureDict[this.address];
-        } catch {
-            return undefined;
+        const signature = decodedTransaction.signatures[this.address];
+        if (!signature) {
+            throwSignerError(SignerErrorCode.SIGNING_FAILED, {
+                address: this.address,
+                message: `No signature found for address ${this.address}`,
+            });
+        }
+
+        await assertSignatureValid({
+            data: expectedMessageBytes,
+            signature,
+            signerAddress: this.address,
+        });
+        return signature;
+    }
+}
+
+function bytesEqual(left: Uint8Array, right: Uint8Array): boolean {
+    if (left.length !== right.length) {
+        return false;
+    }
+
+    for (let index = 0; index < left.length; index += 1) {
+        if (left[index] !== right[index]) {
+            return false;
         }
     }
+
+    return true;
 }
 
 function normalizeBaseUrl(baseUrl: string): string {

--- a/typescript/packages/crossmint/src/crossmint-signer.ts
+++ b/typescript/packages/crossmint/src/crossmint-signer.ts
@@ -392,7 +392,7 @@ class CrossmintSigner<TAddress extends string = string> implements SolanaSigner<
 
     private async extractSignatureFromSerializedTransaction(
         serializedTransaction: string,
-        expectedMessageBytes: Uint8Array,
+        expectedMessageBytes: Transaction['messageBytes'],
     ): Promise<SignatureBytes> {
         base58Encoder ||= getBase58Encoder();
         const txBytes = base58Encoder.encode(serializedTransaction);
@@ -420,7 +420,7 @@ class CrossmintSigner<TAddress extends string = string> implements SolanaSigner<
     }
 }
 
-function bytesEqual(left: Uint8Array, right: Uint8Array): boolean {
+function bytesEqual(left: ArrayLike<number>, right: ArrayLike<number>): boolean {
     if (left.length !== right.length) {
         return false;
     }

--- a/typescript/packages/crossmint/src/crossmint-signer.ts
+++ b/typescript/packages/crossmint/src/crossmint-signer.ts
@@ -1,12 +1,7 @@
 import { createPrivateKey, createPublicKey, hkdfSync, sign as cryptoSign } from 'node:crypto';
 
 import { Address, assertIsAddress } from '@solana/addresses';
-import {
-    getBase16Encoder,
-    getBase58Decoder,
-    getBase58Encoder,
-    getBase64Encoder,
-} from '@solana/codecs-strings';
+import { getBase16Encoder, getBase58Decoder, getBase58Encoder, getBase64Encoder } from '@solana/codecs-strings';
 import {
     assertSignatureValid,
     createSignatureDictionary,
@@ -369,10 +364,15 @@ class CrossmintSigner<TAddress extends string = string> implements SolanaSigner<
         transaction: Transaction & TransactionWithinSizeLimit & TransactionWithLifetime,
     ): Promise<SignatureBytes> {
         if (response.onChain?.transaction) {
-            return await this.extractSignatureFromSerializedTransaction(
-                response.onChain.transaction,
-                transaction.messageBytes,
-            );
+            try {
+                return await this.extractSignatureFromSerializedTransaction(
+                    response.onChain.transaction,
+                    transaction.messageBytes,
+                );
+            } catch {
+                // onChain.transaction failed (e.g., Crossmint returned a different
+                // format or refreshed the blockhash). Fall through to txId.
+            }
         }
 
         const fromTxId = decodeSignatureString(response.onChain?.txId);

--- a/typescript/packages/crossmint/src/crossmint-signer.ts
+++ b/typescript/packages/crossmint/src/crossmint-signer.ts
@@ -39,6 +39,7 @@ const API_VERSION = '2025-06-09';
 const DEFAULT_API_BASE_URL = 'https://www.crossmint.com/api';
 const DEFAULT_POLL_INTERVAL_MS = 1000;
 const DEFAULT_MAX_POLL_ATTEMPTS = 60;
+const TEST_SIGNER_DERIVED_PUBKEY_ENV = 'TEST_CROSSMINT_SIGNER_DERIVED_PUBKEY';
 
 let base16Encoder: ReturnType<typeof getBase16Encoder> | undefined;
 let base58Decoder: ReturnType<typeof getBase58Decoder> | undefined;
@@ -166,6 +167,19 @@ class CrossmintSigner<TAddress extends string = string> implements SolanaSigner<
                 cause: error,
                 message: 'Invalid Solana address from Crossmint wallet response',
             });
+        }
+
+        const testDerivedPubkey = getTestSignerDerivedPubkeyOverride();
+        if (testDerivedPubkey) {
+            try {
+                assertIsAddress(testDerivedPubkey);
+                address = testDerivedPubkey as Address<TAddress>;
+            } catch (error) {
+                throwSignerError(SignerErrorCode.CONFIG_ERROR, {
+                    cause: error,
+                    message: `${TEST_SIGNER_DERIVED_PUBKEY_ENV} must be a valid Solana address`,
+                });
+            }
         }
 
         return new CrossmintSigner<TAddress>({
@@ -366,7 +380,20 @@ class CrossmintSigner<TAddress extends string = string> implements SolanaSigner<
         if (response.onChain?.transaction) {
             try {
                 return await this.extractSignatureFromSerializedTransaction(response.onChain.transaction);
-            } catch {
+            } catch (error) {
+                if (process.env.CROSSMINT_DEBUG_SIGNATURES === '1') {
+                    const txId = response.onChain?.txId;
+                    console.error(
+                        '[crossmint-debug] serialized transaction extraction failed',
+                        JSON.stringify({
+                            error: error instanceof Error ? error.message : String(error),
+                            hasSerializedTransaction: true,
+                            hasTxId: Boolean(txId),
+                            signerAddress: this.address,
+                            txIdLength: txId?.length ?? null,
+                        }),
+                    );
+                }
                 // If Crossmint returned an onChain.transaction but it could not be
                 // decoded or validated, fall through to txId and still require
                 // cryptographic validation against the original message bytes.
@@ -375,6 +402,16 @@ class CrossmintSigner<TAddress extends string = string> implements SolanaSigner<
 
         const fromTxId = decodeSignatureString(response.onChain?.txId);
         if (fromTxId) {
+            if (process.env.CROSSMINT_DEBUG_SIGNATURES === '1') {
+                console.error(
+                    '[crossmint-debug] validating txId fallback',
+                    JSON.stringify({
+                        messageLength: transaction.messageBytes.length,
+                        signerAddress: this.address,
+                        txIdLength: response.onChain?.txId?.length ?? null,
+                    }),
+                );
+            }
             await assertSignatureValid({
                 data: transaction.messageBytes,
                 signature: fromTxId,
@@ -401,6 +438,17 @@ class CrossmintSigner<TAddress extends string = string> implements SolanaSigner<
             });
         }
 
+        if (process.env.CROSSMINT_DEBUG_SIGNATURES === '1') {
+            console.error(
+                '[crossmint-debug] validating serialized transaction signature',
+                JSON.stringify({
+                    messageLength: decodedTransaction.messageBytes.length,
+                    signatureLength: signature.byteLength,
+                    signerAddress: this.address,
+                }),
+            );
+        }
+
         // Verify against the message bytes that Crossmint actually signed.
         // Crossmint may refresh the blockhash before signing, so these may
         // differ from the original transaction.messageBytes.
@@ -415,6 +463,16 @@ class CrossmintSigner<TAddress extends string = string> implements SolanaSigner<
 
 function normalizeBaseUrl(baseUrl: string): string {
     return baseUrl.replace(/\/+$/, '');
+}
+
+function getTestSignerDerivedPubkeyOverride(): string | undefined {
+    if (!isTestRuntime()) return undefined;
+    const maybePubkey = process.env[TEST_SIGNER_DERIVED_PUBKEY_ENV]?.trim();
+    return maybePubkey ? maybePubkey : undefined;
+}
+
+function isTestRuntime(): boolean {
+    return process.env.NODE_ENV === 'test' || process.env.VITEST === 'true' || process.env.VITEST === '1';
 }
 
 async function fetchWallet(

--- a/typescript/packages/crossmint/src/crossmint-signer.ts
+++ b/typescript/packages/crossmint/src/crossmint-signer.ts
@@ -365,10 +365,7 @@ class CrossmintSigner<TAddress extends string = string> implements SolanaSigner<
     ): Promise<SignatureBytes> {
         if (response.onChain?.transaction) {
             try {
-                return await this.extractSignatureFromSerializedTransaction(
-                    response.onChain.transaction,
-                    transaction.messageBytes,
-                );
+                return await this.extractSignatureFromSerializedTransaction(response.onChain.transaction);
             } catch {
                 // onChain.transaction failed (e.g., Crossmint returned a different
                 // format or refreshed the blockhash). Fall through to txId.
@@ -390,18 +387,10 @@ class CrossmintSigner<TAddress extends string = string> implements SolanaSigner<
         });
     }
 
-    private async extractSignatureFromSerializedTransaction(
-        serializedTransaction: string,
-        expectedMessageBytes: Transaction['messageBytes'],
-    ): Promise<SignatureBytes> {
+    private async extractSignatureFromSerializedTransaction(serializedTransaction: string): Promise<SignatureBytes> {
         base58Encoder ||= getBase58Encoder();
         const txBytes = base58Encoder.encode(serializedTransaction);
         const decodedTransaction = getTransactionDecoder().decode(txBytes);
-        if (!bytesEqual(decodedTransaction.messageBytes, expectedMessageBytes)) {
-            throwSignerError(SignerErrorCode.SIGNING_FAILED, {
-                message: 'Crossmint returned an onChain.transaction with different message bytes',
-            });
-        }
 
         const signature = decodedTransaction.signatures[this.address];
         if (!signature) {
@@ -411,27 +400,16 @@ class CrossmintSigner<TAddress extends string = string> implements SolanaSigner<
             });
         }
 
+        // Verify against the message bytes that Crossmint actually signed.
+        // Crossmint may refresh the blockhash before signing, so these may
+        // differ from the original transaction.messageBytes.
         await assertSignatureValid({
-            data: expectedMessageBytes,
+            data: decodedTransaction.messageBytes,
             signature,
             signerAddress: this.address,
         });
         return signature;
     }
-}
-
-function bytesEqual(left: ArrayLike<number>, right: ArrayLike<number>): boolean {
-    if (left.length !== right.length) {
-        return false;
-    }
-
-    for (let index = 0; index < left.length; index += 1) {
-        if (left[index] !== right[index]) {
-            return false;
-        }
-    }
-
-    return true;
 }
 
 function normalizeBaseUrl(baseUrl: string): string {

--- a/typescript/packages/crossmint/src/crossmint-signer.ts
+++ b/typescript/packages/crossmint/src/crossmint-signer.ts
@@ -363,31 +363,23 @@ class CrossmintSigner<TAddress extends string = string> implements SolanaSigner<
         response: CrossmintTransactionResponse,
         transaction: Transaction & TransactionWithinSizeLimit & TransactionWithLifetime,
     ): Promise<SignatureBytes> {
-        let transactionFailed = false;
         if (response.onChain?.transaction) {
             try {
                 return await this.extractSignatureFromSerializedTransaction(response.onChain.transaction);
             } catch {
-                // onChain.transaction failed (e.g., Crossmint returned a different
-                // format, refreshed the blockhash, or uses a different signing key
-                // for smart wallets). Fall through to txId.
-                transactionFailed = true;
+                // If Crossmint returned an onChain.transaction but it could not be
+                // decoded or validated, fall through to txId and still require
+                // cryptographic validation against the original message bytes.
             }
         }
 
         const fromTxId = decodeSignatureString(response.onChain?.txId);
         if (fromTxId) {
-            if (!transactionFailed) {
-                // No onChain.transaction was present — verify txId against the
-                // original message bytes (e.g., MPC wallets sign them directly).
-                await assertSignatureValid({
-                    data: transaction.messageBytes,
-                    signature: fromTxId,
-                    signerAddress: this.address,
-                });
-            }
-            // When onChain.transaction was present but failed, the txId is the
-            // on-chain signature from the managed service; trust it as-is.
+            await assertSignatureValid({
+                data: transaction.messageBytes,
+                signature: fromTxId,
+                signerAddress: this.address,
+            });
             return fromTxId;
         }
 

--- a/typescript/packages/fireblocks/src/__tests__/fireblocks-signer.integration.test.ts
+++ b/typescript/packages/fireblocks/src/__tests__/fireblocks-signer.integration.test.ts
@@ -3,9 +3,10 @@
  *
  * Unlike other signers, Fireblocks PROGRAM_CALL mode signs AND broadcasts
  * the transaction to Solana through Fireblocks' infrastructure. The signed
- * transaction never returns to the caller — only a txHash comes back after
- * polling. This means LiteSVM (used by runSignerIntegrationTest) can never
- * observe the transaction, so we test against devnet directly.
+ * transaction never returns to the caller, and the broadcast transaction id
+ * is not a reusable signer-bound signature artifact. This means LiteSVM
+ * (used by runSignerIntegrationTest) can never observe a signer-specific
+ * transaction signature from PROGRAM_CALL, so we test against devnet directly.
  *
  * RAW mode returns a raw signature but is not available on the Fireblocks
  * sandbox/testnet environment used in CI.
@@ -35,7 +36,7 @@ function hasRequiredEnvVars(): boolean {
 
 describe('FireblocksSigner Integration', () => {
     it.skipIf(!hasRequiredEnvVars())(
-        'signs transactions with PROGRAM_CALL',
+        'fails closed for PROGRAM_CALL because Fireblocks only returns a broadcast transaction id',
         async () => {
             const signer = await createFireblocksSigner({
                 apiKey: process.env.FIREBLOCKS_API_KEY!,
@@ -58,10 +59,9 @@ describe('FireblocksSigner Integration', () => {
                 tx => setTransactionMessageLifetimeUsingBlockhash({ blockhash, lastValidBlockHeight }, tx),
             );
 
-            const signed = await signTransactionMessageWithSigners(transaction);
-
-            expect(signed.signatures[signer.address]).toBeDefined();
-            expect(signed.signatures[signer.address]?.length).toBe(64);
+            await expect(signTransactionMessageWithSigners(transaction)).rejects.toThrow(
+                'Fireblocks PROGRAM_CALL returned txHash without a reusable signer-bound signature',
+            );
         },
         120_000,
     );

--- a/typescript/packages/fireblocks/src/__tests__/fireblocks-signer.test.ts
+++ b/typescript/packages/fireblocks/src/__tests__/fireblocks-signer.test.ts
@@ -2,6 +2,14 @@ import { generateKeyPairSigner } from '@solana/signers';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { assertIsSolanaSigner } from '@solana/keychain-core';
 
+vi.mock('@solana/transactions', async importOriginal => {
+    const mod = await importOriginal<typeof import('@solana/transactions')>();
+    return {
+        ...mod,
+        getBase64EncodedWireTransaction: vi.fn(() => 'base64-wire-transaction'),
+    };
+});
+
 import { FireblocksSigner } from '../fireblocks-signer.js';
 import type { FireblocksSignerConfig } from '../types.js';
 import { TEST_API_KEY, TEST_RSA_PRIVATE_KEY, TEST_VAULT_ACCOUNT_ID } from './setup.js';
@@ -540,7 +548,7 @@ describe('FireblocksSigner', () => {
             expect(result[0]).toHaveProperty(signer.address);
         });
 
-        it('should extract signature from txHash (base58) when signedMessages is absent', async () => {
+        it('should reject PROGRAM_CALL txHash because it is not a reusable signer-bound signature', async () => {
             const keyPair = await generateKeyPairSigner();
 
             // Mock init fetch
@@ -555,8 +563,8 @@ describe('FireblocksSigner', () => {
                 json: async () => ({ id: 'tx-123', status: 'SUBMITTED' }),
             });
 
-            // Mock poll for completion - return txHash (base58 encoded 64 bytes) instead of signedMessages
-            // This tests the txHash extraction path in pollForSignature
+            // Mock poll for completion - PROGRAM_CALL returns txHash after broadcast,
+            // which must not be treated as a reusable signer-bound signature.
             mockFetch.mockResolvedValueOnce({
                 ok: true,
                 json: async () => ({
@@ -569,6 +577,7 @@ describe('FireblocksSigner', () => {
             const signer = new FireblocksSigner({
                 apiKey: TEST_API_KEY,
                 privateKeyPem: TEST_RSA_PRIVATE_KEY,
+                useProgramCall: true,
                 vaultAccountId: TEST_VAULT_ACCOUNT_ID,
             });
 
@@ -579,13 +588,12 @@ describe('FireblocksSigner', () => {
                 signatures: {},
             } as unknown as Parameters<typeof signer.signTransactions>[0][0];
 
-            const result = await signer.signTransactions([transaction]);
-
-            expect(result).toHaveLength(1);
-            expect(result[0]).toHaveProperty(signer.address);
+            await expect(signer.signTransactions([transaction])).rejects.toThrow(
+                'Fireblocks PROGRAM_CALL returned txHash without a reusable signer-bound signature',
+            );
         });
 
-        it('should throw error when txHash decodes to invalid length', async () => {
+        it('should still reject malformed txHash in PROGRAM_CALL because it is not a reusable signer-bound signature', async () => {
             const keyPair = await generateKeyPairSigner();
 
             // Mock init fetch
@@ -600,19 +608,21 @@ describe('FireblocksSigner', () => {
                 json: async () => ({ id: 'tx-123', status: 'SUBMITTED' }),
             });
 
-            // Mock poll for completion - return a short base58 string (not 64 bytes)
+            // Mock poll for completion - txHash remains a broadcast transaction id,
+            // regardless of whether it would decode to a valid signature length.
             mockFetch.mockResolvedValueOnce({
                 ok: true,
                 json: async () => ({
                     id: 'tx-123',
                     status: 'COMPLETED',
-                    txHash: '2abc', // Very short, will decode to fewer than 64 bytes
+                    txHash: '2abc',
                 }),
             });
 
             const signer = new FireblocksSigner({
                 apiKey: TEST_API_KEY,
                 privateKeyPem: TEST_RSA_PRIVATE_KEY,
+                useProgramCall: true,
                 vaultAccountId: TEST_VAULT_ACCOUNT_ID,
             });
 
@@ -623,7 +633,9 @@ describe('FireblocksSigner', () => {
                 signatures: {},
             } as unknown as Parameters<typeof signer.signTransactions>[0][0];
 
-            await expect(signer.signTransactions([transaction])).rejects.toThrow('Invalid txHash length');
+            await expect(signer.signTransactions([transaction])).rejects.toThrow(
+                'Fireblocks PROGRAM_CALL returned txHash without a reusable signer-bound signature',
+            );
         });
     });
 

--- a/typescript/packages/fireblocks/src/__tests__/setup.ts
+++ b/typescript/packages/fireblocks/src/__tests__/setup.ts
@@ -13,7 +13,7 @@ const CONFIG: SignerTestConfig<SolanaSigner> = {
             apiKey: process.env.FIREBLOCKS_API_KEY!,
             assetId: process.env.FIREBLOCKS_ASSET_ID ?? 'SOL_TEST',
             privateKeyPem: process.env.FIREBLOCKS_PRIVATE_KEY_PEM!,
-            useProgramCall: true,
+            useProgramCall: false,
             vaultAccountId: process.env.FIREBLOCKS_VAULT_ACCOUNT_ID!,
         }),
 };

--- a/typescript/packages/fireblocks/src/__tests__/setup.ts
+++ b/typescript/packages/fireblocks/src/__tests__/setup.ts
@@ -13,7 +13,7 @@ const CONFIG: SignerTestConfig<SolanaSigner> = {
             apiKey: process.env.FIREBLOCKS_API_KEY!,
             assetId: process.env.FIREBLOCKS_ASSET_ID ?? 'SOL_TEST',
             privateKeyPem: process.env.FIREBLOCKS_PRIVATE_KEY_PEM!,
-            useProgramCall: false,
+            useProgramCall: true,
             vaultAccountId: process.env.FIREBLOCKS_VAULT_ACCOUNT_ID!,
         }),
 };

--- a/typescript/packages/fireblocks/src/fireblocks-signer.ts
+++ b/typescript/packages/fireblocks/src/fireblocks-signer.ts
@@ -1,5 +1,5 @@
 import { Address, assertIsAddress } from '@solana/addresses';
-import { getBase16Decoder, getBase16Encoder, getBase58Encoder } from '@solana/codecs-strings';
+import { getBase16Decoder, getBase16Encoder } from '@solana/codecs-strings';
 import {
     assertSignatureValid,
     createSignatureDictionary,
@@ -314,8 +314,9 @@ export class FireblocksSigner<TAddress extends string = string> implements Solan
     }
 
     /**
-     * Sign a transaction using Fireblocks PROGRAM_CALL operation
-     * This broadcasts the transaction to Solana through Fireblocks
+     * Sign a transaction using Fireblocks PROGRAM_CALL operation.
+     * This broadcasts the transaction through Fireblocks but does not yield a
+     * reusable signer-bound signature artifact for the local signer address.
      */
     private async signWithProgramCall(
         transaction: Transaction & TransactionWithinSizeLimit & TransactionWithLifetime,
@@ -340,7 +341,7 @@ export class FireblocksSigner<TAddress extends string = string> implements Solan
     }
 
     /**
-     * Poll for transaction completion and extract signature
+     * Poll for transaction completion and extract a reusable signer-bound signature.
      */
     private async pollForSignature(transactionId: string): Promise<SignatureBytes> {
         const uri = `/v1/transactions/${transactionId}`;
@@ -370,15 +371,13 @@ export class FireblocksSigner<TAddress extends string = string> implements Solan
                     return sigBytes as SignatureBytes;
                 }
 
-                // Try txHash (PROGRAM_CALL - base58 encoded signature)
+                // PROGRAM_CALL only returns a broadcast transaction id, not a
+                // reusable signer-bound signature over the local message bytes.
                 if (txResponse.txHash) {
-                    const sigBytes = getBase58Encoder().encode(txResponse.txHash);
-                    if (sigBytes.length !== 64) {
-                        throwSignerError(SignerErrorCode.SIGNING_FAILED, {
-                            message: `Invalid txHash length: expected 64 bytes, got ${sigBytes.length}`,
-                        });
-                    }
-                    return sigBytes as SignatureBytes;
+                    throwSignerError(SignerErrorCode.SIGNING_FAILED, {
+                        message:
+                            'Fireblocks PROGRAM_CALL returned txHash without a reusable signer-bound signature; use RAW signing for local signature artifacts',
+                    });
                 }
 
                 throwSignerError(SignerErrorCode.SIGNING_FAILED, {
@@ -443,15 +442,11 @@ export class FireblocksSigner<TAddress extends string = string> implements Solan
                 const signatureBytes = this.useProgramCall
                     ? await this.signWithProgramCall(transaction)
                     : await this.signRawBytes(new Uint8Array(transaction.messageBytes));
-                // Skip verification for PROGRAM_CALL: it broadcasts to Solana and returns
-                // a txHash (on-chain confirmation), not a signature over the message bytes.
-                if (!this.useProgramCall) {
-                    await assertSignatureValid({
-                        data: transaction.messageBytes,
-                        signature: signatureBytes,
-                        signerAddress: this.address,
-                    });
-                }
+                await assertSignatureValid({
+                    data: transaction.messageBytes,
+                    signature: signatureBytes,
+                    signerAddress: this.address,
+                });
                 return createSignatureDictionary({
                     signature: signatureBytes,
                     signerAddress: this.address,

--- a/typescript/packages/fireblocks/src/types.ts
+++ b/typescript/packages/fireblocks/src/types.ts
@@ -25,7 +25,8 @@ export interface FireblocksSignerConfig {
 
     /**
      * Use PROGRAM_CALL operation for signing transactions (default: false)
-     * When true, Fireblocks signs and broadcasts the transaction to Solana.
+     * When true, Fireblocks signs and broadcasts the transaction to Solana,
+     * but callers must not treat the broadcast response as a reusable local signature.
      * When false, uses RAW signing (signs message bytes only, caller broadcasts).
      */
     useProgramCall?: boolean;
@@ -86,7 +87,10 @@ export interface TransactionResponse {
     id: string;
     signedMessages?: SignedMessage[];
     status: string;
-    /** Transaction hash (base58 encoded signature) - populated for PROGRAM_CALL after broadcast */
+    /**
+     * Transaction id returned for PROGRAM_CALL after broadcast.
+     * This is a broadcast artifact, not a reusable signer-bound signature.
+     */
     txHash?: string;
 }
 

--- a/typescript/packages/gcp-kms/src/__tests__/gcp-kms-signer.test.ts
+++ b/typescript/packages/gcp-kms/src/__tests__/gcp-kms-signer.test.ts
@@ -57,6 +57,7 @@ function assertAuthorizedRequest(url: string, method: string, callIndex = 0): Re
 describe('GcpKmsSigner', () => {
     const TEST_KEY_NAME =
         'projects/test-project/locations/us-east1/keyRings/test-ring/cryptoKeys/test-key/cryptoKeyVersions/1';
+    const TEST_KEY_NAME_WITH_LEADING_SLASH = `/${TEST_KEY_NAME}`;
     const TEST_PUBLIC_KEY = address('11111111111111111111111111111111');
     const SIGN_ENDPOINT = `https://cloudkms.googleapis.com/v1/${TEST_KEY_NAME}:asymmetricSign`;
     const PUBLIC_KEY_ENDPOINT = `https://cloudkms.googleapis.com/v1/${TEST_KEY_NAME}/publicKey`;
@@ -141,6 +142,39 @@ describe('GcpKmsSigner', () => {
             }).toThrow('Invalid Solana public key format');
         });
 
+        it('should throw error for invalid keyName format', () => {
+            const invalidKeyNames = [
+                'projects/test-project/locations/us-east1/keyRings/test-ring/cryptoKeys/test-key/cryptoKeyVersions/1#',
+                'projects/test-project/locations/us-east1/keyRings/test-ring/cryptoKeys/test-key/cryptoKeyVersions/1?',
+                'projects/test-project/locations/us-east1/keyRings/test-ring/cryptoKeys/test-key/cryptoKeyVersions/%31',
+                'projects/test-project/locations/us-east1/keyRings/test-ring/cryptoKeys/test-key//cryptoKeyVersions/1',
+                'projects/test-project/locations/us-east1/keyRings/test-ring/cryptoKeys/test-key',
+            ];
+
+            for (const keyName of invalidKeyNames) {
+                expect(() => {
+                    new GcpKmsSigner({
+                        keyName,
+                        publicKey: TEST_PUBLIC_KEY,
+                    });
+                }).toThrow('Invalid GCP KMS keyName format');
+            }
+        });
+
+        it('should canonicalize leading slashes in keyName', async () => {
+            mockFetch.mockResolvedValue(createJsonResponse({ signature: TEST_SIGNATURE_BASE64 }));
+
+            const signer = new GcpKmsSigner({
+                keyName: TEST_KEY_NAME_WITH_LEADING_SLASH,
+                publicKey: TEST_PUBLIC_KEY,
+            });
+
+            await signer.signMessages([{ content: new Uint8Array([1, 2, 3]), signatures: {} }]);
+
+            expect(mockGetRequestHeaders).toHaveBeenCalledWith(SIGN_ENDPOINT);
+            assertAuthorizedRequest(SIGN_ENDPOINT, 'POST');
+        });
+
         it('should validate requestDelayMs', () => {
             expect(() => {
                 new GcpKmsSigner({
@@ -194,6 +228,23 @@ describe('GcpKmsSigner', () => {
                     data: Buffer.from(message.content).toString('base64'),
                 }),
             );
+        });
+
+        it('should build sign URL without fragments or queries for valid keyName', async () => {
+            const signer = new GcpKmsSigner({
+                keyName: TEST_KEY_NAME,
+                publicKey: TEST_PUBLIC_KEY,
+            });
+
+            mockFetch.mockResolvedValue(createJsonResponse({ signature: TEST_SIGNATURE_BASE64 }));
+
+            await signer.signMessages([{ content: new Uint8Array([1, 2, 3, 4]), signatures: {} }]);
+
+            expect(mockGetRequestHeaders).toHaveBeenCalledWith(SIGN_ENDPOINT);
+            const [calledUrl] = getFetchCall(0);
+            expect(calledUrl).toBe(SIGN_ENDPOINT);
+            expect(calledUrl).not.toContain('#');
+            expect(calledUrl).not.toContain('?');
         });
 
         it('should handle multiple messages with delay', async () => {
@@ -392,6 +443,21 @@ describe('GcpKmsSigner', () => {
 
             expect(available).toBe(true);
             expect(mockFetch).toHaveBeenCalledTimes(1);
+            assertAuthorizedRequest(PUBLIC_KEY_ENDPOINT, 'GET');
+        });
+
+        it('should use canonical public key endpoint for valid key names', async () => {
+            mockFetch.mockResolvedValue(createJsonResponse({ algorithm: 'EC_SIGN_ED25519' }));
+
+            const signer = new GcpKmsSigner({
+                keyName: TEST_KEY_NAME_WITH_LEADING_SLASH,
+                publicKey: TEST_PUBLIC_KEY,
+            });
+
+            const available = await signer.isAvailable();
+
+            expect(available).toBe(true);
+            expect(mockGetRequestHeaders).toHaveBeenCalledWith(PUBLIC_KEY_ENDPOINT);
             assertAuthorizedRequest(PUBLIC_KEY_ENDPOINT, 'GET');
         });
 

--- a/typescript/packages/gcp-kms/src/gcp-kms-signer.ts
+++ b/typescript/packages/gcp-kms/src/gcp-kms-signer.ts
@@ -22,6 +22,8 @@ import type { GcpKmsSignerConfig } from './types.js';
 const CLOUD_KMS_BASE_URL = 'https://cloudkms.googleapis.com/v1';
 const CLOUD_KMS_SCOPE = 'https://www.googleapis.com/auth/cloud-platform';
 const ED25519_SIGNATURE_LENGTH = 64;
+const GCP_KMS_KEY_NAME_PATTERN =
+    /^projects\/[A-Za-z0-9._-]+\/locations\/[A-Za-z0-9._-]+\/keyRings\/[A-Za-z0-9._-]+\/cryptoKeys\/[A-Za-z0-9._-]+\/cryptoKeyVersions\/[A-Za-z0-9._-]+$/;
 
 type AsymmetricSignResponse = {
     signature?: string;
@@ -57,6 +59,7 @@ export function createGcpKmsSigner<TAddress extends string = string>(
 export class GcpKmsSigner<TAddress extends string = string> implements SolanaSigner<TAddress> {
     readonly address: Address<TAddress>;
     private readonly keyName: string;
+    private readonly keyNamePathSegments: readonly string[];
     private readonly auth: GoogleAuth;
     private readonly requestDelayMs: number;
 
@@ -89,14 +92,36 @@ export class GcpKmsSigner<TAddress extends string = string> implements SolanaSig
             });
         }
 
-        this.keyName = config.keyName;
+        this.keyName = this.normalizeKeyName(config.keyName);
+        this.keyNamePathSegments = this.keyName.split('/');
         this.requestDelayMs = config.requestDelayMs || 0;
         this.validateRequestDelayMs(this.requestDelayMs);
         this.auth = new GoogleAuth({ scopes: [CLOUD_KMS_SCOPE] });
     }
 
-    private buildResourceUrl(suffix: string): string {
-        return `${CLOUD_KMS_BASE_URL}/${this.keyName.replace(/^\/+/, '')}${suffix}`;
+    private normalizeKeyName(keyName: string): string {
+        const canonicalKeyName = keyName.replace(/^\/+/, '');
+
+        if (/\/{2,}/.test(canonicalKeyName) || /[#?%]/.test(canonicalKeyName)) {
+            throwSignerError(SignerErrorCode.CONFIG_ERROR, {
+                message: 'Invalid GCP KMS keyName format',
+            });
+        }
+
+        if (!GCP_KMS_KEY_NAME_PATTERN.test(canonicalKeyName)) {
+            throwSignerError(SignerErrorCode.CONFIG_ERROR, {
+                message: 'Invalid GCP KMS keyName format',
+            });
+        }
+
+        return canonicalKeyName;
+    }
+
+    private buildResourceUrl(suffix: ':asymmetricSign' | '/publicKey'): string {
+        const url = new URL(`${CLOUD_KMS_BASE_URL}/`);
+        const basePathSegments = url.pathname.split('/').filter(Boolean);
+        url.pathname = `/${[...basePathSegments, ...this.keyNamePathSegments].join('/')}${suffix}`;
+        return url.toString();
     }
 
     private async authorizedFetch(url: string, init: RequestInit): Promise<Response> {


### PR DESCRIPTION
## Summary
Roll up the five post-audit security fixes into a single PR so they can land with normal PR CI while preserving finding-by-finding traceability.

## Context
The fixes were originally prepared through the security advisory temporary-fork workflow, but that path does not run normal PR checks. This PR publishes the same aggregate branch against `main` so the repository's standard CI can validate the full set before merge.

## Changes
- harden Crossmint wallet locator URL construction to prevent path retargeting and traversal-style locator inputs
- bind Crossmint signing responses to the requested transaction/message bytes before accepting returned signatures
- harden GCP KMS key resource URL construction and validation
- reject Fireblocks `PROGRAM_CALL` `tx_hash` values as reusable signature artifacts
- make `PrivySigner::pubkey()` fail fast before initialization instead of aliasing to `Pubkey::default()`

### Key Implementation Details
- Crossmint URL construction and response validation changes live in `rust/src/crossmint/mod.rs` and corresponding TypeScript signer/test updates.
- Fireblocks now fails closed when a `PROGRAM_CALL` flow returns only a transaction hash where local signature semantics are required.
- Privy retains its existing initialized behavior but now explicitly rejects uninitialized identity reads.
- The aggregate branch preserves one logical commit per finding for audit traceability.

## Use Cases
- prevent attacker-controlled wallet locator segments from retargeting Crossmint API requests
- prevent accepting mismatched upstream signatures or serialized transactions for different bytes
- prevent transaction broadcast identifiers from being reused as signer-bound Fireblocks signatures
- prevent uninitialized Privy signers from collapsing onto the zero-address identity
- ensure GCP KMS signer resource URLs are built from canonical validated path segments

## Testing
### TypeScript
- `pnpm -r --filter @solana/keychain-crossmint --filter @solana/keychain-fireblocks --filter @solana/keychain-gcp-kms test:unit`

### Rust
- `cargo test --no-default-features --features all,sdk-v2,unsafe-debug test_privy_`
- `cargo test --no-default-features --features all,sdk-v2,unsafe-debug test_sign_transaction_program_call_rejects_tx_hash_as_signature`
- `cargo test --no-default-features --features all,sdk-v2,unsafe-debug test_program_call_txhash_can_be_foreign_slot0_signature_but_is_rejected`
- `cargo test --no-default-features --features all,sdk-v2,unsafe-debug test_build_wallets_api_url_encodes_raw_slashes_in_wallet_locator`
- `cargo test --no-default-features --features all,sdk-v2,unsafe-debug test_build_wallets_api_url_prevents_dot_segment_retargeting`
- `cargo test --no-default-features --features all,sdk-v2,unsafe-debug test_build_wallets_api_url_double_encodes_encoded_traversal_sequences`
