### PR TITLE
ci: load github actions secrets from doppler

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,53 +136,27 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - uses: dopplerhq/secrets-fetch-action@v1.3.0
+        id: doppler
+        with:
+          auth-method: oidc
+          doppler-identity-id: ${{ vars.DOPPLER_SERVICE_IDENTITY_ID }}
+          doppler-project: ${{ vars.DOPPLER_PROJECT || 'keychain' }}
+          doppler-config: ${{ vars.DOPPLER_CONFIG_CI || 'stg_github' }}
+          inject-env-vars: true
       - name: Setup GCP credentials
         if: matrix.test == 'test_gcp_kms_integration'
         uses: google-github-actions/auth@v2
         with:
-          credentials_json: ${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}
+          credentials_json: ${{ steps.doppler.outputs.GCP_SERVICE_ACCOUNT_KEY }}
       - name: Configure AWS credentials
         if: matrix.test == 'test_aws_kms_integration'
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
-          aws-region: ${{ secrets.AWS_KMS_REGION }}
+          role-to-assume: ${{ steps.doppler.outputs.AWS_ROLE_ARN }}
+          aws-region: ${{ steps.doppler.outputs.AWS_KMS_REGION }}
       - name: Run ${{ matrix.test }} with SDK ${{ matrix.sdk_version }}
         env:
-          PRIVY_APP_ID: ${{ secrets.PRIVY_APP_ID }}
-          PRIVY_APP_SECRET: ${{ secrets.PRIVY_APP_SECRET }}
-          PRIVY_WALLET_ID: ${{ secrets.PRIVY_WALLET_ID }}
-          TURNKEY_API_PUBLIC_KEY: ${{ secrets.TURNKEY_API_KEY }}
-          TURNKEY_API_PRIVATE_KEY: ${{ secrets.TURNKEY_API_PRIVATE_KEY }}
-          TURNKEY_ORGANIZATION_ID: ${{ secrets.TURNKEY_ORGANIZATION_ID }}
-          TURNKEY_PRIVATE_KEY_ID: ${{ secrets.TURNKEY_PRIVATE_KEY_ID }}
-          TURNKEY_PUBLIC_KEY: ${{ secrets.TURNKEY_SIGNER_PUBKEY }}
-          FIREBLOCKS_API_KEY: ${{ secrets.FIREBLOCKS_API_KEY }}
-          FIREBLOCKS_PRIVATE_KEY_PEM: ${{ secrets.FIREBLOCKS_PRIVATE_KEY_PEM }}
-          FIREBLOCKS_VAULT_ACCOUNT_ID: ${{ secrets.FIREBLOCKS_VAULT_ACCOUNT_ID }}
-          GCP_KMS_KEY_NAME: ${{ secrets.GCP_KMS_KEY_NAME }}
-          GCP_KMS_SIGNER_PUBKEY: ${{ secrets.GCP_KMS_SIGNER_PUBKEY }}
-          AWS_KMS_KEY_ID: ${{ secrets.AWS_KMS_KEY_ID }}
-          AWS_KMS_SIGNER_PUBKEY: ${{ secrets.AWS_KMS_SIGNER_PUBKEY }}
-          AWS_KMS_REGION: ${{ secrets.AWS_KMS_REGION }}
-          PARA_API_KEY: ${{ secrets.PARA_API_KEY }}
-          PARA_WALLET_ID: ${{ secrets.PARA_WALLET_ID }}
-          PARA_API_BASE_URL: ${{ secrets.PARA_API_BASE_URL }}
-          CDP_API_KEY_ID: ${{ secrets.CDP_API_KEY_ID }}
-          CDP_API_KEY_SECRET: ${{ secrets.CDP_API_KEY_SECRET }}
-          CDP_WALLET_SECRET: ${{ secrets.CDP_WALLET_SECRET }}
-          CDP_SOLANA_ADDRESS: ${{ secrets.CDP_SOLANA_ADDRESS }}
-          DFNS_AUTH_TOKEN: ${{ secrets.DFNS_AUTH_TOKEN }}
-          DFNS_CRED_ID: ${{ secrets.DFNS_CRED_ID }}
-          DFNS_PRIVATE_KEY_PEM: ${{ secrets.DFNS_PRIVATE_KEY_PEM }}
-          DFNS_WALLET_ID: ${{ secrets.DFNS_WALLET_ID }}
-          DFNS_API_BASE_URL: ${{ secrets.DFNS_API_BASE_URL }}
-          CROSSMINT_API_KEY: ${{ secrets.CROSSMINT_API_KEY }}
-          CROSSMINT_WALLET_LOCATOR: ${{ secrets.CROSSMINT_WALLET_LOCATOR }}
-          CROSSMINT_API_BASE_URL: ${{ secrets.CROSSMINT_API_BASE_URL }}
-          CROSSMINT_SIGNER_SECRET: ${{ secrets.CROSSMINT_SIGNER_SECRET }}
-          CROSSMINT_SIGNER: ${{ secrets.CROSSMINT_SIGNER }}
-          TEST_CROSSMINT_SIGNER_DERIVED_PUBKEY: ${{ secrets.TEST_CROSSMINT_SIGNER_DERIVED_PUBKEY }}
           SOLANA_RPC_URL: https://api.devnet.solana.com
         run: |
           ci_features="${{ needs.resolve-signers.outputs.rust_ci_features }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-      - uses: dopplerhq/secrets-fetch-action@v1.3.0
+      - uses: dopplerhq/secrets-fetch-action@v2.0.0
         id: doppler
         with:
           auth-method: oidc

--- a/.github/workflows/fork-external-live-manual.yml
+++ b/.github/workflows/fork-external-live-manual.yml
@@ -176,12 +176,21 @@ jobs:
         with:
           version: 10.14.0
 
+      - uses: dopplerhq/secrets-fetch-action@v1.3.0
+        id: doppler
+        with:
+          auth-method: oidc
+          doppler-identity-id: ${{ vars.DOPPLER_SERVICE_IDENTITY_ID }}
+          doppler-project: ${{ vars.DOPPLER_PROJECT || 'keychain' }}
+          doppler-config: ${{ vars.DOPPLER_CONFIG_EXTERNAL_LIVE || vars.DOPPLER_CONFIG_CI || 'stg_github' }}
+          inject-env-vars: true
+
       - name: Configure AWS credentials
         if: ${{ needs.resolve-signers.outputs.aws_kms_enabled == 'true' }}
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
-          aws-region: ${{ secrets.AWS_KMS_REGION }}
+          role-to-assume: ${{ steps.doppler.outputs.AWS_ROLE_ARN }}
+          aws-region: ${{ steps.doppler.outputs.AWS_KMS_REGION }}
 
       - name: Run Rust external live integration tests
         if: ${{ needs.resolve-signers.outputs.rust_live_test_count != '0' }}
@@ -189,38 +198,6 @@ jobs:
         env:
           RUST_LIVE_TESTS: ${{ needs.resolve-signers.outputs.rust_live_tests_space }}
           RUST_CI_FEATURES: ${{ needs.resolve-signers.outputs.rust_ci_features }}
-          PRIVY_APP_ID: ${{ secrets.PRIVY_APP_ID }}
-          PRIVY_APP_SECRET: ${{ secrets.PRIVY_APP_SECRET }}
-          PRIVY_WALLET_ID: ${{ secrets.PRIVY_WALLET_ID }}
-          TURNKEY_API_PUBLIC_KEY: ${{ secrets.TURNKEY_API_KEY }}
-          TURNKEY_API_PRIVATE_KEY: ${{ secrets.TURNKEY_API_PRIVATE_KEY }}
-          TURNKEY_ORGANIZATION_ID: ${{ secrets.TURNKEY_ORGANIZATION_ID }}
-          TURNKEY_PRIVATE_KEY_ID: ${{ secrets.TURNKEY_PRIVATE_KEY_ID }}
-          TURNKEY_PUBLIC_KEY: ${{ secrets.TURNKEY_SIGNER_PUBKEY }}
-          FIREBLOCKS_API_KEY: ${{ secrets.FIREBLOCKS_API_KEY }}
-          FIREBLOCKS_PRIVATE_KEY_PEM: ${{ secrets.FIREBLOCKS_PRIVATE_KEY_PEM }}
-          FIREBLOCKS_VAULT_ACCOUNT_ID: ${{ secrets.FIREBLOCKS_VAULT_ACCOUNT_ID }}
-          AWS_KMS_KEY_ID: ${{ secrets.AWS_KMS_KEY_ID }}
-          AWS_KMS_SIGNER_PUBKEY: ${{ secrets.AWS_KMS_SIGNER_PUBKEY }}
-          AWS_KMS_REGION: ${{ secrets.AWS_KMS_REGION }}
-          PARA_API_KEY: ${{ secrets.PARA_API_KEY }}
-          PARA_WALLET_ID: ${{ secrets.PARA_WALLET_ID }}
-          PARA_API_BASE_URL: ${{ secrets.PARA_API_BASE_URL }}
-          CDP_API_KEY_ID: ${{ secrets.CDP_API_KEY_ID }}
-          CDP_API_KEY_SECRET: ${{ secrets.CDP_API_KEY_SECRET }}
-          CDP_WALLET_SECRET: ${{ secrets.CDP_WALLET_SECRET }}
-          CDP_SOLANA_ADDRESS: ${{ secrets.CDP_SOLANA_ADDRESS }}
-          DFNS_AUTH_TOKEN: ${{ secrets.DFNS_AUTH_TOKEN }}
-          DFNS_CRED_ID: ${{ secrets.DFNS_CRED_ID }}
-          DFNS_PRIVATE_KEY_PEM: ${{ secrets.DFNS_PRIVATE_KEY_PEM }}
-          DFNS_WALLET_ID: ${{ secrets.DFNS_WALLET_ID }}
-          DFNS_API_BASE_URL: ${{ secrets.DFNS_API_BASE_URL }}
-          CROSSMINT_API_KEY: ${{ secrets.CROSSMINT_API_KEY }}
-          CROSSMINT_WALLET_LOCATOR: ${{ secrets.CROSSMINT_WALLET_LOCATOR }}
-          CROSSMINT_API_BASE_URL: ${{ secrets.CROSSMINT_API_BASE_URL }}
-          CROSSMINT_SIGNER_SECRET: ${{ secrets.CROSSMINT_SIGNER_SECRET }}
-          CROSSMINT_SIGNER: ${{ secrets.CROSSMINT_SIGNER }}
-          TEST_CROSSMINT_SIGNER_DERIVED_PUBKEY: ${{ secrets.TEST_CROSSMINT_SIGNER_DERIVED_PUBKEY }}
           SOLANA_RPC_URL: https://api.devnet.solana.com
         run: |
           set -euo pipefail
@@ -267,38 +244,6 @@ jobs:
         working-directory: typescript
         env:
           TS_LIVE_PACKAGES: ${{ needs.resolve-signers.outputs.ts_live_packages_space }}
-          PRIVY_APP_ID: ${{ secrets.PRIVY_APP_ID }}
-          PRIVY_APP_SECRET: ${{ secrets.PRIVY_APP_SECRET }}
-          PRIVY_WALLET_ID: ${{ secrets.PRIVY_WALLET_ID }}
-          TURNKEY_API_PUBLIC_KEY: ${{ secrets.TURNKEY_API_KEY }}
-          TURNKEY_API_PRIVATE_KEY: ${{ secrets.TURNKEY_API_PRIVATE_KEY }}
-          TURNKEY_ORGANIZATION_ID: ${{ secrets.TURNKEY_ORGANIZATION_ID }}
-          TURNKEY_PRIVATE_KEY_ID: ${{ secrets.TURNKEY_PRIVATE_KEY_ID }}
-          TURNKEY_PUBLIC_KEY: ${{ secrets.TURNKEY_SIGNER_PUBKEY }}
-          FIREBLOCKS_API_KEY: ${{ secrets.FIREBLOCKS_API_KEY }}
-          FIREBLOCKS_PRIVATE_KEY_PEM: ${{ secrets.FIREBLOCKS_PRIVATE_KEY_PEM }}
-          FIREBLOCKS_VAULT_ACCOUNT_ID: ${{ secrets.FIREBLOCKS_VAULT_ACCOUNT_ID }}
-          AWS_KMS_KEY_ID: ${{ secrets.AWS_KMS_KEY_ID }}
-          AWS_KMS_SIGNER_PUBKEY: ${{ secrets.AWS_KMS_SIGNER_PUBKEY }}
-          AWS_KMS_REGION: ${{ secrets.AWS_KMS_REGION }}
-          PARA_API_KEY: ${{ secrets.PARA_API_KEY }}
-          PARA_WALLET_ID: ${{ secrets.PARA_WALLET_ID }}
-          PARA_API_BASE_URL: ${{ secrets.PARA_API_BASE_URL }}
-          CDP_API_KEY_ID: ${{ secrets.CDP_API_KEY_ID }}
-          CDP_API_KEY_SECRET: ${{ secrets.CDP_API_KEY_SECRET }}
-          CDP_WALLET_SECRET: ${{ secrets.CDP_WALLET_SECRET }}
-          CDP_SOLANA_ADDRESS: ${{ secrets.CDP_SOLANA_ADDRESS }}
-          DFNS_AUTH_TOKEN: ${{ secrets.DFNS_AUTH_TOKEN }}
-          DFNS_CRED_ID: ${{ secrets.DFNS_CRED_ID }}
-          DFNS_PRIVATE_KEY_PEM: ${{ secrets.DFNS_PRIVATE_KEY_PEM }}
-          DFNS_WALLET_ID: ${{ secrets.DFNS_WALLET_ID }}
-          DFNS_API_BASE_URL: ${{ secrets.DFNS_API_BASE_URL }}
-          CROSSMINT_API_KEY: ${{ secrets.CROSSMINT_API_KEY }}
-          CROSSMINT_WALLET_LOCATOR: ${{ secrets.CROSSMINT_WALLET_LOCATOR }}
-          CROSSMINT_API_BASE_URL: ${{ secrets.CROSSMINT_API_BASE_URL }}
-          CROSSMINT_SIGNER_SECRET: ${{ secrets.CROSSMINT_SIGNER_SECRET }}
-          CROSSMINT_SIGNER: ${{ secrets.CROSSMINT_SIGNER }}
-          TEST_CROSSMINT_SIGNER_DERIVED_PUBKEY: ${{ secrets.TEST_CROSSMINT_SIGNER_DERIVED_PUBKEY }}
         run: |
           set -euo pipefail
 

--- a/.github/workflows/fork-external-live-manual.yml
+++ b/.github/workflows/fork-external-live-manual.yml
@@ -176,7 +176,7 @@ jobs:
         with:
           version: 10.14.0
 
-      - uses: dopplerhq/secrets-fetch-action@v1.3.0
+      - uses: dopplerhq/secrets-fetch-action@v2.0.0
         id: doppler
         with:
           auth-method: oidc

--- a/.github/workflows/typescript-ci.yml
+++ b/.github/workflows/typescript-ci.yml
@@ -161,66 +161,30 @@ jobs:
       - uses: pnpm/action-setup@v2
         with:
           version: 10.14.0
+      - uses: dopplerhq/secrets-fetch-action@v1.3.0
+        id: doppler
+        with:
+          auth-method: oidc
+          doppler-identity-id: ${{ vars.DOPPLER_SERVICE_IDENTITY_ID }}
+          doppler-project: ${{ vars.DOPPLER_PROJECT || 'keychain' }}
+          doppler-config: ${{ vars.DOPPLER_CONFIG_CI || 'stg_github' }}
+          inject-env-vars: true
       - name: Configure AWS credentials
         if: matrix.package == 'aws-kms'
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
-          aws-region: ${{ secrets.AWS_KMS_REGION }}
+          role-to-assume: ${{ steps.doppler.outputs.AWS_ROLE_ARN }}
+          aws-region: ${{ steps.doppler.outputs.AWS_KMS_REGION }}
       - name: Install dependencies
         run: pnpm install
       - name: Setup GCP credentials
         if: matrix.package == 'gcp-kms'
         uses: google-github-actions/auth@v2
         with:
-          credentials_json: ${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}
+          credentials_json: ${{ steps.doppler.outputs.GCP_SERVICE_ACCOUNT_KEY }}
       - name: Build packages
         run: pnpm -F @solana/keychain-${{ matrix.package }}... run build
       - name: Run integration tests for @solana/keychain-${{ matrix.package }}
-        env:
-          # Privy
-          PRIVY_APP_ID: ${{ secrets.PRIVY_APP_ID }}
-          PRIVY_APP_SECRET: ${{ secrets.PRIVY_APP_SECRET }}
-          PRIVY_WALLET_ID: ${{ secrets.PRIVY_WALLET_ID }}
-          # Turnkey
-          TURNKEY_API_PUBLIC_KEY: ${{ secrets.TURNKEY_API_KEY }}
-          TURNKEY_API_PRIVATE_KEY: ${{ secrets.TURNKEY_API_PRIVATE_KEY }}
-          TURNKEY_ORGANIZATION_ID: ${{ secrets.TURNKEY_ORGANIZATION_ID }}
-          TURNKEY_PRIVATE_KEY_ID: ${{ secrets.TURNKEY_PRIVATE_KEY_ID }}
-          TURNKEY_PUBLIC_KEY: ${{ secrets.TURNKEY_SIGNER_PUBKEY }}
-          # Fireblocks
-          FIREBLOCKS_API_KEY: ${{ secrets.FIREBLOCKS_API_KEY }}
-          FIREBLOCKS_PRIVATE_KEY_PEM: ${{ secrets.FIREBLOCKS_PRIVATE_KEY_PEM }}
-          FIREBLOCKS_VAULT_ACCOUNT_ID: ${{ secrets.FIREBLOCKS_VAULT_ACCOUNT_ID }}
-          # GCP KMS
-          GCP_KMS_KEY_NAME: ${{ secrets.GCP_KMS_KEY_NAME }}
-          GCP_KMS_SIGNER_PUBKEY: ${{ secrets.GCP_KMS_SIGNER_PUBKEY }}
-          # AWS KMS
-          AWS_KMS_KEY_ID: ${{ secrets.AWS_KMS_KEY_ID }}
-          AWS_KMS_SIGNER_PUBKEY: ${{ secrets.AWS_KMS_SIGNER_PUBKEY }}
-          AWS_KMS_REGION: ${{ secrets.AWS_KMS_REGION }}
-          # Para
-          PARA_API_KEY: ${{ secrets.PARA_API_KEY }}
-          PARA_WALLET_ID: ${{ secrets.PARA_WALLET_ID }}
-          PARA_API_BASE_URL: ${{ secrets.PARA_API_BASE_URL }}
-          # CDP
-          CDP_API_KEY_ID: ${{ secrets.CDP_API_KEY_ID }}
-          CDP_API_KEY_SECRET: ${{ secrets.CDP_API_KEY_SECRET }}
-          CDP_WALLET_SECRET: ${{ secrets.CDP_WALLET_SECRET }}
-          CDP_SOLANA_ADDRESS: ${{ secrets.CDP_SOLANA_ADDRESS }}
-          # DFNS
-          DFNS_AUTH_TOKEN: ${{ secrets.DFNS_AUTH_TOKEN }}
-          DFNS_CRED_ID: ${{ secrets.DFNS_CRED_ID }}
-          DFNS_PRIVATE_KEY_PEM: ${{ secrets.DFNS_PRIVATE_KEY_PEM }}
-          DFNS_WALLET_ID: ${{ secrets.DFNS_WALLET_ID }}
-          DFNS_API_BASE_URL: ${{ secrets.DFNS_API_BASE_URL }}
-          # Crossmint
-          CROSSMINT_API_KEY: ${{ secrets.CROSSMINT_API_KEY }}
-          CROSSMINT_WALLET_LOCATOR: ${{ secrets.CROSSMINT_WALLET_LOCATOR }}
-          CROSSMINT_API_BASE_URL: ${{ secrets.CROSSMINT_API_BASE_URL }}
-          CROSSMINT_SIGNER_SECRET: ${{ secrets.CROSSMINT_SIGNER_SECRET }}
-          CROSSMINT_SIGNER: ${{ secrets.CROSSMINT_SIGNER }}
-          TEST_CROSSMINT_SIGNER_DERIVED_PUBKEY: ${{ secrets.TEST_CROSSMINT_SIGNER_DERIVED_PUBKEY }}
         run: pnpm -F @solana/keychain-${{ matrix.package }} run test:integration
 
   typescript-lint:

--- a/.github/workflows/typescript-ci.yml
+++ b/.github/workflows/typescript-ci.yml
@@ -161,7 +161,7 @@ jobs:
       - uses: pnpm/action-setup@v2
         with:
           version: 10.14.0
-      - uses: dopplerhq/secrets-fetch-action@v1.3.0
+      - uses: dopplerhq/secrets-fetch-action@v2.0.0
         id: doppler
         with:
           auth-method: oidc

--- a/doppler.yaml
+++ b/doppler.yaml
@@ -1,0 +1,3 @@
+setup:
+  project: keychain
+  config: dev

--- a/doppler.yaml
+++ b/doppler.yaml
@@ -1,3 +1,3 @@
 setup:
-  project: keychain
-  config: dev
+  - project: keychain
+    config: dev_personal

--- a/rust/src/sdk_adapter/v2.rs
+++ b/rust/src/sdk_adapter/v2.rs
@@ -24,6 +24,7 @@ pub fn keypair_pubkey(keypair: &Keypair) -> Pubkey {
 }
 
 /// Derive a keypair from a 32-byte seed (v2 adapter)
+#[allow(dead_code)]
 pub fn keypair_from_seed(seed: &[u8]) -> Result<Keypair, String> {
     #[allow(deprecated)]
     solana_sdk::signer::keypair::keypair_from_seed(seed).map_err(|e| e.to_string())


### PR DESCRIPTION
## Summary
- replace direct GitHub Actions secret references in CI workflows with Doppler secret fetches
- wire AWS and GCP auth actions to consume Doppler-provided values and keep the external live workflow on the same path
- add repo-level `doppler.yaml` and upgrade `dopplerhq/secrets-fetch-action` to `v2.0.0`

## Test Plan
- git diff --check
- not run locally; GitHub Actions validation will happen in CI
