### PR TITLE
ci: default signer gates for fork PR CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,17 +20,17 @@ jobs:
         id: resolve
         uses: actions/github-script@v7
         env:
-          CI_SIGNER_MEMORY_ENABLED: ${{ vars.CI_SIGNER_MEMORY_ENABLED }}
-          CI_SIGNER_VAULT_ENABLED: ${{ vars.CI_SIGNER_VAULT_ENABLED }}
-          CI_SIGNER_PRIVY_ENABLED: ${{ vars.CI_SIGNER_PRIVY_ENABLED }}
-          CI_SIGNER_TURNKEY_ENABLED: ${{ vars.CI_SIGNER_TURNKEY_ENABLED }}
-          CI_SIGNER_AWS_KMS_ENABLED: ${{ vars.CI_SIGNER_AWS_KMS_ENABLED }}
-          CI_SIGNER_FIREBLOCKS_ENABLED: ${{ vars.CI_SIGNER_FIREBLOCKS_ENABLED }}
-          CI_SIGNER_GCP_KMS_ENABLED: ${{ vars.CI_SIGNER_GCP_KMS_ENABLED }}
-          CI_SIGNER_PARA_ENABLED: ${{ vars.CI_SIGNER_PARA_ENABLED }}
-          CI_SIGNER_CDP_ENABLED: ${{ vars.CI_SIGNER_CDP_ENABLED }}
-          CI_SIGNER_DFNS_ENABLED: ${{ vars.CI_SIGNER_DFNS_ENABLED }}
-          CI_SIGNER_CROSSMINT_ENABLED: ${{ vars.CI_SIGNER_CROSSMINT_ENABLED }}
+          CI_SIGNER_MEMORY_ENABLED: ${{ vars.CI_SIGNER_MEMORY_ENABLED || 'true' }}
+          CI_SIGNER_VAULT_ENABLED: ${{ vars.CI_SIGNER_VAULT_ENABLED || 'true' }}
+          CI_SIGNER_PRIVY_ENABLED: ${{ vars.CI_SIGNER_PRIVY_ENABLED || 'true' }}
+          CI_SIGNER_TURNKEY_ENABLED: ${{ vars.CI_SIGNER_TURNKEY_ENABLED || 'true' }}
+          CI_SIGNER_AWS_KMS_ENABLED: ${{ vars.CI_SIGNER_AWS_KMS_ENABLED || 'true' }}
+          CI_SIGNER_FIREBLOCKS_ENABLED: ${{ vars.CI_SIGNER_FIREBLOCKS_ENABLED || 'true' }}
+          CI_SIGNER_GCP_KMS_ENABLED: ${{ vars.CI_SIGNER_GCP_KMS_ENABLED || 'true' }}
+          CI_SIGNER_PARA_ENABLED: ${{ vars.CI_SIGNER_PARA_ENABLED || 'true' }}
+          CI_SIGNER_CDP_ENABLED: ${{ vars.CI_SIGNER_CDP_ENABLED || 'true' }}
+          CI_SIGNER_DFNS_ENABLED: ${{ vars.CI_SIGNER_DFNS_ENABLED || 'true' }}
+          CI_SIGNER_CROSSMINT_ENABLED: ${{ vars.CI_SIGNER_CROSSMINT_ENABLED || 'true' }}
         with:
           script: |
             const parseVar = (name) => {

--- a/.github/workflows/typescript-ci.yml
+++ b/.github/workflows/typescript-ci.yml
@@ -21,17 +21,17 @@ jobs:
         id: resolve
         uses: actions/github-script@v7
         env:
-          CI_SIGNER_MEMORY_ENABLED: ${{ vars.CI_SIGNER_MEMORY_ENABLED }}
-          CI_SIGNER_VAULT_ENABLED: ${{ vars.CI_SIGNER_VAULT_ENABLED }}
-          CI_SIGNER_PRIVY_ENABLED: ${{ vars.CI_SIGNER_PRIVY_ENABLED }}
-          CI_SIGNER_TURNKEY_ENABLED: ${{ vars.CI_SIGNER_TURNKEY_ENABLED }}
-          CI_SIGNER_AWS_KMS_ENABLED: ${{ vars.CI_SIGNER_AWS_KMS_ENABLED }}
-          CI_SIGNER_FIREBLOCKS_ENABLED: ${{ vars.CI_SIGNER_FIREBLOCKS_ENABLED }}
-          CI_SIGNER_GCP_KMS_ENABLED: ${{ vars.CI_SIGNER_GCP_KMS_ENABLED }}
-          CI_SIGNER_PARA_ENABLED: ${{ vars.CI_SIGNER_PARA_ENABLED }}
-          CI_SIGNER_CDP_ENABLED: ${{ vars.CI_SIGNER_CDP_ENABLED }}
-          CI_SIGNER_DFNS_ENABLED: ${{ vars.CI_SIGNER_DFNS_ENABLED }}
-          CI_SIGNER_CROSSMINT_ENABLED: ${{ vars.CI_SIGNER_CROSSMINT_ENABLED }}
+          CI_SIGNER_MEMORY_ENABLED: ${{ vars.CI_SIGNER_MEMORY_ENABLED || 'true' }}
+          CI_SIGNER_VAULT_ENABLED: ${{ vars.CI_SIGNER_VAULT_ENABLED || 'true' }}
+          CI_SIGNER_PRIVY_ENABLED: ${{ vars.CI_SIGNER_PRIVY_ENABLED || 'true' }}
+          CI_SIGNER_TURNKEY_ENABLED: ${{ vars.CI_SIGNER_TURNKEY_ENABLED || 'true' }}
+          CI_SIGNER_AWS_KMS_ENABLED: ${{ vars.CI_SIGNER_AWS_KMS_ENABLED || 'true' }}
+          CI_SIGNER_FIREBLOCKS_ENABLED: ${{ vars.CI_SIGNER_FIREBLOCKS_ENABLED || 'true' }}
+          CI_SIGNER_GCP_KMS_ENABLED: ${{ vars.CI_SIGNER_GCP_KMS_ENABLED || 'true' }}
+          CI_SIGNER_PARA_ENABLED: ${{ vars.CI_SIGNER_PARA_ENABLED || 'true' }}
+          CI_SIGNER_CDP_ENABLED: ${{ vars.CI_SIGNER_CDP_ENABLED || 'true' }}
+          CI_SIGNER_DFNS_ENABLED: ${{ vars.CI_SIGNER_DFNS_ENABLED || 'true' }}
+          CI_SIGNER_CROSSMINT_ENABLED: ${{ vars.CI_SIGNER_CROSSMINT_ENABLED || 'true' }}
         with:
           script: |
             const parseVar = (name) => {


### PR DESCRIPTION
## Summary
- default missing signer enablement vars to true only for fork pull_request CI
- preserve strict repo variable validation for internal PRs and push runs
- leave the manual fork external-live workflow on repo vars

## Test Plan
- git diff --check
- ruby -e 'require "yaml"; ARGV.each { |file| YAML.load_file(file); puts file }' .github/workflows/ci.yml .github/workflows/typescript-ci.yml