### PR TITLE
chore(core): extract ED25519_SIGNATURE_LENGTH constant

### DIFF
--- a/typescript/packages/aws-kms/src/aws-kms-signer.ts
+++ b/typescript/packages/aws-kms/src/aws-kms-signer.ts
@@ -3,6 +3,7 @@ import { Address, assertIsAddress } from '@solana/addresses';
 import {
     assertSignatureValid,
     createSignatureDictionary,
+    ED25519_SIGNATURE_LENGTH,
     SignerErrorCode,
     SolanaSigner,
     throwSignerError,
@@ -142,11 +143,10 @@ export class AwsKmsSigner<TAddress extends string = string> implements SolanaSig
                 });
             }
 
-            // Ed25519 signatures are 64 bytes
             const signature = new Uint8Array(response.Signature);
-            if (signature.length !== 64) {
+            if (signature.length !== ED25519_SIGNATURE_LENGTH) {
                 throwSignerError(SignerErrorCode.SIGNING_FAILED, {
-                    message: `Invalid signature length: expected 64 bytes, got ${signature.length}`,
+                    message: `Invalid signature length: expected ${ED25519_SIGNATURE_LENGTH} bytes, got ${signature.length}`,
                 });
             }
 

--- a/typescript/packages/cdp/src/cdp-signer.ts
+++ b/typescript/packages/cdp/src/cdp-signer.ts
@@ -4,6 +4,7 @@ import {
     assertSignatureValid,
     base64UrlDecoder,
     createSignatureDictionary,
+    ED25519_SIGNATURE_LENGTH,
     extractSignatureFromWireTransaction,
     sanitizeRemoteErrorResponse,
     SignerErrorCode,
@@ -391,9 +392,9 @@ export class CdpSigner<TAddress extends string = string> implements SolanaSigner
         base58Encoder ||= getBase58Encoder();
         const signatureBytes = base58Encoder.encode(data.signature) as SignatureBytes;
 
-        if (signatureBytes.length !== 64) {
+        if (signatureBytes.length !== ED25519_SIGNATURE_LENGTH) {
             throwSignerError(SignerErrorCode.SIGNING_FAILED, {
-                message: `Invalid signature length: expected 64 bytes, got ${signatureBytes.length}`,
+                message: `Invalid signature length: expected ${ED25519_SIGNATURE_LENGTH} bytes, got ${signatureBytes.length}`,
             });
         }
 

--- a/typescript/packages/core/src/constants.ts
+++ b/typescript/packages/core/src/constants.ts
@@ -1,0 +1,4 @@
+/**
+ * Length of an Ed25519 signature in bytes.
+ */
+export const ED25519_SIGNATURE_LENGTH = 64;

--- a/typescript/packages/core/src/index.ts
+++ b/typescript/packages/core/src/index.ts
@@ -1,3 +1,4 @@
+export * from './constants.js';
 export * from './encoding.js';
 export * from './errors.js';
 export * from './types.js';

--- a/typescript/packages/crossmint/src/crossmint-signer.ts
+++ b/typescript/packages/crossmint/src/crossmint-signer.ts
@@ -6,6 +6,7 @@ import {
     assertSignatureValid,
     createSignatureDictionary,
     createSignerError,
+    ED25519_SIGNATURE_LENGTH,
     SignerErrorCode,
     SolanaSigner,
     throwSignerError,
@@ -497,7 +498,7 @@ function decodeSignatureString(value?: string): SignatureBytes | undefined {
     base58Encoder ||= getBase58Encoder();
     try {
         const bytes = base58Encoder.encode(value);
-        return bytes.length === 64 ? (bytes as SignatureBytes) : undefined;
+        return bytes.length === ED25519_SIGNATURE_LENGTH ? (bytes as SignatureBytes) : undefined;
     } catch {
         return undefined;
     }

--- a/typescript/packages/fireblocks/src/fireblocks-signer.ts
+++ b/typescript/packages/fireblocks/src/fireblocks-signer.ts
@@ -3,6 +3,7 @@ import { getBase16Decoder, getBase16Encoder } from '@solana/codecs-strings';
 import {
     assertSignatureValid,
     createSignatureDictionary,
+    ED25519_SIGNATURE_LENGTH,
     sanitizeRemoteErrorResponse,
     SignerErrorCode,
     SolanaSigner,
@@ -363,9 +364,9 @@ export class FireblocksSigner<TAddress extends string = string> implements Solan
                     }
                     base16Encoder ||= getBase16Encoder();
                     const sigBytes = new Uint8Array(base16Encoder.encode(cleanHex.toLowerCase()));
-                    if (sigBytes.length !== 64) {
+                    if (sigBytes.length !== ED25519_SIGNATURE_LENGTH) {
                         throwSignerError(SignerErrorCode.SIGNING_FAILED, {
-                            message: `Invalid signature length: expected 64 bytes, got ${sigBytes.length}`,
+                            message: `Invalid signature length: expected ${ED25519_SIGNATURE_LENGTH} bytes, got ${sigBytes.length}`,
                         });
                     }
                     return sigBytes as SignatureBytes;

--- a/typescript/packages/gcp-kms/src/gcp-kms-signer.ts
+++ b/typescript/packages/gcp-kms/src/gcp-kms-signer.ts
@@ -2,6 +2,7 @@ import { Address, assertIsAddress } from '@solana/addresses';
 import {
     assertSignatureValid,
     createSignatureDictionary,
+    ED25519_SIGNATURE_LENGTH,
     sanitizeRemoteErrorResponse,
     SignerErrorCode,
     SolanaSigner,
@@ -21,7 +22,6 @@ import type { GcpKmsSignerConfig } from './types.js';
  */
 const CLOUD_KMS_BASE_URL = 'https://cloudkms.googleapis.com/v1';
 const CLOUD_KMS_SCOPE = 'https://www.googleapis.com/auth/cloud-platform';
-const ED25519_SIGNATURE_LENGTH = 64;
 const GCP_KMS_KEY_NAME_PATTERN =
     /^projects\/[A-Za-z0-9._-]+\/locations\/[A-Za-z0-9._-]+\/keyRings\/[A-Za-z0-9._-]+\/cryptoKeys\/[A-Za-z0-9._-]+\/cryptoKeyVersions\/[A-Za-z0-9._-]+$/;
 

--- a/typescript/packages/test-utils/src/integration-test-runner.ts
+++ b/typescript/packages/test-utils/src/integration-test-runner.ts
@@ -1,3 +1,4 @@
+import { ED25519_SIGNATURE_LENGTH } from '@solana/keychain-core';
 import type { SignatureBytes, SignaturesMap } from '@solana/kit';
 import {
     appendTransactionMessageInstructions,
@@ -193,8 +194,8 @@ async function testSignMessage<T extends TestSigner>(context: TestContext<T>): P
         throw new Error(`Missing signature for signer address ${signer.address}`);
     }
 
-    if (signature.length !== 64) {
-        throw new Error(`Invalid signature length: expected 64, got ${signature.length}`);
+    if (signature.length !== ED25519_SIGNATURE_LENGTH) {
+        throw new Error(`Invalid signature length: expected ${ED25519_SIGNATURE_LENGTH}, got ${signature.length}`);
     }
 
     if (options.verbose) {


### PR DESCRIPTION
## Summary
- Add `ED25519_SIGNATURE_LENGTH = 64` to `@solana/keychain-core` (new `constants.ts`, re-exported from package root)
- Replace inline `64` / local constants in `aws-kms`, `cdp`, `fireblocks`, `gcp-kms`, and `test-utils` with the shared core export

Closes [PRO-1075](https://linear.app/solana-fndn/issue/PRO-1075/extract-ed25519-signature-length-constant-into-solanakeychain-core)

## Test plan
- [x] `pnpm build`
- [x] `pnpm lint`
- [x] `pnpm test:unit`