### PR TITLE
ci: include openfort in fork live tests

### DIFF
--- a/.github/workflows/fork-external-live-manual.yml
+++ b/.github/workflows/fork-external-live-manual.yml
@@ -34,6 +34,7 @@ jobs:
           CI_SIGNER_CDP_ENABLED: ${{ vars.CI_SIGNER_CDP_ENABLED }}
           CI_SIGNER_DFNS_ENABLED: ${{ vars.CI_SIGNER_DFNS_ENABLED }}
           CI_SIGNER_CROSSMINT_ENABLED: ${{ vars.CI_SIGNER_CROSSMINT_ENABLED }}
+          CI_SIGNER_OPENFORT_ENABLED: ${{ vars.CI_SIGNER_OPENFORT_ENABLED }}
         with:
           script: |
             const parseVar = (name) => {
@@ -58,6 +59,7 @@ jobs:
               cdp: parseVar('CI_SIGNER_CDP_ENABLED'),
               dfns: parseVar('CI_SIGNER_DFNS_ENABLED'),
               crossmint: parseVar('CI_SIGNER_CROSSMINT_ENABLED'),
+              openfort: parseVar('CI_SIGNER_OPENFORT_ENABLED'),
             };
 
             const rustFeatureOrder = [
@@ -72,6 +74,7 @@ jobs:
               'para',
               'dfns',
               'crossmint',
+              'openfort',
             ];
 
             const rustLiveTestMap = [
@@ -84,6 +87,7 @@ jobs:
               ['cdp', 'test_cdp_integration'],
               ['dfns', 'test_dfns_integration'],
               ['crossmint', 'test_crossmint_integration'],
+              ['openfort', 'test_openfort_integration'],
             ];
 
             const tsLivePackageMap = [
@@ -96,6 +100,7 @@ jobs:
               ['cdp', 'cdp'],
               ['dfns', 'dfns'],
               ['crossmint', 'crossmint'],
+              ['openfort', 'openfort'],
             ];
 
             const rustFeatures = rustFeatureOrder.filter((backend) => enabled[backend]);


### PR DESCRIPTION
## Summary
- Add Openfort to the Fork External Live Tests signer resolution.
- Run Rust `test_openfort_integration` and TypeScript `@solana/keychain-openfort` integration tests when Openfort is enabled.

## Test Plan
- `git diff --check -- .github/workflows/fork-external-live-manual.yml`
- Verified `CI_SIGNER_OPENFORT_ENABLED=true` exists as a repository Actions variable.