### PR TITLE
chore: update TS publish workflow and CLAUDE.md

### DIFF
--- a/.github/workflows/typescript-publish.yml
+++ b/.github/workflows/typescript-publish.yml
@@ -286,8 +286,6 @@ jobs:
       - name: Pre-flight - npm publish dry-run for all targets
         if: ${{ github.event.inputs.publish-to-npm == 'true' }}
         working-directory: typescript
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           echo "==> Pre-flight: npm publish --dry-run for each target"
           echo "    Validates tarballs, version conflicts, and registry auth"

--- a/.github/workflows/typescript-publish.yml
+++ b/.github/workflows/typescript-publish.yml
@@ -137,30 +137,58 @@ jobs:
           else
             echo "packages=$SELECTED" >> $GITHUB_OUTPUT
           fi
-          echo "📦 Target packages: ${SELECTED}"
+          echo "Target packages: ${SELECTED}"
 
       - name: Get version and check consistency
         id: version
         working-directory: typescript
         run: |
-          # Get version from umbrella package
           VERSION=$(node -p "require('./packages/keychain/package.json').version")
           echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "📦 Target version: $VERSION"
-
-          # Check that target packages have the expected version
-          echo "🔍 Checking version consistency..."
+          echo "Target version: $VERSION"
 
           for pkg in ${{ steps.targets.outputs.packages }}; do
             PKG_VERSION=$(node -p "require('./packages/${pkg}/package.json').version")
             if [ "$PKG_VERSION" != "$VERSION" ]; then
-              echo "❌ Version mismatch: packages/${pkg} has version ${PKG_VERSION}, expected ${VERSION}"
+              echo "✗ packages/${pkg} has version ${PKG_VERSION}, expected ${VERSION}"
               exit 1
             fi
             echo "  ✓ packages/${pkg}: ${PKG_VERSION}"
           done
 
-          echo "✅ Version check passed"
+      - name: Pre-flight - check target packages exist on npm
+        run: |
+          echo "==> Checking each target package exists on npm registry"
+          echo "    (catches new-package onboarding gaps before we build/pack/publish)"
+          echo ""
+          MISSING=""
+          for pkg in ${{ steps.targets.outputs.packages }}; do
+            if [ "$pkg" = "keychain" ]; then NPM_NAME="@solana/keychain"
+            else NPM_NAME="@solana/keychain-${pkg}"; fi
+            NPM_RC=0
+            NPM_OUT=$(npm view "$NPM_NAME" version 2>&1) || NPM_RC=$?
+            if [ "$NPM_RC" -eq 0 ] && [ -n "$NPM_OUT" ]; then
+              echo "  ✓ $NPM_NAME (latest: $NPM_OUT)"
+            elif echo "$NPM_OUT" | grep -q "E404"; then
+              echo "  ✗ $NPM_NAME does not exist on npm"
+              MISSING="$MISSING $NPM_NAME"
+            else
+              echo "  ✗ $NPM_NAME: registry error (not 404):"
+              echo "$NPM_OUT" | sed 's/^/      /'
+              MISSING="$MISSING $NPM_NAME(registry-error)"
+            fi
+          done
+          if [ -n "$MISSING" ]; then
+            echo ""
+            echo "::error::The following packages cannot be published by CI:$MISSING"
+            echo ""
+            echo "If a package is brand new, an org maintainer must run a manual first-publish:"
+            echo "  cd typescript/packages/<name> && pnpm build && npm publish --access public"
+            echo "Then verify with 'npm view <NPM_NAME>' and re-run this workflow."
+            exit 1
+          fi
+          echo ""
+          echo "✓ all target packages exist on npm"
 
       - name: Check if prerelease
         id: prerelease
@@ -168,7 +196,7 @@ jobs:
           if [[ "${{ steps.version.outputs.version }}" == *"-"* ]]; then
             echo "is_prerelease=true" >> $GITHUB_OUTPUT
             echo "npm_tag=beta" >> $GITHUB_OUTPUT
-            echo "📦 Pre-release version detected, using 'beta' npm tag"
+            echo "Pre-release version detected, using 'beta' npm tag"
           else
             echo "is_prerelease=false" >> $GITHUB_OUTPUT
             echo "npm_tag=latest" >> $GITHUB_OUTPUT
@@ -185,138 +213,188 @@ jobs:
       - name: Pack packages
         working-directory: typescript
         run: |
-          echo "📦 Packing packages..."
-
-          # Create output directory for tarballs
+          echo "==> Packing packages"
           mkdir -p .npm-pack
-
           # Use pnpm pack (not npm pack) to ensure workspace:* is resolved to real versions
           for pkg in ${{ steps.targets.outputs.packages }}; do
-            echo "  Packing packages/${pkg}..."
+            echo "  packages/${pkg}"
             pushd "packages/${pkg}" > /dev/null
             pnpm pack --pack-destination ../../.npm-pack
             popd > /dev/null
           done
-
           echo ""
-          echo "📦 Packed tarballs:"
+          echo "Packed tarballs:"
           ls -la .npm-pack/
 
       - name: "Guard - Fail if tarballs contain workspace: protocol"
         working-directory: typescript
         run: |
-          echo "🔍 Checking tarballs for workspace: protocol..."
-
+          echo "==> Checking tarballs for workspace: protocol"
           FAILED=0
           for tarball in .npm-pack/*.tgz; do
-            echo "  Checking ${tarball}..."
-
-            # Extract package.json from tarball
             tar -xzf "$tarball" package/package.json -O > /tmp/pkg.json
-
-            # Check for workspace: in dependencies
             if grep -q '"workspace:' /tmp/pkg.json; then
-              echo "❌ FAIL: ${tarball} contains workspace: dependencies!"
-              echo "    Found:"
+              echo "  ✗ ${tarball} contains workspace: dependencies"
               grep '"workspace:' /tmp/pkg.json || true
               FAILED=1
             else
-              echo "    ✓ No workspace: dependencies found"
+              echo "  ✓ ${tarball}"
             fi
           done
-
           if [ "$FAILED" -eq 1 ]; then
             echo ""
-            echo "❌ One or more tarballs contain workspace: dependencies."
-            echo "   This indicates npm pack did not resolve workspace dependencies."
-            echo "   Check that pnpm is being used correctly or dependencies are specified with semver ranges."
+            echo "One or more tarballs contain workspace: dependencies."
+            echo "Check that pnpm is being used correctly or dependencies are specified with semver ranges."
             exit 1
           fi
-
-          echo ""
-          echo "✅ All tarballs are clean (no workspace: dependencies)"
 
       - name: Guard - Fail if tarballs are missing dist/ artifacts
         working-directory: typescript
         run: |
-          echo "🔍 Checking tarballs for dist/ artifacts..."
-
+          echo "==> Checking tarballs for dist/ artifacts"
           FAILED=0
           for tarball in .npm-pack/*.tgz; do
-            echo "  Checking ${tarball}..."
-
-            # List tarball contents and check for dist/
             CONTENTS=$(tar -tzf "$tarball")
-
             if ! echo "$CONTENTS" | grep -q "package/dist/index.js"; then
-              echo "❌ FAIL: ${tarball} is missing dist/index.js!"
+              echo "  ✗ ${tarball} missing dist/index.js"
               FAILED=1
             fi
-
             if ! echo "$CONTENTS" | grep -q "package/dist/index.d.ts"; then
-              echo "❌ FAIL: ${tarball} is missing dist/index.d.ts!"
+              echo "  ✗ ${tarball} missing dist/index.d.ts"
               FAILED=1
-            fi
-
-            if [ "$FAILED" -eq 0 ]; then
-              echo "    ✓ dist/index.js and dist/index.d.ts present"
             fi
           done
-
           if [ "$FAILED" -eq 1 ]; then
             echo ""
-            echo "❌ One or more tarballs are missing required dist/ artifacts."
-            echo "   Make sure 'pnpm build' ran successfully before packing."
+            echo "Make sure 'pnpm build' ran successfully before packing."
             exit 1
           fi
-
-          echo ""
-          echo "✅ All tarballs contain required dist/ artifacts"
+          echo "  ✓ all tarballs contain dist/index.js and dist/index.d.ts"
 
       - name: Create and push tag
         if: ${{ github.event.inputs.package == 'all' }}
         run: |
           TAG="ts-keychain-v${{ steps.version.outputs.version }}"
           if git rev-parse "$TAG" >/dev/null 2>&1; then
-            echo "⏭️ Tag $TAG already exists, skipping"
+            echo "· tag $TAG already exists"
           else
             git tag "$TAG"
-            echo "✅ Created tag $TAG"
+            echo "✓ created tag $TAG"
           fi
-          git push origin "$TAG" 2>/dev/null || echo "⏭️ Tag already pushed"
+          git push origin "$TAG" 2>/dev/null || echo "· tag already pushed"
+
+      - name: Pre-flight - npm publish dry-run for all targets
+        if: ${{ github.event.inputs.publish-to-npm == 'true' }}
+        working-directory: typescript
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          echo "==> Pre-flight: npm publish --dry-run for each target"
+          echo "    Validates tarballs, version conflicts, and registry auth"
+          echo "    BEFORE any real publish."
+          echo ""
+          echo "Publishing as: $(npm whoami 2>/dev/null || echo '<no auth>')"
+          echo ""
+
+          VERSION="${{ steps.version.outputs.version }}"
+          NPM_TAG="${{ steps.prerelease.outputs.npm_tag }}"
+          FAILED=0
+          FAILED_PKGS=""
+
+          for pkg in ${{ steps.targets.outputs.packages }}; do
+            if [ "$pkg" = "keychain" ]; then
+              TARBALL=".npm-pack/solana-keychain-${VERSION}.tgz"
+              NPM_NAME="@solana/keychain"
+            else
+              TARBALL=".npm-pack/solana-keychain-${pkg}-${VERSION}.tgz"
+              NPM_NAME="@solana/keychain-${pkg}"
+            fi
+
+            if [ ! -f "$TARBALL" ]; then
+              echo "  ✗ ${pkg}: tarball not found at ${TARBALL}"
+              FAILED=1
+              FAILED_PKGS="${FAILED_PKGS} ${pkg}(missing-tarball)"
+              continue
+            fi
+
+            # Is this version already published?
+            # Distinguish 404 (not published — good) from real registry/auth errors
+            NPM_RC=0
+            NPM_OUT=$(npm view "${NPM_NAME}@${VERSION}" version 2>&1) || NPM_RC=$?
+            if [ "$NPM_RC" -ne 0 ] && ! echo "$NPM_OUT" | grep -q "E404"; then
+              echo "  ✗ ${NPM_NAME}: registry error (not 404):"
+              echo "$NPM_OUT" | sed 's/^/      /'
+              FAILED=1
+              FAILED_PKGS="${FAILED_PKGS} ${pkg}(registry-error)"
+              continue
+            fi
+            if [ "$NPM_RC" -eq 0 ] && [ -n "$NPM_OUT" ]; then
+              echo "  ✗ ${NPM_NAME}@${VERSION} already published — bump version or drop from targets"
+              FAILED=1
+              FAILED_PKGS="${FAILED_PKGS} ${pkg}(already-published)"
+              continue
+            fi
+
+            # Dry-run publish (validates tarball + most registry errors)
+            if ! npm publish "$TARBALL" --access public --tag "$NPM_TAG" --dry-run > /tmp/dryrun-${pkg}.log 2>&1; then
+              echo "  ✗ ${NPM_NAME}: dry-run failed"
+              sed 's/^/      /' /tmp/dryrun-${pkg}.log
+              FAILED=1
+              FAILED_PKGS="${FAILED_PKGS} ${pkg}(dryrun-failed)"
+              continue
+            fi
+            echo "  ✓ ${NPM_NAME}@${VERSION}"
+          done
+
+          echo ""
+          if [ "$FAILED" -eq 1 ]; then
+            echo "Pre-flight failed for:${FAILED_PKGS}"
+            echo "Aborting BEFORE any real publish."
+            exit 1
+          fi
+          echo "✓ pre-flight passed for all targets"
 
       - name: Publish to npm
         if: ${{ github.event.inputs.publish-to-npm == 'true' }}
         working-directory: typescript
         run: |
-          echo "📦 Publishing packages to npm..."
-
+          echo "==> Publishing to npm"
           VERSION="${{ steps.version.outputs.version }}"
           NPM_TAG="${{ steps.prerelease.outputs.npm_tag }}"
           PUBLISHED=0
 
           for pkg in ${{ steps.targets.outputs.packages }}; do
-            # Handle package name: "keychain" -> "solana-keychain", others -> "solana-keychain-{pkg}"
             if [ "$pkg" = "keychain" ]; then
               TARBALL=".npm-pack/solana-keychain-${VERSION}.tgz"
             else
               TARBALL=".npm-pack/solana-keychain-${pkg}-${VERSION}.tgz"
             fi
-
-            if [ -f "$TARBALL" ]; then
-              echo ""
-              echo "📤 Publishing ${TARBALL} with tag '${NPM_TAG}'..."
-              npm publish "$TARBALL" --access public --tag "$NPM_TAG"
-              PUBLISHED=$((PUBLISHED + 1))
-            else
-              echo "⚠️  Tarball not found: ${TARBALL}"
-              echo "   Looking for alternatives..."
-              ls -la .npm-pack/ | grep -i "${pkg}" || true
+            if [ ! -f "$TARBALL" ]; then
+              echo "✗ tarball not found post-preflight: ${TARBALL}"
+              exit 1
             fi
+            echo ""
+            echo "  -> ${TARBALL} (tag '${NPM_TAG}')"
+            npm publish "$TARBALL" --access public --tag "$NPM_TAG"
+            PUBLISHED=$((PUBLISHED + 1))
           done
-
           echo ""
-          echo "✅ Published ${PUBLISHED} packages successfully"
+          echo "✓ published ${PUBLISHED} packages"
+
+      - name: Resolve previous ts-keychain tag
+        id: prev_tag
+        if: ${{ github.event.inputs.create-github-release == 'true' && github.event.inputs.package == 'all' }}
+        run: |
+          CURRENT_TAG="ts-keychain-v${{ steps.version.outputs.version }}"
+          # Most recent ts-keychain-v* tag that isn't the one we just created
+          PREV_TAG=$(git tag -l 'ts-keychain-v*' --sort=-version:refname | grep -v "^${CURRENT_TAG}$" | head -1 || true)
+          if [ -n "$PREV_TAG" ]; then
+            echo "previous_tag=${PREV_TAG}" >> $GITHUB_OUTPUT
+            echo "Previous tag: ${PREV_TAG}"
+          else
+            echo "previous_tag=" >> $GITHUB_OUTPUT
+            echo "No previous ts-keychain-v* tag found (first release)"
+          fi
 
       - name: Create GitHub Release
         if: ${{ github.event.inputs.create-github-release == 'true' && github.event.inputs.package == 'all' }}
@@ -326,10 +404,13 @@ jobs:
           script: |
             const tagName = `ts-keychain-v${{ steps.version.outputs.version }}`;
             const version = `${{ steps.version.outputs.version }}`;
+            const previousTag = `${{ steps.prev_tag.outputs.previous_tag }}`;
             const releaseName = `@solana/keychain v${version}`;
             const isPrerelease = '${{ steps.prerelease.outputs.is_prerelease }}' === 'true';
+            const repoUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}`;
 
             const packages = [
+              '@solana/keychain',
               '@solana/keychain-core',
               '@solana/keychain-aws-kms',
               '@solana/keychain-cdp',
@@ -343,38 +424,42 @@ jobs:
               '@solana/keychain-privy',
               '@solana/keychain-turnkey',
               '@solana/keychain-vault',
-              '@solana/keychain'
             ];
 
-            const packageList = packages.map(p => `- \`${p}@${version}\``).join('\n');
+            const packageList = packages
+              .map(p => `- [\`${p}@${version}\`](https://www.npmjs.com/package/${p}/v/${version})`)
+              .join('\n');
+
+            const changelogLine = previousTag
+              ? `**Full changelog**: [${previousTag}...${tagName}](${repoUrl}/compare/${previousTag}...${tagName})`
+              : `**Full changelog**: [Initial release](${repoUrl}/commits/${tagName})`;
 
             const body = `## TypeScript Packages v${version}
 
-            This release includes the following packages:
+            ${changelogLine}
+
+            ### Published Packages
 
             ${packageList}
 
             ### Installation
 
             \`\`\`bash
-            # Install the umbrella package (includes all signers)
+            # Umbrella package (includes all signers)
             pnpm add @solana/keychain
 
-            # Or install individual packages
-            pnpm add @solana/keychain-core
-            pnpm add @solana/keychain-privy
-            # etc.
+            # Or individual packages
+            pnpm add @solana/keychain-memory @solana/keychain-openfort
             \`\`\`
             `;
 
-            // Check if release already exists
             try {
               await github.rest.repos.getReleaseByTag({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 tag: tagName,
               });
-              console.log(`⏭️ Release ${tagName} already exists, skipping`);
+              console.log(`· release ${tagName} already exists`);
               return;
             } catch (e) {
               if (e.status !== 404) throw e;
@@ -389,14 +474,13 @@ jobs:
               draft: false,
               prerelease: isPrerelease,
             });
-
-            console.log(`✅ Created release: ${releaseName}`);
+            console.log(`✓ created release ${releaseName}`);
 
       - name: Publish summary
         run: |
           VERSION="${{ steps.version.outputs.version }}"
 
-          echo "## 🎉 TypeScript Packages Published" >> $GITHUB_STEP_SUMMARY
+          echo "## TypeScript Packages Published" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Version**: \`${VERSION}\`" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
@@ -417,12 +501,16 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
 
           if [ "${{ github.event.inputs.publish-to-npm }}" == "true" ]; then
-            echo "✅ **Published to npm**" >> $GITHUB_STEP_SUMMARY
+            echo "Published to npm." >> $GITHUB_STEP_SUMMARY
           else
-            echo "⏭️ **Skipped npm publish** (dry run)" >> $GITHUB_STEP_SUMMARY
+            echo "Skipped npm publish (dry run)." >> $GITHUB_STEP_SUMMARY
           fi
 
           if [ "${{ github.event.inputs.package }}" == "all" ] && [ "${{ github.event.inputs.create-github-release }}" == "true" ]; then
             echo "" >> $GITHUB_STEP_SUMMARY
-            echo "✅ **GitHub release created**: https://github.com/${{ github.repository }}/releases/tag/ts-keychain-v${VERSION}" >> $GITHUB_STEP_SUMMARY
+            echo "GitHub release: https://github.com/${{ github.repository }}/releases/tag/ts-keychain-v${VERSION}" >> $GITHUB_STEP_SUMMARY
+            PREV_TAG="${{ steps.prev_tag.outputs.previous_tag }}"
+            if [ -n "$PREV_TAG" ]; then
+              echo "Full changelog: https://github.com/${{ github.repository }}/compare/${PREV_TAG}...ts-keychain-v${VERSION}" >> $GITHUB_STEP_SUMMARY
+            fi
           fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,238 +1,121 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+Guidance for Claude Code working in this repo.
 
 ## Project Overview
 
-`solana-keychain` is a Rust library providing a unified interface for signing Solana transactions across multiple backend implementations. The architecture centers around a single `SolanaSigner` trait that abstracts over nine different signing backends: Memory (local keypairs), Vault (HashiCorp), Privy, Turnkey, AWS KMS, Fireblocks, GCP KMS, Dfns, and Crossmint.
+`solana-keychain` is a Rust + TypeScript library providing a unified `SolanaSigner` interface across twelve backends, with full Rust/TS parity:
 
-## Common Commands
+Memory · Vault · Privy · Turnkey · AWS KMS · Fireblocks · GCP KMS · Dfns · Crossmint · CDP · Para · Openfort
 
-### Build and Test
+## Repo Layout
+
+- `rust/` — Rust crate, feature-gated per backend. See [rust/README.md](rust/README.md).
+- `typescript/` — pnpm monorepo, one package per backend plus core/keychain umbrella. See [typescript/README.md](typescript/README.md).
+- `docs/ADDING_SIGNERS.md` — full guide for adding a new backend (Rust + TS + CI).
+- `audits/AUDIT_STATUS.md` — audited-through commit and unaudited delta.
+- `justfile` — top-level dev commands. Prefer these over raw `cargo`/`pnpm` since they encode the right flags (e.g., `just rust-test` runs both `sdk-v2` and `sdk-v3` matrices — `cargo test --all-features` fails because the SDK features are mutually exclusive).
+
+### Common commands
+
+Always prefer `just` recipes. They encode the right flags (e.g., `just rust-test` runs both `sdk-v2` and `sdk-v3` matrices — `cargo test --all-features` fails because the SDK features are mutually exclusive). Run `just` with no args to list every recipe.
+
 ```bash
-# Build the project (default features only - memory signer)
-cd rust && cargo build
-
-# Build with all features
-cd rust && cargo build --all-features
-
-# Run tests (requires all features for complete test coverage)
-cd rust && cargo test --all-features
-
-# Run tests for a specific signer backend
-cd rust && cargo test --features memory
-cd rust && cargo test --features vault
-cd rust && cargo test --features privy
-cd rust && cargo test --features turnkey
-cd rust && cargo test --features aws_kms
-cd rust && cargo test --features fireblocks
-cd rust && cargo test --features gcp_kms
-cd rust && cargo test --features dfns
-cd rust && cargo test --features crossmint
-
-# Run a single test
-cd rust && cargo test test_name --all-features
-
-# Or use just (runs from project root)
-just build
-just test
+just build              # rust-build + ts-build
+just test               # unit tests (rust + ts)
+just test-integration   # spins up local Vault, runs integration tests (both sides)
+just test-all           # test + test-integration
+just fmt                # cargo fmt/clippy + pnpm lint:fix/format
 ```
 
-### Linting and Formatting
+Per-side recipes (use these to scope work to one language):
+
+| Task | Rust | TypeScript |
+| --- | --- | --- |
+| Build | `just rust-build` | `just ts-build` |
+| Unit tests | `just rust-test` | `just ts-test` |
+| Format + lint | `just rust-fmt` | `just ts-fmt` |
+| Integration tests | `just rust-test-integration` | `just ts-test-integration` |
+| Other | — | `just ts-treeshake` (verifies `@solana/keychain` umbrella + per-pkg tree-shakability) |
+
+Integration recipes auto-spawn a local `vault server -dev` and load `.env` from the repo root — do not run vault yourself or pass secrets via shell.
+
+For releases: `just release` (Rust), `just release-ts`, `just hotfix`, `just publish-ts`. See [RELEASING.md](RELEASING.md) for the full runbook (normal flow, partial-publish recovery, new-package onboarding, concurrency notes). Always check **all** crates/packages in the monorepo for version consistency.
+
+## Repo skills
+
+This repo ships Claude Code skills in [.claude/skills/](.claude/skills/) — invoke them whenever you're starting one of these workflows instead of reinventing the steps:
+
+| Skill | When to use |
+| --- | --- |
+| [`add-signer`](.claude/skills/add-signer/SKILL.md) | Adding a new signing backend (Rust + TS + CI). Pair with [docs/ADDING_SIGNERS.md](docs/ADDING_SIGNERS.md). |
+| [`release`](.claude/skills/release/SKILL.md) | Cutting a new Rust and/or TS release (PR-based flow, version bumps). |
+| [`complete-release`](.claude/skills/complete-release/SKILL.md) | Finalizing an approved release PR — merge, then trigger publish workflows from `main`. |
+
+## Rust
+
+Use `just rust-*` for the common workflows. For a single-backend slice (no `just` recipe), drop to cargo:
+
 ```bash
-# Format and lint code (runs clippy with all warnings as errors)
-just fmt
-
-# Just format code
-cd rust && cargo fmt
-
-# Just run clippy
-cd rust && cargo clippy --all-targets --all-features -- -D warnings
+cd rust && cargo test --no-default-features --features <backend>,sdk-v2 <backend>::tests
 ```
 
-### Branch Workflow
-```bash
-# Show branch workflow guidance
-just branch-info
+Remember to also run `sdk-v3` if your change touches SDK-version-sensitive code — `just rust-test` does both for you.
 
-# Branch strategy:
-#   main                → Integration branch (audited + unaudited commits)
-#   feat/*,fix/*,chore/* → Topic branches from main
-#   hotfix/*            → Urgent fixes from deployed stable tag
+### Architecture
+
+- **Trait** ([rust/src/traits.rs](rust/src/traits.rs)): `SolanaSigner` with `pubkey()`, `sign_transaction()`, `sign_message()`, `is_available()`.
+- **Unified enum** ([rust/src/lib.rs](rust/src/lib.rs)): `Signer` enum wraps every backend, each variant `#[cfg(feature = "...")]`-gated. `Signer::from_<backend>(...)` constructors return a ready-to-use signer (calling `init()` internally where needed).
+- **Errors** ([rust/src/error.rs](rust/src/error.rs)): centralized `SignerError` via `thiserror`.
+
+Per-backend implementation details live in each module's source. See [rust/README.md](rust/README.md) for the supported-backend table and usage examples.
+
+### Feature flags
+
+One feature per backend (`memory` is default), `all` enables everything. At least one is required (enforced by `compile_error!` in `lib.rs`). SDK selection is mutually exclusive: `sdk-v2` (default) or `sdk-v3`.
+
+### Gotchas
+
+- **`init()` required before use:** `PrivySigner`, `FireblocksSigner`, `DfnsSigner`, `CrossmintSigner`, `ParaSigner`, `OpenfortSigner`. The others are ready after construction. The `Signer::from_*` factories handle `init()` for you.
+- **`sign_message` quirks:** `CrossmintSigner` returns `SigningFailed` (intentionally unsupported). `CdpSigner` only accepts UTF-8 payloads.
+- **Turnkey signature padding:** response `r,s` components must be left-padded to 32 bytes each before concatenation ([rust/src/turnkey/mod.rs](rust/src/turnkey/mod.rs)).
+- **GCP KMS:** PureEdDSA mode with `EC_SIGN_ED25519`.
+- **Transaction serialization:** all backends use `bincode` before signing.
+- **Remote-signer tests** use `wiremock`; no live API calls in unit tests.
+
+## TypeScript
+
+Use `just ts-*` for build/test/fmt/treeshake. For a single-package slice (no `just` recipe), drop to pnpm:
+
+```bash
+cd typescript && pnpm install
+cd typescript && pnpm --filter @solana/keychain-<name> <script>   # e.g. test, build, typecheck
+cd typescript && pnpm typecheck                                    # workspace-wide
 ```
 
-### Publishing a Rust Release (Mainline)
-```bash
-# Prepare a new release (prompts for version, generates CHANGELOG, stages changes)
-# Mainline path: run from main after release PR merge
-just release
+### Architecture
 
-# Review the CHANGELOG.md, then commit
-git commit -m "chore: release vX.Y.Z"
+- **Monorepo** ([typescript/](typescript/)): pnpm workspace, one package per backend plus `core` (interfaces) and `keychain` (umbrella factory).
+- **Interface** (`@solana/keychain-core`): every signer implements `SolanaSigner<TAddress>` — `address`, `signMessages()`, `signTransactions()`, `isAvailable()`. Compatible with `@solana/kit` and `@solana/signers`.
+- **Async factory pattern:** each package exports `async createXSigner(config)` returning a ready-to-use `SolanaSigner` (the factory awaits any `init()` internally — TS parity with Rust's `Signer::from_*`). The umbrella `@solana/keychain` exports `createKeychainSigner({ backend, ...config })` that dispatches to the per-backend factory.
+- **Package naming:** `@solana/keychain-<backend>` (e.g. `@solana/keychain-privy`, `@solana/keychain-aws-kms`).
 
-# Push to GitHub
-git push origin HEAD
+See [typescript/README.md](typescript/README.md) for the full package list and usage. When adding a backend, follow [docs/ADDING_SIGNERS.md](docs/ADDING_SIGNERS.md) — the umbrella package needs updates in 6 places.
 
-# Manually trigger "Publish Rust Crate" from main
-# Publish workflows run from the ref you dispatch
-```
+### Gotchas
 
-### Publishing a TypeScript Release (Mainline)
-```bash
-# Prepare a new TypeScript SDK release (prompts for version)
-# Mainline path: run from main after release PR merge
-just release-ts
+- **Async construction:** always `await createXSigner(...)` — direct class construction is deprecated and skips `init()`.
+- **`signMessages` quirks (parity with Rust):** `CrossmintSigner` rejects with "not supported". `CdpSigner` requires UTF-8 message bytes.
+- **HTTPS enforced:** all `apiBaseUrl` config fields must reject non-HTTPS URLs.
+- **Error sanitization:** wrap remote API error text with `sanitizeRemoteErrorResponse()` from `@solana/keychain-core` before surfacing.
+- **Integration tests:** use `runSignerIntegrationTest` + per-package `setup.ts`; spun up via `just ts-test-integration` (loads `.env`, starts local Vault).
+- **Tree-shakability:** run `just ts-treeshake` after touching exports — every package and the umbrella must stay tree-shakable.
+- **Adding a backend:** the umbrella package, `typescript-ci.yml`, and `typescript-publish.yml` all need updates (see [docs/ADDING_SIGNERS.md](docs/ADDING_SIGNERS.md)).
 
-# Commit and push
-git commit -m "chore: release ts-keychain vX.Y.Z"
-git push origin HEAD
+## Branch Workflow
 
-# Manually trigger "Publish TypeScript Packages (Manual)" from main
-```
+- `main` — integration branch (audited + unaudited).
+- `feat/*`, `fix/*`, `chore/*` — topic branches from `main`.
+- `hotfix/*` — urgent fixes from a deployed stable tag (use `just hotfix`).
 
-### Creating a Hotfix Release
-```bash
-# Create a hotfix branch from a deployed stable tag
-just hotfix              # prompts for name
-just hotfix fix-auth     # pass name directly
-just hotfix fix-auth v1.2.3 # optionally pass base tag
-
-# On hotfix/*: apply fixes and prepare release
-just release             # required for Rust publish
-just release-ts          # if TypeScript packages changed
-
-# Commit and push hotfix branch
-git push origin HEAD
-
-# Trigger publish workflows from hotfix/* before merge-back
-# Then open PR from hotfix/* to main and merge back
-```
-
-Release skill references for agents:
-- `.claude/skills/release/SKILL.md`
-- `.claude/skills/complete-release/SKILL.md`
-
-## Architecture
-
-### Core Trait System
-
-The library is built around the `SolanaSigner` trait ([rust/src/traits.rs](rust/src/traits.rs)) which defines the interface all signers must implement:
-- `pubkey()` - Returns the signer's public key
-- `sign_transaction()` - Signs a Solana transaction, modifying it in place
-- `sign_message()` - Signs arbitrary bytes
-- `is_available()` - Checks if the signer backend is healthy/reachable
-
-### Unified Signer Enum
-
-[rust/src/lib.rs](rust/src/lib.rs) provides a `Signer` enum that wraps all backend implementations, allowing runtime selection of signing backends while maintaining a single interface. Each variant corresponds to a feature-gated backend.
-
-### Backend Implementations
-
-All signers follow a consistent pattern but differ in where keys are stored:
-
-1. **MemorySigner** ([rust/src/memory/mod.rs](rust/src/memory/mod.rs))
-   - Stores keypair in memory
-   - Supports multiple input formats: Base58, U8Array string, or JSON file path
-   - Always available (no remote dependencies)
-   - See [rust/src/memory/keypair_util.rs](rust/src/memory/keypair_util.rs) for key parsing logic
-
-2. **VaultSigner** ([rust/src/vault/mod.rs](rust/src/vault/mod.rs))
-   - Uses HashiCorp Vault's Transit engine for signing
-   - Public key provided at construction (must match Vault key)
-   - Uses `vaultrs` client library
-   - Availability checked via key metadata read
-
-3. **PrivySigner** ([rust/src/privy/mod.rs](rust/src/privy/mod.rs))
-   - Requires `init()` call after construction to fetch public key
-   - Uses Basic Auth with app_id:app_secret
-   - RPC-style API with `signTransaction` method
-   - Returns full signed transaction, extracts signature
-
-4. **TurnkeySigner** ([rust/src/turnkey/mod.rs](rust/src/turnkey/mod.rs))
-   - Uses P256 ECDSA signing for API authentication (X-Stamp header)
-   - Signs raw payloads with hex encoding
-   - Response contains r,s signature components that must be padded to 32 bytes each
-   - Availability checked via `whoami` endpoint
-
-5. **AWS KMS** ([rust/src/aws_kms/mod.rs](rust/src/aws_kms/mod.rs))
-   - Uses AWS SDK with EdDSA (Ed25519) signing
-   - Automatic credential discovery via environment or IAM
-   - Availability checked via `DescribeKey`
-
-6. **FireblocksSigner** ([rust/src/fireblocks/mod.rs](rust/src/fireblocks/mod.rs))
-   - Uses Fireblocks API with EdDSA (Ed25519) signing
-   - Requires `init()` to fetch public key before use
-   - JWT-based authentication
-   - Availability checked via user details endpoint
-
-7. **GCP KMS** ([rust/src/gcp_kms/mod.rs](rust/src/gcp_kms/mod.rs))
-   - Uses Google Cloud SDK with EdDSA (Ed25519) signing
-   - PureEdDSA mode with `EC_SIGN_ED25519` algorithm
-   - Automatic credential discovery via ADC
-   - Availability checked via `GetCryptoKeyVersion`
-
-8. **DfnsSigner** ([rust/src/dfns/mod.rs](rust/src/dfns/mod.rs))
-     - Uses Dfns API signing
-     - Requires `init()` to fetch wallet public key before use
-     - User Action Signing flow: 3-step challenge/response
-     - Signature returned as r+s hex components, concatenated to 64-byte Ed25519 signature
-     - Authentication via private key in PEM format
-     - Availability checked via wallet GET endpoint
-
-9. **CrossmintSigner** ([rust/src/crossmint/mod.rs](rust/src/crossmint/mod.rs))
-    - Uses Crossmint Wallets API with managed transaction signing flow
-    - Supports Solana `smart` and `mpc` wallet types
-    - Requires `init()` to resolve wallet and signer public key before use
-    - `sign_message` is intentionally unsupported and returns a signing error
-    - Availability checked via wallet GET endpoint
-
-### Error Handling
-
-All errors are centralized in [rust/src/error.rs](rust/src/error.rs) using `thiserror`. The `SignerError` enum covers key formats, signing failures, remote API errors, serialization, and configuration issues.
-
-### Feature Flags
-
-The library uses Cargo features for zero-cost abstraction:
-- `memory` (default) - Only includes MemorySigner
-- `vault` - Adds VaultSigner with reqwest, vaultrs, base64
-- `privy` - Adds PrivySigner with reqwest, base64
-- `turnkey` - Adds TurnkeySigner with reqwest, base64, p256, hex, chrono
-- `aws_kms` - Adds KmsSigner with aws-sdk-kms
-- `fireblocks` - Adds FireblocksSigner with reqwest, jsonwebtoken
-- `gcp_kms` - Adds GcpKmsSigner with google-cloud-kms-v1, google-cloud-auth
-- `dfns` - Adds DfnsSigner with reqwest, hex, ed25519-dalek
-- `crossmint` - Adds CrossmintSigner with reqwest
-- `all` - Enables all backends
-
-At least one feature must be enabled (enforced by `compile_error!` in lib.rs).
-
-## Testing
-
-Tests are co-located with implementation code in each module. Remote signers (Vault, Privy, Turnkey, AWS, Fireblocks, GCP, DFNS, Crossmint) use `wiremock` to mock HTTP endpoints, avoiding actual API calls during testing. Tests cover:
-- Constructor validation (invalid keys, etc.)
-- Successful signing operations
-- Error cases (unauthorized, malformed responses)
-- Availability checks
-
-Run specific backend tests:
-```bash
-cd rust && cargo test --features vault vault::tests
-cd rust && cargo test --features privy privy::tests
-cd rust && cargo test --features turnkey turnkey::tests
-cd rust && cargo test --features aws_kms aws_kms::tests
-cd rust && cargo test --features fireblocks fireblocks::tests
-cd rust && cargo test --features gcp_kms gcp_kms::tests
-cd rust && cargo test --features dfns dfns::tests
-cd rust && cargo test --features crossmint crossmint::tests
-```
-
-## Key Implementation Notes
-
-- All signers serialize transactions with `bincode` before signing
-- Privy and Turnkey use Base64 encoding for payloads/responses
-- Vault uses Base64 for both input and output
-- Turnkey requires special handling for signature component padding (see [rust/src/turnkey/mod.rs:125-136](rust/src/turnkey/mod.rs))
-- PrivySigner, FireblocksSigner, DfnsSigner, and CrossmintSigner must call `init()` before use; other signers are ready after construction
-- AWS KMS and GCP KMS use official cloud SDKs with automatic credential discovery
-- GCP KMS operates in PureEdDSA mode with `EC_SIGN_ED25519` algorithm
-- The unified `Signer` enum uses conditional compilation extensively with `#[cfg(feature = "...")]`
+`just branch-info` prints the full guidance.

--- a/justfile
+++ b/justfile
@@ -358,6 +358,33 @@ release-ts: _check-ts-release
     git add .
 
     echo ""
+    echo "==> Checking npm registry for each target package..."
+    MISSING=""
+    for pkg in $PACKAGES; do
+        [ "$pkg" = "test-utils" ] && continue
+        if [ "$pkg" = "keychain" ]; then NPM_NAME="@solana/keychain"
+        else NPM_NAME="@solana/keychain-$pkg"; fi
+        if npm view "$NPM_NAME" version >/dev/null 2>&1; then
+            echo "  [ok] $NPM_NAME exists on npm"
+        else
+            echo "  [warn] $NPM_NAME not found on npm — needs first-publish by an org maintainer"
+            MISSING="$MISSING $NPM_NAME"
+        fi
+    done
+    if [ -n "$MISSING" ]; then
+        echo ""
+        echo "==> WARNING: the following packages need a manual first-publish before CI can publish them:"
+        echo "   $MISSING"
+        echo ""
+        echo "   For each, after building the workspace:"
+        echo "     cd typescript/packages/<name> && npm publish --access public"
+        echo "   Then verify with 'npm view <NPM_NAME>' before triggering CI."
+        echo ""
+        read -p "Continue with version bump anyway? [y/N] " ok
+        [[ "$ok" =~ ^[Yy]$ ]] || exit 1
+    fi
+
+    echo ""
     echo "TypeScript release prepared! Next steps:"
     echo "  1. git commit -m 'chore(ts): release v$version'"
     echo "  2. git push origin HEAD"
@@ -367,6 +394,38 @@ release-ts: _check-ts-release
     else
         echo "  3. Trigger 'Publish TypeScript Packages' workflow in GitHub Actions"
     fi
+
+# Trigger TypeScript publish workflow and watch until it finishes.
+# Pass a single package name, or "all" (default). For partial recovery,
+# trigger one run per package via the GitHub Actions UI or repeated calls.
+publish-ts package="all" branch="":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    command -v gh >/dev/null || { echo "Install gh: https://cli.github.com"; exit 1; }
+    valid="all core aws-kms cdp crossmint dfns fireblocks gcp-kms memory openfort para privy turnkey vault keychain"
+    if ! echo " $valid " | grep -q " {{package}} "; then
+        echo "Error: invalid package '{{package}}'. Valid: $valid"
+        exit 1
+    fi
+    ref="{{branch}}"
+    [ -z "$ref" ] && ref=$(git rev-parse --abbrev-ref HEAD)
+    case "$ref" in
+        main|hotfix/*) ;;
+        *) echo "Error: publish-ts must run from main or hotfix/* (got: $ref)"; exit 1 ;;
+    esac
+    echo "==> Triggering TypeScript publish (package={{package}}, ref=$ref)"
+    before=$(gh run list --workflow=typescript-publish.yml --limit 1 --json databaseId -q '.[0].databaseId')
+    gh workflow run typescript-publish.yml --ref "$ref" \
+        -f package="{{package}}" \
+        -f publish-to-npm=true \
+        -f create-github-release=true
+    for _ in {1..15}; do
+        sleep 2
+        run_id=$(gh run list --workflow=typescript-publish.yml --limit 1 --json databaseId -q '.[0].databaseId')
+        [ "$run_id" != "$before" ] && break
+    done
+    echo "==> Watching run $run_id (https://github.com/solana-foundation/solana-keychain/actions/runs/$run_id)"
+    gh run watch "$run_id" --exit-status
 
 [private]
 _check-ts-release:

--- a/rust/src/error.rs
+++ b/rust/src/error.rs
@@ -18,7 +18,7 @@ pub enum SignerError {
     #[error("Signing failed")]
     SigningFailed(String),
 
-    /// Remote API error (Vault, Privy, Turnkey)
+    /// Remote API error (any remote signer backend: Vault, Privy, Turnkey, Fireblocks, AWS/GCP KMS, Dfns, Crossmint, CDP, Para, Openfort)
     #[error("Remote API error")]
     RemoteApiError(String),
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1,7 +1,8 @@
 //! Framework-agnostic Solana signing abstractions
 //!
 //! This crate provides a unified interface for signing Solana transactions
-//! with multiple backend implementations (memory, Vault, Privy, Turnkey, AWS KMS, Para).
+//! with multiple backend implementations (memory, Vault, Privy, Turnkey, AWS KMS,
+//! Fireblocks, GCP KMS, Dfns, Crossmint, CDP, Para, Openfort).
 //!
 //! # Features
 //!

--- a/typescript/packages/core/src/types.ts
+++ b/typescript/packages/core/src/types.ts
@@ -23,7 +23,7 @@ export interface SolanaSigner<TAddress extends string = string>
 
     /**
      * Check if the signer is available and healthy.
-     * For remote signers (Vault, Privy, Turnkey), this performs an API health check.
+     * For remote signers (Vault, Privy, Turnkey, AWS KMS, GCP KMS, Fireblocks, Dfns, Crossmint, CDP, Para, Openfort), this performs an API health check.
      *
      * @throws {SignerError} Some implementations may throw for configuration or initialization errors.
      */

--- a/typescript/packages/keychain/README.md
+++ b/typescript/packages/keychain/README.md
@@ -16,6 +16,8 @@ This installs all signer implementations. For a smaller bundle, install individu
 - `@solana/keychain-dfns` - Dfns signer
 - `@solana/keychain-fireblocks` - Fireblocks signer
 - `@solana/keychain-gcp-kms` - GCP KMS signer
+- `@solana/keychain-memory` - In-memory keypair signer (local Ed25519 signing)
+- `@solana/keychain-openfort` - Openfort backend wallet signer
 - `@solana/keychain-para` - Para MPC signer
 - `@solana/keychain-privy` - Privy signer
 - `@solana/keychain-turnkey` - Turnkey signer


### PR DESCRIPTION
## Summary
- Beef up `CLAUDE.md` for Rust/TS parity: justfile-first command table, async factory note, mirrored gotchas (signMessages quirks, treeshake), and a dedicated **Repo skills** section linking `add-signer` / `release` / `complete-release`.
- Sweep doc/jsdoc backend lists for staleness — umbrella `@solana/keychain` README was missing `memory` and `openfort`; `core/types.ts` and `rust/src/error.rs` doc comments only listed Vault/Privy/Turnkey.
- TS publish workflow: GitHub Release body now includes a **Full changelog** compare link (previous `ts-keychain-v*` tag → current tag), plus the same compare URL in the workflow run summary.

## Test Plan
- [ ] Re-read CLAUDE.md and confirm Rust/TS sections feel symmetric
- [ ] Next TS release: verify the Release body has the `prev...current` compare link and per-package npm links