### PR TITLE
ci: scope PR triggers to changed paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    paths:
+      - 'rust/**'
+      - '.github/workflows/ci.yml'
 
 jobs:
   resolve-signers:

--- a/.github/workflows/typescript-ci.yml
+++ b/.github/workflows/typescript-ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    paths:
+      - 'typescript/**'
+      - '.github/workflows/typescript-ci.yml'
 
 jobs:
   resolve-signers:


### PR DESCRIPTION
## Summary
- Rust CI runs on PRs only when `rust/**`, `Cargo.lock`, or its workflow changes
- TypeScript CI runs on PRs only when `typescript/**` or its workflow changes
- Push to `main` still runs both, unchanged

Verified the repo's "Main & Release" ruleset has no `required_status_checks` rule, so path-skipped workflows won't block merges.

Closes TOO-374