### PR TITLE
ci: ignore dependabot patch updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,13 +7,15 @@ updates:
     open-pull-requests-limit: 10
     cooldown:
       default-days: 7
-      semver-patch-days: 1
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - version-update:semver-patch
     groups:
       cargo-non-major:
         applies-to: version-updates
         update-types:
           - minor
-          - patch
 
   - package-ecosystem: npm
     directory: "/typescript"
@@ -22,13 +24,15 @@ updates:
     open-pull-requests-limit: 10
     cooldown:
       default-days: 7
-      semver-patch-days: 1
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - version-update:semver-patch
     groups:
       npm-non-major:
         applies-to: version-updates
         update-types:
           - minor
-          - patch
 
   - package-ecosystem: github-actions
     directory: "/"
@@ -36,6 +40,10 @@ updates:
       interval: weekly
     cooldown:
       default-days: 7
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - version-update:semver-patch
     groups:
       actions:
         patterns:


### PR DESCRIPTION
## Summary
- Ignore SemVer patch updates in Dependabot version updates.
- Keep grouped Cargo and npm update PRs focused on minor updates.

## Test Plan
- ruby -ryaml -e 'ARGV.each { |path| YAML.load_file(path); puts path }' .github/dependabot.yml