### PR TITLE
ci: broaden miri coverage

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -60,6 +60,4 @@ jobs:
             ~/.cache/org.rust-lang.miri
           key: miri-${{ runner.os }}-${{ hashFiles('rust/Cargo.lock') }}
       - run: cargo +nightly miri setup
-      - run: cargo +nightly miri test --locked --lib error::tests
-      - run: cargo +nightly miri test --locked --lib http_client_config::tests
-      - run: cargo +nightly miri test --locked --lib memory::keypair_util::tests::test_from_json_keypair
+      - run: cargo +nightly miri test --locked --lib

--- a/rust/src/memory/keypair_util.rs
+++ b/rust/src/memory/keypair_util.rs
@@ -206,6 +206,7 @@ mod tests {
         assert!(result.is_err());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[test]
     fn test_from_private_key_string_does_not_read_file_path() {
         let tmp_dir = std::env::temp_dir();
@@ -224,6 +225,7 @@ mod tests {
         let _ = std::fs::remove_file(&file_path);
     }
 
+    #[cfg_attr(miri, ignore)]
     #[test]
     fn test_from_private_key_file_json_keypair() {
         let tmp_dir = std::env::temp_dir();
@@ -243,6 +245,7 @@ mod tests {
         let _ = std::fs::remove_file(&file_path);
     }
 
+    #[cfg_attr(miri, ignore)]
     #[test]
     fn test_from_private_key_file_missing_file() {
         let result =

--- a/rust/src/memory/mod.rs
+++ b/rust/src/memory/mod.rs
@@ -124,6 +124,7 @@ mod tests {
         assert!(signer.is_ok());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[test]
     fn test_create_from_file() {
         let tmp_dir = std::env::temp_dir();
@@ -148,6 +149,7 @@ mod tests {
         assert_eq!(pubkey.to_string(), TEST_PUBKEY);
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_sign_message() {
         let signer = create_test_signer();
@@ -160,12 +162,14 @@ mod tests {
         assert_eq!(sig.as_ref().len(), 64);
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_is_available() {
         let signer = create_test_signer();
         assert!(signer.is_available().await);
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_sign_transaction() {
         let signer = create_test_signer();


### PR DESCRIPTION
## Summary
- Runs the Keychain Miri job across the full library test target instead of selected modules
- Skips the file-system and Tokio-runtime tests that Miri cannot execute
- Leaves the rest of the library tests covered by Miri

## Test Plan
- cargo fmt --all -- --check
- cargo +nightly miri test --locked --lib
- Local pre-commit hook also ran Rust clippy successfully, then failed on existing TypeScript lint errors outside this Rust CI change.