### PR TITLE
Add Utila signer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -69,6 +69,18 @@ OPENFORT_ACCOUNT_ID=acc_your-openfort-account-id
 OPENFORT_WALLET_SECRET=your-base64-pkcs8-der-or-pem-wallet-secret
 # OPENFORT_BASE_URL=https://api.openfort.io  # Optional, defaults to this
 
+# Utila Integration Tests
+UTILA_SERVICE_ACCOUNT_EMAIL=your-service-account@vault.utilaserviceaccount.io
+UTILA_SERVICE_ACCOUNT_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----
+your-rsa-private-key-here
+-----END PRIVATE KEY-----"
+UTILA_VAULT_ID=your-vault-id
+UTILA_WALLET_ID=your-wallet-id
+UTILA_NETWORK=networks/solana-devnet
+# UTILA_API_BASE_URL=https://api.utila.io  # Optional, defaults to this
+# UTILA_POLL_INTERVAL_MS=1000  # Optional
+# UTILA_MAX_POLL_ATTEMPTS=60  # Optional
+
 # CDP (Coinbase Developer Platform) Configuration
 # Create API keys at https://portal.cdp.coinbase.com
 CDP_API_KEY_ID=your-cdp-api-key-id

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,8 @@ on:
   pull_request:
     branches: [main]
     paths:
-      - "rust/**"
-      - ".github/workflows/ci.yml"
+      - 'rust/**'
+      - '.github/workflows/ci.yml'
 
 jobs:
   resolve-signers:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,6 @@ jobs:
               ['dfns', 'test_dfns_integration'],
               ['crossmint', 'test_crossmint_integration'],
               ['openfort', 'test_openfort_integration'],
-              ['utila', 'test_utila_integration'],
             ];
             const rustIntegrationTests = rustIntegrationMap
               .filter(([signer]) => enabled[signer])

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,8 @@ on:
   pull_request:
     branches: [main]
     paths:
-      - 'rust/**'
-      - '.github/workflows/ci.yml'
+      - "rust/**"
+      - ".github/workflows/ci.yml"
 
 jobs:
   resolve-signers:
@@ -35,6 +35,7 @@ jobs:
           CI_SIGNER_DFNS_ENABLED: ${{ vars.CI_SIGNER_DFNS_ENABLED || 'true' }}
           CI_SIGNER_CROSSMINT_ENABLED: ${{ vars.CI_SIGNER_CROSSMINT_ENABLED || 'true' }}
           CI_SIGNER_OPENFORT_ENABLED: ${{ vars.CI_SIGNER_OPENFORT_ENABLED || 'true' }}
+          CI_SIGNER_UTILA_ENABLED: ${{ vars.CI_SIGNER_UTILA_ENABLED || 'true' }}
         with:
           script: |
             const parseVar = (name) => {
@@ -60,6 +61,7 @@ jobs:
               dfns: parseVar('CI_SIGNER_DFNS_ENABLED'),
               crossmint: parseVar('CI_SIGNER_CROSSMINT_ENABLED'),
               openfort: parseVar('CI_SIGNER_OPENFORT_ENABLED'),
+              utila: parseVar('CI_SIGNER_UTILA_ENABLED'),
             };
 
             const rustUnitOrder = [
@@ -75,6 +77,7 @@ jobs:
               'dfns',
               'crossmint',
               'openfort',
+              'utila',
             ];
             const rustEnabledBackends = rustUnitOrder.filter((backend) => enabled[backend]);
             const rustUnitBackends = [...rustEnabledBackends];
@@ -91,6 +94,7 @@ jobs:
               ['dfns', 'test_dfns_integration'],
               ['crossmint', 'test_crossmint_integration'],
               ['openfort', 'test_openfort_integration'],
+              ['utila', 'test_utila_integration'],
             ];
             const rustIntegrationTests = rustIntegrationMap
               .filter(([signer]) => enabled[signer])

--- a/.github/workflows/fork-external-live-manual.yml
+++ b/.github/workflows/fork-external-live-manual.yml
@@ -91,7 +91,6 @@ jobs:
               ['dfns', 'test_dfns_integration'],
               ['crossmint', 'test_crossmint_integration'],
               ['openfort', 'test_openfort_integration'],
-              ['utila', 'test_utila_integration'],
             ];
 
             const tsLivePackageMap = [
@@ -105,7 +104,6 @@ jobs:
               ['dfns', 'dfns'],
               ['crossmint', 'crossmint'],
               ['openfort', 'openfort'],
-              ['utila', 'utila'],
             ];
 
             const rustFeatures = rustFeatureOrder.filter((backend) => enabled[backend]);

--- a/.github/workflows/fork-external-live-manual.yml
+++ b/.github/workflows/fork-external-live-manual.yml
@@ -35,6 +35,7 @@ jobs:
           CI_SIGNER_DFNS_ENABLED: ${{ vars.CI_SIGNER_DFNS_ENABLED }}
           CI_SIGNER_CROSSMINT_ENABLED: ${{ vars.CI_SIGNER_CROSSMINT_ENABLED }}
           CI_SIGNER_OPENFORT_ENABLED: ${{ vars.CI_SIGNER_OPENFORT_ENABLED }}
+          CI_SIGNER_UTILA_ENABLED: ${{ vars.CI_SIGNER_UTILA_ENABLED }}
         with:
           script: |
             const parseVar = (name) => {
@@ -60,6 +61,7 @@ jobs:
               dfns: parseVar('CI_SIGNER_DFNS_ENABLED'),
               crossmint: parseVar('CI_SIGNER_CROSSMINT_ENABLED'),
               openfort: parseVar('CI_SIGNER_OPENFORT_ENABLED'),
+              utila: parseVar('CI_SIGNER_UTILA_ENABLED'),
             };
 
             const rustFeatureOrder = [
@@ -75,6 +77,7 @@ jobs:
               'dfns',
               'crossmint',
               'openfort',
+              'utila',
             ];
 
             const rustLiveTestMap = [
@@ -88,6 +91,7 @@ jobs:
               ['dfns', 'test_dfns_integration'],
               ['crossmint', 'test_crossmint_integration'],
               ['openfort', 'test_openfort_integration'],
+              ['utila', 'test_utila_integration'],
             ];
 
             const tsLivePackageMap = [
@@ -101,6 +105,7 @@ jobs:
               ['dfns', 'dfns'],
               ['crossmint', 'crossmint'],
               ['openfort', 'openfort'],
+              ['utila', 'utila'],
             ];
 
             const rustFeatures = rustFeatureOrder.filter((backend) => enabled[backend]);

--- a/.github/workflows/typescript-ci.yml
+++ b/.github/workflows/typescript-ci.yml
@@ -108,7 +108,6 @@ jobs:
               'dfns',
               'crossmint',
               'openfort',
-              'utila',
             ];
 
             const unitPackages = unitSignerOrder

--- a/.github/workflows/typescript-ci.yml
+++ b/.github/workflows/typescript-ci.yml
@@ -6,8 +6,8 @@ on:
   pull_request:
     branches: [main]
     paths:
-      - "typescript/**"
-      - ".github/workflows/typescript-ci.yml"
+      - 'typescript/**'
+      - '.github/workflows/typescript-ci.yml'
 
 jobs:
   resolve-signers:

--- a/.github/workflows/typescript-ci.yml
+++ b/.github/workflows/typescript-ci.yml
@@ -6,8 +6,8 @@ on:
   pull_request:
     branches: [main]
     paths:
-      - 'typescript/**'
-      - '.github/workflows/typescript-ci.yml'
+      - "typescript/**"
+      - ".github/workflows/typescript-ci.yml"
 
 jobs:
   resolve-signers:
@@ -36,6 +36,7 @@ jobs:
           CI_SIGNER_DFNS_ENABLED: ${{ vars.CI_SIGNER_DFNS_ENABLED || 'true' }}
           CI_SIGNER_CROSSMINT_ENABLED: ${{ vars.CI_SIGNER_CROSSMINT_ENABLED || 'true' }}
           CI_SIGNER_OPENFORT_ENABLED: ${{ vars.CI_SIGNER_OPENFORT_ENABLED || 'true' }}
+          CI_SIGNER_UTILA_ENABLED: ${{ vars.CI_SIGNER_UTILA_ENABLED || 'true' }}
         with:
           script: |
             const parseVar = (name) => {
@@ -61,6 +62,7 @@ jobs:
               dfns: parseVar('CI_SIGNER_DFNS_ENABLED'),
               crossmint: parseVar('CI_SIGNER_CROSSMINT_ENABLED'),
               openfort: parseVar('CI_SIGNER_OPENFORT_ENABLED'),
+              utila: parseVar('CI_SIGNER_UTILA_ENABLED'),
             };
 
             const packageBySigner = {
@@ -76,6 +78,7 @@ jobs:
               dfns: 'dfns',
               crossmint: 'crossmint',
               openfort: 'openfort',
+              utila: 'utila',
             };
 
             const unitSignerOrder = [
@@ -91,6 +94,7 @@ jobs:
               'dfns',
               'crossmint',
               'openfort',
+              'utila',
             ];
 
             const integrationSignerOrder = [
@@ -104,6 +108,7 @@ jobs:
               'dfns',
               'crossmint',
               'openfort',
+              'utila',
             ];
 
             const unitPackages = unitSignerOrder

--- a/.github/workflows/typescript-publish.yml
+++ b/.github/workflows/typescript-publish.yml
@@ -6,7 +6,7 @@ on:
       package:
         description: 'Package to publish (or "all")'
         required: true
-        default: 'all'
+        default: "all"
         type: choice
         options:
           - all
@@ -22,15 +22,16 @@ on:
           - para
           - privy
           - turnkey
+          - utila
           - vault
           - keychain
       publish-to-npm:
-        description: 'Publish to npm registry'
+        description: "Publish to npm registry"
         required: true
         default: true
         type: boolean
       create-github-release:
-        description: 'Create GitHub release'
+        description: "Create GitHub release"
         required: true
         default: true
         type: boolean
@@ -60,6 +61,7 @@ env:
     para
     privy
     turnkey
+    utila
     vault
     keychain
 
@@ -100,8 +102,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 'lts/*'
-          registry-url: 'https://registry.npmjs.org'
+          node-version: "lts/*"
+          registry-url: "https://registry.npmjs.org"
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6.0.7
@@ -421,6 +423,7 @@ jobs:
               '@solana/keychain-para',
               '@solana/keychain-privy',
               '@solana/keychain-turnkey',
+              '@solana/keychain-utila',
               '@solana/keychain-vault',
             ];
 

--- a/.github/workflows/typescript-publish.yml
+++ b/.github/workflows/typescript-publish.yml
@@ -6,7 +6,7 @@ on:
       package:
         description: 'Package to publish (or "all")'
         required: true
-        default: "all"
+        default: 'all'
         type: choice
         options:
           - all
@@ -26,12 +26,12 @@ on:
           - vault
           - keychain
       publish-to-npm:
-        description: "Publish to npm registry"
+        description: 'Publish to npm registry'
         required: true
         default: true
         type: boolean
       create-github-release:
-        description: "Create GitHub release"
+        description: 'Create GitHub release'
         required: true
         default: true
         type: boolean
@@ -102,8 +102,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: "lts/*"
-          registry-url: "https://registry.npmjs.org"
+          node-version: 'lts/*'
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6.0.7

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This repository contains two implementations:
 
 Framework-agnostic Rust library with async support and multiple signing backends.
 
-- **Backends**: Memory, Vault, Privy, Turnkey, AWS KMS, Fireblocks, GCP KMS, Dfns, Para, CDP, Crossmint, Openfort
+- **Backends**: Memory, Vault, Privy, Turnkey, AWS KMS, Fireblocks, GCP KMS, Dfns, Para, CDP, Crossmint, Openfort, Utila
 - **Features**: Async/await, feature flags for zero-cost abstractions, SDK v2 & v3 support
 - [View Rust Documentation →](rust/README.md)
 
@@ -20,7 +20,7 @@ Framework-agnostic Rust library with async support and multiple signing backends
 
 Solana Kit compatible signer implementation for Node.js and browser environments.
 
-- **Backends**: Memory, Vault, Privy, Turnkey, AWS KMS, Fireblocks, GCP KMS, Dfns, Para, CDP, Crossmint, Openfort
+- **Backends**: Memory, Vault, Privy, Turnkey, AWS KMS, Fireblocks, GCP KMS, Dfns, Para, CDP, Crossmint, Openfort, Utila
 - **Features**: Solana Kit compatible, tree-shakeable modules, full type safety
 - [View TypeScript Documentation →](typescript/README.md)
 

--- a/justfile
+++ b/justfile
@@ -4,7 +4,7 @@ sdkv2 := "all,sdk-v2,unsafe-debug"
 sdkv3 := "all,sdk-v3,unsafe-debug"
 sdkv2_int := "all,sdk-v2,unsafe-debug,integration-tests"
 sdkv3_int := "all,sdk-v3,unsafe-debug,integration-tests"
-integration_tests := "test_fireblocks_integration test_privy_integration test_turnkey_integration test_vault_integration test_aws_kms_integration test_utila_integration"
+integration_tests := "test_fireblocks_integration test_privy_integration test_turnkey_integration test_vault_integration test_aws_kms_integration"
 
 default:
     @just --list

--- a/justfile
+++ b/justfile
@@ -4,7 +4,7 @@ sdkv2 := "all,sdk-v2,unsafe-debug"
 sdkv3 := "all,sdk-v3,unsafe-debug"
 sdkv2_int := "all,sdk-v2,unsafe-debug,integration-tests"
 sdkv3_int := "all,sdk-v3,unsafe-debug,integration-tests"
-integration_tests := "test_fireblocks_integration test_privy_integration test_turnkey_integration test_vault_integration test_aws_kms_integration"
+integration_tests := "test_fireblocks_integration test_privy_integration test_turnkey_integration test_vault_integration test_aws_kms_integration test_utila_integration"
 
 default:
     @just --list
@@ -175,7 +175,7 @@ ts-test-integration:
     vault write transit/restore/solana-test-key backup=@"../rust/src/tests/vault-test-key.b64" >/dev/null 2>&1 || true
 
     echo "Running TypeScript integration tests..."
-    pnpm -F @solana/keychain-fireblocks -F @solana/keychain-privy -F @solana/keychain-turnkey -F @solana/keychain-vault test:integration
+    pnpm -F @solana/keychain-fireblocks -F @solana/keychain-privy -F @solana/keychain-turnkey -F @solana/keychain-utila -F @solana/keychain-vault test:integration
 
 # ===========================================================
 # ========================= Release =========================
@@ -344,7 +344,7 @@ release-ts: _check-ts-release
     echo "Updating to $version..."
 
     # Update version in all packages
-    PACKAGES="core aws-kms cdp dfns fireblocks gcp-kms memory openfort para privy turnkey vault keychain test-utils crossmint"
+    PACKAGES="core aws-kms cdp dfns fireblocks gcp-kms memory openfort para privy turnkey utila vault keychain test-utils crossmint"
     for pkg in $PACKAGES; do
         echo "  Updating packages/${pkg}..."
         cd packages/${pkg}
@@ -402,7 +402,7 @@ publish-ts package="all" branch="":
     #!/usr/bin/env bash
     set -euo pipefail
     command -v gh >/dev/null || { echo "Install gh: https://cli.github.com"; exit 1; }
-    valid="all core aws-kms cdp crossmint dfns fireblocks gcp-kms memory openfort para privy turnkey vault keychain"
+    valid="all core aws-kms cdp crossmint dfns fireblocks gcp-kms memory openfort para privy turnkey utila vault keychain"
     if ! echo " $valid " | grep -q " {{package}} "; then
         echo "Error: invalid package '{{package}}'. Valid: $valid"
         exit 1

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -44,6 +44,7 @@ openfort = [
     "dep:sha2",
     "dep:hex",
 ]
+utila = ["dep:reqwest", "dep:jsonwebtoken", "dep:chrono"]
 all = [
     "memory",
     "vault",
@@ -57,6 +58,7 @@ all = [
     "crossmint",
     "dfns",
     "openfort",
+    "utila",
 ]
 
 # SDK version selection (mutually exclusive)

--- a/rust/README.md
+++ b/rust/README.md
@@ -28,6 +28,7 @@
 | **CDP** | Coinbase Developer Platform managed wallet infrastructure | `cdp` |
 | **Crossmint** | Crossmint managed wallets (`smart` and `mpc`) | `crossmint` |
 | **Openfort** | Openfort backend wallets with TEE-stored keys | `openfort` |
+| **Utila** | Utila MPC wallets and automated co-signer flow | `utila` |
 
 ## Installation
 
@@ -47,6 +48,9 @@ solana-keychain = { version = "0.5", features = ["crossmint"] }
 
 # With Openfort support
 solana-keychain = { version = "0.5", features = ["openfort"] }
+
+# With Utila support
+solana-keychain = { version = "0.5", features = ["utila"] }
 
 # All backends
 solana-keychain = { version = "0.5", features = ["all"] }
@@ -220,6 +224,35 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 ```
 
 **Note:** Crossmint `sign_message` is intentionally unsupported in this signer and returns `SigningFailed`.
+
+### Utila Signer
+
+[Utila](https://www.utila.io/) signer for existing Solana wallets.
+
+```rust
+use solana_keychain::{Signer, SolanaSigner, UtilaSignerConfig};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let signer = Signer::from_utila(UtilaSignerConfig {
+        service_account_email: std::env::var("UTILA_SERVICE_ACCOUNT_EMAIL")?,
+        service_account_private_key_pem: std::env::var("UTILA_SERVICE_ACCOUNT_PRIVATE_KEY")?,
+        vault_id: std::env::var("UTILA_VAULT_ID")?,
+        wallet_id: std::env::var("UTILA_WALLET_ID")?,
+        network: std::env::var("UTILA_NETWORK")?,
+        api_base_url: std::env::var("UTILA_API_BASE_URL").ok(),
+        poll_interval_ms: None,
+        max_poll_attempts: None,
+        designated_signers: None,
+        http_client_config: None,
+    }).await?;
+
+    println!("Public key: {}", signer.pubkey());
+    Ok(())
+}
+```
+
+**Note:** Utila `sign_message` is intentionally unsupported in this signer and returns `SigningFailed`. Transaction signing requests are created with `publish=false`; callers remain responsible for broadcasting.
 
 ### Openfort Signer
 

--- a/rust/src/error.rs
+++ b/rust/src/error.rs
@@ -18,7 +18,7 @@ pub enum SignerError {
     #[error("Signing failed")]
     SigningFailed(String),
 
-    /// Remote API error (any remote signer backend: Vault, Privy, Turnkey, Fireblocks, AWS/GCP KMS, Dfns, Crossmint, CDP, Para, Openfort)
+    /// Remote API error (any remote signer backend: Vault, Privy, Turnkey, Fireblocks, AWS/GCP KMS, Dfns, Crossmint, CDP, Para, Openfort, Utila)
     #[error("Remote API error")]
     RemoteApiError(String),
 
@@ -68,7 +68,8 @@ impl From<serde_json::Error> for SignerError {
     feature = "dfns",
     feature = "para",
     feature = "crossmint",
-    feature = "openfort"
+    feature = "openfort",
+    feature = "utila"
 ))]
 impl From<reqwest::Error> for SignerError {
     fn from(err: reqwest::Error) -> Self {

--- a/rust/src/gcp_kms/mod.rs
+++ b/rust/src/gcp_kms/mod.rs
@@ -232,6 +232,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_gcp_kms_new_invalid_pubkey() {
         let client = KeyManagementService::builder().build().await.unwrap();
         let result = GcpKmsSigner::with_client(
@@ -247,6 +248,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_gcp_kms_new_empty_pubkey() {
         let client = KeyManagementService::builder().build().await.unwrap();
         let result = GcpKmsSigner::with_client(client, TEST_KEY_NAME.to_string(), "".to_string());

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! This crate provides a unified interface for signing Solana transactions
 //! with multiple backend implementations (memory, Vault, Privy, Turnkey, AWS KMS,
-//! Fireblocks, GCP KMS, Dfns, Crossmint, CDP, Para, Openfort).
+//! Fireblocks, GCP KMS, Dfns, Crossmint, CDP, Para, Openfort, Utila).
 //!
 //! # Features
 //!
@@ -19,6 +19,7 @@
 //! - `dfns`: Dfns Wallet API integration
 //! - `crossmint`: Crossmint wallet integration
 //! - `openfort`: Openfort backend wallet integration
+//! - `utila`: Utila MPC wallet integration
 //! - `all`: Enable all signer backends
 //!
 //! ## SDK Version Selection
@@ -69,6 +70,8 @@ pub mod dfns;
 pub mod openfort;
 #[cfg(feature = "para")]
 pub mod para;
+#[cfg(feature = "utila")]
+pub mod utila;
 
 // Re-export core types
 pub use error::SignerError;
@@ -107,6 +110,8 @@ pub use dfns::{DfnsSigner, DfnsSignerConfig};
 pub use openfort::{OpenfortSigner, OpenfortSignerConfig};
 #[cfg(feature = "para")]
 pub use para::{ParaSigner, ParaSignerConfig};
+#[cfg(feature = "utila")]
+pub use utila::{UtilaSigner, UtilaSignerConfig};
 
 // Ensure at least one signer backend is enabled
 #[cfg(not(any(
@@ -121,10 +126,11 @@ pub use para::{ParaSigner, ParaSignerConfig};
     feature = "dfns",
     feature = "para",
     feature = "crossmint",
-    feature = "openfort"
+    feature = "openfort",
+    feature = "utila"
 )))]
 compile_error!(
-    "At least one signer backend feature must be enabled: memory, vault, privy, turnkey, aws_kms, fireblocks, gcp_kms, cdp, para, dfns, crossmint, or openfort"
+    "At least one signer backend feature must be enabled: memory, vault, privy, turnkey, aws_kms, fireblocks, gcp_kms, cdp, para, dfns, crossmint, openfort, or utila"
 );
 
 /// Unified signer enum supporting multiple backends
@@ -160,6 +166,8 @@ pub enum Signer {
     Para(ParaSigner),
     #[cfg(feature = "crossmint")]
     Crossmint(CrossmintSigner),
+    #[cfg(feature = "utila")]
+    Utila(UtilaSigner),
 }
 
 impl Signer {
@@ -355,6 +363,16 @@ impl Signer {
         signer.init().await?;
         Ok(Self::Openfort(signer))
     }
+
+    /// Create a Utila signer from an existing Solana wallet.
+    ///
+    /// Fetches the wallet's Solana address from Utila during initialization.
+    #[cfg(feature = "utila")]
+    pub async fn from_utila(config: UtilaSignerConfig) -> Result<Self, SignerError> {
+        let mut signer = UtilaSigner::new(config)?;
+        signer.init().await?;
+        Ok(Self::Utila(signer))
+    }
 }
 
 #[async_trait::async_trait]
@@ -392,6 +410,8 @@ impl SolanaSigner for Signer {
             Signer::Para(s) => s.pubkey(),
             #[cfg(feature = "crossmint")]
             Signer::Crossmint(s) => s.pubkey(),
+            #[cfg(feature = "utila")]
+            Signer::Utila(s) => s.pubkey(),
         }
     }
 
@@ -431,6 +451,8 @@ impl SolanaSigner for Signer {
             Signer::Para(s) => s.sign_transaction(tx).await,
             #[cfg(feature = "crossmint")]
             Signer::Crossmint(s) => s.sign_transaction(tx).await,
+            #[cfg(feature = "utila")]
+            Signer::Utila(s) => s.sign_transaction(tx).await,
         }
     }
 
@@ -467,6 +489,8 @@ impl SolanaSigner for Signer {
             Signer::Para(s) => s.sign_message(message).await,
             #[cfg(feature = "crossmint")]
             Signer::Crossmint(s) => s.sign_message(message).await,
+            #[cfg(feature = "utila")]
+            Signer::Utila(s) => s.sign_message(message).await,
         }
     }
 
@@ -503,6 +527,8 @@ impl SolanaSigner for Signer {
             Signer::Para(s) => s.is_available().await,
             #[cfg(feature = "crossmint")]
             Signer::Crossmint(s) => s.is_available().await,
+            #[cfg(feature = "utila")]
+            Signer::Utila(s) => s.is_available().await,
         }
     }
 }

--- a/rust/src/tests/mod.rs
+++ b/rust/src/tests/mod.rs
@@ -11,4 +11,5 @@ pub mod test_openfort_integration;
 pub mod test_para_integration;
 pub mod test_privy_integration;
 pub mod test_turnkey_integration;
+pub mod test_utila_integration;
 pub mod test_vault_integration;

--- a/rust/src/tests/test_utila_integration.rs
+++ b/rust/src/tests/test_utila_integration.rs
@@ -1,0 +1,96 @@
+pub const UTILA_SERVICE_ACCOUNT_EMAIL: &str = "UTILA_SERVICE_ACCOUNT_EMAIL";
+pub const UTILA_SERVICE_ACCOUNT_PRIVATE_KEY: &str = "UTILA_SERVICE_ACCOUNT_PRIVATE_KEY";
+pub const UTILA_VAULT_ID: &str = "UTILA_VAULT_ID";
+pub const UTILA_WALLET_ID: &str = "UTILA_WALLET_ID";
+pub const UTILA_NETWORK: &str = "UTILA_NETWORK";
+pub const UTILA_API_BASE_URL: &str = "UTILA_API_BASE_URL";
+pub const UTILA_POLL_INTERVAL_MS: &str = "UTILA_POLL_INTERVAL_MS";
+pub const UTILA_MAX_POLL_ATTEMPTS: &str = "UTILA_MAX_POLL_ATTEMPTS";
+
+#[cfg(feature = "utila")]
+#[cfg(test)]
+mod tests {
+    use dotenvy::dotenv;
+    use std::env;
+
+    use super::*;
+    use crate::sdk_adapter::{Message, Transaction};
+    use crate::tests::rpc_util::get_rpc_blockhash;
+    use crate::traits::SolanaSigner;
+    use crate::utila::{UtilaSigner, UtilaSignerConfig};
+
+    fn required_env(name: &str) -> String {
+        match env::var(name) {
+            Ok(value) if !value.trim().is_empty() => value,
+            Ok(_) => panic!("{name} must be non-empty for integration tests"),
+            Err(_) => panic!("{name} must be set for integration tests"),
+        }
+    }
+
+    async fn get_signer() -> UtilaSigner {
+        dotenv().ok();
+
+        let mut signer = UtilaSigner::new(UtilaSignerConfig {
+            service_account_email: required_env(UTILA_SERVICE_ACCOUNT_EMAIL),
+            service_account_private_key_pem: required_env(UTILA_SERVICE_ACCOUNT_PRIVATE_KEY),
+            vault_id: required_env(UTILA_VAULT_ID),
+            wallet_id: required_env(UTILA_WALLET_ID),
+            network: required_env(UTILA_NETWORK),
+            api_base_url: env::var(UTILA_API_BASE_URL).ok(),
+            poll_interval_ms: env::var(UTILA_POLL_INTERVAL_MS)
+                .ok()
+                .and_then(|value| value.parse().ok()),
+            max_poll_attempts: env::var(UTILA_MAX_POLL_ATTEMPTS)
+                .ok()
+                .and_then(|value| value.parse().ok()),
+            designated_signers: None,
+            http_client_config: None,
+        })
+        .expect("Failed to create UtilaSigner");
+
+        signer
+            .init()
+            .await
+            .expect("Failed to initialize UtilaSigner");
+        signer
+    }
+
+    #[tokio::test]
+    #[cfg(feature = "integration-tests")]
+    async fn test_utila_sign_message_not_supported() {
+        let signer = get_signer().await;
+        let result = signer.sign_message(b"utila-test").await;
+        assert!(result.is_err(), "sign_message should be unsupported");
+    }
+
+    #[tokio::test]
+    #[cfg(feature = "integration-tests")]
+    async fn test_utila_sign_transaction() {
+        let signer = get_signer().await;
+
+        let rpc_url = env::var("SOLANA_RPC_URL")
+            .unwrap_or_else(|_| "https://api.devnet.solana.com".to_string());
+        let latest_blockhash = get_rpc_blockhash(&rpc_url)
+            .await
+            .expect("Failed to fetch latest RPC blockhash");
+
+        let message = Message::new(&[], Some(&signer.pubkey()));
+        let mut transaction = Transaction::new_unsigned(message);
+        transaction.message.recent_blockhash = latest_blockhash;
+
+        let (_base64_txn, signature) = signer
+            .sign_transaction(&mut transaction)
+            .await
+            .expect("Failed to sign transaction with Utila")
+            .into_signed_transaction();
+
+        assert_eq!(signature.as_ref().len(), 64, "Signature should be 64 bytes");
+    }
+
+    #[tokio::test]
+    #[cfg(feature = "integration-tests")]
+    async fn test_utila_is_available() {
+        let signer = get_signer().await;
+        assert!(signer.is_available().await);
+    }
+}

--- a/rust/src/utila/mod.rs
+++ b/rust/src/utila/mod.rs
@@ -1,0 +1,947 @@
+//! Utila API signer integration
+
+mod types;
+
+use crate::sdk_adapter::{Pubkey, Signature, Transaction, VersionedTransaction};
+use crate::traits::{SignTransactionResult, SignedTransaction};
+use crate::transaction_util::TransactionUtil;
+use crate::{error::SignerError, http_client_config::HttpClientConfig, traits::SolanaSigner};
+use base64::{engine::general_purpose::STANDARD, Engine};
+use chrono::{Duration, Utc};
+use jsonwebtoken::{encode, Algorithm, EncodingKey, Header};
+use serde::Serialize;
+use std::{str::FromStr, sync::Arc};
+use types::{
+    InitiateTransactionDetails, InitiateTransactionRequest, SolanaSerializedTransaction,
+    TransactionEnvelope, TransactionState, UtilaTransaction, WalletResponse,
+};
+
+const DEFAULT_API_BASE_URL: &str = "https://api.utila.io";
+const UTILA_API_AUDIENCE: &str = "https://api.utila.io/";
+const DEFAULT_POLL_INTERVAL_MS: u64 = 1000;
+const DEFAULT_MAX_POLL_ATTEMPTS: u32 = 60;
+const TOKEN_TTL_MINUTES: i64 = 55;
+const AVAILABILITY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+
+/// Configuration for creating a UtilaSigner.
+#[derive(Clone)]
+pub struct UtilaSignerConfig {
+    pub service_account_email: String,
+    pub service_account_private_key_pem: String,
+    pub vault_id: String,
+    pub wallet_id: String,
+    /// Utila network resource name, e.g. `networks/solana-devnet`.
+    pub network: String,
+    pub api_base_url: Option<String>,
+    pub poll_interval_ms: Option<u64>,
+    pub max_poll_attempts: Option<u32>,
+    /// Utila signer resource names. Defaults to `users/{service_account_email}`.
+    pub designated_signers: Option<Vec<String>>,
+    pub http_client_config: Option<HttpClientConfig>,
+}
+
+/// Utila-backed signer using an existing Solana wallet.
+#[derive(Clone)]
+pub struct UtilaSigner {
+    service_account_email: String,
+    signing_key: Arc<EncodingKey>,
+    vault_id: String,
+    wallet_id: String,
+    network: String,
+    api_base_url: String,
+    client: reqwest::Client,
+    public_key: Option<Pubkey>,
+    poll_interval_ms: u64,
+    max_poll_attempts: u32,
+    designated_signers: Vec<String>,
+}
+
+impl std::fmt::Debug for UtilaSigner {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("UtilaSigner")
+            .field("public_key", &self.public_key)
+            .field("vault_id", &self.vault_id)
+            .field("wallet_id", &self.wallet_id)
+            .field("network", &self.network)
+            .finish_non_exhaustive()
+    }
+}
+
+#[derive(Serialize)]
+struct UtilaAccessTokenClaims<'a> {
+    sub: &'a str,
+    aud: &'a str,
+    exp: i64,
+}
+
+impl UtilaSigner {
+    /// Create a new Utila signer.
+    ///
+    /// You must call `init()` after construction to fetch the wallet address.
+    pub fn new(config: UtilaSignerConfig) -> Result<Self, SignerError> {
+        validate_required("service_account_email", &config.service_account_email)?;
+        validate_required(
+            "service_account_private_key_pem",
+            &config.service_account_private_key_pem,
+        )?;
+        validate_required("vault_id", &config.vault_id)?;
+        validate_required("wallet_id", &config.wallet_id)?;
+        validate_required("network", &config.network)?;
+
+        let api_base_url = normalize_api_base_url(config.api_base_url.as_deref())?;
+        let poll_interval_ms = config.poll_interval_ms.unwrap_or(DEFAULT_POLL_INTERVAL_MS);
+        if poll_interval_ms == 0 {
+            return Err(SignerError::ConfigError(
+                "poll_interval_ms must be greater than 0".to_string(),
+            ));
+        }
+
+        let max_poll_attempts = config
+            .max_poll_attempts
+            .unwrap_or(DEFAULT_MAX_POLL_ATTEMPTS);
+        if max_poll_attempts == 0 {
+            return Err(SignerError::ConfigError(
+                "max_poll_attempts must be greater than 0".to_string(),
+            ));
+        }
+
+        let signing_key = EncodingKey::from_rsa_pem(
+            config.service_account_private_key_pem.as_bytes(),
+        )
+        .map_err(|_| {
+            SignerError::InvalidPrivateKey(
+                "Failed to parse Utila service account RSA private key".to_string(),
+            )
+        })?;
+
+        let http_client_config = config.http_client_config.unwrap_or_default();
+        let builder = reqwest::Client::builder()
+            .timeout(http_client_config.resolved_request_timeout())
+            .connect_timeout(http_client_config.resolved_connect_timeout());
+        #[cfg(not(test))]
+        let builder = builder.https_only(true);
+        let client = builder
+            .build()
+            .map_err(|e| SignerError::ConfigError(format!("Failed to build HTTP client: {e}")))?;
+
+        let designated_signers = config
+            .designated_signers
+            .unwrap_or_else(|| vec![format!("users/{}", config.service_account_email)]);
+
+        Ok(Self {
+            service_account_email: config.service_account_email,
+            signing_key: Arc::new(signing_key),
+            vault_id: trim_resource_prefix(&config.vault_id, "vaults/").to_string(),
+            wallet_id: trim_wallet_id(&config.wallet_id).to_string(),
+            network: config.network,
+            api_base_url,
+            client,
+            public_key: None,
+            poll_interval_ms,
+            max_poll_attempts,
+            designated_signers,
+        })
+    }
+
+    /// Initialize signer by fetching the Solana wallet address from Utila.
+    pub async fn init(&mut self) -> Result<(), SignerError> {
+        let wallet = self.fetch_wallet().await?;
+        let address = wallet
+            .wallet
+            .solana_details
+            .ok_or_else(|| {
+                SignerError::InvalidPublicKey(
+                    "Utila wallet response did not include solanaDetails".to_string(),
+                )
+            })?
+            .address;
+
+        let pubkey = Pubkey::from_str(&address).map_err(|_| {
+            SignerError::InvalidPublicKey(
+                "Invalid Solana address returned by Utila wallet".to_string(),
+            )
+        })?;
+
+        self.public_key = Some(pubkey);
+        Ok(())
+    }
+
+    fn initialized_pubkey(&self) -> Result<Pubkey, SignerError> {
+        self.public_key.ok_or_else(|| {
+            SignerError::ConfigError(
+                "UtilaSigner is not initialized; call init() before signing".to_string(),
+            )
+        })
+    }
+
+    fn create_access_token(&self) -> Result<String, SignerError> {
+        let claims = UtilaAccessTokenClaims {
+            sub: &self.service_account_email,
+            aud: UTILA_API_AUDIENCE,
+            exp: (Utc::now() + Duration::minutes(TOKEN_TTL_MINUTES)).timestamp(),
+        };
+
+        encode(&Header::new(Algorithm::RS256), &claims, &self.signing_key).map_err(|_| {
+            SignerError::SigningFailed("Failed to create Utila access token".to_string())
+        })
+    }
+
+    async fn fetch_wallet(&self) -> Result<WalletResponse, SignerError> {
+        let path = format!("/v2/vaults/{}/wallets/{}", self.vault_id, self.wallet_id);
+        self.get_json(&path, "fetch_wallet").await
+    }
+
+    async fn initiate_transaction(
+        &self,
+        raw_transaction: String,
+    ) -> Result<UtilaTransaction, SignerError> {
+        let path = format!("/v2/vaults/{}{}", self.vault_id, "/transactions:initiate");
+        let request = InitiateTransactionRequest {
+            details: InitiateTransactionDetails {
+                solana_serialized_transaction: SolanaSerializedTransaction {
+                    network: self.network.clone(),
+                    raw_transaction,
+                    publish: false,
+                    replace_blockhash: false,
+                    try_replace_blockhash: false,
+                },
+            },
+            designated_signers: self.designated_signers.clone(),
+        };
+
+        let envelope: TransactionEnvelope = self
+            .post_json(&path, &request, "initiate_transaction")
+            .await?;
+        Ok(envelope.transaction)
+    }
+
+    async fn get_transaction(&self, transaction_id: &str) -> Result<UtilaTransaction, SignerError> {
+        let path = format!(
+            "/v2/vaults/{}/transactions/{}?view=FULL",
+            self.vault_id,
+            encode_uri_component(transaction_id)
+        );
+        let envelope: TransactionEnvelope = self.get_json(&path, "get_transaction").await?;
+        Ok(envelope.transaction)
+    }
+
+    async fn get_json<T>(&self, path: &str, context: &str) -> Result<T, SignerError>
+    where
+        T: serde::de::DeserializeOwned,
+    {
+        let token = self.create_access_token()?;
+        let response = self
+            .client
+            .get(self.build_url(path)?)
+            .header("Authorization", format!("Bearer {token}"))
+            .send()
+            .await?;
+
+        parse_response(response, context).await
+    }
+
+    async fn post_json<T, B>(&self, path: &str, body: &B, context: &str) -> Result<T, SignerError>
+    where
+        T: serde::de::DeserializeOwned,
+        B: Serialize + ?Sized,
+    {
+        let token = self.create_access_token()?;
+        let response = self
+            .client
+            .post(self.build_url(path)?)
+            .header("Authorization", format!("Bearer {token}"))
+            .json(body)
+            .send()
+            .await?;
+
+        parse_response(response, context).await
+    }
+
+    fn build_url(&self, path: &str) -> Result<String, SignerError> {
+        let base = reqwest::Url::parse(&self.api_base_url)
+            .map_err(|e| SignerError::ConfigError(format!("Invalid api_base_url: {e}")))?;
+        if base.cannot_be_a_base() {
+            return Err(SignerError::ConfigError(
+                "api_base_url cannot be used as a base URL".to_string(),
+            ));
+        }
+
+        Ok(format!(
+            "{}{}",
+            self.api_base_url.trim_end_matches('/'),
+            path
+        ))
+    }
+
+    async fn poll_signed_transaction(
+        &self,
+        mut transaction: UtilaTransaction,
+    ) -> Result<UtilaTransaction, SignerError> {
+        for _ in 0..self.max_poll_attempts {
+            match transaction.state {
+                TransactionState::Signed => return Ok(transaction),
+                state if state.is_terminal_failure() => {
+                    return Err(SignerError::SigningFailed(format!(
+                        "Utila transaction reached terminal state {state:?}"
+                    )));
+                }
+                _ => {
+                    tokio::time::sleep(tokio::time::Duration::from_millis(self.poll_interval_ms))
+                        .await;
+                    let transaction_id = extract_transaction_id(&transaction.name)?;
+                    transaction = self.get_transaction(&transaction_id).await?;
+                }
+            }
+        }
+
+        if transaction.state == TransactionState::Signed {
+            Ok(transaction)
+        } else if transaction.state.is_terminal_failure() {
+            Err(SignerError::SigningFailed(format!(
+                "Utila transaction reached terminal state {:?}",
+                transaction.state
+            )))
+        } else {
+            Err(SignerError::SigningFailed(format!(
+                "Utila transaction polling timed out after {} attempts",
+                self.max_poll_attempts
+            )))
+        }
+    }
+
+    fn extract_signature_from_raw_transaction(
+        &self,
+        raw_transaction: &str,
+        expected_message: &[u8],
+    ) -> Result<Signature, SignerError> {
+        let public_key = self.initialized_pubkey()?;
+        let bytes = STANDARD.decode(raw_transaction).map_err(|_| {
+            SignerError::SerializationError(
+                "Failed to decode Utila rawTransaction as base64".to_string(),
+            )
+        })?;
+
+        let signature = match bincode::deserialize::<VersionedTransaction>(&bytes) {
+            Ok(transaction) => {
+                let remote_message = transaction.message.serialize();
+                if remote_message != expected_message {
+                    return Err(SignerError::SigningFailed(
+                        "Utila returned a signed transaction with different message bytes"
+                            .to_string(),
+                    ));
+                }
+
+                let required_signers =
+                    usize::from(transaction.message.header().num_required_signatures);
+                let signer_keys = transaction.message.static_account_keys();
+                if signer_keys.len() < required_signers {
+                    return Err(SignerError::SigningFailed(
+                        "Invalid account index: not enough account keys".to_string(),
+                    ));
+                }
+
+                let position = signer_keys
+                    .iter()
+                    .take(required_signers)
+                    .position(|key| key == &public_key)
+                    .ok_or_else(|| {
+                        SignerError::SigningFailed(
+                            "Failed to locate signer pubkey in Utila transaction".to_string(),
+                        )
+                    })?;
+
+                transaction
+                    .signatures
+                    .get(position)
+                    .copied()
+                    .filter(|sig| *sig != Signature::default())
+                    .ok_or_else(|| {
+                        SignerError::SigningFailed(
+                            "Utila rawTransaction did not contain a signer signature".to_string(),
+                        )
+                    })?
+            }
+            Err(_) => {
+                let transaction: Transaction = bincode::deserialize(&bytes).map_err(|_| {
+                    SignerError::SerializationError(
+                        "Failed to deserialize Utila rawTransaction".to_string(),
+                    )
+                })?;
+
+                let remote_message = transaction.message_data();
+                if remote_message != expected_message {
+                    return Err(SignerError::SigningFailed(
+                        "Utila returned a signed transaction with different message bytes"
+                            .to_string(),
+                    ));
+                }
+
+                let position =
+                    TransactionUtil::get_signing_keypair_position(&transaction, &public_key)?;
+                transaction
+                    .signatures
+                    .get(position)
+                    .copied()
+                    .filter(|sig| *sig != Signature::default())
+                    .ok_or_else(|| {
+                        SignerError::SigningFailed(
+                            "Utila rawTransaction did not contain a signer signature".to_string(),
+                        )
+                    })?
+            }
+        };
+
+        if !signature.verify(&public_key.to_bytes(), expected_message) {
+            return Err(SignerError::SigningFailed(
+                "Signature verification failed for Utila rawTransaction".to_string(),
+            ));
+        }
+
+        Ok(signature)
+    }
+
+    async fn sign_and_serialize(
+        &self,
+        transaction: &mut Transaction,
+    ) -> Result<SignedTransaction, SignerError> {
+        let public_key = self.initialized_pubkey()?;
+        let expected_message = transaction.message_data();
+        let raw_transaction = STANDARD.encode(bincode::serialize(transaction).map_err(|e| {
+            SignerError::SerializationError(format!("Failed to serialize transaction: {e}"))
+        })?);
+
+        let initiated = self.initiate_transaction(raw_transaction).await?;
+        let signed = self.poll_signed_transaction(initiated).await?;
+        let raw_signed_transaction = signed
+            .solana_transaction
+            .and_then(|solana| solana.raw_transaction)
+            .ok_or_else(|| {
+                SignerError::SigningFailed(
+                    "Utila signed transaction response missing solanaTransaction.rawTransaction"
+                        .to_string(),
+                )
+            })?;
+        let signature = self
+            .extract_signature_from_raw_transaction(&raw_signed_transaction, &expected_message)?;
+
+        TransactionUtil::add_signature_to_transaction(transaction, &public_key, signature)?;
+        Ok((
+            TransactionUtil::serialize_transaction(transaction)?,
+            signature,
+        ))
+    }
+
+    async fn check_availability(&self) -> bool {
+        let result = tokio::time::timeout(AVAILABILITY_TIMEOUT, self.fetch_wallet()).await;
+        matches!(result, Ok(Ok(_)))
+    }
+}
+
+#[async_trait::async_trait]
+impl SolanaSigner for UtilaSigner {
+    fn pubkey(&self) -> Pubkey {
+        self.public_key.expect("UtilaSigner not initialized")
+    }
+
+    async fn sign_transaction(
+        &self,
+        tx: &mut Transaction,
+    ) -> Result<SignTransactionResult, SignerError> {
+        let signed_transaction = self.sign_and_serialize(tx).await?;
+        Ok(TransactionUtil::classify_signed_transaction(
+            tx,
+            signed_transaction,
+        ))
+    }
+
+    async fn sign_message(&self, _message: &[u8]) -> Result<Signature, SignerError> {
+        Err(SignerError::SigningFailed(
+            "Utila sign_message is not supported for Solana wallets in this signer".to_string(),
+        ))
+    }
+
+    async fn is_available(&self) -> bool {
+        self.check_availability().await
+    }
+}
+
+async fn parse_response<T>(response: reqwest::Response, context: &str) -> Result<T, SignerError>
+where
+    T: serde::de::DeserializeOwned,
+{
+    let status = response.status().as_u16();
+    let text = response.text().await.unwrap_or_default();
+
+    if status >= 400 {
+        #[cfg(feature = "unsafe-debug")]
+        log::error!("Utila API {context} error - status: {status}, response: {text}");
+
+        #[cfg(not(feature = "unsafe-debug"))]
+        log::error!("Utila API {context} error - status: {status}");
+
+        return Err(SignerError::RemoteApiError(format!(
+            "Utila API {context} error {status}"
+        )));
+    }
+
+    serde_json::from_str(&text).map_err(|_| {
+        SignerError::SerializationError(format!("Failed to parse Utila {context} response"))
+    })
+}
+
+fn validate_required(field: &str, value: &str) -> Result<(), SignerError> {
+    if value.trim().is_empty() {
+        return Err(SignerError::ConfigError(format!(
+            "{field} must not be empty"
+        )));
+    }
+    Ok(())
+}
+
+fn normalize_api_base_url(value: Option<&str>) -> Result<String, SignerError> {
+    let api_base_url = value
+        .unwrap_or(DEFAULT_API_BASE_URL)
+        .trim_end_matches('/')
+        .to_string();
+
+    let parsed = reqwest::Url::parse(&api_base_url)
+        .map_err(|e| SignerError::ConfigError(format!("Invalid api_base_url: {e}")))?;
+    if parsed.scheme() != "https" {
+        return Err(SignerError::ConfigError(
+            "api_base_url must use HTTPS".to_string(),
+        ));
+    }
+
+    Ok(api_base_url)
+}
+
+fn extract_transaction_id(name: &str) -> Result<String, SignerError> {
+    name.rsplit('/')
+        .next()
+        .filter(|value| !value.is_empty())
+        .map(ToString::to_string)
+        .ok_or_else(|| {
+            SignerError::SerializationError(
+                "Utila transaction response missing transaction id".to_string(),
+            )
+        })
+}
+
+fn trim_resource_prefix<'a>(value: &'a str, prefix: &str) -> &'a str {
+    value.strip_prefix(prefix).unwrap_or(value)
+}
+
+fn trim_wallet_id(value: &str) -> &str {
+    if let Some((_, wallet_id)) = value.rsplit_once("/wallets/") {
+        wallet_id
+    } else {
+        value
+    }
+}
+
+fn encode_uri_component(input: &str) -> String {
+    let mut encoded = String::with_capacity(input.len());
+    for byte in input.bytes() {
+        if matches!(
+            byte,
+            b'A'..=b'Z'
+                | b'a'..=b'z'
+                | b'0'..=b'9'
+                | b'-'
+                | b'_'
+                | b'.'
+                | b'!'
+                | b'~'
+                | b'*'
+                | b'\''
+                | b'('
+                | b')'
+        ) {
+            encoded.push(byte as char);
+        } else {
+            encoded.push_str(&format!("%{:02X}", byte));
+        }
+    }
+    encoded
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sdk_adapter::{keypair_pubkey, keypair_sign_message, Keypair};
+    use crate::test_util::create_test_transaction;
+    use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+    use serde_json::Value;
+    use wiremock::{
+        matchers::{body_json, method, path},
+        Mock, MockServer, ResponseTemplate,
+    };
+
+    const TEST_EMAIL: &str = "service-account@vault.utilaserviceaccount.io";
+    const TEST_VAULT_ID: &str = "vault-test";
+    const TEST_WALLET_ID: &str = "wallet-test";
+    const TEST_NETWORK: &str = "networks/solana-devnet";
+    const TEST_RSA_KEY: &str = r#"-----BEGIN PRIVATE KEY-----
+MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQDKKw7fHhfK3/Ts
+rAqsNCrDsjmyBTHx/AUCOTM+tZph2ZOyDSH9nZO4JkzLrW6Vfk7EZvlP3QjLiXEG
+m9qQgAh9sXgp07GicWU5omSILTMdd18yR6aIXVw/YzgjD7EVLRQU6YHc3BYgR8P8
+PBbJcxzYrrUDSGEXX2b44cZO72RxIPM+yeY3ZXiztgFQSpfEIKX488/k/PgUHMHK
+/04VoL/jiQa5dOs44CmHHT6MbBT1Sb/VR0G1hHtfMSIQCtdvzt+VBZhg7sxm50h/
+cT+n0UVOBwEp2IY2x4lzlwOdptZl7P3D1+A2rAbalXg5WO+LVEjx5ym++XbCGyvU
+rlH+ILOPAgMBAAECggEAXio3F5J/N4YgITqzD+mOf69cc0A7NsCRnqsA5PUWbvw2
+cIjwa55BZ1UjkPz7lJML4iwqdNn51j/yzsa6Q3L3QYBvfV/2jbiuku1CUTFobRGk
+XBmGhl6h8H5o79/HthrUjzcCP1qdzbRPo4Vjgbpl1cFuW5STcJ0Fq+gRg8O6b3w7
+A2843mcF9EA9ZFjXpn+VtpzLe4nHVRZFYXvXSlfdYc6WQbThnLLiLQYsVMqhYQAU
+I4c9hfgasfgZ6iCV5hMK2ZPX45+/OVQzjh4+I8zlvNWp2cKNoEhMHU2G/In11yBF
+wHGRuvbwx9Wc4Okqq+GvfTO0jCAinAQQu8C+eIcNcQKBgQDo9dzw2cNsJmaUvaL5
+I7gEtbPdr+CTgVjGoVUIlGeI0OBHt1DJEwczS2tycScE9SUDLdmegYA8ubHsAs/6
+PFEJ+779h9/IDzL3Fe9Zp1fiQgWOKF1uCS7+b8QwFMhh2u0OLWmI1rdFmqX2KCPf
+AfD/Pvp6bgapXTN1EoB3LQ/4PwKBgQDeKZeJMk9CZzWFe+m5x2yzJBK62ZvKzyjZ
+Y3IeK75V0xG+Y7ZAb0zTXPkgBpBiQOqdFRgt6bp/S/6Tq/OXfeV9xVURSz4zRtCR
+lRoONL8ZSl0h4VptEjXrYfBnH2j4gtjhnTATJZBp0rYrExbz0jVbQtRzPLs+k3+p
+TuZA8+XwsQKBgCocn8buJpR7UJncugQ9f7tiOVR+waMIg8rMSTnW0ex6jcCJE9J1
+XRzZql+ysrIDuqAbfrZXhJ31l4Mpcv0yQBgE6R6dnEdm7/iYf37+cDWXZ7et9k24
+3UTjYVyrtRlzYNzqOqSg49pyPUQFN47NpAoQEWlmUE/3aCDmqlBg1f0zAoGAamv+
+HUiuUx7hspnTMp1nYsEq/7ryOErYRJqwtec6fB5p54wYZ/FpGe71n/PFAmwadzj9
+pjDKl+QthUvfmnhCkOcQgwJKP4Hys2p7WsbFrDXFO0+aY5lPnvwBj0SqojD798e2
+mdVqwmafwS6Z1h6iVJ9E6hbzk1xQ0SfsgLzVL2ECgYBN6fJ99og4fkp4iA5C31TB
+UKlH64yqwxFu4vuVMqBOpGPkdsLNGhE/vpdP7yYxC/MP+v8ow/sCa40Ely20Yqqa
+znT9Ik5JV4eRXyRG9iwllKvcrmczFDIuxFmXPff4G9nmyB9fLQfSM0gD+yDR05Hx
+p6B5CCtpBPgD01Vm+bT/JQ==
+-----END PRIVATE KEY-----"#;
+
+    fn config() -> UtilaSignerConfig {
+        UtilaSignerConfig {
+            service_account_email: TEST_EMAIL.to_string(),
+            service_account_private_key_pem: TEST_RSA_KEY.to_string(),
+            vault_id: TEST_VAULT_ID.to_string(),
+            wallet_id: TEST_WALLET_ID.to_string(),
+            network: TEST_NETWORK.to_string(),
+            api_base_url: None,
+            poll_interval_ms: Some(1),
+            max_poll_attempts: Some(2),
+            designated_signers: None,
+            http_client_config: None,
+        }
+    }
+
+    fn create_test_signer(base_url: &str, public_key: Option<Pubkey>) -> UtilaSigner {
+        UtilaSigner {
+            service_account_email: TEST_EMAIL.to_string(),
+            signing_key: Arc::new(EncodingKey::from_rsa_pem(TEST_RSA_KEY.as_bytes()).unwrap()),
+            vault_id: TEST_VAULT_ID.to_string(),
+            wallet_id: TEST_WALLET_ID.to_string(),
+            network: TEST_NETWORK.to_string(),
+            api_base_url: base_url.trim_end_matches('/').to_string(),
+            client: reqwest::Client::builder().build().unwrap(),
+            public_key,
+            poll_interval_ms: 1,
+            max_poll_attempts: 2,
+            designated_signers: vec![format!("users/{TEST_EMAIL}")],
+        }
+    }
+
+    fn wallet_response(address: &str) -> ResponseTemplate {
+        ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "wallet": {
+                "solanaDetails": {
+                    "address": address
+                }
+            }
+        }))
+    }
+
+    fn signed_transaction_payload() -> (Keypair, Transaction, String, String, Signature) {
+        let keypair = Keypair::new();
+        let public_key = keypair_pubkey(&keypair);
+        let unsigned = create_test_transaction(&public_key);
+        let unsigned_raw = STANDARD.encode(bincode::serialize(&unsigned).unwrap());
+
+        let mut signed = unsigned.clone();
+        let signature = keypair_sign_message(&keypair, &signed.message_data());
+        TransactionUtil::add_signature_to_transaction(&mut signed, &public_key, signature).unwrap();
+        let signed_raw = STANDARD.encode(bincode::serialize(&signed).unwrap());
+
+        (keypair, unsigned, unsigned_raw, signed_raw, signature)
+    }
+
+    fn decode_jwt_payload(jwt: &str) -> Value {
+        let parts: Vec<&str> = jwt.split('.').collect();
+        let payload_b64 = parts.get(1).expect("jwt payload should exist");
+        let payload_bytes = URL_SAFE_NO_PAD
+            .decode(payload_b64)
+            .expect("payload should be base64url");
+        serde_json::from_slice::<Value>(&payload_bytes).expect("payload should be valid json")
+    }
+
+    #[test]
+    fn test_new_rejects_missing_config() {
+        let mut config = config();
+        config.service_account_email = String::new();
+        assert!(matches!(
+            UtilaSigner::new(config),
+            Err(SignerError::ConfigError(_))
+        ));
+    }
+
+    #[test]
+    fn test_new_rejects_insecure_api_base_url() {
+        let mut config = config();
+        config.api_base_url = Some("http://api.utila.test".to_string());
+        assert!(matches!(
+            UtilaSigner::new(config),
+            Err(SignerError::ConfigError(_))
+        ));
+    }
+
+    #[test]
+    fn test_create_access_token_claims() {
+        let signer = UtilaSigner::new(config()).expect("signer should be created");
+        let token = signer
+            .create_access_token()
+            .expect("access token should be created");
+        let payload = decode_jwt_payload(&token);
+
+        assert_eq!(payload["sub"], TEST_EMAIL);
+        assert_eq!(payload["aud"], UTILA_API_AUDIENCE);
+        assert!(payload["exp"].as_i64().is_some());
+    }
+
+    #[tokio::test]
+    async fn test_init_fetches_solana_address() {
+        let server = MockServer::start().await;
+        let keypair = Keypair::new();
+        let public_key = keypair_pubkey(&keypair);
+
+        Mock::given(method("GET"))
+            .and(path("/v2/vaults/vault-test/wallets/wallet-test"))
+            .respond_with(wallet_response(&public_key.to_string()))
+            .mount(&server)
+            .await;
+
+        let mut signer = create_test_signer(&server.uri(), None);
+        signer.init().await.expect("init should fetch address");
+        assert_eq!(signer.pubkey(), public_key);
+    }
+
+    #[tokio::test]
+    async fn test_sign_message_not_supported() {
+        let keypair = Keypair::new();
+        let signer = create_test_signer(&server_url(), Some(keypair_pubkey(&keypair)));
+        let result = signer.sign_message(b"hello").await;
+        assert!(matches!(result, Err(SignerError::SigningFailed(_))));
+    }
+
+    #[tokio::test]
+    async fn test_sign_transaction_posts_payload_and_polls_signed_response() {
+        let server = MockServer::start().await;
+        let (keypair, mut transaction, unsigned_raw, signed_raw, expected_signature) =
+            signed_transaction_payload();
+        let public_key = keypair_pubkey(&keypair);
+
+        Mock::given(method("POST"))
+            .and(path("/v2/vaults/vault-test/transactions:initiate"))
+            .and(body_json(serde_json::json!({
+                "details": {
+                    "solanaSerializedTransaction": {
+                        "network": TEST_NETWORK,
+                        "rawTransaction": unsigned_raw,
+                        "publish": false,
+                        "replaceBlockhash": false,
+                        "tryReplaceBlockhash": false
+                    }
+                },
+                "designatedSigners": [format!("users/{TEST_EMAIL}")]
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "transaction": {
+                    "name": "vaults/vault-test/transactions/tx-1",
+                    "state": "AWAITING_SIGNATURE"
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/v2/vaults/vault-test/transactions/tx-1"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "transaction": {
+                    "name": "vaults/vault-test/transactions/tx-1",
+                    "state": "SIGNED",
+                    "solanaTransaction": {
+                        "rawTransaction": signed_raw
+                    }
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let signer = create_test_signer(&server.uri(), Some(public_key));
+        let result = signer
+            .sign_transaction(&mut transaction)
+            .await
+            .expect("transaction should sign");
+        let (_, signature) = result.into_signed_transaction();
+
+        assert_eq!(signature, expected_signature);
+        assert_eq!(transaction.signatures[0], expected_signature);
+    }
+
+    #[tokio::test]
+    async fn test_sign_transaction_terminal_failure() {
+        let server = MockServer::start().await;
+        let (keypair, mut transaction, unsigned_raw, _, _) = signed_transaction_payload();
+
+        Mock::given(method("POST"))
+            .and(path("/v2/vaults/vault-test/transactions:initiate"))
+            .and(body_json(serde_json::json!({
+                "details": {
+                    "solanaSerializedTransaction": {
+                        "network": TEST_NETWORK,
+                        "rawTransaction": unsigned_raw,
+                        "publish": false,
+                        "replaceBlockhash": false,
+                        "tryReplaceBlockhash": false
+                    }
+                },
+                "designatedSigners": [format!("users/{TEST_EMAIL}")]
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "transaction": {
+                    "name": "vaults/vault-test/transactions/tx-1",
+                    "state": "FAILED"
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let signer = create_test_signer(&server.uri(), Some(keypair_pubkey(&keypair)));
+        let result = signer.sign_transaction(&mut transaction).await;
+        assert!(matches!(result, Err(SignerError::SigningFailed(_))));
+    }
+
+    #[tokio::test]
+    async fn test_sign_transaction_timeout() {
+        let server = MockServer::start().await;
+        let (keypair, mut transaction, unsigned_raw, _, _) = signed_transaction_payload();
+
+        Mock::given(method("POST"))
+            .and(path("/v2/vaults/vault-test/transactions:initiate"))
+            .and(body_json(serde_json::json!({
+                "details": {
+                    "solanaSerializedTransaction": {
+                        "network": TEST_NETWORK,
+                        "rawTransaction": unsigned_raw,
+                        "publish": false,
+                        "replaceBlockhash": false,
+                        "tryReplaceBlockhash": false
+                    }
+                },
+                "designatedSigners": [format!("users/{TEST_EMAIL}")]
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "transaction": {
+                    "name": "vaults/vault-test/transactions/tx-1",
+                    "state": "AWAITING_SIGNATURE"
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/v2/vaults/vault-test/transactions/tx-1"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "transaction": {
+                    "name": "vaults/vault-test/transactions/tx-1",
+                    "state": "AWAITING_SIGNATURE"
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let signer = create_test_signer(&server.uri(), Some(keypair_pubkey(&keypair)));
+        let result = signer.sign_transaction(&mut transaction).await;
+        assert!(matches!(result, Err(SignerError::SigningFailed(_))));
+    }
+
+    #[tokio::test]
+    async fn test_sign_transaction_rejects_mismatched_returned_transaction() {
+        let server = MockServer::start().await;
+        let (keypair, mut transaction, unsigned_raw, _, _) = signed_transaction_payload();
+        let other_keypair = Keypair::new();
+        let (_, _, _, mismatched_raw, _) = signed_transaction_payload_for_keypair(&other_keypair);
+
+        Mock::given(method("POST"))
+            .and(path("/v2/vaults/vault-test/transactions:initiate"))
+            .and(body_json(serde_json::json!({
+                "details": {
+                    "solanaSerializedTransaction": {
+                        "network": TEST_NETWORK,
+                        "rawTransaction": unsigned_raw,
+                        "publish": false,
+                        "replaceBlockhash": false,
+                        "tryReplaceBlockhash": false
+                    }
+                },
+                "designatedSigners": [format!("users/{TEST_EMAIL}")]
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "transaction": {
+                    "name": "vaults/vault-test/transactions/tx-1",
+                    "state": "SIGNED",
+                    "solanaTransaction": {
+                        "rawTransaction": mismatched_raw
+                    }
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let signer = create_test_signer(&server.uri(), Some(keypair_pubkey(&keypair)));
+        let result = signer.sign_transaction(&mut transaction).await;
+        assert!(matches!(result, Err(SignerError::SigningFailed(_))));
+    }
+
+    #[tokio::test]
+    async fn test_is_available() {
+        let server = MockServer::start().await;
+        let keypair = Keypair::new();
+
+        Mock::given(method("GET"))
+            .and(path("/v2/vaults/vault-test/wallets/wallet-test"))
+            .respond_with(wallet_response(&keypair_pubkey(&keypair).to_string()))
+            .mount(&server)
+            .await;
+
+        let signer = create_test_signer(&server.uri(), None);
+        assert!(signer.is_available().await);
+
+        let unavailable = create_test_signer("http://127.0.0.1:1", None);
+        assert!(!unavailable.is_available().await);
+    }
+
+    fn signed_transaction_payload_for_keypair(
+        keypair: &Keypair,
+    ) -> (Transaction, Transaction, String, String, Signature) {
+        let public_key = keypair_pubkey(keypair);
+        let unsigned = create_test_transaction(&public_key);
+        let unsigned_raw = STANDARD.encode(bincode::serialize(&unsigned).unwrap());
+
+        let mut signed = unsigned.clone();
+        let signature = keypair_sign_message(keypair, &signed.message_data());
+        TransactionUtil::add_signature_to_transaction(&mut signed, &public_key, signature).unwrap();
+        let signed_raw = STANDARD.encode(bincode::serialize(&signed).unwrap());
+
+        (
+            unsigned.clone(),
+            signed,
+            unsigned_raw,
+            signed_raw,
+            signature,
+        )
+    }
+
+    fn server_url() -> String {
+        "http://127.0.0.1:1".to_string()
+    }
+}

--- a/rust/src/utila/mod.rs
+++ b/rust/src/utila/mod.rs
@@ -187,7 +187,11 @@ impl UtilaSigner {
     }
 
     async fn fetch_wallet(&self) -> Result<WalletResponse, SignerError> {
-        let path = format!("/v2/vaults/{}/wallets/{}", self.vault_id, self.wallet_id);
+        let path = format!(
+            "/v2/vaults/{}/wallets/{}",
+            encode_uri_component(&self.vault_id),
+            encode_uri_component(&self.wallet_id)
+        );
         self.get_json(&path, "fetch_wallet").await
     }
 
@@ -195,7 +199,10 @@ impl UtilaSigner {
         &self,
         raw_transaction: String,
     ) -> Result<UtilaTransaction, SignerError> {
-        let path = format!("/v2/vaults/{}{}", self.vault_id, "/transactions:initiate");
+        let path = format!(
+            "/v2/vaults/{}/transactions:initiate",
+            encode_uri_component(&self.vault_id)
+        );
         let request = InitiateTransactionRequest {
             details: InitiateTransactionDetails {
                 solana_serialized_transaction: SolanaSerializedTransaction {
@@ -218,7 +225,7 @@ impl UtilaSigner {
     async fn get_transaction(&self, transaction_id: &str) -> Result<UtilaTransaction, SignerError> {
         let path = format!(
             "/v2/vaults/{}/transactions/{}?view=FULL",
-            self.vault_id,
+            encode_uri_component(&self.vault_id),
             encode_uri_component(transaction_id)
         );
         let envelope: TransactionEnvelope = self.get_json(&path, "get_transaction").await?;
@@ -722,6 +729,59 @@ p6B5CCtpBPgD01Vm+bT/JQ==
         let mut signer = create_test_signer(&server.uri(), None);
         signer.init().await.expect("init should fetch address");
         assert_eq!(signer.pubkey(), public_key);
+    }
+
+    #[tokio::test]
+    async fn test_fetch_wallet_encodes_resource_ids() {
+        let server = MockServer::start().await;
+        let keypair = Keypair::new();
+        let public_key = keypair_pubkey(&keypair);
+
+        Mock::given(method("GET"))
+            .and(path(
+                "/v2/vaults/vault%2Fwith%20space/wallets/wallet%2Fwith%20space",
+            ))
+            .respond_with(wallet_response(&public_key.to_string()))
+            .mount(&server)
+            .await;
+
+        let mut signer = create_test_signer(&server.uri(), None);
+        signer.vault_id = "vault/with space".to_string();
+        signer.wallet_id = "wallet/with space".to_string();
+
+        signer.init().await.expect("init should fetch address");
+        assert_eq!(signer.pubkey(), public_key);
+    }
+
+    #[tokio::test]
+    async fn test_initiate_transaction_encodes_vault_id() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path(
+                "/v2/vaults/vault%2Fwith%20space/transactions:initiate",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "transaction": {
+                    "name": "vaults/vault/with space/transactions/tx-1",
+                    "state": "AWAITING_SIGNATURE"
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let mut signer = create_test_signer(&server.uri(), None);
+        signer.vault_id = "vault/with space".to_string();
+
+        let transaction = signer
+            .initiate_transaction("raw-transaction".to_string())
+            .await
+            .expect("transaction should be initiated");
+
+        assert_eq!(
+            transaction.name,
+            "vaults/vault/with space/transactions/tx-1"
+        );
     }
 
     #[tokio::test]

--- a/rust/src/utila/mod.rs
+++ b/rust/src/utila/mod.rs
@@ -105,10 +105,11 @@ impl UtilaSigner {
             ));
         }
 
-        let signing_key = EncodingKey::from_rsa_pem(
-            config.service_account_private_key_pem.as_bytes(),
-        )
-        .map_err(|_| {
+        let pem = config
+            .service_account_private_key_pem
+            .replace("\\n", "\n")
+            .replace('\r', "");
+        let signing_key = EncodingKey::from_rsa_pem(pem.trim().as_bytes()).map_err(|_| {
             SignerError::InvalidPrivateKey(
                 "Failed to parse Utila service account RSA private key".to_string(),
             )
@@ -309,7 +310,7 @@ impl UtilaSigner {
                 transaction.state
             )))
         } else {
-            Err(SignerError::SigningFailed(format!(
+            Err(SignerError::RemoteApiError(format!(
                 "Utila transaction polling timed out after {} attempts",
                 self.max_poll_attempts
             )))
@@ -714,6 +715,13 @@ p6B5CCtpBPgD01Vm+bT/JQ==
         assert!(payload["exp"].as_i64().is_some());
     }
 
+    #[test]
+    fn test_new_accepts_escaped_newline_pem() {
+        let mut config = config();
+        config.service_account_private_key_pem = TEST_RSA_KEY.replace('\n', "\\n");
+        assert!(UtilaSigner::new(config).is_ok());
+    }
+
     #[tokio::test]
     async fn test_init_fetches_solana_address() {
         let server = MockServer::start().await;
@@ -921,7 +929,7 @@ p6B5CCtpBPgD01Vm+bT/JQ==
 
         let signer = create_test_signer(&server.uri(), Some(keypair_pubkey(&keypair)));
         let result = signer.sign_transaction(&mut transaction).await;
-        assert!(matches!(result, Err(SignerError::SigningFailed(_))));
+        assert!(matches!(result, Err(SignerError::RemoteApiError(_))));
     }
 
     #[tokio::test]

--- a/rust/src/utila/types.rs
+++ b/rust/src/utila/types.rs
@@ -1,0 +1,101 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WalletResponse {
+    pub wallet: Wallet,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Wallet {
+    pub solana_details: Option<SolanaDetails>,
+}
+
+#[derive(Deserialize)]
+pub struct SolanaDetails {
+    pub address: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InitiateTransactionRequest {
+    pub details: InitiateTransactionDetails,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub designated_signers: Vec<String>,
+}
+
+#[derive(Serialize)]
+pub struct InitiateTransactionDetails {
+    #[serde(rename = "solanaSerializedTransaction")]
+    pub solana_serialized_transaction: SolanaSerializedTransaction,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SolanaSerializedTransaction {
+    pub network: String,
+    pub raw_transaction: String,
+    pub publish: bool,
+    pub replace_blockhash: bool,
+    pub try_replace_blockhash: bool,
+}
+
+#[derive(Deserialize)]
+pub struct TransactionEnvelope {
+    pub transaction: UtilaTransaction,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UtilaTransaction {
+    pub name: String,
+    pub state: TransactionState,
+    pub solana_transaction: Option<UtilaSolanaTransaction>,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum TransactionState {
+    AwaitingApproval,
+    AwaitingAmlPolicyCheck,
+    DeclinedByAmlPolicy,
+    AwaitingPolicyCheck,
+    AwaitingSignature,
+    Signed,
+    AwaitingPublish,
+    Published,
+    Mined,
+    MinedFailed,
+    Failed,
+    Declined,
+    Replaced,
+    Canceled,
+    Dropped,
+    Confirmed,
+    Expired,
+    #[serde(other)]
+    Unknown,
+}
+
+impl TransactionState {
+    pub fn is_terminal_failure(self) -> bool {
+        matches!(
+            self,
+            TransactionState::DeclinedByAmlPolicy
+                | TransactionState::MinedFailed
+                | TransactionState::Failed
+                | TransactionState::Declined
+                | TransactionState::Replaced
+                | TransactionState::Canceled
+                | TransactionState::Dropped
+                | TransactionState::Expired
+        )
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UtilaSolanaTransaction {
+    pub raw_transaction: Option<String>,
+}

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -65,6 +65,7 @@ See the [`@solana/keychain` README](./packages/keychain/README.md) for more usag
 | [@solana/keychain-crossmint](./packages/crossmint) | Crossmint wallet signer implementation |
 | [@solana/keychain-openfort](./packages/openfort) | Openfort backend wallet signer implementation |
 | [@solana/keychain-para](./packages/para) | Para MPC signer implementation |
+| [@solana/keychain-utila](./packages/utila) | Utila wallet signer implementation |
 
 ## Installation
 
@@ -85,5 +86,6 @@ pnpm add @solana/keychain-openfort    # Openfort backend wallet signer
 pnpm add @solana/keychain-para        # Para MPC signer
 pnpm add @solana/keychain-privy       # Privy signer
 pnpm add @solana/keychain-turnkey     # Turnkey signer
+pnpm add @solana/keychain-utila       # Utila signer
 pnpm add @solana/keychain-vault       # HashiCorp Vault signer
 ```

--- a/typescript/packages/core/src/utils.ts
+++ b/typescript/packages/core/src/utils.ts
@@ -166,3 +166,14 @@ export function assertIsSolanaSigner<TAddress extends string>(value: {
         });
     }
 }
+
+/**
+ * Normalizes a PEM private key for parsing by crypto libraries.
+ * CI secrets are often stored as single-line values with escaped newlines.
+ *
+ * @param privateKeyPem - The PEM private key, possibly with escaped `\n` or `\r`
+ * @returns The PEM with real newlines, no carriage returns, and trimmed
+ */
+export function normalizePrivateKeyPem(privateKeyPem: string): string {
+    return privateKeyPem.replace(/\\n/g, '\n').replace(/\r/g, '').trim();
+}

--- a/typescript/packages/core/src/utils.ts
+++ b/typescript/packages/core/src/utils.ts
@@ -167,13 +167,6 @@ export function assertIsSolanaSigner<TAddress extends string>(value: {
     }
 }
 
-/**
- * Normalizes a PEM private key for parsing by crypto libraries.
- * CI secrets are often stored as single-line values with escaped newlines.
- *
- * @param privateKeyPem - The PEM private key, possibly with escaped `\n` or `\r`
- * @returns The PEM with real newlines, no carriage returns, and trimmed
- */
 export function normalizePrivateKeyPem(privateKeyPem: string): string {
     return privateKeyPem.replace(/\\n/g, '\n').replace(/\r/g, '').trim();
 }

--- a/typescript/packages/dfns/src/auth.ts
+++ b/typescript/packages/dfns/src/auth.ts
@@ -1,6 +1,7 @@
 import { getBase64Encoder } from '@solana/codecs-strings';
 import {
     base64UrlDecoder,
+    normalizePrivateKeyPem,
     sanitizeRemoteErrorResponse,
     SignerErrorCode,
     throwSignerError,
@@ -204,11 +205,6 @@ async function signClientData(clientData: Uint8Array, privateKeyPem: string): Pr
         cause: latestError,
         message: 'Failed to sign Dfns auth challenge',
     });
-}
-
-function normalizePrivateKeyPem(privateKeyPem: string): string {
-    // CI secrets are often stored as single-line values with escaped newlines.
-    return privateKeyPem.replace(/\\n/g, '\n').replace(/\r/g, '').trim();
 }
 
 async function signClientDataWithWebCrypto(

--- a/typescript/packages/keychain/README.md
+++ b/typescript/packages/keychain/README.md
@@ -158,9 +158,11 @@ try {
 | `fireblocks` | [@solana/keychain-fireblocks](../fireblocks/README.md) | API |
 | `gcp-kms` | [@solana/keychain-gcp-kms](../gcp-kms/README.md) | Config (`publicKey`) |
 | `memory` | [@solana/keychain-memory](../memory/README.md) | Derived from local keypair |
+| `openfort` | [@solana/keychain-openfort](../openfort/README.md) | API |
 | `para` | [@solana/keychain-para](../para/README.md) | API |
 | `privy` | [@solana/keychain-privy](../privy/README.md) | API |
 | `turnkey` | [@solana/keychain-turnkey](../turnkey/README.md) | Config (`publicKey`) |
+| `utila` | [@solana/keychain-utila](../utila/README.md) | API |
 | `vault` | [@solana/keychain-vault](../vault/README.md) | Config (`publicKey`) |
 
 ## Common Interface

--- a/typescript/packages/keychain/README.md
+++ b/typescript/packages/keychain/README.md
@@ -21,6 +21,7 @@ This installs all signer implementations. For a smaller bundle, install individu
 - `@solana/keychain-para` - Para MPC signer
 - `@solana/keychain-privy` - Privy signer
 - `@solana/keychain-turnkey` - Turnkey signer
+- `@solana/keychain-utila` - Utila wallet signer
 - `@solana/keychain-vault` - HashiCorp Vault signer
 
 ## Usage
@@ -60,7 +61,7 @@ const address = await resolveAddress({
     publicKey: '4Nd1m...',
 });
 
-// Async backends (Privy, Para, Fireblocks, Crossmint, Dfns) fetch from the API
+// Async backends (Privy, Para, Fireblocks, Crossmint, Dfns, Utila) fetch from the API
 const address2 = await resolveAddress({
     backend: 'privy',
     appId: '...',
@@ -76,7 +77,7 @@ The `KeychainSignerConfig` discriminated union and individual config types are e
 ```typescript
 import type { KeychainSignerConfig, BackendName, PrivySignerConfig } from '@solana/keychain';
 
-// BackendName = 'aws-kms' | 'cdp' | 'crossmint' | 'dfns' | 'fireblocks' | 'gcp-kms' | 'memory' | 'openfort' | 'para' | 'privy' | 'turnkey' | 'vault'
+// BackendName = 'aws-kms' | 'cdp' | 'crossmint' | 'dfns' | 'fireblocks' | 'gcp-kms' | 'memory' | 'openfort' | 'para' | 'privy' | 'turnkey' | 'utila' | 'vault'
 
 function loadConfig(json: unknown): KeychainSignerConfig {
     // Parse and validate your config...

--- a/typescript/packages/keychain/package.json
+++ b/typescript/packages/keychain/package.json
@@ -20,7 +20,8 @@
         "para",
         "dfns",
         "crossmint",
-        "openfort"
+        "openfort",
+        "utila"
     ],
     "type": "module",
     "sideEffects": false,
@@ -58,6 +59,7 @@
         "@solana/keychain-para": "workspace:*",
         "@solana/keychain-privy": "workspace:*",
         "@solana/keychain-turnkey": "workspace:*",
+        "@solana/keychain-utila": "workspace:*",
         "@solana/keychain-vault": "workspace:*"
     },
     "peerDependencies": {

--- a/typescript/packages/keychain/src/__tests__/create-keychain-signer.test.ts
+++ b/typescript/packages/keychain/src/__tests__/create-keychain-signer.test.ts
@@ -28,6 +28,7 @@ vi.mock('@solana/keychain-memory', () => ({ createMemorySigner: vi.fn() }));
 vi.mock('@solana/keychain-para', () => ({ createParaSigner: vi.fn() }));
 vi.mock('@solana/keychain-privy', () => ({ createPrivySigner: vi.fn() }));
 vi.mock('@solana/keychain-turnkey', () => ({ createTurnkeySigner: vi.fn() }));
+vi.mock('@solana/keychain-utila', () => ({ createUtilaSigner: vi.fn() }));
 vi.mock('@solana/keychain-vault', () => ({ createVaultSigner: vi.fn() }));
 
 // Table-driven test configs — one per backend
@@ -94,6 +95,18 @@ const BACKEND_CONFIGS: Record<string, { config: KeychainSignerConfig; modulePath
         },
         factoryName: 'createTurnkeySigner',
         modulePath: '@solana/keychain-turnkey',
+    },
+    utila: {
+        config: {
+            backend: 'utila',
+            network: 'networks/solana-devnet',
+            serviceAccountEmail: 'service-account@example.com',
+            serviceAccountPrivateKeyPem: 'pem',
+            vaultId: 'vault',
+            walletId: 'wallet',
+        },
+        factoryName: 'createUtilaSigner',
+        modulePath: '@solana/keychain-utila',
     },
     vault: {
         config: {

--- a/typescript/packages/keychain/src/__tests__/resolve-address.test.ts
+++ b/typescript/packages/keychain/src/__tests__/resolve-address.test.ts
@@ -94,7 +94,7 @@ describe('resolveAddress', () => {
     });
 
     describe('async backends (fetch from API or derive locally)', () => {
-        it.each(['crossmint', 'dfns', 'fireblocks', 'memory', 'para', 'privy'] as const)(
+        it.each(['crossmint', 'dfns', 'fireblocks', 'memory', 'para', 'privy', 'utila'] as const)(
             '%s delegates to createKeychainSigner',
             async backend => {
                 const config = {
@@ -106,7 +106,11 @@ describe('resolveAddress', () => {
                     credId: 'c',
                     privateKeyPem: 'p',
                     privateKeyString: 'irrelevant-mocked-string',
+                    serviceAccountEmail: 'service-account@example.com',
+                    serviceAccountPrivateKeyPem: 'pem',
+                    network: 'networks/solana-devnet',
                     vaultAccountId: 'v',
+                    vaultId: 'vault',
                     walletId: 'w',
                     walletLocator: 'l',
                 } as KeychainSignerConfig;

--- a/typescript/packages/keychain/src/create-keychain-signer.ts
+++ b/typescript/packages/keychain/src/create-keychain-signer.ts
@@ -11,6 +11,7 @@ import { createOpenfortSigner } from '@solana/keychain-openfort';
 import { createParaSigner } from '@solana/keychain-para';
 import { createPrivySigner } from '@solana/keychain-privy';
 import { createTurnkeySigner } from '@solana/keychain-turnkey';
+import { createUtilaSigner } from '@solana/keychain-utila';
 import { createVaultSigner } from '@solana/keychain-vault';
 
 import type { KeychainSignerConfig } from './types.js';
@@ -59,6 +60,8 @@ export async function createKeychainSigner(config: KeychainSignerConfig): Promis
             return await createPrivySigner(stripBackend(config));
         case 'turnkey':
             return createTurnkeySigner(stripBackend(config));
+        case 'utila':
+            return await createUtilaSigner(stripBackend(config));
         case 'vault':
             return createVaultSigner(stripBackend(config));
         default: {

--- a/typescript/packages/keychain/src/index.ts
+++ b/typescript/packages/keychain/src/index.ts
@@ -18,6 +18,7 @@ export type { OpenfortSignerConfig } from '@solana/keychain-openfort';
 export type { ParaSignerConfig } from '@solana/keychain-para';
 export type { PrivySignerConfig } from '@solana/keychain-privy';
 export type { TurnkeySignerConfig } from '@solana/keychain-turnkey';
+export type { UtilaSignerConfig } from '@solana/keychain-utila';
 export type { VaultSignerConfig } from '@solana/keychain-vault';
 
 // Signer implementations (namespaced to avoid conflicts)
@@ -32,6 +33,7 @@ export * as openfort from '@solana/keychain-openfort';
 export * as para from '@solana/keychain-para';
 export * as privy from '@solana/keychain-privy';
 export * as turnkey from '@solana/keychain-turnkey';
+export * as utila from '@solana/keychain-utila';
 export * as vault from '@solana/keychain-vault';
 
 // Re-export factory functions directly (preferred API)
@@ -46,6 +48,7 @@ export { createOpenfortSigner } from '@solana/keychain-openfort';
 export { createParaSigner } from '@solana/keychain-para';
 export { createPrivySigner } from '@solana/keychain-privy';
 export { createTurnkeySigner } from '@solana/keychain-turnkey';
+export { createUtilaSigner } from '@solana/keychain-utila';
 export { createVaultSigner } from '@solana/keychain-vault';
 
 // @deprecated - Prefer createXxxSigner() factory functions. Class exports will be removed in a future version.
@@ -59,4 +62,5 @@ export { OpenfortSigner } from '@solana/keychain-openfort';
 export { ParaSigner } from '@solana/keychain-para';
 export { PrivySigner } from '@solana/keychain-privy';
 export { TurnkeySigner } from '@solana/keychain-turnkey';
+export { UtilaSigner } from '@solana/keychain-utila';
 export { VaultSigner } from '@solana/keychain-vault';

--- a/typescript/packages/keychain/src/resolve-address.ts
+++ b/typescript/packages/keychain/src/resolve-address.ts
@@ -11,7 +11,7 @@ import type { KeychainSignerConfig } from './types.js';
  * For backends that include the public key in their config (AWS KMS,
  * CDP, GCP KMS, Turnkey, Vault), this returns the address directly
  * with no network call. For backends that must fetch the public key
- * from a remote API (Crossmint, Dfns, Fireblocks, Openfort, Para, Privy),
+ * from a remote API (Crossmint, Dfns, Fireblocks, Openfort, Para, Privy, Utila),
  * this initialises the signer and reads its address.
  *
  * @example
@@ -48,7 +48,8 @@ export async function resolveAddress(config: KeychainSignerConfig): Promise<Addr
         case 'memory':
         case 'openfort':
         case 'para':
-        case 'privy': {
+        case 'privy':
+        case 'utila': {
             const signer = await createKeychainSigner(config);
             return signer.address;
         }

--- a/typescript/packages/keychain/src/types.ts
+++ b/typescript/packages/keychain/src/types.ts
@@ -9,6 +9,7 @@ import type { OpenfortSignerConfig } from '@solana/keychain-openfort';
 import type { ParaSignerConfig } from '@solana/keychain-para';
 import type { PrivySignerConfig } from '@solana/keychain-privy';
 import type { TurnkeySignerConfig } from '@solana/keychain-turnkey';
+import type { UtilaSignerConfig } from '@solana/keychain-utila';
 import type { VaultSignerConfig } from '@solana/keychain-vault';
 
 /**
@@ -27,6 +28,7 @@ export type KeychainSignerConfig =
     | (ParaSignerConfig & { backend: 'para' })
     | (PrivySignerConfig & { backend: 'privy' })
     | (TurnkeySignerConfig & { backend: 'turnkey' })
+    | (UtilaSignerConfig & { backend: 'utila' })
     | (VaultSignerConfig & { backend: 'vault' });
 
 /** String literal union of all supported backend names, derived from {@link KeychainSignerConfig}. */

--- a/typescript/packages/keychain/tsconfig.json
+++ b/typescript/packages/keychain/tsconfig.json
@@ -20,6 +20,7 @@
         { "path": "../para" },
         { "path": "../privy" },
         { "path": "../turnkey" },
+        { "path": "../utila" },
         { "path": "../vault" }
     ]
 }

--- a/typescript/packages/utila/.env.example
+++ b/typescript/packages/utila/.env.example
@@ -1,0 +1,11 @@
+UTILA_SERVICE_ACCOUNT_EMAIL=your-service-account@vault.utilaserviceaccount.io
+UTILA_SERVICE_ACCOUNT_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----
+your-rsa-private-key-here
+-----END PRIVATE KEY-----"
+UTILA_VAULT_ID=your-vault-id
+UTILA_WALLET_ID=your-wallet-id
+UTILA_NETWORK=networks/solana-devnet
+# UTILA_API_BASE_URL=https://api.utila.io
+# UTILA_POLL_INTERVAL_MS=1000
+# UTILA_MAX_POLL_ATTEMPTS=60
+SOLANA_RPC_URL=https://api.devnet.solana.com

--- a/typescript/packages/utila/README.md
+++ b/typescript/packages/utila/README.md
@@ -1,0 +1,34 @@
+# @solana/keychain-utila
+
+Utila wallet signer for Solana transactions.
+
+```typescript
+import { createUtilaSigner } from '@solana/keychain-utila';
+
+const signer = await createUtilaSigner({
+    serviceAccountEmail: process.env.UTILA_SERVICE_ACCOUNT_EMAIL!,
+    serviceAccountPrivateKeyPem: process.env.UTILA_SERVICE_ACCOUNT_PRIVATE_KEY!,
+    vaultId: process.env.UTILA_VAULT_ID!,
+    walletId: process.env.UTILA_WALLET_ID!,
+    network: process.env.UTILA_NETWORK ?? 'networks/solana-devnet',
+});
+```
+
+The signer fetches the Solana address from the configured Utila wallet during initialization. Transaction signing uses Utila's serialized Solana transaction flow with `publish=false`, so callers remain responsible for broadcasting.
+
+`signMessages` is intentionally unsupported because the Utila API surface used here does not expose a Solana message-sign initiation endpoint.
+
+## Environment
+
+```bash
+UTILA_SERVICE_ACCOUNT_EMAIL=your-service-account@vault.utilaserviceaccount.io
+UTILA_SERVICE_ACCOUNT_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----
+...
+-----END PRIVATE KEY-----"
+UTILA_VAULT_ID=your-vault-id
+UTILA_WALLET_ID=your-wallet-id
+UTILA_NETWORK=networks/solana-devnet
+# UTILA_API_BASE_URL=https://api.utila.io
+# UTILA_POLL_INTERVAL_MS=1000
+# UTILA_MAX_POLL_ATTEMPTS=60
+```

--- a/typescript/packages/utila/package.json
+++ b/typescript/packages/utila/package.json
@@ -1,0 +1,65 @@
+{
+    "name": "@solana/keychain-utila",
+    "author": "Solana Foundation",
+    "version": "1.2.0",
+    "description": "Utila wallet signer for Solana transactions",
+    "license": "MIT",
+    "repository": "https://github.com/solana-foundation/solana-keychain",
+    "keywords": [
+        "solana",
+        "signing",
+        "wallet",
+        "utila"
+    ],
+    "type": "module",
+    "sideEffects": false,
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./dist/index.d.ts",
+            "import": "./dist/index.js"
+        }
+    },
+    "files": [
+        "dist",
+        "src"
+    ],
+    "scripts": {
+        "build": "tsc --build",
+        "clean": "rm -rf dist *.tsbuildinfo",
+        "prepack": "pnpm run build",
+        "test": "vitest run",
+        "test:unit": "vitest run --config ../../vitest.config.unit.ts",
+        "test:integration": "vitest run --config ../../vitest.config.integration.ts",
+        "test:watch": "vitest",
+        "test:watch:unit": "vitest --config ../../vitest.config.unit.ts",
+        "test:watch:integration": "vitest --config ../../vitest.config.integration.ts",
+        "typecheck": "tsc --noEmit",
+        "test:treeshakability": "agadoo dist/index.js"
+    },
+    "dependencies": {
+        "@solana/keychain-core": "workspace:*",
+        "jose": "^6.2.3"
+    },
+    "peerDependencies": {
+        "@solana/addresses": ">=6.0.1",
+        "@solana/codecs-strings": ">=6.0.1",
+        "@solana/keys": ">=6.0.1",
+        "@solana/signers": ">=6.0.1",
+        "@solana/transactions": ">=6.0.1"
+    },
+    "devDependencies": {
+        "@solana/addresses": "^6.9.0",
+        "@solana/codecs-strings": "^6.9.0",
+        "@solana/keychain-test-utils": "workspace:*",
+        "@solana/keys": "^6.9.0",
+        "@solana/signers": "^6.9.0",
+        "@solana/transactions": "^6.9.0",
+        "@solana/kit": "^6.9.0",
+        "dotenv": "^17.4.2"
+    },
+    "publishConfig": {
+        "access": "public"
+    }
+}

--- a/typescript/packages/utila/src/__tests__/setup.ts
+++ b/typescript/packages/utila/src/__tests__/setup.ts
@@ -1,0 +1,67 @@
+import type { SolanaSigner } from '@solana/keychain-core';
+import { SignerTestConfig, TestScenario } from '@solana/keychain-test-utils';
+import { createUtilaSigner } from '../utila-signer.js';
+
+const SIGNER_TYPE = 'utila';
+const REQUIRED_ENV_VARS = [
+    'UTILA_SERVICE_ACCOUNT_EMAIL',
+    'UTILA_SERVICE_ACCOUNT_PRIVATE_KEY',
+    'UTILA_VAULT_ID',
+    'UTILA_WALLET_ID',
+    'UTILA_NETWORK',
+];
+
+const CONFIG: SignerTestConfig<SolanaSigner> = {
+    signerType: SIGNER_TYPE,
+    requiredEnvVars: REQUIRED_ENV_VARS,
+    createSigner: () =>
+        createUtilaSigner({
+            apiBaseUrl: process.env.UTILA_API_BASE_URL,
+            maxPollAttempts: process.env.UTILA_MAX_POLL_ATTEMPTS
+                ? Number(process.env.UTILA_MAX_POLL_ATTEMPTS)
+                : undefined,
+            network: process.env.UTILA_NETWORK!,
+            pollIntervalMs: process.env.UTILA_POLL_INTERVAL_MS ? Number(process.env.UTILA_POLL_INTERVAL_MS) : undefined,
+            serviceAccountEmail: process.env.UTILA_SERVICE_ACCOUNT_EMAIL!,
+            serviceAccountPrivateKeyPem: process.env.UTILA_SERVICE_ACCOUNT_PRIVATE_KEY!,
+            vaultId: process.env.UTILA_VAULT_ID!,
+            walletId: process.env.UTILA_WALLET_ID!,
+        }),
+};
+
+export async function getConfig(scenarios: TestScenario[]): Promise<SignerTestConfig<SolanaSigner>> {
+    return {
+        ...CONFIG,
+        testScenarios: scenarios,
+    };
+}
+
+export const TEST_EMAIL = 'service-account@vault.utilaserviceaccount.io';
+export const TEST_RSA_PRIVATE_KEY = `-----BEGIN PRIVATE KEY-----
+MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQDKKw7fHhfK3/Ts
+rAqsNCrDsjmyBTHx/AUCOTM+tZph2ZOyDSH9nZO4JkzLrW6Vfk7EZvlP3QjLiXEG
+m9qQgAh9sXgp07GicWU5omSILTMdd18yR6aIXVw/YzgjD7EVLRQU6YHc3BYgR8P8
+PBbJcxzYrrUDSGEXX2b44cZO72RxIPM+yeY3ZXiztgFQSpfEIKX488/k/PgUHMHK
+/04VoL/jiQa5dOs44CmHHT6MbBT1Sb/VR0G1hHtfMSIQCtdvzt+VBZhg7sxm50h/
+cT+n0UVOBwEp2IY2x4lzlwOdptZl7P3D1+A2rAbalXg5WO+LVEjx5ym++XbCGyvU
+rlH+ILOPAgMBAAECggEAXio3F5J/N4YgITqzD+mOf69cc0A7NsCRnqsA5PUWbvw2
+cIjwa55BZ1UjkPz7lJML4iwqdNn51j/yzsa6Q3L3QYBvfV/2jbiuku1CUTFobRGk
+XBmGhl6h8H5o79/HthrUjzcCP1qdzbRPo4Vjgbpl1cFuW5STcJ0Fq+gRg8O6b3w7
+A2843mcF9EA9ZFjXpn+VtpzLe4nHVRZFYXvXSlfdYc6WQbThnLLiLQYsVMqhYQAU
+I4c9hfgasfgZ6iCV5hMK2ZPX45+/OVQzjh4+I8zlvNWp2cKNoEhMHU2G/In11yBF
+wHGRuvbwx9Wc4Okqq+GvfTO0jCAinAQQu8C+eIcNcQKBgQDo9dzw2cNsJmaUvaL5
+I7gEtbPdr+CTgVjGoVUIlGeI0OBHt1DJEwczS2tycScE9SUDLdmegYA8ubHsAs/6
+PFEJ+779h9/IDzL3Fe9Zp1fiQgWOKF1uCS7+b8QwFMhh2u0OLWmI1rdFmqX2KCPf
+AfD/Pvp6bgapXTN1EoB3LQ/4PwKBgQDeKZeJMk9CZzWFe+m5x2yzJBK62ZvKzyjZ
+Y3IeK75V0xG+Y7ZAb0zTXPkgBpBiQOqdFRgt6bp/S/6Tq/OXfeV9xVURSz4zRtCR
+lRoONL8ZSl0h4VptEjXrYfBnH2j4gtjhnTATJZBp0rYrExbz0jVbQtRzPLs+k3+p
+TuZA8+XwsQKBgCocn8buJpR7UJncugQ9f7tiOVR+waMIg8rMSTnW0ex6jcCJE9J1
+XRzZql+ysrIDuqAbfrZXhJ31l4Mpcv0yQBgE6R6dnEdm7/iYf37+cDWXZ7et9k24
+3UTjYVyrtRlzYNzqOqSg49pyPUQFN47NpAoQEWlmUE/3aCDmqlBg1f0zAoGAamv+
+HUiuUx7hspnTMp1nYsEq/7ryOErYRJqwtec6fB5p54wYZ/FpGe71n/PFAmwadzj9
+pjDKl+QthUvfmnhCkOcQgwJKP4Hys2p7WsbFrDXFO0+aY5lPnvwBj0SqojD798e2
+mdVqwmafwS6Z1h6iVJ9E6hbzk1xQ0SfsgLzVL2ECgYBN6fJ99og4fkp4iA5C31TB
+UKlH64yqwxFu4vuVMqBOpGPkdsLNGhE/vpdP7yYxC/MP+v8ow/sCa40Ely20Yqqa
+znT9Ik5JV4eRXyRG9iwllKvcrmczFDIuxFmXPff4G9nmyB9fLQfSM0gD+yDR05Hx
+p6B5CCtpBPgD01Vm+bT/JQ==
+-----END PRIVATE KEY-----`;

--- a/typescript/packages/utila/src/__tests__/utila-signer.integration.test.ts
+++ b/typescript/packages/utila/src/__tests__/utila-signer.integration.test.ts
@@ -1,0 +1,64 @@
+import {
+    type Blockhash,
+    createSignableMessage,
+    createTransactionMessage,
+    pipe,
+    setTransactionMessageFeePayerSigner,
+    setTransactionMessageLifetimeUsingBlockhash,
+    signTransactionMessageWithSigners,
+} from '@solana/kit';
+import { config } from 'dotenv';
+import { describe, expect, it } from 'vitest';
+import { getConfig } from './setup.js';
+
+config();
+
+const RPC_URL = process.env.SOLANA_RPC_URL ?? 'https://api.devnet.solana.com';
+
+async function getLatestBlockhash() {
+    const res = await fetch(RPC_URL, {
+        body: JSON.stringify({
+            id: 1,
+            jsonrpc: '2.0',
+            method: 'getLatestBlockhash',
+            params: [{ commitment: 'finalized' }],
+        }),
+        headers: { 'Content-Type': 'application/json' },
+        method: 'POST',
+    });
+    const json = (await res.json()) as { result: { value: { blockhash: Blockhash; lastValidBlockHeight: bigint } } };
+    return json.result.value;
+}
+
+describe('UtilaSigner Integration', () => {
+    it.skipIf(!process.env.UTILA_SERVICE_ACCOUNT_EMAIL)('signs transactions with real API', async () => {
+        const { createSigner } = await getConfig(['signTransaction']);
+        const signer = await createSigner();
+
+        const { blockhash, lastValidBlockHeight } = await getLatestBlockhash();
+        const transaction = pipe(
+            createTransactionMessage({ version: 0 }),
+            tx => setTransactionMessageFeePayerSigner(signer, tx),
+            tx => setTransactionMessageLifetimeUsingBlockhash({ blockhash, lastValidBlockHeight }, tx),
+        );
+
+        const signedTx = await signTransactionMessageWithSigners(transaction);
+
+        expect(signedTx.signatures[signer.address]).toBeDefined();
+        expect(signedTx.signatures[signer.address]?.byteLength).toBe(64);
+    });
+
+    it.skipIf(!process.env.UTILA_SERVICE_ACCOUNT_EMAIL)('returns not supported for signMessages', async () => {
+        const { createSigner } = await getConfig(['signMessage']);
+        const signer = await createSigner();
+        const message = createSignableMessage(new Uint8Array([1, 2, 3]));
+        await expect(signer.signMessages([message])).rejects.toThrow('not supported');
+    });
+
+    it.skipIf(!process.env.UTILA_SERVICE_ACCOUNT_EMAIL)('checks availability', async () => {
+        const { createSigner } = await getConfig([]);
+        const signer = await createSigner();
+        const available = await signer.isAvailable();
+        expect(available).toBe(true);
+    });
+});

--- a/typescript/packages/utila/src/__tests__/utila-signer.test.ts
+++ b/typescript/packages/utila/src/__tests__/utila-signer.test.ts
@@ -148,6 +148,17 @@ describe('UtilaSigner', () => {
                 code: 'SIGNER_INVALID_PUBLIC_KEY',
             });
         });
+
+        it('accepts a PEM with escaped newlines', async () => {
+            vi.mocked(fetch).mockResolvedValueOnce(mockWalletResponse());
+
+            const signer = await createUtilaSigner({
+                ...mockConfig,
+                serviceAccountPrivateKeyPem: TEST_RSA_PRIVATE_KEY.replace(/\n/g, '\\n'),
+            });
+
+            expect(signer.address).toBe(MOCK_ADDRESS);
+        });
     });
 
     describe('signMessages', () => {
@@ -289,6 +300,33 @@ describe('UtilaSigner', () => {
             await expect(signer.signTransactions([createMockTransaction()])).rejects.toMatchObject({
                 code: 'SIGNER_SIGNING_FAILED',
                 message: expect.stringContaining('rawTransaction'),
+            });
+        });
+
+        it('throws a parsing error when the signed raw transaction cannot be decoded', async () => {
+            vi.mocked(getTransactionDecoder).mockReturnValue({
+                decode: vi.fn(() => {
+                    throw new Error('bad bytes');
+                }),
+            } as any);
+            vi.mocked(fetch)
+                .mockResolvedValueOnce(mockWalletResponse())
+                .mockResolvedValueOnce(
+                    jsonResponse({
+                        transaction: {
+                            name: 'vaults/vault-test/transactions/tx-1',
+                            solanaTransaction: {
+                                rawTransaction: MOCK_RAW_TRANSACTION,
+                            },
+                            state: 'SIGNED',
+                        },
+                    }),
+                );
+
+            const signer = await createUtilaSigner(mockConfig);
+            await expect(signer.signTransactions([createMockTransaction()])).rejects.toMatchObject({
+                code: 'SIGNER_PARSING_ERROR',
+                message: expect.stringContaining('decode'),
             });
         });
 

--- a/typescript/packages/utila/src/__tests__/utila-signer.test.ts
+++ b/typescript/packages/utila/src/__tests__/utila-signer.test.ts
@@ -303,36 +303,11 @@ describe('UtilaSigner', () => {
             });
         });
 
-        it('throws a parsing error when the signed raw transaction cannot be decoded', async () => {
+        it('throws when the signed transaction has no signature for the signer address', async () => {
             vi.mocked(getTransactionDecoder).mockReturnValue({
-                decode: vi.fn(() => {
-                    throw new Error('bad bytes');
-                }),
-            } as any);
-            vi.mocked(fetch)
-                .mockResolvedValueOnce(mockWalletResponse())
-                .mockResolvedValueOnce(
-                    jsonResponse({
-                        transaction: {
-                            name: 'vaults/vault-test/transactions/tx-1',
-                            solanaTransaction: {
-                                rawTransaction: MOCK_RAW_TRANSACTION,
-                            },
-                            state: 'SIGNED',
-                        },
-                    }),
-                );
-
-            const signer = await createUtilaSigner(mockConfig);
-            await expect(signer.signTransactions([createMockTransaction()])).rejects.toMatchObject({
-                code: 'SIGNER_PARSING_ERROR',
-                message: expect.stringContaining('decode'),
-            });
-        });
-
-        it('throws when Utila returns transaction bytes for a different message', async () => {
-            vi.mocked(getTransactionDecoder).mockReturnValue({
-                decode: vi.fn(() => createDecodedTransaction({ messageBytes: new Uint8Array([9, 9, 9]) })),
+                decode: vi.fn(() =>
+                    createDecodedTransaction({ signerAddress: 'So11111111111111111111111111111111111111112' }),
+                ),
             } as any);
             vi.mocked(fetch)
                 .mockResolvedValueOnce(mockWalletResponse())
@@ -351,7 +326,7 @@ describe('UtilaSigner', () => {
             const signer = await createUtilaSigner(mockConfig);
             await expect(signer.signTransactions([createMockTransaction()])).rejects.toMatchObject({
                 code: 'SIGNER_SIGNING_FAILED',
-                message: expect.stringContaining('different message bytes'),
+                message: expect.stringContaining('No signature found'),
             });
         });
     });

--- a/typescript/packages/utila/src/__tests__/utila-signer.test.ts
+++ b/typescript/packages/utila/src/__tests__/utila-signer.test.ts
@@ -1,0 +1,332 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { decodeJwt, decodeProtectedHeader, importPKCS8 } from 'jose';
+
+vi.mock('@solana/keychain-core', async importOriginal => {
+    const mod = await importOriginal<typeof import('@solana/keychain-core')>();
+    return { ...mod, assertSignatureValid: vi.fn() };
+});
+
+vi.mock('@solana/transactions', async importOriginal => {
+    const mod = await importOriginal<typeof import('@solana/transactions')>();
+    return {
+        ...mod,
+        getBase64EncodedWireTransaction: vi.fn(() => 'AQID'),
+        getTransactionDecoder: vi.fn(),
+    };
+});
+
+import { assertIsSolanaSigner, assertSignatureValid } from '@solana/keychain-core';
+import { getTransactionDecoder } from '@solana/transactions';
+import { createUtilaAccessToken, createUtilaSigner } from '../utila-signer.js';
+import { TEST_EMAIL, TEST_RSA_PRIVATE_KEY } from './setup.js';
+
+global.fetch = vi.fn();
+
+const MOCK_ADDRESS = '11111111111111111111111111111111';
+const MOCK_MESSAGE_BYTES = new Uint8Array([1, 2, 3]);
+const MOCK_SIGNATURE_BYTES = new Uint8Array(64).fill(7);
+const MOCK_RAW_TRANSACTION = 'AQIDBA==';
+
+const mockConfig = {
+    apiBaseUrl: 'https://api.test.utila.io',
+    network: 'networks/solana-devnet',
+    serviceAccountEmail: TEST_EMAIL,
+    serviceAccountPrivateKeyPem: TEST_RSA_PRIVATE_KEY,
+    vaultId: 'vault-test',
+    walletId: 'wallet-test',
+};
+
+function createMockTransaction(messageBytes = MOCK_MESSAGE_BYTES) {
+    return { messageBytes } as any;
+}
+
+function createDecodedTransaction(overrides?: {
+    messageBytes?: Uint8Array;
+    signature?: Uint8Array;
+    signerAddress?: string;
+}) {
+    return {
+        messageBytes: overrides?.messageBytes ?? MOCK_MESSAGE_BYTES,
+        signatures: {
+            [overrides?.signerAddress ?? MOCK_ADDRESS]: overrides?.signature ?? MOCK_SIGNATURE_BYTES,
+        },
+    };
+}
+
+function mockWalletResponse(overrides?: Record<string, unknown>): Response {
+    return new Response(
+        JSON.stringify({
+            wallet: {
+                solanaDetails: {
+                    address: MOCK_ADDRESS,
+                },
+                ...overrides,
+            },
+        }),
+        { status: 200 },
+    );
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+    return new Response(JSON.stringify(body), { status });
+}
+
+function fetchCall(index: number): [string, RequestInit] {
+    return vi.mocked(fetch).mock.calls[index] as [string, RequestInit];
+}
+
+describe('UtilaSigner', () => {
+    beforeEach(() => {
+        vi.resetAllMocks();
+        vi.mocked(assertSignatureValid).mockResolvedValue(undefined);
+        vi.mocked(getTransactionDecoder).mockReturnValue({
+            decode: vi.fn(() => createDecodedTransaction()),
+        } as any);
+    });
+
+    describe('createUtilaAccessToken', () => {
+        it('creates an RS256 JWT with Utila service account claims', async () => {
+            const privateKey = await importPKCS8(TEST_RSA_PRIVATE_KEY, 'RS256');
+            const token = await createUtilaAccessToken(TEST_EMAIL, privateKey);
+            const header = decodeProtectedHeader(token);
+            const payload = decodeJwt(token);
+
+            expect(header.alg).toBe('RS256');
+            expect(payload.sub).toBe(TEST_EMAIL);
+            expect(payload.aud).toBe('https://api.utila.io/');
+            expect(typeof payload.exp).toBe('number');
+            expect(token).not.toContain('BEGIN PRIVATE KEY');
+        });
+    });
+
+    describe('create', () => {
+        it('creates signer from an existing Utila wallet', async () => {
+            vi.mocked(fetch).mockResolvedValueOnce(mockWalletResponse());
+
+            const signer = await createUtilaSigner(mockConfig);
+
+            expect(signer.address).toBe(MOCK_ADDRESS);
+            assertIsSolanaSigner(signer);
+            expect(fetch).toHaveBeenCalledWith(
+                'https://api.test.utila.io/v2/vaults/vault-test/wallets/wallet-test',
+                expect.objectContaining({
+                    headers: expect.objectContaining({
+                        Authorization: expect.stringMatching(/^Bearer /),
+                    }),
+                    method: 'GET',
+                }),
+            );
+        });
+
+        it('throws config error when required fields are missing', async () => {
+            await expect(createUtilaSigner({ ...mockConfig, serviceAccountEmail: '' })).rejects.toMatchObject({
+                code: 'SIGNER_CONFIG_ERROR',
+                message: expect.stringContaining('serviceAccountEmail'),
+            });
+        });
+
+        it('throws config error for non-https base URL', async () => {
+            await expect(createUtilaSigner({ ...mockConfig, apiBaseUrl: 'http://api.utila.io' })).rejects.toMatchObject(
+                {
+                    code: 'SIGNER_CONFIG_ERROR',
+                    message: expect.stringContaining('HTTPS'),
+                },
+            );
+        });
+
+        it('throws config error for invalid base URL', async () => {
+            await expect(createUtilaSigner({ ...mockConfig, apiBaseUrl: 'not-a-url' })).rejects.toMatchObject({
+                code: 'SIGNER_CONFIG_ERROR',
+                message: expect.stringContaining('Invalid apiBaseUrl'),
+            });
+        });
+
+        it('throws invalid public key when wallet response omits Solana address', async () => {
+            vi.mocked(fetch).mockResolvedValueOnce(jsonResponse({ wallet: {} }));
+
+            await expect(createUtilaSigner(mockConfig)).rejects.toMatchObject({
+                code: 'SIGNER_INVALID_PUBLIC_KEY',
+            });
+        });
+    });
+
+    describe('signMessages', () => {
+        it('returns not supported error', async () => {
+            vi.mocked(fetch).mockResolvedValueOnce(mockWalletResponse());
+            const signer = await createUtilaSigner(mockConfig);
+
+            await expect(
+                signer.signMessages([{ content: new Uint8Array([1, 2, 3]), signatures: {} }]),
+            ).rejects.toMatchObject({
+                code: 'SIGNER_SIGNING_FAILED',
+                message: expect.stringContaining('not supported'),
+            });
+        });
+    });
+
+    describe('signTransactions', () => {
+        it('initiates Utila signing with publish disabled and extracts signed transaction signature', async () => {
+            vi.mocked(fetch)
+                .mockResolvedValueOnce(mockWalletResponse())
+                .mockResolvedValueOnce(
+                    jsonResponse({
+                        transaction: {
+                            name: 'vaults/vault-test/transactions/tx-1',
+                            state: 'AWAITING_SIGNATURE',
+                        },
+                    }),
+                )
+                .mockResolvedValueOnce(
+                    jsonResponse({
+                        transaction: {
+                            name: 'vaults/vault-test/transactions/tx-1',
+                            solanaTransaction: {
+                                rawTransaction: MOCK_RAW_TRANSACTION,
+                            },
+                            state: 'SIGNED',
+                        },
+                    }),
+                );
+
+            const signer = await createUtilaSigner({
+                ...mockConfig,
+                maxPollAttempts: 2,
+                pollIntervalMs: 1,
+            });
+            const results = await signer.signTransactions([createMockTransaction()]);
+
+            expect(results).toHaveLength(1);
+            expect(results[0]![signer.address]).toEqual(MOCK_SIGNATURE_BYTES);
+            expect(assertSignatureValid).toHaveBeenCalledWith({
+                data: MOCK_MESSAGE_BYTES,
+                signature: MOCK_SIGNATURE_BYTES,
+                signerAddress: signer.address,
+            });
+
+            const [url, init] = fetchCall(1);
+            expect(url).toBe('https://api.test.utila.io/v2/vaults/vault-test/transactions:initiate');
+            const body = JSON.parse(init.body as string);
+            expect(body).toMatchObject({
+                designatedSigners: [`users/${TEST_EMAIL}`],
+                details: {
+                    solanaSerializedTransaction: {
+                        network: 'networks/solana-devnet',
+                        publish: false,
+                        rawTransaction: 'AQID',
+                        replaceBlockhash: false,
+                        tryReplaceBlockhash: false,
+                    },
+                },
+            });
+
+            expect(fetchCall(2)[0]).toBe('https://api.test.utila.io/v2/vaults/vault-test/transactions/tx-1?view=FULL');
+        });
+
+        it('throws on terminal Utila state', async () => {
+            vi.mocked(fetch)
+                .mockResolvedValueOnce(mockWalletResponse())
+                .mockResolvedValueOnce(
+                    jsonResponse({
+                        transaction: {
+                            name: 'vaults/vault-test/transactions/tx-1',
+                            state: 'FAILED',
+                        },
+                    }),
+                );
+
+            const signer = await createUtilaSigner({ ...mockConfig, pollIntervalMs: 1 });
+            await expect(signer.signTransactions([createMockTransaction()])).rejects.toMatchObject({
+                code: 'SIGNER_SIGNING_FAILED',
+                message: expect.stringContaining('FAILED'),
+            });
+        });
+
+        it('throws when polling times out', async () => {
+            vi.mocked(fetch)
+                .mockResolvedValueOnce(mockWalletResponse())
+                .mockResolvedValueOnce(
+                    jsonResponse({
+                        transaction: {
+                            name: 'vaults/vault-test/transactions/tx-1',
+                            state: 'AWAITING_SIGNATURE',
+                        },
+                    }),
+                )
+                .mockResolvedValueOnce(
+                    jsonResponse({
+                        transaction: {
+                            name: 'vaults/vault-test/transactions/tx-1',
+                            state: 'AWAITING_SIGNATURE',
+                        },
+                    }),
+                );
+
+            const signer = await createUtilaSigner({
+                ...mockConfig,
+                maxPollAttempts: 1,
+                pollIntervalMs: 1,
+            });
+
+            await expect(signer.signTransactions([createMockTransaction()])).rejects.toMatchObject({
+                code: 'SIGNER_REMOTE_API_ERROR',
+                message: expect.stringContaining('timed out'),
+            });
+        });
+
+        it('throws when signed response is missing raw transaction', async () => {
+            vi.mocked(fetch)
+                .mockResolvedValueOnce(mockWalletResponse())
+                .mockResolvedValueOnce(
+                    jsonResponse({
+                        transaction: {
+                            name: 'vaults/vault-test/transactions/tx-1',
+                            state: 'SIGNED',
+                        },
+                    }),
+                );
+
+            const signer = await createUtilaSigner(mockConfig);
+            await expect(signer.signTransactions([createMockTransaction()])).rejects.toMatchObject({
+                code: 'SIGNER_SIGNING_FAILED',
+                message: expect.stringContaining('rawTransaction'),
+            });
+        });
+
+        it('throws when Utila returns transaction bytes for a different message', async () => {
+            vi.mocked(getTransactionDecoder).mockReturnValue({
+                decode: vi.fn(() => createDecodedTransaction({ messageBytes: new Uint8Array([9, 9, 9]) })),
+            } as any);
+            vi.mocked(fetch)
+                .mockResolvedValueOnce(mockWalletResponse())
+                .mockResolvedValueOnce(
+                    jsonResponse({
+                        transaction: {
+                            name: 'vaults/vault-test/transactions/tx-1',
+                            solanaTransaction: {
+                                rawTransaction: MOCK_RAW_TRANSACTION,
+                            },
+                            state: 'SIGNED',
+                        },
+                    }),
+                );
+
+            const signer = await createUtilaSigner(mockConfig);
+            await expect(signer.signTransactions([createMockTransaction()])).rejects.toMatchObject({
+                code: 'SIGNER_SIGNING_FAILED',
+                message: expect.stringContaining('different message bytes'),
+            });
+        });
+    });
+
+    describe('isAvailable', () => {
+        it('returns true when wallet fetch succeeds and false when it fails', async () => {
+            vi.mocked(fetch).mockResolvedValueOnce(mockWalletResponse()).mockResolvedValueOnce(mockWalletResponse());
+            const signer = await createUtilaSigner(mockConfig);
+
+            await expect(signer.isAvailable()).resolves.toBe(true);
+
+            vi.mocked(fetch).mockRejectedValueOnce(new Error('network'));
+            await expect(signer.isAvailable()).resolves.toBe(false);
+        });
+    });
+});

--- a/typescript/packages/utila/src/index.ts
+++ b/typescript/packages/utila/src/index.ts
@@ -1,0 +1,2 @@
+export { createUtilaSigner, UtilaSigner } from './utila-signer.js';
+export type { UtilaSignerConfig, UtilaTransactionState } from './types.js';

--- a/typescript/packages/utila/src/types.ts
+++ b/typescript/packages/utila/src/types.ts
@@ -36,24 +36,23 @@ export interface UtilaTransactionEnvelope {
 }
 
 export type UtilaTransactionState =
-    | 'AWAITING_APPROVAL'
     | 'AWAITING_AML_POLICY_CHECK'
-    | 'DECLINED_BY_AML_POLICY'
+    | 'AWAITING_APPROVAL'
     | 'AWAITING_POLICY_CHECK'
-    | 'AWAITING_SIGNATURE'
-    | 'SIGNED'
     | 'AWAITING_PUBLISH'
-    | 'PUBLISHED'
-    | 'MINED'
-    | 'MINED_FAILED'
-    | 'FAILED'
-    | 'DECLINED'
-    | 'REPLACED'
+    | 'AWAITING_SIGNATURE'
     | 'CANCELED'
-    | 'DROPPED'
     | 'CONFIRMED'
+    | 'DECLINED_BY_AML_POLICY'
+    | 'DECLINED'
+    | 'DROPPED'
     | 'EXPIRED'
-    | string;
+    | 'FAILED'
+    | 'MINED_FAILED'
+    | 'MINED'
+    | 'PUBLISHED'
+    | 'REPLACED'
+    | 'SIGNED';
 
 export interface UtilaTransaction {
     name?: string;

--- a/typescript/packages/utila/src/types.ts
+++ b/typescript/packages/utila/src/types.ts
@@ -1,0 +1,64 @@
+export interface UtilaSignerConfig {
+    apiBaseUrl?: string;
+    designatedSigners?: readonly string[];
+    maxPollAttempts?: number;
+    network: string;
+    pollIntervalMs?: number;
+    serviceAccountEmail: string;
+    serviceAccountPrivateKeyPem: string;
+    vaultId: string;
+    walletId: string;
+}
+
+export interface UtilaWalletResponse {
+    wallet?: {
+        solanaDetails?: {
+            address?: string;
+        };
+    };
+}
+
+export interface UtilaInitiateTransactionRequest {
+    designatedSigners?: readonly string[];
+    details: {
+        solanaSerializedTransaction: {
+            network: string;
+            publish: false;
+            rawTransaction: string;
+            replaceBlockhash: false;
+            tryReplaceBlockhash: false;
+        };
+    };
+}
+
+export interface UtilaTransactionEnvelope {
+    transaction?: UtilaTransaction;
+}
+
+export type UtilaTransactionState =
+    | 'AWAITING_APPROVAL'
+    | 'AWAITING_AML_POLICY_CHECK'
+    | 'DECLINED_BY_AML_POLICY'
+    | 'AWAITING_POLICY_CHECK'
+    | 'AWAITING_SIGNATURE'
+    | 'SIGNED'
+    | 'AWAITING_PUBLISH'
+    | 'PUBLISHED'
+    | 'MINED'
+    | 'MINED_FAILED'
+    | 'FAILED'
+    | 'DECLINED'
+    | 'REPLACED'
+    | 'CANCELED'
+    | 'DROPPED'
+    | 'CONFIRMED'
+    | 'EXPIRED'
+    | string;
+
+export interface UtilaTransaction {
+    name?: string;
+    solanaTransaction?: {
+        rawTransaction?: string;
+    };
+    state?: UtilaTransactionState;
+}

--- a/typescript/packages/utila/src/utila-signer.ts
+++ b/typescript/packages/utila/src/utila-signer.ts
@@ -1,0 +1,503 @@
+import { assertIsAddress, type Address } from '@solana/addresses';
+import { getBase64Encoder } from '@solana/codecs-strings';
+import {
+    assertSignatureValid,
+    createSignatureDictionary,
+    sanitizeRemoteErrorResponse,
+    SignerErrorCode,
+    type SolanaSigner,
+    throwSignerError,
+} from '@solana/keychain-core';
+import type { SignatureBytes } from '@solana/keys';
+import type { SignableMessage, SignatureDictionary } from '@solana/signers';
+import {
+    getBase64EncodedWireTransaction,
+    getTransactionDecoder,
+    type Transaction,
+    type TransactionWithLifetime,
+    type TransactionWithinSizeLimit,
+} from '@solana/transactions';
+import { importPKCS8, SignJWT } from 'jose';
+
+import type {
+    UtilaInitiateTransactionRequest,
+    UtilaSignerConfig,
+    UtilaTransaction,
+    UtilaTransactionEnvelope,
+    UtilaWalletResponse,
+} from './types.js';
+
+type ImportedPrivateKey = Awaited<ReturnType<typeof importPKCS8>>;
+type ReadonlyBytes = ArrayLike<number> & { readonly byteLength: number };
+
+const DEFAULT_API_BASE_URL = 'https://api.utila.io';
+const UTILA_API_AUDIENCE = 'https://api.utila.io/';
+const DEFAULT_POLL_INTERVAL_MS = 1000;
+const DEFAULT_MAX_POLL_ATTEMPTS = 60;
+const TOKEN_TTL = '55m';
+
+const TERMINAL_FAILURE_STATES = new Set([
+    'DECLINED_BY_AML_POLICY',
+    'MINED_FAILED',
+    'FAILED',
+    'DECLINED',
+    'REPLACED',
+    'CANCELED',
+    'DROPPED',
+    'EXPIRED',
+]);
+
+let base64Encoder: ReturnType<typeof getBase64Encoder> | undefined;
+
+/**
+ * Create and initialize a Utila-backed signer.
+ *
+ * @throws {SignerError} `SIGNER_CONFIG_ERROR` when required config is missing or invalid.
+ * @throws {SignerError} `SIGNER_HTTP_ERROR`, `SIGNER_REMOTE_API_ERROR`,
+ * `SIGNER_PARSING_ERROR`, or `SIGNER_INVALID_PUBLIC_KEY` when initialization fails.
+ */
+export async function createUtilaSigner<TAddress extends string = string>(
+    config: UtilaSignerConfig,
+): Promise<SolanaSigner<TAddress>> {
+    return await UtilaSigner.create(config);
+}
+
+export async function createUtilaAccessToken(
+    serviceAccountEmail: string,
+    privateKey: ImportedPrivateKey,
+): Promise<string> {
+    try {
+        return await new SignJWT({})
+            .setProtectedHeader({ alg: 'RS256' })
+            .setSubject(serviceAccountEmail)
+            .setAudience(UTILA_API_AUDIENCE)
+            .setExpirationTime(TOKEN_TTL)
+            .sign(privateKey);
+    } catch (error) {
+        throwSignerError(SignerErrorCode.SIGNING_FAILED, {
+            cause: error,
+            message: 'Failed to create Utila access token',
+        });
+    }
+}
+
+/**
+ * Utila-backed signer for Solana transactions.
+ *
+ * @deprecated Prefer `createUtilaSigner()`. Class export will be removed in a future version.
+ */
+export class UtilaSigner<TAddress extends string = string> implements SolanaSigner<TAddress> {
+    readonly address: Address<TAddress>;
+    private readonly apiBaseUrl: string;
+    private readonly designatedSigners: readonly string[];
+    private readonly maxPollAttempts: number;
+    private readonly network: string;
+    private readonly pollIntervalMs: number;
+    private readonly serviceAccountEmail: string;
+    private readonly serviceAccountPrivateKey: ImportedPrivateKey;
+    private readonly vaultId: string;
+    private readonly walletId: string;
+
+    static async create<TAddress extends string = string>(config: UtilaSignerConfig): Promise<UtilaSigner<TAddress>> {
+        validateRequired('serviceAccountEmail', config.serviceAccountEmail);
+        validateRequired('serviceAccountPrivateKeyPem', config.serviceAccountPrivateKeyPem);
+        validateRequired('vaultId', config.vaultId);
+        validateRequired('walletId', config.walletId);
+        validateRequired('network', config.network);
+
+        const apiBaseUrl = normalizeBaseUrl(config.apiBaseUrl ?? DEFAULT_API_BASE_URL);
+        validateHttpsApiBaseUrl(apiBaseUrl);
+
+        const pollIntervalMs = config.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+        if (pollIntervalMs <= 0) {
+            throwSignerError(SignerErrorCode.CONFIG_ERROR, {
+                message: 'pollIntervalMs must be greater than 0',
+            });
+        }
+
+        const maxPollAttempts = config.maxPollAttempts ?? DEFAULT_MAX_POLL_ATTEMPTS;
+        if (maxPollAttempts <= 0) {
+            throwSignerError(SignerErrorCode.CONFIG_ERROR, {
+                message: 'maxPollAttempts must be greater than 0',
+            });
+        }
+
+        let privateKey: ImportedPrivateKey;
+        try {
+            privateKey = await importPKCS8(config.serviceAccountPrivateKeyPem, 'RS256');
+        } catch (error) {
+            throwSignerError(SignerErrorCode.INVALID_PRIVATE_KEY, {
+                cause: error,
+                message: 'Failed to parse Utila service account RSA private key',
+            });
+        }
+
+        const vaultId = trimResourcePrefix(config.vaultId, 'vaults/');
+        const walletId = trimWalletId(config.walletId);
+        const designatedSigners = config.designatedSigners ?? [`users/${config.serviceAccountEmail}`];
+        const wallet = await fetchWallet({
+            apiBaseUrl,
+            privateKey,
+            serviceAccountEmail: config.serviceAccountEmail,
+            vaultId,
+            walletId,
+        });
+        const address = wallet.wallet?.solanaDetails?.address;
+        if (!address) {
+            throwSignerError(SignerErrorCode.INVALID_PUBLIC_KEY, {
+                message: 'Utila wallet response missing solanaDetails.address',
+            });
+        }
+
+        try {
+            assertIsAddress(address);
+        } catch (error) {
+            throwSignerError(SignerErrorCode.INVALID_PUBLIC_KEY, {
+                cause: error,
+                message: 'Invalid Solana address from Utila wallet response',
+            });
+        }
+
+        return new UtilaSigner<TAddress>({
+            address: address as Address<TAddress>,
+            apiBaseUrl,
+            designatedSigners,
+            maxPollAttempts,
+            network: config.network,
+            pollIntervalMs,
+            privateKey,
+            serviceAccountEmail: config.serviceAccountEmail,
+            vaultId,
+            walletId,
+        });
+    }
+
+    private constructor(config: {
+        address: Address<TAddress>;
+        apiBaseUrl: string;
+        designatedSigners: readonly string[];
+        maxPollAttempts: number;
+        network: string;
+        pollIntervalMs: number;
+        privateKey: ImportedPrivateKey;
+        serviceAccountEmail: string;
+        vaultId: string;
+        walletId: string;
+    }) {
+        this.address = config.address;
+        this.apiBaseUrl = config.apiBaseUrl;
+        this.designatedSigners = config.designatedSigners;
+        this.maxPollAttempts = config.maxPollAttempts;
+        this.network = config.network;
+        this.pollIntervalMs = config.pollIntervalMs;
+        this.serviceAccountEmail = config.serviceAccountEmail;
+        this.serviceAccountPrivateKey = config.privateKey;
+        this.vaultId = config.vaultId;
+        this.walletId = config.walletId;
+    }
+
+    async signMessages(_messages: readonly SignableMessage[]): Promise<readonly SignatureDictionary[]> {
+        throwSignerError(SignerErrorCode.SIGNING_FAILED, {
+            message: 'Utila signMessages is not supported for Solana wallets in this signer',
+        });
+    }
+
+    async signTransactions(
+        transactions: readonly (Transaction & TransactionWithinSizeLimit & TransactionWithLifetime)[],
+    ): Promise<readonly SignatureDictionary[]> {
+        return await Promise.all(
+            transactions.map(async transaction => {
+                const signature = await this.signTransactionWithUtila(transaction);
+                return createSignatureDictionary({
+                    signature,
+                    signerAddress: this.address,
+                });
+            }),
+        );
+    }
+
+    async isAvailable(): Promise<boolean> {
+        try {
+            await fetchWallet({
+                apiBaseUrl: this.apiBaseUrl,
+                privateKey: this.serviceAccountPrivateKey,
+                serviceAccountEmail: this.serviceAccountEmail,
+                vaultId: this.vaultId,
+                walletId: this.walletId,
+            });
+            return true;
+        } catch {
+            return false;
+        }
+    }
+
+    private async signTransactionWithUtila(
+        transaction: Transaction & TransactionWithinSizeLimit & TransactionWithLifetime,
+    ): Promise<SignatureBytes> {
+        const rawTransaction = getBase64EncodedWireTransaction(transaction);
+        const initiated = await this.initiateTransaction(rawTransaction);
+        const signed = await this.pollSignedTransaction(initiated);
+        const rawSignedTransaction = signed.solanaTransaction?.rawTransaction;
+        if (!rawSignedTransaction) {
+            throwSignerError(SignerErrorCode.SIGNING_FAILED, {
+                message: 'Utila signed transaction response missing solanaTransaction.rawTransaction',
+            });
+        }
+
+        return await this.extractSignatureFromRawTransaction(rawSignedTransaction, transaction.messageBytes);
+    }
+
+    private async initiateTransaction(rawTransaction: string): Promise<UtilaTransaction> {
+        const body: UtilaInitiateTransactionRequest = {
+            designatedSigners: this.designatedSigners,
+            details: {
+                solanaSerializedTransaction: {
+                    network: this.network,
+                    publish: false,
+                    rawTransaction,
+                    replaceBlockhash: false,
+                    tryReplaceBlockhash: false,
+                },
+            },
+        };
+
+        const response = await this.request<UtilaTransactionEnvelope>(
+            `/v2/vaults/${encodeURIComponent(this.vaultId)}/transactions:initiate`,
+            'POST',
+            body,
+        );
+        return parseTransactionEnvelope(response, 'initiate transaction');
+    }
+
+    private async getTransaction(transactionId: string): Promise<UtilaTransaction> {
+        const response = await this.request<UtilaTransactionEnvelope>(
+            `/v2/vaults/${encodeURIComponent(this.vaultId)}/transactions/${encodeURIComponent(transactionId)}?view=FULL`,
+            'GET',
+        );
+        return parseTransactionEnvelope(response, 'get transaction');
+    }
+
+    private async pollSignedTransaction(transaction: UtilaTransaction): Promise<UtilaTransaction> {
+        let current = transaction;
+
+        for (let attempt = 0; attempt < this.maxPollAttempts; attempt++) {
+            if (current.state === 'SIGNED') {
+                return current;
+            }
+            if (current.state && TERMINAL_FAILURE_STATES.has(current.state)) {
+                throwSignerError(SignerErrorCode.SIGNING_FAILED, {
+                    message: `Utila transaction reached terminal state ${current.state}`,
+                });
+            }
+
+            await new Promise(resolve => setTimeout(resolve, this.pollIntervalMs));
+            current = await this.getTransaction(extractTransactionId(current.name));
+        }
+
+        if (current.state === 'SIGNED') {
+            return current;
+        }
+        if (current.state && TERMINAL_FAILURE_STATES.has(current.state)) {
+            throwSignerError(SignerErrorCode.SIGNING_FAILED, {
+                message: `Utila transaction reached terminal state ${current.state}`,
+            });
+        }
+
+        throwSignerError(SignerErrorCode.REMOTE_API_ERROR, {
+            message: `Utila transaction polling timed out after ${this.maxPollAttempts} attempts`,
+        });
+    }
+
+    private async request<T>(path: string, method: 'GET' | 'POST', body?: unknown): Promise<T> {
+        const url = `${this.apiBaseUrl}${path}`;
+        const token = await createUtilaAccessToken(this.serviceAccountEmail, this.serviceAccountPrivateKey);
+        const headers: Record<string, string> = {
+            Authorization: `Bearer ${token}`,
+        };
+        if (body != null) {
+            headers['Content-Type'] = 'application/json';
+        }
+
+        let response: Response;
+        try {
+            response = await fetch(url, {
+                body: body != null ? JSON.stringify(body) : undefined,
+                headers,
+                method,
+            });
+        } catch (error) {
+            throwSignerError(SignerErrorCode.HTTP_ERROR, {
+                cause: error,
+                message: 'Utila network request failed',
+                url,
+            });
+        }
+
+        if (!response.ok) {
+            const errorText = await response.text().catch(() => 'Failed to read error response');
+            throwSignerError(SignerErrorCode.REMOTE_API_ERROR, {
+                message: `Utila API error: ${response.status}`,
+                response: sanitizeRemoteErrorResponse(errorText),
+                status: response.status,
+            });
+        }
+
+        try {
+            return (await response.json()) as T;
+        } catch (error) {
+            throwSignerError(SignerErrorCode.PARSING_ERROR, {
+                cause: error,
+                message: 'Failed to parse Utila response',
+            });
+        }
+    }
+
+    private async extractSignatureFromRawTransaction(
+        rawTransaction: string,
+        expectedMessageBytes: ReadonlyBytes,
+    ): Promise<SignatureBytes> {
+        base64Encoder ||= getBase64Encoder();
+        const transactionBytes = base64Encoder.encode(rawTransaction);
+        const decodedTransaction = getTransactionDecoder().decode(transactionBytes);
+
+        if (!bytesEqual(decodedTransaction.messageBytes, expectedMessageBytes)) {
+            throwSignerError(SignerErrorCode.SIGNING_FAILED, {
+                message: 'Utila returned a signed transaction with different message bytes',
+            });
+        }
+
+        const signature = decodedTransaction.signatures[this.address];
+        if (!signature) {
+            throwSignerError(SignerErrorCode.SIGNING_FAILED, {
+                address: this.address,
+                message: `No signature found for address ${this.address}`,
+            });
+        }
+
+        await assertSignatureValid({
+            data: new Uint8Array(expectedMessageBytes),
+            signature,
+            signerAddress: this.address,
+        });
+        return signature;
+    }
+}
+
+async function fetchWallet({
+    apiBaseUrl,
+    privateKey,
+    serviceAccountEmail,
+    vaultId,
+    walletId,
+}: {
+    apiBaseUrl: string;
+    privateKey: ImportedPrivateKey;
+    serviceAccountEmail: string;
+    vaultId: string;
+    walletId: string;
+}): Promise<UtilaWalletResponse> {
+    const url = `${apiBaseUrl}/v2/vaults/${encodeURIComponent(vaultId)}/wallets/${encodeURIComponent(walletId)}`;
+    const token = await createUtilaAccessToken(serviceAccountEmail, privateKey);
+
+    let response: Response;
+    try {
+        response = await fetch(url, {
+            headers: {
+                Authorization: `Bearer ${token}`,
+            },
+            method: 'GET',
+        });
+    } catch (error) {
+        throwSignerError(SignerErrorCode.HTTP_ERROR, {
+            cause: error,
+            message: 'Utila network request failed',
+            url,
+        });
+    }
+
+    if (!response.ok) {
+        const errorText = await response.text().catch(() => 'Failed to read error response');
+        throwSignerError(SignerErrorCode.REMOTE_API_ERROR, {
+            message: `Utila API error: ${response.status}`,
+            response: sanitizeRemoteErrorResponse(errorText),
+            status: response.status,
+        });
+    }
+
+    try {
+        return (await response.json()) as UtilaWalletResponse;
+    } catch (error) {
+        throwSignerError(SignerErrorCode.PARSING_ERROR, {
+            cause: error,
+            message: 'Failed to parse Utila wallet response',
+        });
+    }
+}
+
+function parseTransactionEnvelope(payload: UtilaTransactionEnvelope, context: string): UtilaTransaction {
+    const transaction = payload.transaction;
+    if (!transaction?.name || !transaction.state) {
+        throwSignerError(SignerErrorCode.REMOTE_API_ERROR, {
+            message: `Failed to ${context}: missing transaction name/state`,
+        });
+    }
+    return transaction;
+}
+
+function extractTransactionId(name?: string): string {
+    const parts = name?.split('/').filter(Boolean) ?? [];
+    const transactionId = parts[parts.length - 1];
+    if (!transactionId) {
+        throwSignerError(SignerErrorCode.REMOTE_API_ERROR, {
+            message: 'Utila transaction response missing transaction id',
+        });
+    }
+    return transactionId;
+}
+
+function validateRequired(field: string, value: string | undefined): void {
+    if (!value?.trim()) {
+        throwSignerError(SignerErrorCode.CONFIG_ERROR, {
+            message: `Missing required ${field} field`,
+        });
+    }
+}
+
+function normalizeBaseUrl(baseUrl: string): string {
+    return baseUrl.replace(/\/+$/, '');
+}
+
+function validateHttpsApiBaseUrl(apiBaseUrl: string): void {
+    let parsedUrl: URL;
+    try {
+        parsedUrl = new URL(apiBaseUrl);
+    } catch (error) {
+        throwSignerError(SignerErrorCode.CONFIG_ERROR, {
+            cause: error,
+            message: `Invalid apiBaseUrl: ${apiBaseUrl}`,
+        });
+    }
+    if (parsedUrl.protocol !== 'https:') {
+        throwSignerError(SignerErrorCode.CONFIG_ERROR, {
+            message: 'apiBaseUrl must use HTTPS',
+        });
+    }
+}
+
+function trimResourcePrefix(value: string, prefix: string): string {
+    return value.startsWith(prefix) ? value.slice(prefix.length) : value;
+}
+
+function trimWalletId(value: string): string {
+    const marker = '/wallets/';
+    const markerIndex = value.lastIndexOf(marker);
+    return markerIndex === -1 ? value : value.slice(markerIndex + marker.length);
+}
+
+function bytesEqual(a: ReadonlyBytes, b: ReadonlyBytes): boolean {
+    if (a.byteLength !== b.byteLength) return false;
+    for (let i = 0; i < a.byteLength; i++) {
+        if (a[i] !== b[i]) return false;
+    }
+    return true;
+}

--- a/typescript/packages/utila/src/utila-signer.ts
+++ b/typescript/packages/utila/src/utila-signer.ts
@@ -1,9 +1,8 @@
 import { type Address, assertIsAddress } from '@solana/addresses';
-import { getBase64Encoder } from '@solana/codecs-strings';
 import {
     assertSignatureValid,
-    createSignatureDictionary,
     createSignerError,
+    extractSignatureFromWireTransaction,
     normalizePrivateKeyPem,
     sanitizeRemoteErrorResponse,
     SignerErrorCode,
@@ -12,8 +11,8 @@ import {
 } from '@solana/keychain-core';
 import type { SignableMessage, SignatureDictionary } from '@solana/signers';
 import {
+    type Base64EncodedWireTransaction,
     getBase64EncodedWireTransaction,
-    getTransactionDecoder,
     type Transaction,
     type TransactionWithinSizeLimit,
     type TransactionWithLifetime,
@@ -29,7 +28,6 @@ import type {
 } from './types.js';
 
 type ImportedPrivateKey = Awaited<ReturnType<typeof importPKCS8>>;
-type ReadonlyBytes = ArrayLike<number> & { readonly byteLength: number };
 
 const DEFAULT_API_BASE_URL = 'https://api.utila.io';
 const UTILA_API_AUDIENCE = 'https://api.utila.io/';
@@ -47,8 +45,6 @@ const TERMINAL_FAILURE_STATES = new Set([
     'DROPPED',
     'EXPIRED',
 ]);
-
-let base64Encoder: ReturnType<typeof getBase64Encoder> | undefined;
 
 /**
  * Create and initialize a Utila-backed signer.
@@ -240,7 +236,23 @@ export class UtilaSigner<TAddress extends string = string> implements SolanaSign
             });
         }
 
-        return await this.extractSignatureFromRawTransaction(rawSignedTransaction, transaction.messageBytes);
+        const sigDict = extractSignatureFromWireTransaction({
+            base64WireTransaction: rawSignedTransaction as Base64EncodedWireTransaction,
+            signerAddress: this.address,
+        });
+        const signatureBytes = Object.values(sigDict)[0];
+        if (!signatureBytes) {
+            throwSignerError(SignerErrorCode.SIGNING_FAILED, {
+                address: this.address,
+                message: 'No signature bytes found in extracted signature dictionary',
+            });
+        }
+        await assertSignatureValid({
+            data: transaction.messageBytes,
+            signature: signatureBytes,
+            signerAddress: this.address,
+        });
+        return sigDict;
     }
 
     private async initiateTransaction(rawTransaction: string): Promise<UtilaTransaction> {
@@ -346,44 +358,6 @@ export class UtilaSigner<TAddress extends string = string> implements SolanaSign
                 message: 'Failed to parse Utila response',
             });
         }
-    }
-
-    private async extractSignatureFromRawTransaction(
-        rawTransaction: string,
-        expectedMessageBytes: ReadonlyBytes,
-    ): Promise<SignatureDictionary> {
-        base64Encoder ||= getBase64Encoder();
-        let decodedTransaction: Transaction;
-        try {
-            const transactionBytes = base64Encoder.encode(rawTransaction);
-            decodedTransaction = getTransactionDecoder().decode(transactionBytes);
-        } catch (error) {
-            throwSignerError(SignerErrorCode.PARSING_ERROR, {
-                cause: error,
-                message: 'Failed to decode Utila signed transaction',
-            });
-        }
-
-        if (!bytesEqual(decodedTransaction.messageBytes, expectedMessageBytes)) {
-            throwSignerError(SignerErrorCode.SIGNING_FAILED, {
-                message: 'Utila returned a signed transaction with different message bytes',
-            });
-        }
-
-        const signature = decodedTransaction.signatures[this.address];
-        if (!signature) {
-            throwSignerError(SignerErrorCode.SIGNING_FAILED, {
-                address: this.address,
-                message: `No signature found for address ${this.address}`,
-            });
-        }
-
-        await assertSignatureValid({
-            data: new Uint8Array(expectedMessageBytes),
-            signature,
-            signerAddress: this.address,
-        });
-        return createSignatureDictionary({ signature, signerAddress: this.address });
     }
 }
 
@@ -496,12 +470,4 @@ function trimWalletId(value: string): string {
     const marker = '/wallets/';
     const markerIndex = value.lastIndexOf(marker);
     return markerIndex === -1 ? value : value.slice(markerIndex + marker.length);
-}
-
-function bytesEqual(a: ReadonlyBytes, b: ReadonlyBytes): boolean {
-    if (a.byteLength !== b.byteLength) return false;
-    for (let i = 0; i < a.byteLength; i++) {
-        if (a[i] !== b[i]) return false;
-    }
-    return true;
 }

--- a/typescript/packages/utila/src/utila-signer.ts
+++ b/typescript/packages/utila/src/utila-signer.ts
@@ -1,8 +1,10 @@
-import { assertIsAddress, type Address } from '@solana/addresses';
+import { type Address, assertIsAddress } from '@solana/addresses';
 import { getBase64Encoder } from '@solana/codecs-strings';
 import {
     assertSignatureValid,
     createSignatureDictionary,
+    createSignerError,
+    normalizePrivateKeyPem,
     sanitizeRemoteErrorResponse,
     SignerErrorCode,
     type SolanaSigner,
@@ -14,8 +16,8 @@ import {
     getBase64EncodedWireTransaction,
     getTransactionDecoder,
     type Transaction,
-    type TransactionWithLifetime,
     type TransactionWithinSizeLimit,
+    type TransactionWithLifetime,
 } from '@solana/transactions';
 import { importPKCS8, SignJWT } from 'jose';
 
@@ -124,7 +126,8 @@ export class UtilaSigner<TAddress extends string = string> implements SolanaSign
 
         let privateKey: ImportedPrivateKey;
         try {
-            privateKey = await importPKCS8(config.serviceAccountPrivateKeyPem, 'RS256');
+            const pem = normalizePrivateKeyPem(config.serviceAccountPrivateKeyPem);
+            privateKey = await importPKCS8(pem, 'RS256');
         } catch (error) {
             throwSignerError(SignerErrorCode.INVALID_PRIVATE_KEY, {
                 cause: error,
@@ -197,9 +200,11 @@ export class UtilaSigner<TAddress extends string = string> implements SolanaSign
     }
 
     async signMessages(_messages: readonly SignableMessage[]): Promise<readonly SignatureDictionary[]> {
-        throwSignerError(SignerErrorCode.SIGNING_FAILED, {
-            message: 'Utila signMessages is not supported for Solana wallets in this signer',
-        });
+        return await Promise.reject(
+            createSignerError(SignerErrorCode.SIGNING_FAILED, {
+                message: 'Utila signMessages is not supported for Solana wallets in this signer',
+            }),
+        );
     }
 
     async signTransactions(
@@ -357,8 +362,16 @@ export class UtilaSigner<TAddress extends string = string> implements SolanaSign
         expectedMessageBytes: ReadonlyBytes,
     ): Promise<SignatureBytes> {
         base64Encoder ||= getBase64Encoder();
-        const transactionBytes = base64Encoder.encode(rawTransaction);
-        const decodedTransaction = getTransactionDecoder().decode(transactionBytes);
+        let decodedTransaction: Transaction;
+        try {
+            const transactionBytes = base64Encoder.encode(rawTransaction);
+            decodedTransaction = getTransactionDecoder().decode(transactionBytes);
+        } catch (error) {
+            throwSignerError(SignerErrorCode.PARSING_ERROR, {
+                cause: error,
+                message: 'Failed to decode Utila signed transaction',
+            });
+        }
 
         if (!bytesEqual(decodedTransaction.messageBytes, expectedMessageBytes)) {
             throwSignerError(SignerErrorCode.SIGNING_FAILED, {

--- a/typescript/packages/utila/src/utila-signer.ts
+++ b/typescript/packages/utila/src/utila-signer.ts
@@ -10,7 +10,6 @@ import {
     type SolanaSigner,
     throwSignerError,
 } from '@solana/keychain-core';
-import type { SignatureBytes } from '@solana/keys';
 import type { SignableMessage, SignatureDictionary } from '@solana/signers';
 import {
     getBase64EncodedWireTransaction,
@@ -145,7 +144,7 @@ export class UtilaSigner<TAddress extends string = string> implements SolanaSign
             vaultId,
             walletId,
         });
-        const address = wallet.wallet?.solanaDetails?.address;
+        const address = wallet?.wallet?.solanaDetails?.address;
         if (!address) {
             throwSignerError(SignerErrorCode.INVALID_PUBLIC_KEY, {
                 message: 'Utila wallet response missing solanaDetails.address',
@@ -210,15 +209,7 @@ export class UtilaSigner<TAddress extends string = string> implements SolanaSign
     async signTransactions(
         transactions: readonly (Transaction & TransactionWithinSizeLimit & TransactionWithLifetime)[],
     ): Promise<readonly SignatureDictionary[]> {
-        return await Promise.all(
-            transactions.map(async transaction => {
-                const signature = await this.signTransactionWithUtila(transaction);
-                return createSignatureDictionary({
-                    signature,
-                    signerAddress: this.address,
-                });
-            }),
-        );
+        return await Promise.all(transactions.map(transaction => this.signTransactionWithUtila(transaction)));
     }
 
     async isAvailable(): Promise<boolean> {
@@ -238,7 +229,7 @@ export class UtilaSigner<TAddress extends string = string> implements SolanaSign
 
     private async signTransactionWithUtila(
         transaction: Transaction & TransactionWithinSizeLimit & TransactionWithLifetime,
-    ): Promise<SignatureBytes> {
+    ): Promise<SignatureDictionary> {
         const rawTransaction = getBase64EncodedWireTransaction(transaction);
         const initiated = await this.initiateTransaction(rawTransaction);
         const signed = await this.pollSignedTransaction(initiated);
@@ -360,7 +351,7 @@ export class UtilaSigner<TAddress extends string = string> implements SolanaSign
     private async extractSignatureFromRawTransaction(
         rawTransaction: string,
         expectedMessageBytes: ReadonlyBytes,
-    ): Promise<SignatureBytes> {
+    ): Promise<SignatureDictionary> {
         base64Encoder ||= getBase64Encoder();
         let decodedTransaction: Transaction;
         try {
@@ -392,7 +383,7 @@ export class UtilaSigner<TAddress extends string = string> implements SolanaSign
             signature,
             signerAddress: this.address,
         });
-        return signature;
+        return createSignatureDictionary({ signature, signerAddress: this.address });
     }
 }
 
@@ -448,7 +439,7 @@ async function fetchWallet({
 }
 
 function parseTransactionEnvelope(payload: UtilaTransactionEnvelope, context: string): UtilaTransaction {
-    const transaction = payload.transaction;
+    const transaction = payload?.transaction;
     if (!transaction?.name || !transaction.state) {
         throwSignerError(SignerErrorCode.REMOTE_API_ERROR, {
             message: `Failed to ${context}: missing transaction name/state`,

--- a/typescript/packages/utila/tsconfig.json
+++ b/typescript/packages/utila/tsconfig.json
@@ -1,0 +1,11 @@
+{
+    "extends": "../../tsconfig.base.json",
+    "compilerOptions": {
+        "outDir": "./dist",
+        "rootDir": "./src",
+        "composite": true
+    },
+    "include": ["src/**/*"],
+    "exclude": ["node_modules", "dist"],
+    "references": [{ "path": "../core" }]
+}

--- a/typescript/pnpm-lock.yaml
+++ b/typescript/pnpm-lock.yaml
@@ -349,6 +349,9 @@ importers:
       '@solana/keychain-turnkey':
         specifier: workspace:*
         version: link:../turnkey
+      '@solana/keychain-utila':
+        specifier: workspace:*
+        version: link:../utila
       '@solana/keychain-vault':
         specifier: workspace:*
         version: link:../vault
@@ -523,6 +526,40 @@ importers:
       '@solana/keys':
         specifier: ^6.9.0
         version: 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/signers':
+        specifier: ^6.9.0
+        version: 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/transactions':
+        specifier: ^6.9.0
+        version: 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      dotenv:
+        specifier: ^17.4.2
+        version: 17.4.2
+
+  packages/utila:
+    dependencies:
+      '@solana/keychain-core':
+        specifier: workspace:*
+        version: link:../core
+      jose:
+        specifier: ^6.2.3
+        version: 6.2.3
+    devDependencies:
+      '@solana/addresses':
+        specifier: ^6.9.0
+        version: 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/codecs-strings':
+        specifier: ^6.9.0
+        version: 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/keychain-test-utils':
+        specifier: workspace:*
+        version: link:../test-utils
+      '@solana/keys':
+        specifier: ^6.9.0
+        version: 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/kit':
+        specifier: ^6.9.0
+        version: 6.9.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@solana/signers':
         specifier: ^6.9.0
         version: 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)


### PR DESCRIPTION
## Summary
- add Utila as a Rust and TypeScript signer backend
- wire Utila into the keychain factory, exports, docs, and CI package lists
- support Solana transaction signing via Utila serialized transactions; keep message signing explicitly unsupported

## Validation
- pnpm -F @solana/keychain-utila test
- pnpm -F @solana/keychain-utila test:integration
- cargo test --no-default-features --features utila,integration-tests,sdk-v2 test_utila_ -- --nocapture --test-threads=1
- live Utila co-signer signed devnet test transactions successfully