### PR TITLE
ci: include utila in fork live tests

### DIFF
--- a/.github/workflows/fork-external-live-manual.yml
+++ b/.github/workflows/fork-external-live-manual.yml
@@ -35,6 +35,7 @@ jobs:
           CI_SIGNER_DFNS_ENABLED: ${{ vars.CI_SIGNER_DFNS_ENABLED }}
           CI_SIGNER_CROSSMINT_ENABLED: ${{ vars.CI_SIGNER_CROSSMINT_ENABLED }}
           CI_SIGNER_OPENFORT_ENABLED: ${{ vars.CI_SIGNER_OPENFORT_ENABLED }}
+          CI_SIGNER_UTILA_ENABLED: ${{ vars.CI_SIGNER_UTILA_ENABLED }}
         with:
           script: |
             const parseVar = (name) => {
@@ -60,6 +61,7 @@ jobs:
               dfns: parseVar('CI_SIGNER_DFNS_ENABLED'),
               crossmint: parseVar('CI_SIGNER_CROSSMINT_ENABLED'),
               openfort: parseVar('CI_SIGNER_OPENFORT_ENABLED'),
+              utila: parseVar('CI_SIGNER_UTILA_ENABLED'),
             };
 
             const rustFeatureOrder = [
@@ -75,6 +77,7 @@ jobs:
               'dfns',
               'crossmint',
               'openfort',
+              'utila',
             ];
 
             const rustLiveTestMap = [
@@ -88,6 +91,7 @@ jobs:
               ['dfns', 'test_dfns_integration'],
               ['crossmint', 'test_crossmint_integration'],
               ['openfort', 'test_openfort_integration'],
+              ['utila', 'test_utila_integration'],
             ];
 
             const tsLivePackageMap = [
@@ -101,6 +105,7 @@ jobs:
               ['dfns', 'dfns'],
               ['crossmint', 'crossmint'],
               ['openfort', 'openfort'],
+              ['utila', 'utila'],
             ];
 
             const rustFeatures = rustFeatureOrder.filter((backend) => enabled[backend]);


### PR DESCRIPTION
Adds `utila` to `fork-external-live-manual.yml` so the Fork External Live Tests workflow (which runs from `main`) includes the Utila signer when validating fork PR #145.

Mirrors #112 (openfort). Five additions to the `resolve-signers` script: env var, `enabled` map, `rustFeatureOrder`, `rustLiveTestMap`, `tsLivePackageMap`.

**Prerequisite before dispatch works:** the repo Actions variable `CI_SIGNER_UTILA_ENABLED` must be set to `true` — `fork-external-live-manual.yml` uses `parseVar` with no default, so a missing variable fails `resolve-signers`.

Must merge before triggering fork live tests for the Utila PR.