### PR TITLE
ci: extend stale PR window from 7 to 30 days

### DIFF
--- a/.github/workflows/stale-prs.yml
+++ b/.github/workflows/stale-prs.yml
@@ -13,12 +13,12 @@ jobs:
     steps:
       - uses: actions/stale@v10.3.0
         with:
-          days-before-pr-stale: 7
+          days-before-pr-stale: 30
           days-before-pr-close: 5
           days-before-issue-stale: -1
           days-before-issue-close: -1
           stale-pr-message: >
-            This PR has been inactive for 7 days and has been marked as stale.
+            This PR has been inactive for 30 days and has been marked as stale.
             It will be closed in 5 days if there is no further activity.
           close-pr-message: 'Closed due to inactivity.'
           stale-pr-label: 'stale'


### PR DESCRIPTION
## Summary
- Change `days-before-pr-stale` from 7 to 30 in the stale PR workflow
- Update the stale-pr-message to reflect the 30-day window

The 5-day close grace period after a PR is marked stale is unchanged.