### PR TITLE
fix(dfns): DER-encode WebCrypto ECDSA P-256 signatures

### DIFF
--- a/typescript/packages/dfns/src/__tests__/auth-ecdsa-der.test.ts
+++ b/typescript/packages/dfns/src/__tests__/auth-ecdsa-der.test.ts
@@ -82,6 +82,11 @@ describe('p1363ToDer', () => {
         expect(parsed.r).toStrictEqual(new Uint8Array([0x05])); // minimal length
         expect(toFixed(parsed.s, 32)).toStrictEqual(s);
     });
+
+    it('rejects odd-length and empty inputs', () => {
+        expect(() => p1363ToDer(new Uint8Array(0))).toThrow(/even-length/);
+        expect(() => p1363ToDer(new Uint8Array(63))).toThrow(/even-length/);
+    });
 });
 
 describe('signClientData', () => {

--- a/typescript/packages/dfns/src/__tests__/auth-ecdsa-der.test.ts
+++ b/typescript/packages/dfns/src/__tests__/auth-ecdsa-der.test.ts
@@ -1,0 +1,116 @@
+import * as nodeCrypto from 'node:crypto';
+
+import { describe, it, expect } from 'vitest';
+
+import { p1363ToDer, signClientData } from '../auth.js';
+
+/**
+ * Parse a DER `SEQUENCE { INTEGER r, INTEGER s }` into its two unsigned
+ * big-endian components (with any DER `0x00` sign-padding stripped).
+ */
+function parseDerEcdsa(der: Uint8Array): { r: Uint8Array; s: Uint8Array } {
+    expect(der[0]).toBe(0x30); // SEQUENCE
+    expect(der[1]).toBe(der.length - 2); // single-byte length matches body
+    let offset = 2;
+
+    const readInteger = (): Uint8Array => {
+        expect(der[offset]).toBe(0x02); // INTEGER
+        const len = der[offset + 1] ?? 0;
+        let content = der.subarray(offset + 2, offset + 2 + len);
+        offset += 2 + len;
+        // Strip a single leading 0x00 sign byte if present.
+        if (content.length > 1 && content[0] === 0x00) {
+            content = content.subarray(1);
+        }
+        return content;
+    };
+
+    const r = readInteger();
+    const s = readInteger();
+    expect(offset).toBe(der.length); // exactly two integers, no trailing bytes
+    return { r, s };
+}
+
+/** Left-pad (or strip leading zeros) to exactly `length` bytes. */
+function toFixed(bytes: Uint8Array, length: number): Uint8Array {
+    const out = new Uint8Array(length);
+    out.set(bytes.subarray(Math.max(0, bytes.length - length)), length - Math.min(length, bytes.length));
+    return out;
+}
+
+describe('p1363ToDer', () => {
+    it('encodes a 64-byte raw r||s as a DER SEQUENCE of two INTEGERs', () => {
+        const r = new Uint8Array(32).fill(0x01);
+        const s = new Uint8Array(32).fill(0x02);
+        const raw = new Uint8Array([...r, ...s]);
+
+        const der = p1363ToDer(raw);
+        expect(der[0]).toBe(0x30);
+        const parsed = parseDerEcdsa(der);
+        expect(toFixed(parsed.r, 32)).toStrictEqual(r);
+        expect(toFixed(parsed.s, 32)).toStrictEqual(s);
+    });
+
+    it('prepends a 0x00 byte when the high bit of r or s is set', () => {
+        const r = new Uint8Array(32);
+        r[0] = 0x80; // high bit set -> must be padded to stay positive
+        const s = new Uint8Array(32);
+        s[0] = 0x7f; // high bit clear -> no padding
+        const raw = new Uint8Array([...r, ...s]);
+
+        const der = p1363ToDer(raw);
+        // r INTEGER content starts right after the outer SEQUENCE header (2 bytes)
+        // + r INTEGER header (2 bytes).
+        expect(der[2]).toBe(0x02); // INTEGER tag for r
+        expect(der[3]).toBe(33); // 32 bytes + 1 sign byte
+        expect(der[4]).toBe(0x00); // sign-padding byte
+        expect(der[5]).toBe(0x80);
+
+        const parsed = parseDerEcdsa(der);
+        expect(toFixed(parsed.r, 32)).toStrictEqual(r);
+        expect(toFixed(parsed.s, 32)).toStrictEqual(s);
+    });
+
+    it('strips leading zero bytes to a minimal-length encoding', () => {
+        const r = new Uint8Array(32);
+        r[31] = 0x05; // value 5, lots of leading zeros
+        const s = new Uint8Array(32).fill(0x33);
+        const raw = new Uint8Array([...r, ...s]);
+
+        const der = p1363ToDer(raw);
+        const parsed = parseDerEcdsa(der);
+        expect(parsed.r).toStrictEqual(new Uint8Array([0x05])); // minimal length
+        expect(toFixed(parsed.s, 32)).toStrictEqual(s);
+    });
+});
+
+describe('signClientData', () => {
+    const clientData = new TextEncoder().encode('{"challenge":"abc","type":"key.get"}');
+
+    it('produces a DER-encoded signature for a P-256 (prime256v1) credential that node verifies', async () => {
+        const { privateKey, publicKey } = nodeCrypto.generateKeyPairSync('ec', { namedCurve: 'prime256v1' });
+        const pem = privateKey.export({ format: 'pem', type: 'pkcs8' }).toString();
+
+        const signature = await signClientData(clientData, pem);
+
+        // DER SEQUENCE tag.
+        expect(signature[0]).toBe(0x30);
+        // Parses as SEQUENCE of exactly two INTEGERs.
+        expect(() => parseDerEcdsa(signature)).not.toThrow();
+
+        // node:crypto verifies the DER signature (dsaEncoding 'der' is the default).
+        const verified = nodeCrypto.verify('sha256', clientData, { dsaEncoding: 'der', key: publicKey }, signature);
+        expect(verified).toBe(true);
+    });
+
+    it('passes Ed25519 signatures through unchanged (64 bytes, no DER wrapping)', async () => {
+        const { privateKey, publicKey } = nodeCrypto.generateKeyPairSync('ed25519');
+        const pem = privateKey.export({ format: 'pem', type: 'pkcs8' }).toString();
+
+        const signature = await signClientData(clientData, pem);
+
+        expect(signature.length).toBe(64); // raw Ed25519 signature, not DER-wrapped
+        const verified = nodeCrypto.verify(null, clientData, publicKey, signature);
+        expect(verified).toBe(true);
+    });
+});

--- a/typescript/packages/dfns/src/auth.ts
+++ b/typescript/packages/dfns/src/auth.ts
@@ -257,6 +257,9 @@ async function signClientDataWithWebCrypto(
  * Dfns (and node:crypto's default) expect DER.
  */
 export function p1363ToDer(raw: Uint8Array): Uint8Array {
+    if (raw.length === 0 || raw.length % 2 !== 0) {
+        throw new Error(`p1363ToDer: expected an even-length byte array, got ${raw.length}`);
+    }
     const half = raw.length / 2;
     const r = encodeDerInteger(raw.subarray(0, half));
     const s = encodeDerInteger(raw.subarray(half));

--- a/typescript/packages/dfns/src/auth.ts
+++ b/typescript/packages/dfns/src/auth.ts
@@ -176,7 +176,7 @@ function isObject(value: unknown): value is Record<string, unknown> {
     return typeof value === 'object' && value !== null;
 }
 
-async function signClientData(clientData: Uint8Array, privateKeyPem: string): Promise<Uint8Array> {
+export async function signClientData(clientData: Uint8Array, privateKeyPem: string): Promise<Uint8Array> {
     const normalizedPem = normalizePrivateKeyPem(privateKeyPem);
 
     let latestError: unknown;
@@ -217,15 +217,22 @@ async function signClientDataWithWebCrypto(
 
     const attempts: ReadonlyArray<{
         importAlgorithm: AlgorithmIdentifier | EcKeyImportParams | RsaHashedImportParams;
+        // When true, the WebCrypto output is an IEEE-P1363 (raw r||s) ECDSA
+        // signature that must be re-encoded as ASN.1 DER before returning, since
+        // Dfns user-action verification expects DER (parity with node:crypto and
+        // the Rust implementation). See rust/src/dfns/auth.rs.
+        isEcdsa: boolean;
         signAlgorithm: AlgorithmIdentifier | EcdsaParams;
     }> = [
-        { importAlgorithm: 'Ed25519', signAlgorithm: 'Ed25519' },
+        { importAlgorithm: 'Ed25519', isEcdsa: false, signAlgorithm: 'Ed25519' },
         {
             importAlgorithm: { name: 'ECDSA', namedCurve: 'P-256' },
+            isEcdsa: true,
             signAlgorithm: { hash: 'SHA-256', name: 'ECDSA' },
         },
         {
             importAlgorithm: { hash: 'SHA-256', name: 'RSASSA-PKCS1-v1_5' },
+            isEcdsa: false,
             signAlgorithm: 'RSASSA-PKCS1-v1_5',
         },
     ];
@@ -233,14 +240,59 @@ async function signClientDataWithWebCrypto(
     for (const attempt of attempts) {
         try {
             const privateKey = await subtle.importKey('pkcs8', privateKeyDer, attempt.importAlgorithm, false, ['sign']);
-            const signature = await subtle.sign(attempt.signAlgorithm, privateKey, input);
-            return new Uint8Array(signature);
+            const signature = new Uint8Array(await subtle.sign(attempt.signAlgorithm, privateKey, input));
+            return attempt.isEcdsa ? p1363ToDer(signature) : signature;
         } catch {
             // Try the next key algorithm.
         }
     }
 
     return undefined;
+}
+
+/**
+ * Convert an IEEE-P1363 (raw r||s) P-256 ECDSA signature into an ASN.1
+ * DER-encoded `SEQUENCE { INTEGER r, INTEGER s }`. WebCrypto's
+ * `subtle.sign({ name: 'ECDSA' }, ...)` returns the 64-byte P1363 form, but
+ * Dfns (and node:crypto's default) expect DER.
+ */
+export function p1363ToDer(raw: Uint8Array): Uint8Array {
+    const half = raw.length / 2;
+    const r = encodeDerInteger(raw.subarray(0, half));
+    const s = encodeDerInteger(raw.subarray(half));
+    const body = new Uint8Array(r.length + s.length);
+    body.set(r, 0);
+    body.set(s, r.length);
+
+    const out = new Uint8Array(2 + body.length);
+    out[0] = 0x30; // SEQUENCE
+    out[1] = body.length; // P-256 bodies are always < 128 bytes (single-byte length)
+    out.set(body, 2);
+    return out;
+}
+
+/**
+ * DER-encode a single unsigned big-endian integer (an ECDSA `r` or `s`
+ * component): strip leading zero bytes to the minimal length, then prepend a
+ * `0x00` byte when the high bit of the first content byte is set so the value
+ * is interpreted as positive.
+ */
+function encodeDerInteger(value: Uint8Array): Uint8Array {
+    let start = 0;
+    while (start < value.length - 1 && value[start] === 0x00) {
+        start += 1;
+    }
+    let content = value.subarray(start);
+    if (((content[0] ?? 0) & 0x80) !== 0) {
+        const padded = new Uint8Array(content.length + 1);
+        padded.set(content, 1);
+        content = padded;
+    }
+    const out = new Uint8Array(2 + content.length);
+    out[0] = 0x02; // INTEGER
+    out[1] = content.length;
+    out.set(content, 2);
+    return out;
 }
 
 async function signClientDataWithNodeCrypto(


### PR DESCRIPTION
## Summary

The Dfns WebCrypto signing path returned IEEE-P1363 (raw `r‖s`) ECDSA signatures, but Dfns user-action verification requires ASN.1 DER. The DER-producing `node:crypto` fallback was unreachable in WebCrypto-capable runtimes, so **P-256 credentials failed on every sign** (browsers, Deno, Bun, modern Node).

This converts the P1363 output to DER for the ECDSA branch only; Ed25519/RSA pass through unchanged.

## Parity

Matches the Rust implementation, which already DER-encodes P-256 signatures via `sig.to_der()` — see [`rust/src/dfns/auth.rs:144`](../blob/main/rust/src/dfns/auth.rs#L144).

## Test

Adds `auth-ecdsa-der.test.ts` covering the P1363→DER conversion (including the high-bit `0x00` padding case).

Closes TOO-481