### PR TITLE
fix(crossmint): sequential signing + scoped approval for managed flow

### DIFF
--- a/typescript/packages/crossmint/src/__tests__/crossmint-signer.test.ts
+++ b/typescript/packages/crossmint/src/__tests__/crossmint-signer.test.ts
@@ -673,8 +673,8 @@ describe('CrossmintSigner', () => {
                             approvals: {
                                 // pending[0] belongs to ANOTHER approver.
                                 pending: [
-                                    { signer: OTHER_SIGNER, message: OTHER_MESSAGE_B58 },
-                                    { signer: OUR_SIGNER, message: OUR_MESSAGE_B58 },
+                                    { signer: { locator: OTHER_SIGNER }, message: OTHER_MESSAGE_B58 },
+                                    { signer: { locator: OUR_SIGNER }, message: OUR_MESSAGE_B58 },
                                 ],
                             },
                         }),
@@ -728,7 +728,7 @@ describe('CrossmintSigner', () => {
                         JSON.stringify({
                             id: 'tx-happy',
                             status: 'awaiting-approval',
-                            approvals: { pending: [{ signer: OUR_SIGNER, message: OUR_MESSAGE_B58 }] },
+                            approvals: { pending: [{ signer: { locator: OUR_SIGNER }, message: OUR_MESSAGE_B58 }] },
                         }),
                         { status: 201 },
                     ),
@@ -761,7 +761,7 @@ describe('CrossmintSigner', () => {
                             id: 'tx-other-only',
                             status: 'awaiting-approval',
                             // Only OTHER approver pending; nothing for us.
-                            approvals: { pending: [{ signer: OTHER_SIGNER, message: OTHER_MESSAGE_B58 }] },
+                            approvals: { pending: [{ signer: { locator: OTHER_SIGNER }, message: OTHER_MESSAGE_B58 }] },
                         }),
                         { status: 201 },
                     ),
@@ -787,7 +787,7 @@ describe('CrossmintSigner', () => {
                         JSON.stringify({
                             id: 'tx-persist',
                             status: 'awaiting-approval',
-                            approvals: { pending: [{ signer: OUR_SIGNER, message: OUR_MESSAGE_B58 }] },
+                            approvals: { pending: [{ signer: { locator: OUR_SIGNER }, message: OUR_MESSAGE_B58 }] },
                         }),
                         { status: 201 },
                     ),
@@ -799,7 +799,7 @@ describe('CrossmintSigner', () => {
                         JSON.stringify({
                             id: 'tx-persist',
                             status: 'awaiting-approval',
-                            approvals: { pending: [{ signer: OUR_SIGNER, message: OUR_MESSAGE_B58 }] },
+                            approvals: { pending: [{ signer: { locator: OUR_SIGNER }, message: OUR_MESSAGE_B58 }] },
                         }),
                         { status: 200 },
                     ),

--- a/typescript/packages/crossmint/src/__tests__/crossmint-signer.test.ts
+++ b/typescript/packages/crossmint/src/__tests__/crossmint-signer.test.ts
@@ -212,6 +212,40 @@ describe('CrossmintSigner', () => {
             });
         });
 
+        it('signs sequentially and stops creating transactions after a failure', async () => {
+            vi.mocked(fetch)
+                .mockResolvedValueOnce(mockWalletResponse()) // create()
+                // tx 0: create -> success
+                .mockResolvedValueOnce(
+                    new Response(
+                        JSON.stringify({ id: 'tx-0', status: 'success', onChain: { txId: MOCK_SIGNATURE_B58 } }),
+                        { status: 201 },
+                    ),
+                )
+                // tx 1: create -> 500 (fails the batch)
+                .mockResolvedValueOnce(new Response(JSON.stringify({ message: 'boom' }), { status: 500 }))
+                // tx 2: should NEVER be created (would only be reached under concurrent Promise.all)
+                .mockResolvedValueOnce(
+                    new Response(
+                        JSON.stringify({ id: 'tx-2', status: 'success', onChain: { txId: MOCK_SIGNATURE_B58 } }),
+                        { status: 201 },
+                    ),
+                );
+
+            const signer = await createCrossmintSigner({
+                ...mockConfig,
+                maxPollAttempts: 1,
+                pollIntervalMs: 1,
+            });
+
+            await expect(
+                signer.signTransactions([createMockTransaction(), createMockTransaction(), createMockTransaction()]),
+            ).rejects.toMatchObject({ code: 'SIGNER_REMOTE_API_ERROR' });
+
+            // wallet create + tx0 create + tx1 create = 3 fetches; tx2 must not be created.
+            expect(vi.mocked(fetch)).toHaveBeenCalledTimes(3);
+        });
+
         it('signs via managed flow and extracts signature from serialized transaction', async () => {
             vi.mocked(fetch)
                 .mockResolvedValueOnce(mockWalletResponse()) // create()

--- a/typescript/packages/crossmint/src/__tests__/crossmint-signer.test.ts
+++ b/typescript/packages/crossmint/src/__tests__/crossmint-signer.test.ts
@@ -1,5 +1,7 @@
+import { createPrivateKey, createPublicKey, hkdfSync, sign as cryptoSign, verify as cryptoVerify } from 'node:crypto';
+
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { getBase58Decoder } from '@solana/codecs-strings';
+import { getBase16Encoder, getBase58Decoder, getBase58Encoder } from '@solana/codecs-strings';
 
 vi.mock('@solana/keychain-core', async importOriginal => {
     const mod = await importOriginal<typeof import('@solana/keychain-core')>();
@@ -29,6 +31,34 @@ const mockConfig = {
 };
 
 const base58Decoder = getBase58Decoder();
+const base58Encoder = getBase58Encoder();
+const base16Encoder = getBase16Encoder();
+
+const PKCS8_ED25519_PREFIX = new Uint8Array([
+    0x30, 0x2e, 0x02, 0x01, 0x00, 0x30, 0x05, 0x06, 0x03, 0x2b, 0x65, 0x70, 0x04, 0x22, 0x04, 0x20,
+]);
+
+// Mirror of the source's deriveSignerSeed so tests can reconstruct the signing
+// key and assert WHICH message bytes the submitted approval signature covers.
+function deriveTestSeed(secret: string, apiKey: string): Uint8Array {
+    const rawSecret = secret.startsWith('xmsk1_') ? secret.slice(6) : secret;
+    const ikm = Buffer.from(base16Encoder.encode(rawSecret));
+    const parts = apiKey.split('_');
+    const environment = parts[1];
+    const base58Data = parts.slice(2).join('_');
+    const decoded = base58Encoder.encode(base58Data);
+    const projectId = new TextDecoder().decode(decoded).split(':')[0];
+    const info = `${projectId}:${environment}:solana-ed25519`;
+    return new Uint8Array(hkdfSync('sha256', ikm, 'crossmint', info, 32));
+}
+
+function testPrivateKey(seed: Uint8Array) {
+    return createPrivateKey({
+        format: 'der',
+        key: Buffer.concat([PKCS8_ED25519_PREFIX, seed]),
+        type: 'pkcs8',
+    });
+}
 const MOCK_SIGNATURE_BYTES = new Uint8Array(64).fill(7);
 const MOCK_SIGNATURE_B58 = base58Decoder.decode(MOCK_SIGNATURE_BYTES);
 const MOCK_MESSAGE_BYTES = new Uint8Array([1, 2, 3]);
@@ -606,6 +636,184 @@ describe('CrossmintSigner', () => {
             const createCall = vi.mocked(fetch).mock.calls[1]!;
             const body = JSON.parse(createCall[1]?.body as string);
             expect(body.params.signer).toBe('my-signer-id');
+        });
+    });
+
+    describe('approvals', () => {
+        // Real Crossmint API key so deriveSignerSeed() succeeds:
+        // {ck|sk}_{env}_{base58(projectId:nacl_signature)}.
+        const SIGNER_API_KEY = `sk_staging_${base58Decoder.decode(new TextEncoder().encode('proj:sig'))}`;
+        const SIGNER_SECRET = 'a'.repeat(64);
+        const OUR_SIGNER = 'server:our-signer-locator';
+        const OTHER_SIGNER = 'server:other-approver-locator';
+
+        const OUR_MESSAGE_B58 = base58Decoder.decode(new Uint8Array([10, 20, 30]));
+        const OTHER_MESSAGE_B58 = base58Decoder.decode(new Uint8Array([40, 50, 60]));
+
+        function approvalConfig(overrides?: Record<string, unknown>) {
+            return {
+                ...mockConfig,
+                apiKey: SIGNER_API_KEY,
+                signer: OUR_SIGNER,
+                signerSecret: SIGNER_SECRET,
+                maxPollAttempts: 3,
+                pollIntervalMs: 1,
+                ...overrides,
+            };
+        }
+
+        it('signs the pending message belonging to ITS signer locator, not pending[0]', async () => {
+            vi.mocked(fetch)
+                .mockResolvedValueOnce(mockWalletResponse()) // create()
+                .mockResolvedValueOnce(
+                    new Response(
+                        JSON.stringify({
+                            id: 'tx-multi',
+                            status: 'awaiting-approval',
+                            approvals: {
+                                // pending[0] belongs to ANOTHER approver.
+                                pending: [
+                                    { signer: OTHER_SIGNER, message: OTHER_MESSAGE_B58 },
+                                    { signer: OUR_SIGNER, message: OUR_MESSAGE_B58 },
+                                ],
+                            },
+                        }),
+                        { status: 201 },
+                    ),
+                )
+                // approvals POST response -> success
+                .mockResolvedValueOnce(
+                    new Response(
+                        JSON.stringify({
+                            id: 'tx-multi',
+                            status: 'success',
+                            onChain: { txId: MOCK_SIGNATURE_B58 },
+                        }),
+                        { status: 200 },
+                    ),
+                );
+
+            const signer = await createCrossmintSigner(approvalConfig());
+            const results = await signer.signTransactions([createMockTransaction()]);
+            expect(results).toHaveLength(1);
+
+            // The approval POST must carry OUR signer locator, and the signature
+            // must be over OUR message bytes (not pending[0]'s).
+            const approvalCall = vi.mocked(fetch).mock.calls[2]!;
+            expect(approvalCall[0]).toContain('/transactions/tx-multi/approvals');
+            const body = JSON.parse(approvalCall[1]?.body as string);
+            expect(body.approvals).toHaveLength(1);
+            expect(body.approvals[0].signer).toBe(OUR_SIGNER);
+
+            // The submitted signature must be over OUR message bytes, not the
+            // other approver's (pending[0]) bytes. Reconstruct the signing key
+            // and verify the signature covers OUR message and NOT the other.
+            const ourMessageBytes = Buffer.from(base58Encoder.encode(OUR_MESSAGE_B58));
+            const otherMessageBytes = Buffer.from(base58Encoder.encode(OTHER_MESSAGE_B58));
+            const sigBytes = Buffer.from(base58Encoder.encode(body.approvals[0].signature));
+
+            const privateKey = testPrivateKey(deriveTestSeed(SIGNER_SECRET, SIGNER_API_KEY));
+            const pub = createPublicKey(privateKey);
+            const expectedOur = Buffer.from(cryptoSign(null, ourMessageBytes, privateKey));
+            expect(cryptoVerify(null, ourMessageBytes, pub, sigBytes)).toBe(true);
+            expect(cryptoVerify(null, otherMessageBytes, pub, sigBytes)).toBe(false);
+            expect(sigBytes.equals(expectedOur)).toBe(true);
+        });
+
+        it('drives the tx to success after a single sufficient approval (happy path)', async () => {
+            vi.mocked(fetch)
+                .mockResolvedValueOnce(mockWalletResponse()) // create()
+                .mockResolvedValueOnce(
+                    new Response(
+                        JSON.stringify({
+                            id: 'tx-happy',
+                            status: 'awaiting-approval',
+                            approvals: { pending: [{ signer: OUR_SIGNER, message: OUR_MESSAGE_B58 }] },
+                        }),
+                        { status: 201 },
+                    ),
+                )
+                .mockResolvedValueOnce(
+                    new Response(
+                        JSON.stringify({
+                            id: 'tx-happy',
+                            status: 'success',
+                            onChain: { txId: MOCK_SIGNATURE_B58 },
+                        }),
+                        { status: 200 },
+                    ),
+                );
+
+            const signer = await createCrossmintSigner(approvalConfig());
+            const results = await signer.signTransactions([createMockTransaction()]);
+            expect(results).toHaveLength(1);
+            expect(results[0]![signer.address]?.length).toBe(64);
+            // wallet + create + approvals = 3 fetches; no extra polling.
+            expect(vi.mocked(fetch)).toHaveBeenCalledTimes(3);
+        });
+
+        it('does not resubmit in a loop when no pending entry is for us; errors with approvals-required', async () => {
+            vi.mocked(fetch)
+                .mockResolvedValueOnce(mockWalletResponse()) // create()
+                .mockResolvedValue(
+                    new Response(
+                        JSON.stringify({
+                            id: 'tx-other-only',
+                            status: 'awaiting-approval',
+                            // Only OTHER approver pending; nothing for us.
+                            approvals: { pending: [{ signer: OTHER_SIGNER, message: OTHER_MESSAGE_B58 }] },
+                        }),
+                        { status: 201 },
+                    ),
+                );
+
+            const signer = await createCrossmintSigner(approvalConfig({ maxPollAttempts: 5 }));
+
+            await expect(signer.signTransactions([createMockTransaction()])).rejects.toMatchObject({
+                code: 'SIGNER_SIGNING_FAILED',
+                message: expect.stringContaining('additional signer approvals are required'),
+            });
+
+            // No approval POST should ever happen (nothing pending for us).
+            const approvalPosts = vi.mocked(fetch).mock.calls.filter(call => String(call[0]).includes('/approvals'));
+            expect(approvalPosts.length).toBe(0);
+        });
+
+        it('submits our approval at most once even when status persists as awaiting-approval', async () => {
+            vi.mocked(fetch)
+                .mockResolvedValueOnce(mockWalletResponse()) // create()
+                .mockResolvedValueOnce(
+                    new Response(
+                        JSON.stringify({
+                            id: 'tx-persist',
+                            status: 'awaiting-approval',
+                            approvals: { pending: [{ signer: OUR_SIGNER, message: OUR_MESSAGE_B58 }] },
+                        }),
+                        { status: 201 },
+                    ),
+                )
+                // approval POST response still awaiting-approval, and our entry
+                // still appears pending (vendor lag). We must NOT resubmit.
+                .mockResolvedValue(
+                    new Response(
+                        JSON.stringify({
+                            id: 'tx-persist',
+                            status: 'awaiting-approval',
+                            approvals: { pending: [{ signer: OUR_SIGNER, message: OUR_MESSAGE_B58 }] },
+                        }),
+                        { status: 200 },
+                    ),
+                );
+
+            const signer = await createCrossmintSigner(approvalConfig({ maxPollAttempts: 5 }));
+
+            await expect(signer.signTransactions([createMockTransaction()])).rejects.toMatchObject({
+                code: 'SIGNER_SIGNING_FAILED',
+                message: expect.stringContaining('additional signer approvals are required'),
+            });
+
+            const approvalPosts = vi.mocked(fetch).mock.calls.filter(call => String(call[0]).includes('/approvals'));
+            expect(approvalPosts.length).toBe(1);
         });
     });
 

--- a/typescript/packages/crossmint/src/crossmint-signer.ts
+++ b/typescript/packages/crossmint/src/crossmint-signer.ts
@@ -296,8 +296,10 @@ class CrossmintSigner<TAddress extends string = string> implements SolanaSigner<
      */
     private findPendingApprovalForSigner(
         response: CrossmintTransactionResponse,
-    ): { message?: string; signer?: unknown } | undefined {
-        return response.approvals?.pending?.find(entry => entry.signer === this.signer);
+    ): { message?: string; signer?: { locator?: string } } | undefined {
+        // The response-side signer is a nested object; match on its `locator`
+        // string (the same value we submit as `signer` when approving).
+        return response.approvals?.pending?.find(entry => entry.signer?.locator === this.signer);
     }
 
     private async submitApproval(response: CrossmintTransactionResponse): Promise<CrossmintTransactionResponse> {

--- a/typescript/packages/crossmint/src/crossmint-signer.ts
+++ b/typescript/packages/crossmint/src/crossmint-signer.ts
@@ -193,18 +193,22 @@ class CrossmintSigner<TAddress extends string = string> implements SolanaSigner<
     async signTransactions(
         transactions: readonly (Transaction & TransactionWithinSizeLimit & TransactionWithLifetime)[],
     ): Promise<readonly SignatureDictionary[]> {
-        return await Promise.all(
-            transactions.map(async (transaction, index) => {
-                if (this.requestDelayMs > 0 && index > 0) {
-                    await new Promise(resolve => setTimeout(resolve, index * this.requestDelayMs));
-                }
-                const signature = await this.signTransactionManaged(transaction);
-                return createSignatureDictionary({
-                    signature,
-                    signerAddress: this.address,
-                });
-            }),
-        );
+        // Sign sequentially, not via Promise.all: each transaction has
+        // irreversible server-side effects (createTransaction, and auto-approval
+        // when signerSecret is set). Concurrent submission means a failure in one
+        // transaction would abandon siblings that Crossmint has already created
+        // and may execute, leading to duplicate spends on retry. Sequential
+        // execution stops on the first error before any further transaction is
+        // created.
+        const results: SignatureDictionary[] = [];
+        for (const [index, transaction] of transactions.entries()) {
+            if (this.requestDelayMs > 0 && index > 0) {
+                await new Promise(resolve => setTimeout(resolve, this.requestDelayMs));
+            }
+            const signature = await this.signTransactionManaged(transaction);
+            results.push(createSignatureDictionary({ signature, signerAddress: this.address }));
+        }
+        return results;
     }
 
     async isAvailable(): Promise<boolean> {

--- a/typescript/packages/crossmint/src/crossmint-signer.ts
+++ b/typescript/packages/crossmint/src/crossmint-signer.ts
@@ -224,10 +224,21 @@ class CrossmintSigner<TAddress extends string = string> implements SolanaSigner<
         transaction: Transaction & TransactionWithinSizeLimit & TransactionWithLifetime,
     ): Promise<SignatureBytes> {
         let response = await this.createTransaction(transaction);
+        let approvalSubmitted = false;
 
         for (let attempt = 0; attempt < this.maxPollAttempts; attempt++) {
-            if (response.status === 'awaiting-approval' && this.signerSeed && this.signer) {
+            if (
+                response.status === 'awaiting-approval' &&
+                this.signerSeed &&
+                this.signer &&
+                !approvalSubmitted &&
+                this.findPendingApprovalForSigner(response) !== undefined
+            ) {
                 response = await this.submitApproval(response);
+                approvalSubmitted = true;
+                // Re-evaluate the new status immediately; the approvalSubmitted
+                // guard prevents this branch from re-running, so we cannot
+                // busy-loop re-signing/re-submitting the same approval.
                 continue;
             }
             const terminalSignature = await this.resolveTerminalStatus(response, transaction);
@@ -271,8 +282,29 @@ class CrossmintSigner<TAddress extends string = string> implements SolanaSigner<
         }
     }
 
+    /**
+     * Finds the pending approval entry that belongs to this signer's locator.
+     * On a multi-approver wallet, `pending` may contain challenges for other
+     * approvers; signing the wrong one with our key and submitting it under our
+     * locator yields a vendor 4xx. Returns `undefined` when there is nothing for
+     * us to approve.
+     */
+    private findPendingApprovalForSigner(
+        response: CrossmintTransactionResponse,
+    ): { message?: string; signer?: unknown } | undefined {
+        return response.approvals?.pending?.find(entry => entry.signer === this.signer);
+    }
+
     private async submitApproval(response: CrossmintTransactionResponse): Promise<CrossmintTransactionResponse> {
-        const message = response.approvals?.pending?.[0]?.message;
+        const pending = this.findPendingApprovalForSigner(response);
+        // Nothing pending for us: do not sign another approver's challenge.
+        // Return the response unchanged so the caller falls through to
+        // resolveTerminalStatus (which surfaces the awaiting-approval error).
+        if (!pending) {
+            return response;
+        }
+
+        const message = pending.message;
         if (!message) {
             throwSignerError(SignerErrorCode.SIGNING_FAILED, {
                 message: 'Crossmint transaction awaiting approval but no pending message found',

--- a/typescript/packages/crossmint/src/crossmint-signer.ts
+++ b/typescript/packages/crossmint/src/crossmint-signer.ts
@@ -46,6 +46,11 @@ let base58Decoder: ReturnType<typeof getBase58Decoder> | undefined;
 let base58Encoder: ReturnType<typeof getBase58Encoder> | undefined;
 let base64Encoder: ReturnType<typeof getBase64Encoder> | undefined;
 
+/**
+ * Crossmint is a broadcast-managed signer: it rewrites the transaction (gas
+ * sponsorship, priority fee, its own blockhash) and broadcasts server-side, so
+ * returned signatures cover Crossmint's bytes, not the caller's `messageBytes`.
+ */
 class CrossmintSigner<TAddress extends string = string> implements SolanaSigner<TAddress> {
     readonly address: Address<TAddress>;
     private readonly apiKey: string;
@@ -438,9 +443,9 @@ class CrossmintSigner<TAddress extends string = string> implements SolanaSigner<
             });
         }
 
-        // Verify against the message bytes that Crossmint actually signed.
-        // Crossmint may refresh the blockhash before signing, so these may
-        // differ from the original transaction.messageBytes.
+        // Verify against the bytes Crossmint actually signed, not the caller's
+        // messageBytes: Crossmint rewrites the tx (blockhash/fees) before signing,
+        // so a strict check against caller bytes would reject legitimately landed txs.
         await assertSignatureValid({
             data: decodedTransaction.messageBytes,
             signature,

--- a/typescript/packages/crossmint/src/types.ts
+++ b/typescript/packages/crossmint/src/types.ts
@@ -36,7 +36,9 @@ export interface CrossmintTransactionOnChain {
 export interface CrossmintTransactionApprovals {
     pending?: Array<{
         message?: string;
-        signer?: unknown;
+        // The response-side signer is a nested object; the matchable locator
+        // string (e.g. `server:<address>`) lives at `signer.locator`.
+        signer?: { locator?: string };
     }>;
     submitted?: Array<{
         signature?: string;


### PR DESCRIPTION
## Summary

Two correctness fixes for the Crossmint signer's managed transaction flow, plus a doc-only note documenting an intentional verification decision.

- **Sign transactions sequentially** (`signTransactions`): replace `Promise.all` with a sequential loop. Crossmint auto-broadcasts each created transaction server-side once approved, so concurrent batch submission risks landing some transactions while abandoning siblings on a mid-batch failure — leading to duplicate spends on retry. Sequential execution stops on the first error before any further transaction is created.
- **Approve only this signer's pending challenge, once**: on multi-approver wallets `approvals.pending[]` can contain challenges for other approvers. Match the pending entry by this signer's locator instead of blindly signing `pending[0]`, and guard with an `approvalSubmitted` flag so the poll loop can't re-submit the same approval.
- **Docs**: class-level note + guard comment clarifying that the Crossmint signer is *broadcast-managed* (not a self-broadcast partial signer), so it intentionally verifies returned signatures against the bytes Crossmint actually signed rather than the caller's original `messageBytes`.

## Why the verification stays lenient

An earlier draft of this work also flipped signature verification to check against the caller's original transaction bytes. We dropped that change: per [Crossmint's docs](https://docs.crossmint.com/api-reference/wallets/create-transaction), Crossmint broadcasts server-side and rewrites the transaction before signing (gas sponsorship sets `feePayer`, priority-fee optimization, its own recent blockhash). A strict check against the caller's bytes would false-reject every legitimately landed transaction — and would hard-fail the default gas-sponsored flow (`SIGNING_FAILED`). The lenient check (introduced in #102) is the docs-correct behavior: it still proves Crossmint signed a coherent transaction with our key without rejecting legitimate rewrites. The new comments record this so it isn't re-flagged.

## Test plan

- `pnpm --filter @solana/keychain-crossmint typecheck` — passes
- `pnpm --filter @solana/keychain-crossmint test` — 31 passed, 3 skipped
- `just ts-fmt` — clean, no changes

closes TOO-482