### PR TITLE
fix(fireblocks): reject useProgramCall at construction, before any broadcast

### DIFF
--- a/rust/src/fireblocks/mod.rs
+++ b/rust/src/fireblocks/mod.rs
@@ -10,12 +10,10 @@ use crate::{
     error::SignerError, http_client_config::HttpClientConfig, traits::SolanaSigner,
     transaction_util::TransactionUtil,
 };
-use base64::{engine::general_purpose::STANDARD, Engine};
 use std::{str::FromStr, sync::Arc};
 use types::{
-    CreateTransactionRequest, CreateTransactionResponse, ExtraParameters,
-    ProgramCallExtraParameters, RawExtraParameters, RawMessage, RawMessageData,
-    TransactionResponse, TransactionSource, VaultAddressesResponse,
+    CreateTransactionRequest, CreateTransactionResponse, RawExtraParameters, RawMessage,
+    RawMessageData, TransactionResponse, TransactionSource, VaultAddressesResponse,
 };
 
 use crate::signature_util::EXPECTED_SIGNATURE_LENGTH;
@@ -57,10 +55,17 @@ pub struct FireblocksSignerConfig {
     pub api_base_url: Option<String>,
     pub poll_interval_ms: Option<u64>,
     pub max_poll_attempts: Option<u32>,
-    /// Use PROGRAM_CALL operation for transaction signing (auto-broadcasts to Solana).
-    /// PROGRAM_CALL returns a broadcast transaction id, not a reusable signer-bound
-    /// signature for local transaction classification.
-    /// Default: false (uses RAW signing)
+    /// **Deprecated and unsupported.** Setting this to `Some(true)` causes
+    /// `init()` to fail with `SignerError::ConfigError` before any network call.
+    ///
+    /// Fireblocks PROGRAM_CALL signing broadcasts the transaction on-chain and
+    /// only returns a broadcast transaction id, not a reusable signer-bound
+    /// signature over the local message bytes. That violates the `SolanaSigner`
+    /// contract and risks duplicate spends, so the signer always uses RAW signing
+    /// (signs message bytes only; the caller broadcasts).
+    ///
+    /// Retained for now so existing callers get a clear error instead of silently
+    /// different behavior; it will be removed in a future major version.
     pub use_program_call: Option<bool>,
     /// Optional HTTP client timeout config.
     pub http_client_config: Option<HttpClientConfig>,
@@ -109,6 +114,12 @@ impl FireblocksSigner {
 
     /// Initialize the signer by fetching the public key from Fireblocks
     pub async fn init(&mut self) -> Result<(), SignerError> {
+        if self.use_program_call {
+            return Err(SignerError::ConfigError(
+                "use_program_call (Fireblocks PROGRAM_CALL signing) is not supported: it broadcasts the transaction on-chain without producing a reusable signer-bound signature, which violates the SolanaSigner contract and risks duplicate spends. Use RAW signing (the default, omit use_program_call) instead.".to_string(),
+            ));
+        }
+
         let pubkey = self.fetch_public_key().await?;
         self.public_key = Some(pubkey);
         Ok(())
@@ -200,13 +211,13 @@ impl FireblocksSigner {
                 source_type: "VAULT_ACCOUNT".to_string(),
                 id: self.vault_account_id.clone(),
             },
-            extra_parameters: Some(ExtraParameters::Raw(RawExtraParameters {
+            extra_parameters: Some(RawExtraParameters {
                 raw_message_data: RawMessageData {
                     messages: vec![RawMessage {
                         content: hex_message,
                     }],
                 },
-            })),
+            }),
         };
 
         let sig = self.request_and_poll_signature(request).await?;
@@ -220,37 +231,6 @@ impl FireblocksSigner {
         Ok(sig)
     }
 
-    /// Sign a transaction using PROGRAM_CALL operation.
-    ///
-    /// PROGRAM_CALL broadcasts through Fireblocks and only yields a transaction
-    /// id after submission. That broadcast artifact is not a reusable
-    /// signer-bound signature for the local Fireblocks pubkey.
-    async fn sign_with_program_call(
-        &self,
-        transaction: &Transaction,
-    ) -> Result<String, SignerError> {
-        self.initialized_pubkey()?;
-
-        let serialized = bincode::serialize(transaction).map_err(|e| {
-            SignerError::SerializationError(format!("Failed to serialize transaction: {e}"))
-        })?;
-        let base64_content = STANDARD.encode(&serialized);
-
-        let request = CreateTransactionRequest {
-            asset_id: self.asset_id.clone(),
-            operation: "PROGRAM_CALL".to_string(),
-            source: TransactionSource {
-                source_type: "VAULT_ACCOUNT".to_string(),
-                id: self.vault_account_id.clone(),
-            },
-            extra_parameters: Some(ExtraParameters::ProgramCall(ProgramCallExtraParameters {
-                program_call_data: base64_content,
-            })),
-        };
-
-        self.request_and_poll_program_call_tx_id(request).await
-    }
-
     /// Request a raw signature from Fireblocks and poll until complete
     async fn request_and_poll_signature(
         &self,
@@ -260,22 +240,6 @@ impl FireblocksSigner {
         let tx_response = self.poll_for_signature(&create_response.id).await?;
 
         self.extract_signature(&tx_response)
-    }
-
-    /// Request a PROGRAM_CALL broadcast through Fireblocks and return the transaction id.
-    async fn request_and_poll_program_call_tx_id(
-        &self,
-        request: CreateTransactionRequest,
-    ) -> Result<String, SignerError> {
-        let create_response = self.create_transaction(request).await?;
-        let tx_response = self.poll_for_signature(&create_response.id).await?;
-
-        tx_response.tx_hash.ok_or_else(|| {
-            SignerError::SigningFailed(
-                "Fireblocks PROGRAM_CALL completed without returning a broadcast transaction id"
-                    .to_string(),
-            )
-        })
     }
 
     /// Create a transaction (signing request) in Fireblocks
@@ -402,11 +366,8 @@ impl FireblocksSigner {
         })
     }
 
-    /// Extract signer-bound signature from transaction response.
-    /// PROGRAM_CALL responses only carry a broadcast transaction id in `tx_hash`,
-    /// which must not be treated as a reusable signature for the Fireblocks pubkey.
+    /// Extract the signer-bound signature from a RAW signing response.
     fn extract_signature(&self, response: &TransactionResponse) -> Result<Signature, SignerError> {
-        // Try signed_messages first (RAW operations)
         if let Some(signed_message) = response.signed_messages.first() {
             let sig_hex = &signed_message.signature.full_sig;
             let sig_bytes = hex::decode(sig_hex).map_err(|_e| {
@@ -430,13 +391,6 @@ impl FireblocksSigner {
             return Ok(Signature::from(sig_array));
         }
 
-        if response.tx_hash.is_some() {
-            return Err(SignerError::SigningFailed(
-                "Fireblocks PROGRAM_CALL returned tx_hash without a reusable signer-bound signature; use RAW signing for local signature artifacts"
-                    .to_string(),
-            ));
-        }
-
         Err(SignerError::SigningFailed(
             "No reusable signature found in response (no signed_messages)".to_string(),
         ))
@@ -446,13 +400,6 @@ impl FireblocksSigner {
         &self,
         transaction: &mut Transaction,
     ) -> Result<SignedTransaction, SignerError> {
-        if self.use_program_call {
-            let tx_id = self.sign_with_program_call(transaction).await?;
-            return Err(SignerError::SigningFailed(format!(
-                "Fireblocks PROGRAM_CALL returned broadcast transaction id {tx_id} without a reusable signer-bound signature; use RAW signing for local signature artifacts"
-            )));
-        }
-
         let public_key = self.initialized_pubkey()?;
         let message_bytes = transaction.message_data();
         let signature = self.sign_raw_bytes(&message_bytes).await?;
@@ -595,18 +542,18 @@ p6B5CCtpBPgD01Vm+bT/JQ==
         }
     }
 
-    fn create_test_signer_program_call(base_url: &str) -> FireblocksSigner {
+    fn create_test_signer_program_call_uninit(base_url: &str) -> FireblocksSigner {
         FireblocksSigner {
             api_key: "test-api-key".to_string(),
             signing_key: Some(test_signing_key()),
             vault_account_id: "test-vault-id".to_string(),
             asset_id: "SOL".to_string(),
-            public_key: Some(Pubkey::from_str(TEST_PUBKEY).unwrap()),
+            public_key: None,
             api_base_url: base_url.to_string(),
             client: reqwest::Client::new(),
             poll_interval_ms: 10,
             max_poll_attempts: 3,
-            use_program_call: true, // Use PROGRAM_CALL for transaction tests
+            use_program_call: true, // Unsupported: init() must reject this
         }
     }
 
@@ -855,144 +802,26 @@ p6B5CCtpBPgD01Vm+bT/JQ==
     }
 
     #[tokio::test]
-    async fn test_sign_transaction_program_call_rejects_tx_hash_as_signature() {
+    async fn test_init_rejects_program_call_before_any_network_call() {
         let mock_server = MockServer::start().await;
-        let signer = create_test_signer_program_call(&mock_server.uri());
+        let mut signer = create_test_signer_program_call_uninit(&mock_server.uri());
 
-        // Mock create transaction for PROGRAM_CALL
-        Mock::given(method("POST"))
-            .and(path("/v1/transactions"))
-            .and(header("X-API-Key", "test-api-key"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-                "id": "tx-456",
-                "status": "SUBMITTED"
-            })))
-            .expect(1)
-            .mount(&mock_server)
-            .await;
-
-        // Mock get transaction (polling) returning only txHash after broadcast.
-        Mock::given(method("GET"))
-            .and(path("/v1/transactions/tx-456"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-                "id": "tx-456",
-                "status": "COMPLETED",
-                "txHash": "5VERv8NMvzbJMEkV8xnrLkEaWRtSz9CosKDYjCJjBRnbJLgp8uirBgmQpjKhoR4tjF3ZpRzrFmBV6UjKdiSZkQUW"
-            })))
-            .expect(1)
-            .mount(&mock_server)
-            .await;
-
-        let mut transaction = create_test_transaction(&signer.pubkey());
-        let result = signer.sign_transaction(&mut transaction).await;
+        let result = signer.init().await;
 
         assert!(result.is_err());
-        let error = result.unwrap_err();
-        assert!(matches!(error, SignerError::SigningFailed(_)));
-        match error {
-            SignerError::SigningFailed(message) => {
-                assert!(
-                    message.contains("Fireblocks PROGRAM_CALL returned broadcast transaction id"),
-                    "unexpected error message: {message}"
-                );
-            }
-            _ => unreachable!("expected signing failure"),
-        }
-        assert!(
-            transaction
-                .signatures
-                .iter()
-                .all(|signature| *signature == Signature::default()),
-            "PROGRAM_CALL must not inject txHash into signer slots"
-        );
-    }
-
-    #[tokio::test]
-    async fn test_program_call_txhash_can_be_foreign_slot0_signature_but_is_rejected() {
-        let mock_server = MockServer::start().await;
-        let mut signer = create_test_signer_program_call(&mock_server.uri());
-
-        let payer = Keypair::new();
-        let fireblocks_vault = Keypair::new();
-        signer.public_key = Some(keypair_pubkey(&fireblocks_vault));
-
-        let program_id = Pubkey::new_unique();
-        let recipient = Pubkey::new_unique();
-        let instruction = crate::sdk_adapter::Instruction {
-            program_id,
-            accounts: vec![
-                crate::sdk_adapter::AccountMeta::new(keypair_pubkey(&payer), true),
-                crate::sdk_adapter::AccountMeta::new(keypair_pubkey(&fireblocks_vault), true),
-                crate::sdk_adapter::AccountMeta::new(recipient, false),
-            ],
-            data: vec![1, 2, 3],
-        };
-        let message =
-            crate::sdk_adapter::Message::new(&[instruction], Some(&keypair_pubkey(&payer)));
-        let mut transaction = crate::sdk_adapter::Transaction::new_unsigned(message);
-        transaction.message.recent_blockhash = crate::sdk_adapter::Hash::default();
-
-        let required = transaction.message.header.num_required_signatures as usize;
-        assert_eq!(required, 2, "POC requires exactly 2 required signatures");
-
-        let message_bytes = transaction.message_data();
-        let payer_sig = payer.sign_message(&message_bytes);
-        assert!(
-            payer_sig.verify(&keypair_pubkey(&payer).to_bytes(), &message_bytes),
-            "sanity: payer signature must verify for slot-0 pubkey"
-        );
-
-        transaction.signatures = vec![Signature::default(); required];
-        transaction.signatures[0] = payer_sig;
-
-        let tx_hash = bs58::encode(payer_sig.as_ref()).into_string();
-
-        Mock::given(method("POST"))
-            .and(path("/v1/transactions"))
-            .and(header("X-API-Key", "test-api-key"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-                "id": "tx-456",
-                "status": "SUBMITTED"
-            })))
-            .expect(1)
-            .mount(&mock_server)
-            .await;
-
-        Mock::given(method("GET"))
-            .and(path("/v1/transactions/tx-456"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-                "id": "tx-456",
-                "status": "COMPLETED",
-                "txHash": tx_hash
-            })))
-            .expect(1)
-            .mount(&mock_server)
-            .await;
-
-        let result = signer.sign_transaction(&mut transaction).await;
-
-        assert!(result.is_err(), "PROGRAM_CALL txHash must be rejected");
-        let error = result.unwrap_err();
-        assert!(matches!(error, SignerError::SigningFailed(_)));
-        match error {
-            SignerError::SigningFailed(message) => {
-                assert!(
-                    message.contains("Fireblocks PROGRAM_CALL returned broadcast transaction id"),
-                    "unexpected error message: {message}"
-                );
-            }
-            _ => unreachable!("expected signing failure"),
+        match result.unwrap_err() {
+            SignerError::ConfigError(message) => assert!(
+                message.contains("use_program_call"),
+                "unexpected error message: {message}"
+            ),
+            other => unreachable!("expected ConfigError, got {other:?}"),
         }
 
-        assert_eq!(
-            transaction.signatures[0].as_ref(),
-            payer_sig.as_ref(),
-            "Existing payer slot must be preserved"
-        );
-        assert_eq!(
-            transaction.signatures[1],
-            Signature::default(),
-            "Fireblocks slot must remain unsigned"
+        // Fail closed: no request may reach Fireblocks before rejection.
+        let requests = mock_server.received_requests().await.unwrap();
+        assert!(
+            requests.is_empty(),
+            "init() must reject use_program_call before any network call"
         );
     }
 
@@ -1007,8 +836,9 @@ p6B5CCtpBPgD01Vm+bT/JQ==
     }
 
     #[test]
-    fn test_use_program_call_config() {
-        // Test with use_program_call = true (PROGRAM_CALL mode)
+    fn test_use_program_call_config_carried_but_constructor_is_infallible() {
+        // Construction never fails; the unsupported PROGRAM_CALL flag is carried
+        // through and rejected later at init() (see the init rejection test).
         let signer_program_call = FireblocksSigner::new(FireblocksSignerConfig {
             api_key: "test-key".to_string(),
             private_key_pem: TEST_RSA_KEY.to_string(),
@@ -1022,7 +852,7 @@ p6B5CCtpBPgD01Vm+bT/JQ==
         });
         assert!(signer_program_call.use_program_call);
 
-        // Test with use_program_call = false (explicit RAW mode)
+        // Explicit RAW mode (the only supported mode).
         let signer_raw = FireblocksSigner::new(FireblocksSignerConfig {
             api_key: "test-key".to_string(),
             private_key_pem: TEST_RSA_KEY.to_string(),

--- a/rust/src/fireblocks/types.rs
+++ b/rust/src/fireblocks/types.rs
@@ -10,7 +10,7 @@ pub struct CreateTransactionRequest {
     pub operation: String,
     pub source: TransactionSource,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub extra_parameters: Option<ExtraParameters>,
+    pub extra_parameters: Option<RawExtraParameters>,
 }
 
 #[derive(Serialize)]
@@ -19,16 +19,6 @@ pub struct TransactionSource {
     #[serde(rename = "type")]
     pub source_type: String,
     pub id: String,
-}
-
-/// Extra parameters for Fireblocks signing operations
-#[derive(Serialize)]
-#[serde(untagged)]
-pub enum ExtraParameters {
-    /// RAW signing operation
-    Raw(RawExtraParameters),
-    /// PROGRAM_CALL signing operation
-    ProgramCall(ProgramCallExtraParameters),
 }
 
 /// Extra parameters for RAW signing
@@ -48,14 +38,6 @@ pub struct RawMessageData {
 #[serde(rename_all = "camelCase")]
 pub struct RawMessage {
     pub content: String,
-}
-
-/// Extra parameters for PROGRAM_CALL signing
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct ProgramCallExtraParameters {
-    /// Base64-encoded serialized Solana transaction
-    pub program_call_data: String,
 }
 
 /// Response from creating a transaction
@@ -79,10 +61,6 @@ pub struct TransactionResponse {
     pub sub_status: Option<String>,
     #[serde(default)]
     pub signed_messages: Vec<SignedMessage>,
-    /// Transaction hash returned for PROGRAM_CALL after broadcast.
-    /// This is a broadcast artifact, not a reusable signer-bound signature.
-    #[serde(default)]
-    pub tx_hash: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/rust/src/tests/test_fireblocks_integration.rs
+++ b/rust/src/tests/test_fireblocks_integration.rs
@@ -3,7 +3,6 @@ pub const FIREBLOCKS_PRIVATE_KEY_PEM: &str = "FIREBLOCKS_PRIVATE_KEY_PEM";
 pub const FIREBLOCKS_VAULT_ACCOUNT_ID: &str = "FIREBLOCKS_VAULT_ACCOUNT_ID";
 pub const FIREBLOCKS_API_BASE_URL: &str = "FIREBLOCKS_API_BASE_URL";
 pub const FIREBLOCKS_ASSET_ID: &str = "FIREBLOCKS_ASSET_ID";
-pub const SOLANA_RPC_URL: &str = "SOLANA_RPC_URL";
 
 #[cfg(feature = "fireblocks")]
 #[cfg(test)]
@@ -13,8 +12,7 @@ mod tests {
 
     use super::*;
     use crate::fireblocks::{FireblocksSigner, FireblocksSignerConfig};
-    use crate::test_util::{create_test_transaction, create_test_transaction_with_recipient};
-    use crate::tests::rpc_util::get_rpc_blockhash;
+    use crate::test_util::create_test_transaction;
     use crate::traits::SolanaSigner;
     use std::env;
 
@@ -46,7 +44,7 @@ mod tests {
             ),
             poll_interval_ms: None,
             max_poll_attempts: None,
-            use_program_call: Some(true),
+            use_program_call: None,
             http_client_config: None,
         };
 
@@ -80,33 +78,33 @@ mod tests {
     #[tokio::test]
     #[cfg(feature = "integration-tests")]
     #[serial]
-    async fn test_fireblocks_sign_transaction() {
-        let signer = get_signer().await;
-        let pubkey = signer.pubkey();
+    async fn test_fireblocks_rejects_program_call_before_broadcast() {
+        // PROGRAM_CALL is unsupported: init() must fail closed with ConfigError
+        // before any network call, so it can never broadcast on-chain. Uses dummy
+        // credentials because the rejection happens before any of them are used.
+        let config = FireblocksSignerConfig {
+            api_key: "test-api-key".to_string(),
+            private_key_pem: "test-private-key-pem".to_string(),
+            vault_account_id: "0".to_string(),
+            asset_id: Some("SOL_TEST".to_string()),
+            api_base_url: None,
+            poll_interval_ms: None,
+            max_poll_attempts: None,
+            use_program_call: Some(true),
+            http_client_config: None,
+        };
 
-        // Self-transfer: from vault to same vault address
-        let mut transaction = create_test_transaction_with_recipient(&pubkey, &pubkey);
-
-        // PROGRAM_CALL needs real devnet blockhash
-        let rpc_url = env::var(SOLANA_RPC_URL)
-            .unwrap_or_else(|_| "https://api.devnet.solana.com".to_string());
-
-        transaction.message.recent_blockhash = get_rpc_blockhash(&rpc_url)
+        let mut signer = FireblocksSigner::new(config);
+        let error = signer
+            .init()
             .await
-            .expect("Failed to get blockhash from RPC");
-
-        let result = signer.sign_transaction(&mut transaction).await;
-
-        let error =
-            result.expect_err("PROGRAM_CALL should fail closed without a signer-bound signature");
+            .expect_err("init() must reject use_program_call before any broadcast");
         match error {
-            crate::error::SignerError::SigningFailed(message) => {
-                assert!(
-                    message.contains("Fireblocks PROGRAM_CALL returned broadcast transaction id"),
-                    "unexpected error message: {message}"
-                );
-            }
-            other => panic!("expected signing failure, got {other:?}"),
+            crate::error::SignerError::ConfigError(message) => assert!(
+                message.contains("use_program_call"),
+                "unexpected error message: {message}"
+            ),
+            other => panic!("expected ConfigError, got {other:?}"),
         }
     }
 

--- a/typescript/packages/fireblocks/README.md
+++ b/typescript/packages/fireblocks/README.md
@@ -58,18 +58,11 @@ const message = new TextEncoder().encode('Hello, Solana!');
 const signature = await signMessage([signer], message);
 ```
 
-### With Program Call Mode
+### Signing Mode
 
-By default, the signer uses RAW signing (signs bytes, you broadcast). Enable `useProgramCall` to have Fireblocks broadcast the transaction:
+The signer always uses Fireblocks **RAW signing**: it signs the message bytes and returns the signature to you, and you broadcast the transaction yourself. This is the only mode compatible with the `SolanaSigner` contract.
 
-```typescript
-const signer = await createFireblocksSigner({
-    apiKey: 'your-fireblocks-api-key',
-    privateKeyPem: '...',
-    vaultAccountId: '0',
-    useProgramCall: true, // Fireblocks signs and broadcasts the transaction to Solana
-});
-```
+Fireblocks `PROGRAM_CALL` signing is **not supported**. It broadcasts the transaction on-chain and only returns a broadcast transaction id, not a reusable signer-bound signature, which would risk duplicate spends. Passing `useProgramCall: true` is rejected at construction with a `CONFIG_ERROR`.
 
 ### With Devnet
 
@@ -86,29 +79,28 @@ const signer = await createFireblocksSigner({
 
 ### FireblocksSignerConfig
 
-| Field | Type | Required | Default | Description |
-|-------|------|----------|---------|-------------|
-| `apiKey` | `string` | Yes | - | Fireblocks API key (X-API-Key header) |
-| `privateKeyPem` | `string` | Yes | - | RSA 4096 private key in PEM format for JWT signing |
-| `vaultAccountId` | `string` | Yes | - | Fireblocks vault account ID |
-| `apiBaseUrl` | `string` | No | `https://api.fireblocks.io` | Custom API base URL |
-| `assetId` | `string` | No | `SOL` | Asset ID (`SOL` for mainnet, `SOL_TEST` for devnet) |
-| `pollIntervalMs` | `number` | No | `1000` | Polling interval in ms when waiting for transaction completion |
-| `maxPollAttempts` | `number` | No | `60` | Maximum polling attempts before timeout |
-| `requestDelayMs` | `number` | No | `0` | Delay in ms between concurrent signing requests |
-| `useProgramCall` | `boolean` | No | `false` | When true, Fireblocks broadcasts the transaction |
+| Field             | Type      | Required | Default                     | Description                                                                                                                                                                                                |
+| ----------------- | --------- | -------- | --------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `apiKey`          | `string`  | Yes      | -                           | Fireblocks API key (X-API-Key header)                                                                                                                                                                      |
+| `privateKeyPem`   | `string`  | Yes      | -                           | RSA 4096 private key in PEM format for JWT signing                                                                                                                                                         |
+| `vaultAccountId`  | `string`  | Yes      | -                           | Fireblocks vault account ID                                                                                                                                                                                |
+| `apiBaseUrl`      | `string`  | No       | `https://api.fireblocks.io` | Custom API base URL                                                                                                                                                                                        |
+| `assetId`         | `string`  | No       | `SOL`                       | Asset ID (`SOL` for mainnet, `SOL_TEST` for devnet)                                                                                                                                                        |
+| `pollIntervalMs`  | `number`  | No       | `1000`                      | Polling interval in ms when waiting for transaction completion                                                                                                                                             |
+| `maxPollAttempts` | `number`  | No       | `60`                        | Maximum polling attempts before timeout                                                                                                                                                                    |
+| `requestDelayMs`  | `number`  | No       | `0`                         | Delay in ms between concurrent signing requests                                                                                                                                                            |
+| `useProgramCall`  | `boolean` | No       | `false`                     | **Deprecated, unsupported.** Setting `true` is rejected at construction with a `CONFIG_ERROR` (PROGRAM_CALL broadcasts on-chain without a reusable signature). Omit it; removal planned in a future major. |
 
 ## How It Works
 
 1. **Initialization**: Fetches the vault account's Solana address from Fireblocks API
 2. **JWT Authentication**: Signs API requests with RS256 JWT using your RSA private key
-3. **Transaction Creation**: Creates a signing transaction in Fireblocks (RAW or PROGRAM_CALL operation)
+3. **Transaction Creation**: Creates a RAW signing transaction in Fireblocks
 4. **Signature Extraction**: Extracts the Ed25519 signature from the completed transaction/message
 
-### Signing Modes
+### Signing Mode
 
-- **RAW** (default): Signs the message bytes only. You receive the signature and broadcast the transaction yourself.
-- **PROGRAM_CALL**: Fireblocks signs and broadcasts the transaction to Solana. The `txHash` is returned in the response.
+- **RAW** (only supported mode): Signs the message bytes only. You receive the signature and broadcast the transaction yourself. Fireblocks `PROGRAM_CALL` (broadcast) signing is not supported — see [Signing Mode](#signing-mode) above.
 
 ## Security Considerations
 

--- a/typescript/packages/fireblocks/src/__tests__/fireblocks-signer.integration.test.ts
+++ b/typescript/packages/fireblocks/src/__tests__/fireblocks-signer.integration.test.ts
@@ -24,24 +24,20 @@ function hasRequiredEnvVars(): boolean {
 }
 
 describe('FireblocksSigner Integration', () => {
-    it.skipIf(!hasRequiredEnvVars())(
-        'fails closed for PROGRAM_CALL by rejecting at construction before any broadcast',
-        async () => {
-            await expect(
-                createFireblocksSigner({
-                    apiKey: process.env.FIREBLOCKS_API_KEY!,
-                    assetId: process.env.FIREBLOCKS_ASSET_ID ?? 'SOL_TEST',
-                    privateKeyPem: process.env.FIREBLOCKS_PRIVATE_KEY_PEM!,
-                    useProgramCall: true,
-                    vaultAccountId: process.env.FIREBLOCKS_VAULT_ACCOUNT_ID!,
-                }),
-            ).rejects.toMatchObject({
-                code: 'SIGNER_CONFIG_ERROR',
-                message: expect.stringContaining('useProgramCall'),
-            });
-        },
-        120_000,
-    );
+    it('fails closed for PROGRAM_CALL by rejecting at construction before any broadcast', async () => {
+        await expect(
+            createFireblocksSigner({
+                apiKey: 'test-api-key',
+                assetId: 'SOL_TEST',
+                privateKeyPem: 'test-private-key-pem',
+                useProgramCall: true,
+                vaultAccountId: '0',
+            }),
+        ).rejects.toMatchObject({
+            code: 'SIGNER_CONFIG_ERROR',
+            message: expect.stringContaining('useProgramCall'),
+        });
+    });
 
     // RAW signing not available on Fireblocks testnet/sandbox
     it.skip('signs messages with real API', () => {});

--- a/typescript/packages/fireblocks/src/__tests__/fireblocks-signer.integration.test.ts
+++ b/typescript/packages/fireblocks/src/__tests__/fireblocks-signer.integration.test.ts
@@ -1,26 +1,15 @@
 /**
- * Fireblocks PROGRAM_CALL integration tests (devnet, not LiteSVM)
+ * Fireblocks integration tests.
  *
- * Unlike other signers, Fireblocks PROGRAM_CALL mode signs AND broadcasts
- * the transaction to Solana through Fireblocks' infrastructure. The signed
- * transaction never returns to the caller, and the broadcast transaction id
- * is not a reusable signer-bound signature artifact. This means LiteSVM
- * (used by runSignerIntegrationTest) can never observe a signer-specific
- * transaction signature from PROGRAM_CALL, so we test against devnet directly.
+ * The signer only supports Fireblocks RAW signing. Fireblocks PROGRAM_CALL
+ * signing is unsupported: it broadcasts the transaction on-chain and only
+ * returns a broadcast transaction id, not a reusable signer-bound signature.
+ * `useProgramCall: true` is therefore rejected at construction, before any
+ * network call or broadcast can occur (fail closed).
  *
  * RAW mode returns a raw signature but is not available on the Fireblocks
- * sandbox/testnet environment used in CI.
+ * sandbox/testnet environment used in CI, so it is not exercised here.
  */
-import {
-    appendTransactionMessageInstructions,
-    createSolanaRpc,
-    createTransactionMessage,
-    pipe,
-    setTransactionMessageFeePayerSigner,
-    setTransactionMessageLifetimeUsingBlockhash,
-    signTransactionMessageWithSigners,
-} from '@solana/kit';
-import { getAddMemoInstruction } from '@solana-program/memo';
 import { config } from 'dotenv';
 import { describe, expect, it } from 'vitest';
 
@@ -36,32 +25,20 @@ function hasRequiredEnvVars(): boolean {
 
 describe('FireblocksSigner Integration', () => {
     it.skipIf(!hasRequiredEnvVars())(
-        'fails closed for PROGRAM_CALL because Fireblocks only returns a broadcast transaction id',
+        'fails closed for PROGRAM_CALL by rejecting at construction before any broadcast',
         async () => {
-            const signer = await createFireblocksSigner({
-                apiKey: process.env.FIREBLOCKS_API_KEY!,
-                assetId: process.env.FIREBLOCKS_ASSET_ID ?? 'SOL_TEST',
-                privateKeyPem: process.env.FIREBLOCKS_PRIVATE_KEY_PEM!,
-                useProgramCall: true,
-                vaultAccountId: process.env.FIREBLOCKS_VAULT_ACCOUNT_ID!,
+            await expect(
+                createFireblocksSigner({
+                    apiKey: process.env.FIREBLOCKS_API_KEY!,
+                    assetId: process.env.FIREBLOCKS_ASSET_ID ?? 'SOL_TEST',
+                    privateKeyPem: process.env.FIREBLOCKS_PRIVATE_KEY_PEM!,
+                    useProgramCall: true,
+                    vaultAccountId: process.env.FIREBLOCKS_VAULT_ACCOUNT_ID!,
+                }),
+            ).rejects.toMatchObject({
+                code: 'SIGNER_CONFIG_ERROR',
+                message: expect.stringContaining('useProgramCall'),
             });
-            const rpcUrl = process.env.SOLANA_RPC_URL ?? 'https://api.devnet.solana.com';
-
-            const rpc = createSolanaRpc(rpcUrl);
-            const {
-                value: { blockhash, lastValidBlockHeight },
-            } = await rpc.getLatestBlockhash().send();
-
-            const transaction = pipe(
-                createTransactionMessage({ version: 0 }),
-                tx => setTransactionMessageFeePayerSigner(signer, tx),
-                tx => appendTransactionMessageInstructions([getAddMemoInstruction({ memo: 'Fireblocks test' })], tx),
-                tx => setTransactionMessageLifetimeUsingBlockhash({ blockhash, lastValidBlockHeight }, tx),
-            );
-
-            await expect(signTransactionMessageWithSigners(transaction)).rejects.toThrow(
-                'Fireblocks PROGRAM_CALL returned txHash without a reusable signer-bound signature',
-            );
         },
         120_000,
     );

--- a/typescript/packages/fireblocks/src/__tests__/fireblocks-signer.test.ts
+++ b/typescript/packages/fireblocks/src/__tests__/fireblocks-signer.test.ts
@@ -2,15 +2,7 @@ import { generateKeyPairSigner } from '@solana/signers';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { assertIsSolanaSigner } from '@solana/keychain-core';
 
-vi.mock('@solana/transactions', async importOriginal => {
-    const mod = await importOriginal<typeof import('@solana/transactions')>();
-    return {
-        ...mod,
-        getBase64EncodedWireTransaction: vi.fn(() => 'base64-wire-transaction'),
-    };
-});
-
-import { FireblocksSigner } from '../fireblocks-signer.js';
+import { createFireblocksSigner, FireblocksSigner } from '../fireblocks-signer.js';
 import type { FireblocksSignerConfig } from '../types.js';
 import { TEST_API_KEY, TEST_RSA_PRIVATE_KEY, TEST_VAULT_ACCOUNT_ID } from './setup.js';
 
@@ -146,6 +138,46 @@ describe('FireblocksSigner', () => {
                 privateKeyPem: TEST_RSA_PRIVATE_KEY,
                 vaultAccountId: TEST_VAULT_ACCOUNT_ID,
                 assetId: 'SOL_TEST',
+            });
+
+            expect(signer).toBeDefined();
+        });
+
+        it('should reject useProgramCall:true with CONFIG_ERROR and never make a network call', () => {
+            expect(() => {
+                new FireblocksSigner({
+                    apiKey: TEST_API_KEY,
+                    privateKeyPem: TEST_RSA_PRIVATE_KEY,
+                    useProgramCall: true,
+                    vaultAccountId: TEST_VAULT_ACCOUNT_ID,
+                });
+            }).toThrow(/useProgramCall.*not supported/);
+
+            expect(mockFetch).not.toHaveBeenCalled();
+        });
+
+        it('should reject useProgramCall:true via createFireblocksSigner before any broadcast', async () => {
+            await expect(
+                createFireblocksSigner({
+                    apiKey: TEST_API_KEY,
+                    privateKeyPem: TEST_RSA_PRIVATE_KEY,
+                    useProgramCall: true,
+                    vaultAccountId: TEST_VAULT_ACCOUNT_ID,
+                }),
+            ).rejects.toMatchObject({
+                code: 'SIGNER_CONFIG_ERROR',
+                message: expect.stringContaining('useProgramCall'),
+            });
+
+            expect(mockFetch).not.toHaveBeenCalled();
+        });
+
+        it('should allow useProgramCall:false', () => {
+            const signer = new FireblocksSigner({
+                apiKey: TEST_API_KEY,
+                privateKeyPem: TEST_RSA_PRIVATE_KEY,
+                useProgramCall: false,
+                vaultAccountId: TEST_VAULT_ACCOUNT_ID,
             });
 
             expect(signer).toBeDefined();
@@ -548,7 +580,7 @@ describe('FireblocksSigner', () => {
             expect(result[0]).toHaveProperty(signer.address);
         });
 
-        it('should reject PROGRAM_CALL txHash because it is not a reusable signer-bound signature', async () => {
+        it('should throw when COMPLETED response has no signedMessages', async () => {
             const keyPair = await generateKeyPairSigner();
 
             // Mock init fetch
@@ -563,21 +595,18 @@ describe('FireblocksSigner', () => {
                 json: async () => ({ id: 'tx-123', status: 'SUBMITTED' }),
             });
 
-            // Mock poll for completion - PROGRAM_CALL returns txHash after broadcast,
-            // which must not be treated as a reusable signer-bound signature.
+            // Mock poll for completion with no signedMessages
             mockFetch.mockResolvedValueOnce({
                 ok: true,
                 json: async () => ({
                     id: 'tx-123',
                     status: 'COMPLETED',
-                    txHash: '5VERv8NMvzbJMEkV8xnrLkEaWRtSz9CosKDYjCJjBRnbJLgp8uirBgmQpjKhoR4tjF3ZpRzrFmBV6UjKdiSZkQUW',
                 }),
             });
 
             const signer = new FireblocksSigner({
                 apiKey: TEST_API_KEY,
                 privateKeyPem: TEST_RSA_PRIVATE_KEY,
-                useProgramCall: true,
                 vaultAccountId: TEST_VAULT_ACCOUNT_ID,
             });
 
@@ -589,52 +618,7 @@ describe('FireblocksSigner', () => {
             } as unknown as Parameters<typeof signer.signTransactions>[0][0];
 
             await expect(signer.signTransactions([transaction])).rejects.toThrow(
-                'Fireblocks PROGRAM_CALL returned txHash without a reusable signer-bound signature',
-            );
-        });
-
-        it('should still reject malformed txHash in PROGRAM_CALL because it is not a reusable signer-bound signature', async () => {
-            const keyPair = await generateKeyPairSigner();
-
-            // Mock init fetch
-            mockFetch.mockResolvedValueOnce({
-                ok: true,
-                json: async () => ({ addresses: [{ address: keyPair.address }] }),
-            });
-
-            // Mock create transaction
-            mockFetch.mockResolvedValueOnce({
-                ok: true,
-                json: async () => ({ id: 'tx-123', status: 'SUBMITTED' }),
-            });
-
-            // Mock poll for completion - txHash remains a broadcast transaction id,
-            // regardless of whether it would decode to a valid signature length.
-            mockFetch.mockResolvedValueOnce({
-                ok: true,
-                json: async () => ({
-                    id: 'tx-123',
-                    status: 'COMPLETED',
-                    txHash: '2abc',
-                }),
-            });
-
-            const signer = new FireblocksSigner({
-                apiKey: TEST_API_KEY,
-                privateKeyPem: TEST_RSA_PRIVATE_KEY,
-                useProgramCall: true,
-                vaultAccountId: TEST_VAULT_ACCOUNT_ID,
-            });
-
-            await signer.init();
-
-            const transaction = {
-                messageBytes: new Uint8Array([1, 2, 3, 4]),
-                signatures: {},
-            } as unknown as Parameters<typeof signer.signTransactions>[0][0];
-
-            await expect(signer.signTransactions([transaction])).rejects.toThrow(
-                'Fireblocks PROGRAM_CALL returned txHash without a reusable signer-bound signature',
+                'No signature found in response (no signedMessages)',
             );
         });
     });

--- a/typescript/packages/fireblocks/src/fireblocks-signer.ts
+++ b/typescript/packages/fireblocks/src/fireblocks-signer.ts
@@ -11,12 +11,7 @@ import {
 } from '@solana/keychain-core';
 import { SignatureBytes } from '@solana/keys';
 import { SignableMessage, SignatureDictionary } from '@solana/signers';
-import {
-    getBase64EncodedWireTransaction,
-    Transaction,
-    TransactionWithinSizeLimit,
-    TransactionWithLifetime,
-} from '@solana/transactions';
+import { Transaction, TransactionWithinSizeLimit, TransactionWithLifetime } from '@solana/transactions';
 
 import { createJwt } from './jwt.js';
 import type {
@@ -76,7 +71,6 @@ export class FireblocksSigner<TAddress extends string = string> implements Solan
     private readonly pollIntervalMs: number;
     private readonly maxPollAttempts: number;
     private readonly requestDelayMs: number;
-    private readonly useProgramCall: boolean;
     private initialized = false;
 
     /**
@@ -113,6 +107,13 @@ export class FireblocksSigner<TAddress extends string = string> implements Solan
             });
         }
 
+        if (config.useProgramCall === true) {
+            throwSignerError(SignerErrorCode.CONFIG_ERROR, {
+                message:
+                    'useProgramCall (Fireblocks PROGRAM_CALL signing) is not supported: it broadcasts the transaction on-chain without producing a reusable signer-bound signature, which violates the SolanaSigner contract and risks duplicate spends. Use RAW signing (the default, omit useProgramCall) instead.',
+            });
+        }
+
         this.apiKey = config.apiKey;
         this.privateKeyPem = config.privateKeyPem;
         this.vaultAccountId = config.vaultAccountId;
@@ -124,7 +125,6 @@ export class FireblocksSigner<TAddress extends string = string> implements Solan
         this.pollIntervalMs = config.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
         this.maxPollAttempts = config.maxPollAttempts ?? DEFAULT_MAX_POLL_ATTEMPTS;
         this.requestDelayMs = config.requestDelayMs ?? 0;
-        this.useProgramCall = config.useProgramCall ?? false;
 
         this.validateRequestDelayMs(this.requestDelayMs);
     }
@@ -315,33 +315,6 @@ export class FireblocksSigner<TAddress extends string = string> implements Solan
     }
 
     /**
-     * Sign a transaction using Fireblocks PROGRAM_CALL operation.
-     * This broadcasts the transaction through Fireblocks but does not yield a
-     * reusable signer-bound signature artifact for the local signer address.
-     */
-    private async signWithProgramCall(
-        transaction: Transaction & TransactionWithinSizeLimit & TransactionWithLifetime,
-    ): Promise<SignatureBytes> {
-        // Use the same serialization as Privy - proper wire format with all signatures
-        const base64WireTransaction = getBase64EncodedWireTransaction(transaction);
-
-        const request: CreateTransactionRequest = {
-            assetId: this.assetId,
-            extraParameters: {
-                programCallData: base64WireTransaction,
-            },
-            operation: 'PROGRAM_CALL',
-            source: {
-                id: this.vaultAccountId,
-                type: 'VAULT_ACCOUNT',
-            },
-        };
-
-        const createResponse = await this.request<CreateTransactionResponse>('POST', '/v1/transactions', request);
-        return await this.pollForSignature(createResponse.id);
-    }
-
-    /**
      * Poll for transaction completion and extract a reusable signer-bound signature.
      */
     private async pollForSignature(transactionId: string): Promise<SignatureBytes> {
@@ -353,7 +326,7 @@ export class FireblocksSigner<TAddress extends string = string> implements Solan
             const status = txResponse.status as FireblocksTransactionStatus;
 
             if (txResponse.status === 'COMPLETED') {
-                // Try signedMessages first (RAW signing - hex encoded)
+                // RAW signing returns the signature in signedMessages (hex encoded)
                 const fullSig = txResponse.signedMessages?.[0]?.signature?.fullSig;
                 if (fullSig) {
                     const cleanHex = fullSig.startsWith('0x') || fullSig.startsWith('0X') ? fullSig.slice(2) : fullSig;
@@ -372,17 +345,8 @@ export class FireblocksSigner<TAddress extends string = string> implements Solan
                     return sigBytes as SignatureBytes;
                 }
 
-                // PROGRAM_CALL only returns a broadcast transaction id, not a
-                // reusable signer-bound signature over the local message bytes.
-                if (txResponse.txHash) {
-                    throwSignerError(SignerErrorCode.SIGNING_FAILED, {
-                        message:
-                            'Fireblocks PROGRAM_CALL returned txHash without a reusable signer-bound signature; use RAW signing for local signature artifacts',
-                    });
-                }
-
                 throwSignerError(SignerErrorCode.SIGNING_FAILED, {
-                    message: 'No signature found in response (no signedMessages or txHash)',
+                    message: 'No signature found in response (no signedMessages)',
                 });
             }
 
@@ -440,9 +404,7 @@ export class FireblocksSigner<TAddress extends string = string> implements Solan
         return await Promise.all(
             transactions.map(async (transaction, index) => {
                 await this.delay(index);
-                const signatureBytes = this.useProgramCall
-                    ? await this.signWithProgramCall(transaction)
-                    : await this.signRawBytes(new Uint8Array(transaction.messageBytes));
+                const signatureBytes = await this.signRawBytes(new Uint8Array(transaction.messageBytes));
                 await assertSignatureValid({
                     data: transaction.messageBytes,
                     signature: signatureBytes,

--- a/typescript/packages/fireblocks/src/types.ts
+++ b/typescript/packages/fireblocks/src/types.ts
@@ -24,10 +24,19 @@ export interface FireblocksSignerConfig {
     requestDelayMs?: number;
 
     /**
-     * Use PROGRAM_CALL operation for signing transactions (default: false)
-     * When true, Fireblocks signs and broadcasts the transaction to Solana,
-     * but callers must not treat the broadcast response as a reusable local signature.
-     * When false, uses RAW signing (signs message bytes only, caller broadcasts).
+     * @deprecated Unsupported and slated for removal. Setting this to `true` is
+     * rejected at construction with a `CONFIG_ERROR`; omit it (RAW signing is
+     * always used).
+     *
+     * Fireblocks PROGRAM_CALL signing broadcasts the transaction on-chain and
+     * only returns a broadcast transaction id, not a reusable signer-bound
+     * signature over the local message bytes. That violates the `SolanaSigner`
+     * contract and risks duplicate spends, so the signer always uses RAW signing
+     * (signs message bytes only; the caller broadcasts).
+     *
+     * The field key is retained for now so existing callers passing `true` get a
+     * clear error instead of silently different behavior; it will be removed in a
+     * future major version.
      */
     useProgramCall?: boolean;
 
@@ -40,8 +49,8 @@ export interface FireblocksSignerConfig {
  */
 export interface CreateTransactionRequest {
     assetId: string;
-    extraParameters: ProgramCallExtraParameters | RawExtraParameters;
-    operation: 'PROGRAM_CALL' | 'RAW';
+    extraParameters: RawExtraParameters;
+    operation: 'RAW';
     source: TransactionSource;
 }
 
@@ -55,13 +64,6 @@ export interface TransactionSource {
  */
 export interface RawExtraParameters {
     rawMessageData: RawMessageData;
-}
-
-/**
- * Extra parameters for PROGRAM_CALL signing operation
- */
-export interface ProgramCallExtraParameters {
-    programCallData: string;
 }
 
 export interface RawMessageData {
@@ -87,11 +89,6 @@ export interface TransactionResponse {
     id: string;
     signedMessages?: SignedMessage[];
     status: string;
-    /**
-     * Transaction id returned for PROGRAM_CALL after broadcast.
-     * This is a broadcast artifact, not a reusable signer-bound signature.
-     */
-    txHash?: string;
 }
 
 export interface SignedMessage {


### PR DESCRIPTION
## Summary

Fireblocks `PROGRAM_CALL` signing is incompatible with the `SolanaSigner` contract: it broadcasts the transaction on-chain and only returns a broadcast transaction id, never a reusable signer-bound signature over the local message bytes. The old code attempted it and then always threw `SIGNING_FAILED` — *after* the on-chain broadcast — risking duplicate spends on retry.

This PR rejects `useProgramCall: true` at construction with a `CONFIG_ERROR` (before any network call) and removes the dead PROGRAM_CALL path. RAW signing (sign bytes, caller broadcasts) is the only supported mode and the default.

https://developers.fireblocks.com/reference/interact-with-solana-programs

## Changes

- Reject `useProgramCall: true` in the constructor, fail-closed before any I/O.
- Remove the PROGRAM_CALL signing path, `ProgramCallExtraParameters`, and `txHash` handling.
- Mark `useProgramCall` `@deprecated` — retained for now so existing callers get a clear error instead of silent behavior change; removal planned in a future major.
- Update tests (construction-time rejection, no network call) and README.

## Notes

- RAW already provides no-broadcast, exact-message-bytes signing with a documented response — `signOnly`/`useDurableNonce` on PROGRAM_CALL would only reconstruct RAW the hard way.
- Rust parity: `rust/src/fireblocks/` still has the broadcast-then-fail path; if we merge this, we should do same for rust side @dev-jodee 

Closes TOO-483