### PR TITLE
fix(keychain): harden TS signers (TOO-484)

### DIFF
--- a/typescript/packages/cdp/src/cdp-signer.ts
+++ b/typescript/packages/cdp/src/cdp-signer.ts
@@ -360,6 +360,7 @@ export class CdpSigner<TAddress extends string = string> implements SolanaSigner
                 body: JSON.stringify(body),
                 headers,
                 method: 'POST',
+                redirect: 'error',
             });
         } catch (error) {
             throwSignerError(SignerErrorCode.HTTP_ERROR, {
@@ -419,6 +420,7 @@ export class CdpSigner<TAddress extends string = string> implements SolanaSigner
                 body: JSON.stringify(body),
                 headers,
                 method: 'POST',
+                redirect: 'error',
             });
         } catch (error) {
             throwSignerError(SignerErrorCode.HTTP_ERROR, {
@@ -516,6 +518,7 @@ export class CdpSigner<TAddress extends string = string> implements SolanaSigner
             const response = await fetch(`${this.baseUrl}${path}`, {
                 headers,
                 method: 'GET',
+                redirect: 'error',
             });
             return response.ok;
         } catch {

--- a/typescript/packages/crossmint/src/__tests__/crossmint-signer.test.ts
+++ b/typescript/packages/crossmint/src/__tests__/crossmint-signer.test.ts
@@ -119,6 +119,25 @@ describe('CrossmintSigner', () => {
             );
         });
 
+        it('sanitizes remote API error messages before surfacing them', async () => {
+            const malicious = `evil\u0000\u0007control\nbreak ${'A'.repeat(400)}`;
+            vi.mocked(fetch).mockResolvedValueOnce(
+                new Response(JSON.stringify({ message: malicious }), { status: 400 }),
+            );
+
+            let thrown: Error | undefined;
+            try {
+                await createCrossmintSigner(mockConfig);
+            } catch (error) {
+                thrown = error as Error;
+            }
+
+            expect(thrown).toBeDefined();
+            // eslint-disable-next-line no-control-regex
+            expect(thrown?.message).not.toMatch(/[\u0000-\u001f]/);
+            expect(thrown?.message).toContain('[truncated]');
+        });
+
         it('throws config error when apiKey is missing', async () => {
             await expect(createCrossmintSigner({ ...mockConfig, apiKey: '' })).rejects.toMatchObject({
                 code: 'SIGNER_CONFIG_ERROR',

--- a/typescript/packages/crossmint/src/crossmint-signer.ts
+++ b/typescript/packages/crossmint/src/crossmint-signer.ts
@@ -7,6 +7,7 @@ import {
     createSignatureDictionary,
     createSignerError,
     ED25519_SIGNATURE_LENGTH,
+    sanitizeRemoteErrorResponse,
     SignerErrorCode,
     SolanaSigner,
     throwSignerError,
@@ -374,6 +375,7 @@ class CrossmintSigner<TAddress extends string = string> implements SolanaSigner<
                 body: body != null ? JSON.stringify(body) : undefined,
                 headers,
                 method,
+                redirect: 'error',
             });
         } catch (error) {
             throwSignerError(SignerErrorCode.HTTP_ERROR, {
@@ -474,6 +476,7 @@ async function fetchWallet(
                 'X-API-KEY': apiKey,
             },
             method: 'GET',
+            redirect: 'error',
         });
     } catch (error) {
         throwSignerError(SignerErrorCode.HTTP_ERROR, {
@@ -526,11 +529,11 @@ function parseTransactionResponse(payload: unknown, context: string): CrossmintT
 function extractApiErrorMessage(payload: unknown, fallback: string): string {
     if (payload && typeof payload === 'object') {
         const obj = payload as Record<string, unknown>;
-        if (typeof obj.message === 'string') return obj.message;
-        if (typeof obj.error === 'string') return obj.error;
+        if (typeof obj.message === 'string') return sanitizeRemoteErrorResponse(obj.message);
+        if (typeof obj.error === 'string') return sanitizeRemoteErrorResponse(obj.error);
         if (obj.error && typeof obj.error === 'object') {
             const errorObj = obj.error as Record<string, unknown>;
-            if (typeof errorObj.message === 'string') return errorObj.message;
+            if (typeof errorObj.message === 'string') return sanitizeRemoteErrorResponse(errorObj.message);
         }
     }
     return fallback;
@@ -598,16 +601,16 @@ function ed25519Sign(seed: Uint8Array, message: Uint8Array): Uint8Array {
 }
 
 function stringifyError(error: unknown): string {
-    if (typeof error === 'string') return error;
+    if (typeof error === 'string') return sanitizeRemoteErrorResponse(error);
     if (typeof error === 'number' || typeof error === 'boolean' || typeof error === 'bigint') {
         return String(error);
     }
     if (error instanceof Error) {
-        return error.message;
+        return sanitizeRemoteErrorResponse(error.message);
     }
     if (error == null) return 'unknown error';
     try {
-        return JSON.stringify(error);
+        return sanitizeRemoteErrorResponse(JSON.stringify(error));
     } catch {
         return 'unknown error';
     }

--- a/typescript/packages/dfns/src/auth.ts
+++ b/typescript/packages/dfns/src/auth.ts
@@ -41,6 +41,7 @@ export async function signUserAction(
                 'Content-Type': 'application/json',
             },
             method: 'POST',
+            redirect: 'error',
         });
     } catch (error) {
         throwSignerError(SignerErrorCode.HTTP_ERROR, {
@@ -113,6 +114,7 @@ export async function signUserAction(
                 'Content-Type': 'application/json',
             },
             method: 'POST',
+            redirect: 'error',
         });
     } catch (error) {
         throwSignerError(SignerErrorCode.HTTP_ERROR, {

--- a/typescript/packages/dfns/src/dfns-signer.ts
+++ b/typescript/packages/dfns/src/dfns-signer.ts
@@ -284,7 +284,7 @@ export class DfnsSigner<TAddress extends string = string> implements SolanaSigne
      * Send a signature request to the Dfns Keys API
      */
     private async sendSignatureRequest(request: GenerateSignatureRequest): Promise<SignatureBytes> {
-        const httpPath = `/keys/${this.keyId}/signatures`;
+        const httpPath = `/keys/${encodeURIComponent(this.keyId)}/signatures`;
         const requestBody = JSON.stringify(request);
 
         const userAction = await signUserAction(
@@ -308,6 +308,7 @@ export class DfnsSigner<TAddress extends string = string> implements SolanaSigne
                     'x-dfns-useraction': userAction,
                 },
                 method: 'POST',
+                redirect: 'error',
             });
         } catch (error) {
             throwSignerError(SignerErrorCode.HTTP_ERROR, {
@@ -364,7 +365,7 @@ export class DfnsSigner<TAddress extends string = string> implements SolanaSigne
  * Fetch wallet details from Dfns
  */
 async function fetchWallet(apiBaseUrl: string, authToken: string, walletId: string): Promise<GetWalletResponse> {
-    const url = `${apiBaseUrl}/wallets/${walletId}`;
+    const url = `${apiBaseUrl}/wallets/${encodeURIComponent(walletId)}`;
     let response: Response;
     try {
         response = await fetch(url, {
@@ -372,6 +373,7 @@ async function fetchWallet(apiBaseUrl: string, authToken: string, walletId: stri
                 Authorization: `Bearer ${authToken}`,
             },
             method: 'GET',
+            redirect: 'error',
         });
     } catch (error) {
         throwSignerError(SignerErrorCode.HTTP_ERROR, {

--- a/typescript/packages/dfns/src/dfns-signer.ts
+++ b/typescript/packages/dfns/src/dfns-signer.ts
@@ -284,7 +284,10 @@ export class DfnsSigner<TAddress extends string = string> implements SolanaSigne
      * Send a signature request to the Dfns Keys API
      */
     private async sendSignatureRequest(request: GenerateSignatureRequest): Promise<SignatureBytes> {
-        const httpPath = `/keys/${encodeURIComponent(this.keyId)}/signatures`;
+        // keyId is server-issued (from the wallet response) and this path is signed into the
+        // Dfns user-action challenge, which must match the routed request path verbatim — so it
+        // is interpolated raw rather than percent-encoded.
+        const httpPath = `/keys/${this.keyId}/signatures`;
         const requestBody = JSON.stringify(request);
 
         const userAction = await signUserAction(

--- a/typescript/packages/fireblocks/src/fireblocks-signer.ts
+++ b/typescript/packages/fireblocks/src/fireblocks-signer.ts
@@ -185,7 +185,7 @@ export class FireblocksSigner<TAddress extends string = string> implements Solan
      * Fetch the public key from Fireblocks API
      */
     private async fetchPublicKey(): Promise<Address> {
-        const uri = `/v1/vault/accounts/${this.vaultAccountId}/${this.assetId}/addresses_paginated`;
+        const uri = `/v1/vault/accounts/${encodeURIComponent(this.vaultAccountId)}/${encodeURIComponent(this.assetId)}/addresses_paginated`;
         const token = await createJwt(this.apiKey, this.privateKeyPem, uri, '');
 
         const url = `${this.apiBaseUrl}${uri}`;
@@ -197,6 +197,7 @@ export class FireblocksSigner<TAddress extends string = string> implements Solan
                     'X-API-Key': this.apiKey,
                 },
                 method: 'GET',
+                redirect: 'error',
             });
         } catch (error) {
             throwSignerError(SignerErrorCode.HTTP_ERROR, {
@@ -261,6 +262,7 @@ export class FireblocksSigner<TAddress extends string = string> implements Solan
                     'X-API-Key': this.apiKey,
                 },
                 method,
+                redirect: 'error',
             });
         } catch (error) {
             throwSignerError(SignerErrorCode.HTTP_ERROR, {
@@ -345,7 +347,7 @@ export class FireblocksSigner<TAddress extends string = string> implements Solan
      * Poll for transaction completion and extract a reusable signer-bound signature.
      */
     private async pollForSignature(transactionId: string): Promise<SignatureBytes> {
-        const uri = `/v1/transactions/${transactionId}`;
+        const uri = `/v1/transactions/${encodeURIComponent(transactionId)}`;
 
         for (let attempt = 0; attempt < this.maxPollAttempts; attempt++) {
             const txResponse = await this.request<TransactionResponse>('GET', uri);
@@ -461,7 +463,7 @@ export class FireblocksSigner<TAddress extends string = string> implements Solan
      */
     async isAvailable(): Promise<boolean> {
         try {
-            const uri = `/v1/vault/accounts/${this.vaultAccountId}`;
+            const uri = `/v1/vault/accounts/${encodeURIComponent(this.vaultAccountId)}`;
             const token = await createJwt(this.apiKey, this.privateKeyPem, uri, '');
 
             const url = `${this.apiBaseUrl}${uri}`;
@@ -471,6 +473,7 @@ export class FireblocksSigner<TAddress extends string = string> implements Solan
                     'X-API-Key': this.apiKey,
                 },
                 method: 'GET',
+                redirect: 'error',
             });
 
             return response.ok;

--- a/typescript/packages/gcp-kms/src/gcp-kms-signer.ts
+++ b/typescript/packages/gcp-kms/src/gcp-kms-signer.ts
@@ -136,7 +136,7 @@ export class GcpKmsSigner<TAddress extends string = string> implements SolanaSig
             headers.set('content-type', 'application/json');
         }
 
-        return await fetch(url, { ...init, headers });
+        return await fetch(url, { ...init, headers, redirect: 'error' });
     }
 
     private async request<TResponse>(url: string, init: RequestInit): Promise<TResponse> {

--- a/typescript/packages/openfort/src/openfort-signer.ts
+++ b/typescript/packages/openfort/src/openfort-signer.ts
@@ -161,7 +161,7 @@ export class OpenfortSigner<TAddress extends string = string> implements SolanaS
      */
     private async signBytes(message: Uint8Array): Promise<SignatureBytes> {
         const dataHex = `0x${getBase16Decoder().decode(message)}`;
-        const path = `${BACKEND_PATH}/${this.accountId}/sign`;
+        const path = `${BACKEND_PATH}/${encodeURIComponent(this.accountId)}/sign`;
         const url = `${this.baseUrl}${path}`;
         const body = { data: dataHex };
 
@@ -178,6 +178,7 @@ export class OpenfortSigner<TAddress extends string = string> implements SolanaS
                 body: JSON.stringify(body),
                 headers,
                 method: 'POST',
+                redirect: 'error',
             });
         } catch (error) {
             throwSignerError(SignerErrorCode.HTTP_ERROR, {
@@ -394,7 +395,7 @@ async function fetchAddress<TAddress extends string = string>(config: {
     baseUrl: string;
     secretKey: string;
 }): Promise<Address<TAddress>> {
-    const url = `${config.baseUrl}${ACCOUNTS_PATH}/${config.accountId}`;
+    const url = `${config.baseUrl}${ACCOUNTS_PATH}/${encodeURIComponent(config.accountId)}`;
 
     let response: Response;
     try {
@@ -403,6 +404,7 @@ async function fetchAddress<TAddress extends string = string>(config: {
                 Authorization: `Bearer ${config.secretKey}`,
             },
             method: 'GET',
+            redirect: 'error',
         });
     } catch (error) {
         throwSignerError(SignerErrorCode.HTTP_ERROR, {

--- a/typescript/packages/para/src/para-signer.ts
+++ b/typescript/packages/para/src/para-signer.ts
@@ -115,6 +115,7 @@ export class ParaSigner<TAddress extends string = string> implements SolanaSigne
                     'X-API-Key': config.apiKey,
                 },
                 method: 'GET',
+                redirect: 'error',
             });
         } catch (error) {
             return throwSignerError(SignerErrorCode.HTTP_ERROR, {
@@ -178,6 +179,7 @@ export class ParaSigner<TAddress extends string = string> implements SolanaSigne
             const response = await fetch(url, {
                 headers: { 'X-API-Key': this.apiKey },
                 method: 'GET',
+                redirect: 'error',
                 signal: AbortSignal.timeout(5_000),
             });
 
@@ -258,6 +260,7 @@ export class ParaSigner<TAddress extends string = string> implements SolanaSigne
                     'X-API-Key': this.apiKey,
                 },
                 method: 'POST',
+                redirect: 'error',
             });
         } catch (error) {
             return throwSignerError(SignerErrorCode.HTTP_ERROR, {

--- a/typescript/packages/privy/src/__tests__/privy-signer.test.ts
+++ b/typescript/packages/privy/src/__tests__/privy-signer.test.ts
@@ -115,6 +115,21 @@ describe('PrivySigner', () => {
             expect(signer.address).toBe(keyPair.address);
         });
 
+        it('URL-encodes walletId in the request path and disables redirect following', async () => {
+            const keyPair = await generateKeyPairSigner();
+            (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+                json: () => Promise.resolve({ address: keyPair.address, chain_type: 'solana', id: '../../evil' }),
+                ok: true,
+                status: 200,
+            });
+
+            await PrivySigner.create({ ...mockConfig, walletId: '../../evil' });
+
+            const [url, init] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [string, RequestInit];
+            expect(url).toBe('https://api.privy.test/wallets/..%2F..%2Fevil');
+            expect(init.redirect).toBe('error');
+        });
+
         it('throws error on API failure', async () => {
             (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
                 ok: false,

--- a/typescript/packages/privy/src/__tests__/privy-signer.test.ts
+++ b/typescript/packages/privy/src/__tests__/privy-signer.test.ts
@@ -333,6 +333,7 @@ describe('PrivySigner', () => {
                     'privy-request-expiry': '1900000',
                 },
                 method: 'POST',
+                redirect: 'error',
             });
         });
 

--- a/typescript/packages/privy/src/privy-signer.ts
+++ b/typescript/packages/privy/src/privy-signer.ts
@@ -173,7 +173,7 @@ export class PrivySigner<TAddress extends string = string> implements SolanaSign
     private async signTransaction(
         base64WireTransaction: Base64EncodedWireTransaction,
     ): Promise<Base64EncodedWireTransaction> {
-        const url = `${this.apiBaseUrl}/wallets/${this.walletId}/rpc`;
+        const url = `${this.apiBaseUrl}/wallets/${encodeURIComponent(this.walletId)}/rpc`;
 
         const request: SignTransactionRequest = {
             chain_type: 'solana',
@@ -203,6 +203,7 @@ export class PrivySigner<TAddress extends string = string> implements SolanaSign
                     ...authorizationHeaders,
                 },
                 method: 'POST',
+                redirect: 'error',
             });
         } catch (error) {
             throwSignerError(SignerErrorCode.HTTP_ERROR, {
@@ -246,7 +247,7 @@ export class PrivySigner<TAddress extends string = string> implements SolanaSign
      * @returns The signature bytes
      */
     private async signMessage(base64EncodedMessage: TransactionMessageBytesBase64): Promise<SignatureBytes> {
-        const url = `${this.apiBaseUrl}/wallets/${this.walletId}/rpc`;
+        const url = `${this.apiBaseUrl}/wallets/${encodeURIComponent(this.walletId)}/rpc`;
 
         const request: SignMessageRequest = {
             chain_type: 'solana',
@@ -276,6 +277,7 @@ export class PrivySigner<TAddress extends string = string> implements SolanaSign
                     ...authorizationHeaders,
                 },
                 method: 'POST',
+                redirect: 'error',
             });
         } catch (error) {
             throwSignerError(SignerErrorCode.HTTP_ERROR, {
@@ -444,7 +446,7 @@ async function fetchPublicKey<TAddress extends string = string>(config: {
     walletId: string;
 }): Promise<Address<TAddress>> {
     const apiBaseUrl = config.apiBaseUrl || DEFAULT_API_BASE_URL;
-    const url = `${apiBaseUrl}/wallets/${config.walletId}`;
+    const url = `${apiBaseUrl}/wallets/${encodeURIComponent(config.walletId)}`;
 
     let response: Response;
     try {
@@ -454,6 +456,7 @@ async function fetchPublicKey<TAddress extends string = string>(config: {
                 'privy-app-id': config.appId,
             },
             method: 'GET',
+            redirect: 'error',
         });
     } catch (error) {
         throwSignerError(SignerErrorCode.HTTP_ERROR, {

--- a/typescript/packages/turnkey/src/turnkey-signer.ts
+++ b/typescript/packages/turnkey/src/turnkey-signer.ts
@@ -195,6 +195,7 @@ export class TurnkeySigner<TAddress extends string = string> implements SolanaSi
                     [stamp.stampHeaderName]: stamp.stampHeaderValue,
                 },
                 method: 'POST',
+                redirect: 'error',
             });
         } catch (error) {
             throwSignerError(SignerErrorCode.HTTP_ERROR, {
@@ -301,6 +302,7 @@ export class TurnkeySigner<TAddress extends string = string> implements SolanaSi
                     [stamp.stampHeaderName]: stamp.stampHeaderValue,
                 },
                 method: 'POST',
+                redirect: 'error',
             });
         } catch (error) {
             throwSignerError(SignerErrorCode.HTTP_ERROR, {
@@ -409,6 +411,7 @@ export class TurnkeySigner<TAddress extends string = string> implements SolanaSi
                     [stamp.stampHeaderName]: stamp.stampHeaderValue,
                 },
                 method: 'POST',
+                redirect: 'error',
             });
             if (!response.ok) {
                 return false;

--- a/typescript/packages/utila/src/utila-signer.ts
+++ b/typescript/packages/utila/src/utila-signer.ts
@@ -332,6 +332,7 @@ export class UtilaSigner<TAddress extends string = string> implements SolanaSign
                 body: body != null ? JSON.stringify(body) : undefined,
                 headers,
                 method,
+                redirect: 'error',
             });
         } catch (error) {
             throwSignerError(SignerErrorCode.HTTP_ERROR, {
@@ -384,6 +385,7 @@ async function fetchWallet({
                 Authorization: `Bearer ${token}`,
             },
             method: 'GET',
+            redirect: 'error',
         });
     } catch (error) {
         throwSignerError(SignerErrorCode.HTTP_ERROR, {

--- a/typescript/packages/vault/src/vault-signer.ts
+++ b/typescript/packages/vault/src/vault-signer.ts
@@ -147,7 +147,7 @@ export class VaultSigner<TAddress extends string = string> implements SolanaSign
      * Sign data using Vault's transit engine
      */
     private async signWithVault(base64Data: string): Promise<SignatureBytes> {
-        const url = `${this.vaultAddr}/v1/transit/sign/${this.keyName}`;
+        const url = `${this.vaultAddr}/v1/transit/sign/${encodeURIComponent(this.keyName)}`;
 
         const request: VaultSignRequest = {
             input: base64Data as VaultPayloadBase64,
@@ -162,6 +162,7 @@ export class VaultSigner<TAddress extends string = string> implements SolanaSign
                     'X-Vault-Token': this.vaultToken,
                 },
                 method: 'POST',
+                redirect: 'error',
             });
         } catch (error) {
             return throwSignerError(SignerErrorCode.HTTP_ERROR, {
@@ -267,7 +268,7 @@ export class VaultSigner<TAddress extends string = string> implements SolanaSign
      * Check if the Vault signer is available by attempting to read key metadata
      */
     async isAvailable(): Promise<boolean> {
-        const url = `${this.vaultAddr}/v1/transit/keys/${this.keyName}`;
+        const url = `${this.vaultAddr}/v1/transit/keys/${encodeURIComponent(this.keyName)}`;
 
         try {
             const response = await fetch(url, {
@@ -275,6 +276,7 @@ export class VaultSigner<TAddress extends string = string> implements SolanaSign
                     'X-Vault-Token': this.vaultToken,
                 },
                 method: 'GET',
+                redirect: 'error',
             });
 
             if (!response.ok) {


### PR DESCRIPTION
Three TS security/hardening findings (TOO-484, parent TOO-479). Defense-in-depth; no behavior change for well-formed inputs.

- `redirect: 'error'` on every signer `fetch()` so cross-origin redirects can't forward custom auth headers (`X-Vault-Token`, `X-API-Key`, …). Note: this hard-fails on any 3xx — intentional, these JSON APIs don't legitimately redirect.
- `encodeURIComponent` on interpolated IDs where input isn't already format-validated (vault `keyName`; privy `walletId`; dfns `keyId`/`walletId`; fireblocks `vaultAccountId`/`assetId`/`transactionId`; openfort `accountId`). Para (UUID) and CDP (address) are already validated.
- crossmint error extraction now routes through `sanitizeRemoteErrorResponse`, matching the other backends.

Tests: regression tests for privy (encoding + redirect) and crossmint (sanitization); full TS unit suite, lint, typecheck pass.

Closes TOO-484.