### PR TITLE
fix(dfns): check wallet status, scheme, and curve in availability checks

### DIFF
--- a/rust/src/dfns/mod.rs
+++ b/rust/src/dfns/mod.rs
@@ -299,9 +299,17 @@ impl DfnsSigner {
         ))
     }
 
-    /// Check if Dfns API is available by fetching wallet details
+    /// Check if the Dfns wallet is available and healthy: reachable, active,
+    /// and backed by an EdDSA/ed25519 signing key
     async fn check_availability(&self) -> bool {
-        self.get_wallet().await.is_ok()
+        match self.get_wallet().await {
+            Ok(wallet) => {
+                wallet.status == "Active"
+                    && wallet.signing_key.scheme == "EdDSA"
+                    && wallet.signing_key.curve == "ed25519"
+            }
+            Err(_) => false,
+        }
     }
 }
 
@@ -740,7 +748,61 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_is_available_failure() {
+    async fn test_is_available_archived_wallet() {
+        let mock_server = MockServer::start().await;
+        let signer = create_test_signer(&mock_server.uri());
+
+        let mut body = wallet_response_json();
+        body["status"] = serde_json::json!("Archived");
+
+        Mock::given(method("GET"))
+            .and(path("/wallets/test-wallet-id"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(body))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        assert!(!signer.is_available().await);
+    }
+
+    #[tokio::test]
+    async fn test_is_available_wrong_scheme() {
+        let mock_server = MockServer::start().await;
+        let signer = create_test_signer(&mock_server.uri());
+
+        let mut body = wallet_response_json();
+        body["signingKey"]["scheme"] = serde_json::json!("ECDSA");
+
+        Mock::given(method("GET"))
+            .and(path("/wallets/test-wallet-id"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(body))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        assert!(!signer.is_available().await);
+    }
+
+    #[tokio::test]
+    async fn test_is_available_wrong_curve() {
+        let mock_server = MockServer::start().await;
+        let signer = create_test_signer(&mock_server.uri());
+
+        let mut body = wallet_response_json();
+        body["signingKey"]["curve"] = serde_json::json!("secp256k1");
+
+        Mock::given(method("GET"))
+            .and(path("/wallets/test-wallet-id"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(body))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        assert!(!signer.is_available().await);
+    }
+
+    #[tokio::test]
+    async fn test_is_available_api_error() {
         let mock_server = MockServer::start().await;
         let signer = create_test_signer(&mock_server.uri());
 

--- a/typescript/packages/dfns/src/__tests__/dfns-signer.test.ts
+++ b/typescript/packages/dfns/src/__tests__/dfns-signer.test.ts
@@ -390,9 +390,8 @@ describe('DfnsSigner', () => {
 
     describe('isAvailable', () => {
         it('returns true when API responds', async () => {
-            mockWalletFetch();
-            // isAvailable doesn't need create(), but we need a signer instance
-            mockWalletFetch(); // for the isAvailable call
+            mockWalletFetch(); // for create()
+            mockWalletFetch(); // for the isAvailable() call
             const signer = await DfnsSigner.create(defaultConfig);
             expect(await signer.isAvailable()).toBe(true);
         });
@@ -406,6 +405,30 @@ describe('DfnsSigner', () => {
                 status: 500,
                 text: async () => 'server error',
             });
+            expect(await signer.isAvailable()).toBe(false);
+        });
+
+        it('returns false for an archived wallet', async () => {
+            mockWalletFetch(); // for create()
+            const signer = await DfnsSigner.create(defaultConfig);
+
+            mockWalletFetch({ status: 'Archived' });
+            expect(await signer.isAvailable()).toBe(false);
+        });
+
+        it('returns false for a non-EdDSA scheme', async () => {
+            mockWalletFetch(); // for create()
+            const signer = await DfnsSigner.create(defaultConfig);
+
+            mockWalletFetch({ scheme: 'ECDSA' });
+            expect(await signer.isAvailable()).toBe(false);
+        });
+
+        it('returns false for a non-ed25519 curve', async () => {
+            mockWalletFetch(); // for create()
+            const signer = await DfnsSigner.create(defaultConfig);
+
+            mockWalletFetch({ curve: 'secp256k1' });
             expect(await signer.isAvailable()).toBe(false);
         });
     });

--- a/typescript/packages/dfns/src/dfns-signer.ts
+++ b/typescript/packages/dfns/src/dfns-signer.ts
@@ -266,12 +266,17 @@ export class DfnsSigner<TAddress extends string = string> implements SolanaSigne
     }
 
     /**
-     * Check if Dfns API is available
+     * Check if the Dfns wallet is available and healthy: reachable, active,
+     * and backed by an EdDSA/ed25519 signing key.
      */
     async isAvailable(): Promise<boolean> {
         try {
-            await fetchWallet(this.apiBaseUrl, this.authToken, this.walletId);
-            return true;
+            const wallet = await fetchWallet(this.apiBaseUrl, this.authToken, this.walletId);
+            return (
+                wallet.status === 'Active' &&
+                wallet.signingKey.scheme === 'EdDSA' &&
+                wallet.signingKey.curve === 'ed25519'
+            );
         } catch {
             return false;
         }


### PR DESCRIPTION
## Summary
- Rust `check_availability()` and TS `isAvailable()` previously returned `true` whenever the wallet fetch succeeded, so an archived or wrong-curve wallet reported healthy while every sign call failed (audit finding #14)
- Both sides now verify `status == "Active"`, `signingKey.scheme == "EdDSA"`, and `signingKey.curve == "ed25519"` — the same fields `init()`/`create()` already validate, mirroring para's availability pattern
- Adds tests on both sides: archived wallet, wrong scheme, wrong curve → `false`

The original TS-only version of this fix in #155 was reverted to avoid Rust/TS divergence; this lands both sides together.

Privy and Fireblocks share the same reachability-only pattern — left for a follow-up to keep this a clean paired dfns fix.

## Test Plan
- `just rust-test` (dfns tests pass on both `sdk-v2` and `sdk-v3`)
- `just ts-test` (all packages green)
- `just fmt` + workspace typecheck clean

Closes TOO-492