### PR TITLE
fix(crossmint): improve CI stability via approval-polling hardening (TOO-495)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ on:
       - 'rust/**'
       - '.github/workflows/ci.yml'
 
+env:
+  CARGO_NET_RETRY: 10
+
 jobs:
   resolve-signers:
     runs-on: ubuntu-latest

--- a/rust/src/crossmint/mod.rs
+++ b/rust/src/crossmint/mod.rs
@@ -12,7 +12,7 @@ use types::{
 };
 
 const DEFAULT_BASE_URL: &str = "https://www.crossmint.com/api";
-const CLIENT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+const CLIENT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
 const AVAILABILITY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 const DEFAULT_POLL_INTERVAL_MS: u64 = 1000;
 const DEFAULT_MAX_POLL_ATTEMPTS: u32 = 60;
@@ -319,6 +319,7 @@ impl CrossmintSigner {
         &self,
         mut response: TransactionResponse,
     ) -> Result<TransactionResponse, SignerError> {
+        let mut approval_submitted = false;
         for _ in 0..self.max_poll_attempts {
             match response.status.as_str() {
                 "success" => return Ok(response),
@@ -332,8 +333,12 @@ impl CrossmintSigner {
                         "Crossmint transaction failed: {detail}"
                     )));
                 }
-                "awaiting-approval" => {
+                // Submit our approval at most once; Crossmint may register it
+                // asynchronously, so afterwards awaiting-approval is treated
+                // like any other in-flight status and re-polled.
+                "awaiting-approval" if !approval_submitted => {
                     response = self.handle_awaiting_approval(response).await?;
+                    approval_submitted = true;
                 }
                 _ => {
                     tokio::time::sleep(tokio::time::Duration::from_millis(self.poll_interval_ms))
@@ -355,7 +360,7 @@ impl CrossmintSigner {
                     "Crossmint transaction failed: {detail}"
                 )))
             }
-            "awaiting-approval" => Err(SignerError::SigningFailed(
+            "awaiting-approval" if !approval_submitted => Err(SignerError::SigningFailed(
                 "Crossmint transaction is awaiting approval; additional signer approvals are required"
                     .to_string(),
             )),
@@ -376,17 +381,29 @@ impl CrossmintSigner {
             ));
         };
 
-        let message = response
+        // On a multi-approver wallet `pending` may contain challenges for other
+        // approvers; signing one of those with our key yields a vendor 4xx, so
+        // only the entry matching our signer locator is ours to approve.
+        let pending = response
             .approvals
             .as_ref()
-            .and_then(|a| a.pending.first())
-            .and_then(|p| p.message.as_deref())
+            .and_then(|a| {
+                a.pending.iter().find(|p| {
+                    p.signer.as_ref().and_then(|s| s.locator.as_deref())
+                        == Some(signer_locator.as_str())
+                })
+            })
             .ok_or_else(|| {
                 SignerError::SigningFailed(
-                    "Crossmint transaction awaiting approval but no pending message found"
-                        .to_string(),
+                    "Crossmint transaction is awaiting approval; additional signer approvals are required".to_string(),
                 )
             })?;
+
+        let message = pending.message.as_deref().ok_or_else(|| {
+            SignerError::SigningFailed(
+                "Crossmint transaction awaiting approval but no pending message found".to_string(),
+            )
+        })?;
 
         self.submit_approval(&response.id, signer_locator, message, signing_key)
             .await
@@ -1153,6 +1170,159 @@ mod tests {
             }
             other => panic!("Expected SigningFailed error, got: {:?}", other),
         }
+    }
+
+    fn attach_approval_signer(
+        signer: &mut CrossmintSigner,
+        locator: &str,
+    ) -> ed25519_dalek::SigningKey {
+        let key = ed25519_dalek::SigningKey::from_bytes(&[7u8; 32]);
+        signer.signing_key = Some(key.clone());
+        signer.signer = Some(locator.to_string());
+        key
+    }
+
+    #[tokio::test]
+    async fn test_sign_transaction_submits_approval_once_and_polls_after_async_registration() {
+        let server = MockServer::start().await;
+        let keypair = Keypair::new();
+        let signer_pubkey = keypair_pubkey(&keypair);
+        let locator = "server:test-approver";
+        let approval_message = bs58::encode(b"approval-challenge").into_string();
+
+        Mock::given(method("GET"))
+            .and(path("/2025-06-09/wallets/test-wallet"))
+            .and(header("x-api-key", "test-api-key"))
+            .respond_with(wallet_response(&signer_pubkey.to_string()))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/2025-06-09/wallets/test-wallet/transactions"))
+            .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
+                "id": "tx-123",
+                "status": "awaiting-approval",
+                "approvals": {
+                    "pending": [
+                        { "signer": { "locator": locator }, "message": approval_message }
+                    ]
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        // Approval is acknowledged but Crossmint has not registered it yet:
+        // the transaction still reports awaiting-approval with nothing pending.
+        Mock::given(method("POST"))
+            .and(path(
+                "/2025-06-09/wallets/test-wallet/transactions/tx-123/approvals",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "tx-123",
+                "status": "awaiting-approval",
+                "approvals": { "pending": [] }
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let mut signer = create_test_signer(&server.uri(), 1, 5);
+        attach_approval_signer(&mut signer, locator);
+        signer.init().await.unwrap();
+
+        let mut tx = create_test_transaction(&signer_pubkey);
+        let expected_signature = keypair_sign_message(&keypair, &tx.message_data());
+        let tx_id = bs58::encode(expected_signature.as_ref()).into_string();
+
+        Mock::given(method("GET"))
+            .and(path("/2025-06-09/wallets/test-wallet/transactions/tx-123"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "tx-123",
+                "status": "success",
+                "onChain": { "txId": tx_id }
+            })))
+            .mount(&server)
+            .await;
+
+        let (_serialized, signature) = signer
+            .sign_transaction(&mut tx)
+            .await
+            .unwrap()
+            .into_signed_transaction();
+        assert_eq!(signature, expected_signature);
+    }
+
+    #[tokio::test]
+    async fn test_sign_transaction_selects_pending_approval_matching_signer_locator() {
+        use ed25519_dalek::Signer as _;
+        use wiremock::matchers::body_string_contains;
+
+        let server = MockServer::start().await;
+        let keypair = Keypair::new();
+        let signer_pubkey = keypair_pubkey(&keypair);
+        let locator = "server:test-approver";
+
+        let our_message_bytes = b"our-approval-challenge";
+        let our_message = bs58::encode(our_message_bytes).into_string();
+        let other_message = bs58::encode(b"someone-elses-challenge").into_string();
+
+        Mock::given(method("GET"))
+            .and(path("/2025-06-09/wallets/test-wallet"))
+            .and(header("x-api-key", "test-api-key"))
+            .respond_with(wallet_response(&signer_pubkey.to_string()))
+            .mount(&server)
+            .await;
+
+        // pending[0] belongs to another approver; ours is second.
+        Mock::given(method("POST"))
+            .and(path("/2025-06-09/wallets/test-wallet/transactions"))
+            .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
+                "id": "tx-multi",
+                "status": "awaiting-approval",
+                "approvals": {
+                    "pending": [
+                        { "signer": { "locator": "server:other-approver" }, "message": other_message },
+                        { "signer": { "locator": locator }, "message": our_message }
+                    ]
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let mut signer = create_test_signer(&server.uri(), 1, 5);
+        let signing_key = attach_approval_signer(&mut signer, locator);
+        signer.init().await.unwrap();
+
+        let mut tx = create_test_transaction(&signer_pubkey);
+        let expected_tx_signature = keypair_sign_message(&keypair, &tx.message_data());
+        let tx_id = bs58::encode(expected_tx_signature.as_ref()).into_string();
+
+        // Only an approval whose signature covers OUR challenge bytes (and
+        // carries our locator) is answered; signing pending[0] would miss this
+        // mock and fail the test.
+        let expected_approval_signature =
+            bs58::encode(signing_key.sign(our_message_bytes).to_bytes()).into_string();
+        Mock::given(method("POST"))
+            .and(path(
+                "/2025-06-09/wallets/test-wallet/transactions/tx-multi/approvals",
+            ))
+            .and(body_string_contains(&expected_approval_signature))
+            .and(body_string_contains(locator))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "tx-multi",
+                "status": "success",
+                "onChain": { "txId": tx_id }
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let (_serialized, signature) = signer
+            .sign_transaction(&mut tx)
+            .await
+            .unwrap()
+            .into_signed_transaction();
+        assert_eq!(signature, expected_tx_signature);
     }
 
     #[tokio::test]

--- a/rust/src/crossmint/types.rs
+++ b/rust/src/crossmint/types.rs
@@ -57,4 +57,13 @@ pub struct Approvals {
 pub struct PendingApproval {
     #[serde(default)]
     pub message: Option<String>,
+    #[serde(default)]
+    pub signer: Option<ApprovalSigner>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ApprovalSigner {
+    #[serde(default)]
+    pub locator: Option<String>,
 }

--- a/rust/src/gcp_kms/mod.rs
+++ b/rust/src/gcp_kms/mod.rs
@@ -213,7 +213,7 @@ mod tests {
     use google_cloud_kms_v1::client::KeyManagementService;
     use scoped_env::ScopedEnv;
     use serial_test::serial;
-    use wiremock::matchers::{any, method, path};
+    use wiremock::matchers::{method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     const TEST_KEY_NAME: &str = "projects/test-project/locations/us-east1/keyRings/test-ring/cryptoKeys/test-key/cryptoKeyVersions/1";
@@ -346,8 +346,11 @@ mod tests {
         )
         .expect("Failed to create signer");
 
-        // Mock GetPublicKey
-        Mock::given(any())
+        // Mock GetPublicKey. Matched by path (not a catch-all) so the auth
+        // client's variable number of metadata probes (e.g. universe-domain)
+        // cannot inflate the match count of the strict expect(1) below.
+        Mock::given(method("GET"))
+            .and(path(format!("/v1/{TEST_KEY_NAME}/publicKey")))
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!(
                 {
                     "name": TEST_KEY_NAME,
@@ -397,7 +400,8 @@ mod tests {
         let signature = keypair.sign_message(message);
 
         // Mock AsymmetricSign
-        Mock::given(any())
+        Mock::given(method("POST"))
+            .and(path(format!("/v1/{TEST_KEY_NAME}:asymmetricSign")))
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!(
                 {
                     "signature": STANDARD.encode(signature.as_ref()),
@@ -449,7 +453,8 @@ mod tests {
         let message = b"test message";
         let signature = signing_keypair.sign_message(message);
 
-        Mock::given(any())
+        Mock::given(method("POST"))
+            .and(path(format!("/v1/{TEST_KEY_NAME}:asymmetricSign")))
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!(
                 {
                     "signature": STANDARD.encode(signature.as_ref()),
@@ -502,7 +507,8 @@ mod tests {
         let signature = keypair.sign_message(&tx.message_data());
 
         // Mock AsymmetricSign
-        Mock::given(any())
+        Mock::given(method("POST"))
+            .and(path(format!("/v1/{TEST_KEY_NAME}:asymmetricSign")))
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!(
                 {
                     "signature": STANDARD.encode(signature.as_ref()),
@@ -559,7 +565,8 @@ mod tests {
         .expect("Failed to create signer");
 
         // Return invalid signature (not 64 bytes)
-        Mock::given(any())
+        Mock::given(method("POST"))
+            .and(path(format!("/v1/{TEST_KEY_NAME}:asymmetricSign")))
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!(
                 {
                     "signature": STANDARD.encode(vec![0u8; 32]),
@@ -607,7 +614,8 @@ mod tests {
         )
         .expect("Failed to create signer");
 
-        Mock::given(any())
+        Mock::given(method("POST"))
+            .and(path(format!("/v1/{TEST_KEY_NAME}:asymmetricSign")))
             .respond_with(ResponseTemplate::new(400).set_body_json(serde_json::json!(
                 {
                     "error": {
@@ -661,7 +669,8 @@ mod tests {
         .expect("Failed to create signer");
 
         // Mock 403 Forbidden
-        Mock::given(any())
+        Mock::given(method("POST"))
+            .and(path(format!("/v1/{TEST_KEY_NAME}:asymmetricSign")))
             .respond_with(ResponseTemplate::new(403).set_body_json(serde_json::json!(
                 {
                     "error": {
@@ -716,7 +725,8 @@ mod tests {
         .expect("Failed to create signer");
 
         // Mock GetPublicKey with WRONG algorithm
-        Mock::given(any())
+        Mock::given(method("GET"))
+            .and(path(format!("/v1/{TEST_KEY_NAME}/publicKey")))
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!(
                 {
                     "name": TEST_KEY_NAME,

--- a/typescript/packages/crossmint/src/__tests__/crossmint-signer.integration.test.ts
+++ b/typescript/packages/crossmint/src/__tests__/crossmint-signer.integration.test.ts
@@ -29,23 +29,33 @@ async function getLatestBlockhash() {
     return json.result.value;
 }
 
+// Crossmint is broadcast-managed: "success" requires the transaction to land
+// on devnet, so signing can take the signer's full polling budget (60 × 1s in
+// crossmint-signer.ts). The test timeout must exceed that budget so the
+// signer's own timeout error surfaces instead of a vitest kill.
+const SIGN_TEST_TIMEOUT_MS = 90_000;
+
 describe('CrossmintSigner Integration', () => {
-    it.skipIf(!process.env.CROSSMINT_API_KEY)('signs transactions with real API', async () => {
-        const { createSigner } = await getConfig(['signTransaction']);
-        const signer = await createSigner();
+    it.skipIf(!process.env.CROSSMINT_API_KEY)(
+        'signs transactions with real API',
+        { timeout: SIGN_TEST_TIMEOUT_MS },
+        async () => {
+            const { createSigner } = await getConfig(['signTransaction']);
+            const signer = await createSigner();
 
-        const { blockhash, lastValidBlockHeight } = await getLatestBlockhash();
-        const transaction = pipe(
-            createTransactionMessage({ version: 0 }),
-            tx => setTransactionMessageFeePayerSigner(signer, tx),
-            tx => setTransactionMessageLifetimeUsingBlockhash({ blockhash, lastValidBlockHeight }, tx),
-        );
+            const { blockhash, lastValidBlockHeight } = await getLatestBlockhash();
+            const transaction = pipe(
+                createTransactionMessage({ version: 0 }),
+                tx => setTransactionMessageFeePayerSigner(signer, tx),
+                tx => setTransactionMessageLifetimeUsingBlockhash({ blockhash, lastValidBlockHeight }, tx),
+            );
 
-        const signedTx = await signTransactionMessageWithSigners(transaction);
+            const signedTx = await signTransactionMessageWithSigners(transaction);
 
-        expect(signedTx.signatures[signer.address]).toBeDefined();
-        expect(signedTx.signatures[signer.address]?.byteLength).toBe(64);
-    });
+            expect(signedTx.signatures[signer.address]).toBeDefined();
+            expect(signedTx.signatures[signer.address]?.byteLength).toBe(64);
+        },
+    );
 
     it.skipIf(!process.env.CROSSMINT_API_KEY)('returns not supported for signMessages', async () => {
         const { createSigner } = await getConfig(['signMessage']);

--- a/typescript/packages/crossmint/src/__tests__/crossmint-signer.test.ts
+++ b/typescript/packages/crossmint/src/__tests__/crossmint-signer.test.ts
@@ -820,26 +820,83 @@ describe('CrossmintSigner', () => {
                 )
                 // approval POST response still awaiting-approval, and our entry
                 // still appears pending (vendor lag). We must NOT resubmit.
-                .mockResolvedValue(
-                    new Response(
-                        JSON.stringify({
-                            id: 'tx-persist',
-                            status: 'awaiting-approval',
-                            approvals: { pending: [{ signer: { locator: OUR_SIGNER }, message: OUR_MESSAGE_B58 }] },
-                        }),
-                        { status: 200 },
+                // Fresh Response per call: a Response body is single-read, and
+                // this state is served across several polls.
+                .mockImplementation(() =>
+                    Promise.resolve(
+                        new Response(
+                            JSON.stringify({
+                                id: 'tx-persist',
+                                status: 'awaiting-approval',
+                                approvals: {
+                                    pending: [{ signer: { locator: OUR_SIGNER }, message: OUR_MESSAGE_B58 }],
+                                },
+                            }),
+                            { status: 200 },
+                        ),
                     ),
                 );
 
             const signer = await createCrossmintSigner(approvalConfig({ maxPollAttempts: 5 }));
 
+            // Once our approval is in, a persistent awaiting-approval status is
+            // an in-flight state, not a terminal failure: the signer keeps
+            // polling and surfaces its own timeout when the budget runs out.
             await expect(signer.signTransactions([createMockTransaction()])).rejects.toMatchObject({
-                code: 'SIGNER_SIGNING_FAILED',
-                message: expect.stringContaining('additional signer approvals are required'),
+                code: 'SIGNER_REMOTE_API_ERROR',
+                message: expect.stringContaining('polling timed out'),
             });
 
             const approvalPosts = vi.mocked(fetch).mock.calls.filter(call => String(call[0]).includes('/approvals'));
             expect(approvalPosts.length).toBe(1);
+        });
+
+        it('keeps polling when approval registers asynchronously and resolves on later success', async () => {
+            vi.mocked(fetch)
+                .mockResolvedValueOnce(mockWalletResponse()) // create()
+                .mockResolvedValueOnce(
+                    new Response(
+                        JSON.stringify({
+                            id: 'tx-async-approval',
+                            status: 'awaiting-approval',
+                            approvals: { pending: [{ signer: { locator: OUR_SIGNER }, message: OUR_MESSAGE_B58 }] },
+                        }),
+                        { status: 201 },
+                    ),
+                )
+                // approval POST acknowledged, but Crossmint has not registered
+                // it yet: status is still awaiting-approval with nothing
+                // pending for us.
+                .mockResolvedValueOnce(
+                    new Response(
+                        JSON.stringify({
+                            id: 'tx-async-approval',
+                            status: 'awaiting-approval',
+                            approvals: { pending: [] },
+                        }),
+                        { status: 200 },
+                    ),
+                )
+                .mockResolvedValueOnce(
+                    new Response(
+                        JSON.stringify({
+                            id: 'tx-async-approval',
+                            status: 'success',
+                            onChain: { txId: MOCK_SIGNATURE_B58 },
+                        }),
+                        { status: 200 },
+                    ),
+                );
+
+            const signer = await createCrossmintSigner(approvalConfig());
+            const results = await signer.signTransactions([createMockTransaction()]);
+            expect(results).toHaveLength(1);
+            expect(results[0]![signer.address]?.length).toBe(64);
+
+            const approvalPosts = vi.mocked(fetch).mock.calls.filter(call => String(call[0]).includes('/approvals'));
+            expect(approvalPosts.length).toBe(1);
+            // wallet + create + approvals + final poll = 4 fetches.
+            expect(vi.mocked(fetch)).toHaveBeenCalledTimes(4);
         });
     });
 

--- a/typescript/packages/crossmint/src/crossmint-signer.ts
+++ b/typescript/packages/crossmint/src/crossmint-signer.ts
@@ -222,9 +222,8 @@ class CrossmintSigner<TAddress extends string = string> implements SolanaSigner<
             ) {
                 response = await this.submitApproval(response, pending);
                 approvalSubmitted = true;
-                // Re-evaluate the new status immediately; the approvalSubmitted
-                // guard prevents this branch from re-running, so we cannot
-                // busy-loop re-signing/re-submitting the same approval.
+                // Re-evaluate the new status immediately; approvalSubmitted
+                // ensures the approval is signed and submitted at most once.
                 continue;
             }
             const terminalSignature = await this.resolveTerminalStatus(response, transaction, approvalSubmitted);

--- a/typescript/packages/crossmint/src/crossmint-signer.ts
+++ b/typescript/packages/crossmint/src/crossmint-signer.ts
@@ -227,7 +227,7 @@ class CrossmintSigner<TAddress extends string = string> implements SolanaSigner<
                 // busy-loop re-signing/re-submitting the same approval.
                 continue;
             }
-            const terminalSignature = await this.resolveTerminalStatus(response, transaction);
+            const terminalSignature = await this.resolveTerminalStatus(response, transaction, approvalSubmitted);
             if (terminalSignature) {
                 return terminalSignature;
             }
@@ -236,7 +236,7 @@ class CrossmintSigner<TAddress extends string = string> implements SolanaSigner<
             response = await this.getTransaction(response.id);
         }
 
-        const terminalSignature = await this.resolveTerminalStatus(response, transaction);
+        const terminalSignature = await this.resolveTerminalStatus(response, transaction, approvalSubmitted);
         if (terminalSignature) {
             return terminalSignature;
         }
@@ -249,6 +249,7 @@ class CrossmintSigner<TAddress extends string = string> implements SolanaSigner<
     private async resolveTerminalStatus(
         response: CrossmintTransactionResponse,
         transaction: Transaction & TransactionWithinSizeLimit & TransactionWithLifetime,
+        approvalSubmitted: boolean,
     ): Promise<SignatureBytes | undefined> {
         const status = response.status as CrossmintTransactionStatus;
         switch (status) {
@@ -259,6 +260,12 @@ class CrossmintSigner<TAddress extends string = string> implements SolanaSigner<
                     message: `Crossmint transaction failed: ${stringifyError(response.error)}`,
                 });
             case 'awaiting-approval':
+                // Crossmint may register a submitted approval asynchronously, so
+                // awaiting-approval is only terminal while no approval of ours is
+                // in flight; otherwise keep polling until the status advances.
+                if (approvalSubmitted) {
+                    return undefined;
+                }
                 return throwSignerError(SignerErrorCode.SIGNING_FAILED, {
                     message: 'Crossmint transaction is awaiting approval; additional signer approvals are required',
                 });


### PR DESCRIPTION
Hardens Crossmint approval polling in both implementations and removes two unrelated sources of CI flakiness.

- Crossmint signing no longer fails spuriously when Crossmint registers a submitted approval asynchronously: `awaiting-approval` is treated as in-flight (not terminal) once our approval has been submitted, in both Rust and TypeScript.
- Rust now submits an approval at most once per transaction and selects the pending approval matching its own signer locator instead of `pending.first()`, preventing rapid duplicate approval POSTs and wrong-challenge signing on multi-approver wallets (parity with the TypeScript guard). The reqwest client timeout is raised to 60s for parity with `fetchSignerJson`.
- The TS real-API integration test timeout is raised to 90s so it exceeds the signer's 60s polling budget; previously vitest killed the test at 30s and masked the real diagnostic.
- gcp_kms unit tests no longer flake: wiremock mocks are scoped by method and path so the GCP auth client's variable metadata probes cannot inflate strict `expect(1)` match counts (failed ~50% of full-suite runs locally).
- CI sets `CARGO_NET_RETRY: 10` to ride out transient crates.io download errors (e.g. run 27426217751).

Closes TOO-495.

Test coverage added on both sides for the approval-registers-asynchronously path, single-submission guarantee, and locator-based pending selection.