### PR TITLE
feat(keychain-ts): add @solana/keychain-kit-plugin package (TOO-496)

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -99,7 +99,7 @@ git commit -m "chore: bump rust version to vX.Y.Z"
 
 ```bash
 cd typescript
-for pkg in core aws-kms cdp dfns fireblocks gcp-kms para privy turnkey vault keychain test-utils crossmint; do
+for pkg in core aws-kms cdp dfns fireblocks gcp-kms memory openfort para privy turnkey utila vault keychain kit-plugin test-utils crossmint; do
   cd packages/${pkg} && npm version "A.B.C" --no-git-tag-version && cd ../..
 done
 npm version "A.B.C" --no-git-tag-version

--- a/.github/workflows/typescript-ci.yml
+++ b/.github/workflows/typescript-ci.yml
@@ -228,6 +228,7 @@ jobs:
           done
           if [ "${{ needs.resolve-signers.outputs.ts_all_signers_enabled }}" = "true" ]; then
             pnpm -F @solana/keychain... run build
+            pnpm -F @solana/keychain-kit-plugin run build
           fi
       - name: Typecheck
         run: |
@@ -239,7 +240,11 @@ jobs:
           done
           if [ "${{ needs.resolve-signers.outputs.ts_all_signers_enabled }}" = "true" ]; then
             pnpm -F @solana/keychain run typecheck
+            pnpm -F @solana/keychain-kit-plugin run typecheck
           fi
+      - name: Run unit tests for @solana/keychain-kit-plugin
+        if: ${{ needs.resolve-signers.outputs.ts_all_signers_enabled == 'true' }}
+        run: pnpm -F @solana/keychain-kit-plugin run test:unit
       - name: Lint
         run: |
           set -euo pipefail
@@ -249,6 +254,7 @@ jobs:
           done
           if [ "${{ needs.resolve-signers.outputs.ts_all_signers_enabled }}" = "true" ]; then
             targets+=("packages/keychain")
+            targets+=("packages/kit-plugin")
           fi
           pnpm exec eslint "${targets[@]}" --ext .ts
       - name: Format check
@@ -260,6 +266,7 @@ jobs:
           done
           if [ "${{ needs.resolve-signers.outputs.ts_all_signers_enabled }}" = "true" ]; then
             pnpm exec prettier --check "packages/keychain/**/*.{ts,json,md}"
+            pnpm exec prettier --check "packages/kit-plugin/**/*.{ts,json,md}"
           fi
       - name: Tree-shakability check
         run: |
@@ -269,6 +276,7 @@ jobs:
           done
           if [ "${{ needs.resolve-signers.outputs.ts_all_signers_enabled }}" = "true" ]; then
             pnpm test:treeshakability:umbrella
+            pnpm -F @solana/keychain-kit-plugin run test:treeshakability
           else
             echo "Skipping umbrella tree-shakability check because one or more signers are disabled."
           fi

--- a/.github/workflows/typescript-publish.yml
+++ b/.github/workflows/typescript-publish.yml
@@ -25,6 +25,7 @@ on:
           - utila
           - vault
           - keychain
+          - kit-plugin
       publish-to-npm:
         description: 'Publish to npm registry'
         required: true
@@ -64,6 +65,7 @@ env:
     utila
     vault
     keychain
+    kit-plugin
 
 jobs:
   guard-allowed-branch:
@@ -418,6 +420,7 @@ jobs:
               '@solana/keychain-dfns',
               '@solana/keychain-fireblocks',
               '@solana/keychain-gcp-kms',
+              '@solana/keychain-kit-plugin',
               '@solana/keychain-memory',
               '@solana/keychain-openfort',
               '@solana/keychain-para',

--- a/justfile
+++ b/justfile
@@ -344,7 +344,7 @@ release-ts: _check-ts-release
     echo "Updating to $version..."
 
     # Update version in all packages
-    PACKAGES="core aws-kms cdp dfns fireblocks gcp-kms memory openfort para privy turnkey utila vault keychain test-utils crossmint"
+    PACKAGES="core aws-kms cdp dfns fireblocks gcp-kms memory openfort para privy turnkey utila vault keychain kit-plugin test-utils crossmint"
     for pkg in $PACKAGES; do
         echo "  Updating packages/${pkg}..."
         cd packages/${pkg}

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -48,6 +48,21 @@ interface SolanaSigner<TAddress extends string = string> {
 
 See the [`@solana/keychain` README](./packages/keychain/README.md) for more usage patterns.
 
+### Using with Kit clients
+
+`@solana/keychain-kit-plugin` installs a keychain signer on a [Kit client](https://github.com/anza-xyz/kit) as the `payer` and/or `identity`:
+
+```typescript
+import { createClient } from '@solana/kit';
+import { keychainSigner } from '@solana/keychain-kit-plugin';
+
+const client = await createClient().use(
+    keychainSigner({ backend: 'privy', appId, appSecret, walletId }),
+);
+
+client.payer; // SolanaSigner — also a Kit TransactionSigner
+```
+
 ## Packages
 
 | Package | Description |
@@ -66,6 +81,7 @@ See the [`@solana/keychain` README](./packages/keychain/README.md) for more usag
 | [@solana/keychain-openfort](./packages/openfort) | Openfort backend wallet signer implementation |
 | [@solana/keychain-para](./packages/para) | Para MPC signer implementation |
 | [@solana/keychain-utila](./packages/utila) | Utila wallet signer implementation |
+| [@solana/keychain-kit-plugin](./packages/kit-plugin) | Kit client plugins (`keychainSigner`/`keychainPayer`/`keychainIdentity`) |
 
 ## Installation
 
@@ -88,4 +104,7 @@ pnpm add @solana/keychain-privy       # Privy signer
 pnpm add @solana/keychain-turnkey     # Turnkey signer
 pnpm add @solana/keychain-utila       # Utila signer
 pnpm add @solana/keychain-vault       # HashiCorp Vault signer
+
+# Kit client plugins
+pnpm add @solana/keychain-kit-plugin  # keychainSigner/keychainPayer/keychainIdentity
 ```

--- a/typescript/packages/kit-plugin/README.md
+++ b/typescript/packages/kit-plugin/README.md
@@ -1,0 +1,63 @@
+# @solana/keychain-kit-plugin
+
+[Kit client](https://github.com/anza-xyz/kit) plugins that create a keychain signer from any supported backend and install it on the client as the `payer` and/or `identity`.
+
+## Installation
+
+```sh
+pnpm add @solana/keychain-kit-plugin @solana/kit
+```
+
+## Usage
+
+Each plugin accepts the same backend-tagged configuration as [`createKeychainSigner`](../keychain/README.md) from `@solana/keychain`:
+
+```ts
+import { createClient } from '@solana/kit';
+import { keychainSigner } from '@solana/keychain-kit-plugin';
+
+const client = await createClient().use(
+    keychainSigner({
+        backend: 'privy',
+        appId: process.env.PRIVY_APP_ID!,
+        appSecret: process.env.PRIVY_APP_SECRET!,
+        walletId: process.env.PRIVY_WALLET_ID!,
+    }),
+);
+
+client.payer; // SolanaSigner — also a Kit TransactionSigner
+client.identity; // same signer instance
+```
+
+Only the backend a configuration dispatches to is bundled — backend packages are loaded with dynamic `import()`.
+
+## Plugin variants
+
+| Plugin                    | Sets                                          |
+| ------------------------- | --------------------------------------------- |
+| `keychainSigner(config)`  | Both `payer` **and** `identity` (same signer) |
+| `keychainPayer(config)`   | Only `payer`                                  |
+| `keychainIdentity(config)` | Only `identity`                               |
+
+Mix backends on one client:
+
+```ts
+import { createClient } from '@solana/kit';
+import { keychainIdentity, keychainPayer } from '@solana/keychain-kit-plugin';
+
+const client = await createClient()
+    .use(keychainPayer({ backend: 'memory', privateKeyPath: '~/.config/solana/id.json' }))
+    .use(keychainIdentity({ backend: 'turnkey', ...turnkeyConfig }));
+```
+
+## Already have a signer?
+
+If you've already constructed a `SolanaSigner` (or want to share one across clients), you don't need this package — every keychain signer is a valid Kit `TransactionSigner`, so [`@solana/kit-plugin-signer`](https://github.com/anza-xyz/kit-plugins/tree/main/packages/kit-plugin-signer) works directly:
+
+```ts
+import { signer } from '@solana/kit-plugin-signer';
+import { createKeychainSigner } from '@solana/keychain';
+
+const mySigner = await createKeychainSigner({ backend: 'vault', ...vaultConfig });
+const client = createClient().use(signer(mySigner));
+```

--- a/typescript/packages/kit-plugin/package.json
+++ b/typescript/packages/kit-plugin/package.json
@@ -1,0 +1,55 @@
+{
+    "name": "@solana/keychain-kit-plugin",
+    "author": "Solana Foundation",
+    "version": "1.3.0",
+    "description": "Kit client plugins that install keychain signers as payer and identity",
+    "license": "MIT",
+    "repository": "https://github.com/solana-foundation/solana-keychain",
+    "keywords": [
+        "solana",
+        "signing",
+        "wallet",
+        "kit",
+        "plugin",
+        "payer",
+        "identity",
+        "keychain"
+    ],
+    "type": "module",
+    "sideEffects": false,
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./dist/index.d.ts",
+            "import": "./dist/index.js"
+        }
+    },
+    "files": [
+        "dist",
+        "src"
+    ],
+    "scripts": {
+        "build": "tsc --build",
+        "clean": "rm -rf dist *.tsbuildinfo",
+        "prepack": "pnpm run build",
+        "test": "vitest run",
+        "test:unit": "vitest run --config ../../vitest.config.unit.ts",
+        "test:watch": "vitest",
+        "test:watch:unit": "vitest --config ../../vitest.config.unit.ts",
+        "typecheck": "tsc --noEmit",
+        "test:treeshakability": "agadoo dist/index.js"
+    },
+    "dependencies": {
+        "@solana/keychain": "workspace:*"
+    },
+    "peerDependencies": {
+        "@solana/kit": ">=6.8.0"
+    },
+    "devDependencies": {
+        "@solana/kit": "^6.9.0"
+    },
+    "publishConfig": {
+        "access": "public"
+    }
+}

--- a/typescript/packages/kit-plugin/src/__tests__/keychain-plugin.test.ts
+++ b/typescript/packages/kit-plugin/src/__tests__/keychain-plugin.test.ts
@@ -1,0 +1,67 @@
+import { createClient } from '@solana/kit';
+import { describe, expect, it } from 'vitest';
+
+import { keychainIdentity, keychainPayer, keychainSigner } from '../keychain-plugin.js';
+
+const TEST_SEED = new Uint8Array(32).fill(7);
+const MEMORY_CONFIG = { backend: 'memory', privateKey: TEST_SEED } as const;
+
+describe('keychainSigner', () => {
+    it('sets the same signer as both payer and identity', async () => {
+        const client = await createClient().use(keychainSigner(MEMORY_CONFIG));
+
+        expect(client.payer).toBe(client.identity);
+        expect(client.payer.address).toMatch(/^[1-9A-HJ-NP-Za-km-z]{32,44}$/);
+    });
+
+    it('preserves existing client properties', async () => {
+        const base = { rpc: 'fake-rpc' };
+        const extended = await keychainSigner(MEMORY_CONFIG)(base);
+
+        expect(extended.rpc).toBe('fake-rpc');
+        expect(extended.payer.address).toBe(extended.identity.address);
+    });
+
+    it('installs a functional signer', async () => {
+        const client = await createClient().use(keychainSigner(MEMORY_CONFIG));
+
+        expect(typeof client.payer.signTransactions).toBe('function');
+        expect(typeof client.payer.signMessages).toBe('function');
+        await expect(client.payer.isAvailable()).resolves.toBe(true);
+    });
+});
+
+describe('keychainPayer', () => {
+    it('sets only the payer', async () => {
+        const client = await createClient().use(keychainPayer(MEMORY_CONFIG));
+
+        expect(client.payer.address).toMatch(/^[1-9A-HJ-NP-Za-km-z]{32,44}$/);
+        expect(client).not.toHaveProperty('identity');
+    });
+});
+
+describe('keychainIdentity', () => {
+    it('sets only the identity', async () => {
+        const client = await createClient().use(keychainIdentity(MEMORY_CONFIG));
+
+        expect(client.identity.address).toMatch(/^[1-9A-HJ-NP-Za-km-z]{32,44}$/);
+        expect(client).not.toHaveProperty('payer');
+    });
+});
+
+describe('composition', () => {
+    it('allows separate payer and identity signers on one client', async () => {
+        const otherSeed = new Uint8Array(32).fill(9);
+        const client = await createClient()
+            .use(keychainPayer(MEMORY_CONFIG))
+            .use(keychainIdentity({ backend: 'memory', privateKey: otherSeed }));
+
+        expect(client.payer.address).not.toBe(client.identity.address);
+    });
+
+    it('propagates signer construction failures', async () => {
+        await expect(
+            createClient().use(keychainSigner({ backend: 'memory', privateKey: new Uint8Array(5) })),
+        ).rejects.toThrow();
+    });
+});

--- a/typescript/packages/kit-plugin/src/index.ts
+++ b/typescript/packages/kit-plugin/src/index.ts
@@ -1,0 +1,1 @@
+export { keychainIdentity, keychainPayer, keychainSigner } from './keychain-plugin.js';

--- a/typescript/packages/kit-plugin/src/keychain-plugin.ts
+++ b/typescript/packages/kit-plugin/src/keychain-plugin.ts
@@ -1,0 +1,96 @@
+import type { KeychainSignerConfig } from '@solana/keychain';
+import { createKeychainSigner } from '@solana/keychain';
+import { extendClient } from '@solana/kit';
+
+/**
+ * Creates a keychain signer from a backend-tagged configuration and sets it
+ * as both the `payer` and `identity` properties on the client.
+ *
+ * This is a convenience shorthand for installing {@link keychainPayer} and
+ * {@link keychainIdentity} with the same configuration, without creating the
+ * signer twice.
+ *
+ * A new signer is created each time the plugin is applied to a client. To
+ * share one signer across clients, create it with `createKeychainSigner()`
+ * and install it with `@solana/kit-plugin-signer`'s `signer()` instead.
+ *
+ * @param config - The backend-tagged keychain signer configuration.
+ *
+ * @example
+ * ```ts
+ * import { createClient } from '@solana/kit';
+ * import { keychainSigner } from '@solana/keychain-kit-plugin';
+ *
+ * const client = await createClient().use(
+ *     keychainSigner({ backend: 'privy', appId, appSecret, walletId }),
+ * );
+ * ```
+ *
+ * @see {@link keychainPayer}
+ * @see {@link keychainIdentity}
+ */
+export function keychainSigner(config: KeychainSignerConfig) {
+    return async <TClient extends object>(client: TClient) => {
+        const signer = await createKeychainSigner(config);
+        return extendClient(client, { identity: signer, payer: signer });
+    };
+}
+
+/**
+ * Creates a keychain signer from a backend-tagged configuration and sets it
+ * as the `payer` property on the client.
+ *
+ * The payer is the signer responsible for paying transaction fees and
+ * storage costs (i.e. rent for newly created accounts).
+ *
+ * @param config - The backend-tagged keychain signer configuration.
+ *
+ * @example
+ * ```ts
+ * import { createClient } from '@solana/kit';
+ * import { keychainPayer } from '@solana/keychain-kit-plugin';
+ *
+ * const client = await createClient().use(
+ *     keychainPayer({ backend: 'vault', vaultUrl, vaultToken, keyName }),
+ * );
+ * ```
+ *
+ * @see {@link keychainIdentity}
+ * @see {@link keychainSigner}
+ */
+export function keychainPayer(config: KeychainSignerConfig) {
+    return async <TClient extends object>(client: TClient) => {
+        const payer = await createKeychainSigner(config);
+        return extendClient(client, { payer });
+    };
+}
+
+/**
+ * Creates a keychain signer from a backend-tagged configuration and sets it
+ * as the `identity` property on the client.
+ *
+ * The identity is the signer representing the wallet that owns things in
+ * the application, such as the authority over accounts, tokens, or other
+ * on-chain assets.
+ *
+ * @param config - The backend-tagged keychain signer configuration.
+ *
+ * @example
+ * ```ts
+ * import { createClient } from '@solana/kit';
+ * import { keychainIdentity } from '@solana/keychain-kit-plugin';
+ *
+ * const client = await createClient().use(
+ *     keychainIdentity({ backend: 'turnkey', ...turnkeyConfig }),
+ * );
+ * ```
+ *
+ * @see {@link keychainPayer}
+ * @see {@link keychainSigner}
+ */
+export function keychainIdentity(config: KeychainSignerConfig) {
+    return async <TClient extends object>(client: TClient) => {
+        const identity = await createKeychainSigner(config);
+        return extendClient(client, { identity });
+    };
+}

--- a/typescript/packages/kit-plugin/tsconfig.json
+++ b/typescript/packages/kit-plugin/tsconfig.json
@@ -1,0 +1,11 @@
+{
+    "extends": "../../tsconfig.base.json",
+    "compilerOptions": {
+        "outDir": "./dist",
+        "rootDir": "./src",
+        "composite": true
+    },
+    "include": ["src/**/*"],
+    "exclude": ["node_modules", "dist"],
+    "references": [{ "path": "../keychain" }]
+}

--- a/typescript/pnpm-lock.yaml
+++ b/typescript/pnpm-lock.yaml
@@ -365,6 +365,16 @@ importers:
         specifier: '>=6.0.1'
         version: 6.0.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
 
+  packages/kit-plugin:
+    dependencies:
+      '@solana/keychain':
+        specifier: workspace:*
+        version: link:../keychain
+    devDependencies:
+      '@solana/kit':
+        specifier: ^6.9.0
+        version: 6.9.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
+
   packages/memory:
     dependencies:
       '@solana/keychain-core':


### PR DESCRIPTION
Adds @solana/keychain-kit-plugin, a Kit client plugin package that creates a keychain signer from any backend config and installs it on the client.

Each plugin accepts the same backend-tagged configuration as `createKeychainSigner` from `@solana/keychain`:

```ts
import { createClient } from '@solana/kit';
import { keychainSigner } from '@solana/keychain-kit-plugin';

const client = await createClient().use(
    keychainSigner({
        backend: 'privy',
        appId: process.env.PRIVY_APP_ID!,
        appSecret: process.env.PRIVY_APP_SECRET!,
        walletId: process.env.PRIVY_WALLET_ID!,
    }),
);

client.payer; // SolanaSigner — also a Kit TransactionSigner
client.identity; // same signer instance
```

### Plugin variants

| Plugin                    | Sets                                          |
| ------------------------- | --------------------------------------------- |
| `keychainSigner(config)`  | Both `payer` **and** `identity` (same signer) |
| `keychainPayer(config)`   | Only `payer`                                  |
| `keychainIdentity(config)` | Only `identity`  

- Backend packages remain dynamically imported through the umbrella, so bundles only include the backend a config dispatches to; the package is agadoo-verified tree-shakable.
- Wires the package into CI (build, typecheck, lint, format, unit tests, treeshake — gated on all signers enabled, like the umbrella), the publish workflow, the `release-ts` version-bump list, and the release skill (whose package list was also missing `memory`/`openfort`/`utila`).
- Peer dependency: `@solana/kit >=6.8.0` (`extendClient`/`createClient` landed in 6.8). 

Linear: TOO-496

@lorisleiva would appreciate a quick look if you have a minute. Also WDYT about naming `@solana/kit-plugin-keychain` or would you rather reserve that for the kit-plugins repo?