### PR TITLE
fix(keychain-ts): correct vaultAddr field in kit-plugin JSDoc example

### DIFF
--- a/typescript/packages/kit-plugin/src/keychain-plugin.ts
+++ b/typescript/packages/kit-plugin/src/keychain-plugin.ts
@@ -51,7 +51,7 @@ export function keychainSigner(config: KeychainSignerConfig) {
  * import { keychainPayer } from '@solana/keychain-kit-plugin';
  *
  * const client = await createClient().use(
- *     keychainPayer({ backend: 'vault', vaultUrl, vaultToken, keyName }),
+ *     keychainPayer({ backend: 'vault', vaultAddr, vaultToken, keyName }),
  * );
  * ```
  *


### PR DESCRIPTION
The `keychainPayer` JSDoc example referenced `vaultUrl`; the real Vault config field is `vaultAddr`. Comment-only fix.