### PR TITLE
chore: release rust v1.4.0

### DIFF
--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -1,8 +1,16 @@
-## Unreleased
+## 1.4.0 - 2026-06-29
 
 ### Features
 
-- add `sdk-v4` feature for the Solana SDK 4.x line (`solana-sdk` 4.0.1), alongside the existing `sdk-v2` and `sdk-v3`
+- add `sdk-v4` feature for the Solana SDK 4.x line (`solana-sdk` 4.0.1), alongside the existing `sdk-v2` and `sdk-v3` (#169)
+- add Privy authorization context support (#119)
+
+### Bug Fixes
+
+- reject `useProgramCall` at construction for Fireblocks, before any broadcast (#153)
+- check wallet status, scheme, and curve in Dfns availability checks (#160)
+- harden Crossmint approval-polling for CI stability (#161)
+- bump `quinn-proto` to 0.11.15 for RUSTSEC-2026-0185 (#170)
 
 ## 1.3.0 - 2026-06-01
 

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -6538,7 +6538,7 @@ dependencies = [
 
 [[package]]
 name = "solana-keychain"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "agave-feature-set 3.0.11",
  "async-trait",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-keychain"
-version = "1.3.0"
+version = "1.4.0"
 edition = "2021"
 license = "MIT"
 description = "Framework-agnostic Solana signing abstractions"


### PR DESCRIPTION
## Summary
- Bump Rust crate `solana-keychain` 1.3.0 → **1.4.0** (TypeScript already published at 1.4.0 on June 22; this catches the crate up).
- Publishes all Rust source changes that landed on `main` after the June 1 (v1.3.0) publish but were never released to crates.io:
  - **feat** `sdk-v4` feature for the Solana SDK 4.x line (#169)
  - **feat** Privy authorization context support (#119)
  - **fix** reject `useProgramCall` at construction for Fireblocks (#153)
  - **fix** check wallet status, scheme, and curve in Dfns availability checks (#160)
  - **fix** harden Crossmint approval-polling for CI stability (#161)
  - **fix** bump `quinn-proto` to 0.11.15 for RUSTSEC-2026-0185 (#170)
- Cargo.lock-only dep bumps (#157, #172) are folded in via `cargo update`; not listed individually (matches changelog convention).

## Why
The June 22 release bumped only the TS packages, so `rust-publish` correctly didn't run. Six Rust source PRs have accumulated on `main` since the June 1 crate publish. This release ships them to crates.io.

## Merge
For mainline releases, a reviewer runs the `complete-release` skill to review CI, approve, squash-merge, and trigger the `rust-publish` workflow from `main`.