### PR TITLE
fix(ci): restore pnpm vulnerability audit

### DIFF
--- a/.github/workflows/fork-external-live-manual.yml
+++ b/.github/workflows/fork-external-live-manual.yml
@@ -179,7 +179,7 @@ jobs:
       - if: ${{ needs.resolve-signers.outputs.ts_live_package_count != '0' }}
         uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "22"
 
       - if: ${{ needs.resolve-signers.outputs.ts_live_package_count != '0' }}
         uses: pnpm/action-setup@v6.0.7

--- a/.github/workflows/fork-external-live-manual.yml
+++ b/.github/workflows/fork-external-live-manual.yml
@@ -182,7 +182,7 @@ jobs:
           node-version: "20"
 
       - if: ${{ needs.resolve-signers.outputs.ts_live_package_count != '0' }}
-        uses: pnpm/action-setup@v6.0.9
+        uses: pnpm/action-setup@v6.0.7
         with:
           version: 11.13.0
 

--- a/.github/workflows/fork-external-live-manual.yml
+++ b/.github/workflows/fork-external-live-manual.yml
@@ -184,7 +184,7 @@ jobs:
       - if: ${{ needs.resolve-signers.outputs.ts_live_package_count != '0' }}
         uses: pnpm/action-setup@v6.0.9
         with:
-          version: 10.14.0
+          version: 11.13.0
 
       - uses: dopplerhq/secrets-fetch-action@v2.0.0
         id: doppler

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: '20'
-      - uses: pnpm/action-setup@v6.0.9
+      - uses: pnpm/action-setup@v6.0.7
         with:
           version: 11.13.0
       - run: pnpm audit --ignore-unfixable

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -41,7 +41,7 @@ jobs:
           node-version: '20'
       - uses: pnpm/action-setup@v6.0.9
         with:
-          version: 10.14.0
+          version: 11.13.0
       - run: pnpm audit --ignore-unfixable
 
   miri:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
       - uses: pnpm/action-setup@v6.0.7
         with:
           version: 11.13.0

--- a/.github/workflows/typescript-ci.yml
+++ b/.github/workflows/typescript-ci.yml
@@ -144,7 +144,7 @@ jobs:
           node-version: "20"
       - uses: pnpm/action-setup@v6.0.9
         with:
-          version: 10.14.0
+          version: 11.13.0
       - name: Install dependencies
         run: pnpm install
       - name: Build packages
@@ -172,7 +172,7 @@ jobs:
           node-version: "20"
       - uses: pnpm/action-setup@v6.0.9
         with:
-          version: 10.14.0
+          version: 11.13.0
       - uses: dopplerhq/secrets-fetch-action@v2.0.0
         id: doppler
         with:
@@ -215,7 +215,7 @@ jobs:
           node-version: "20"
       - uses: pnpm/action-setup@v6.0.9
         with:
-          version: 10.14.0
+          version: 11.13.0
       - name: Install dependencies
         run: pnpm install
       - name: Build packages

--- a/.github/workflows/typescript-ci.yml
+++ b/.github/workflows/typescript-ci.yml
@@ -142,7 +142,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: "20"
-      - uses: pnpm/action-setup@v6.0.9
+      - uses: pnpm/action-setup@v6.0.7
         with:
           version: 11.13.0
       - name: Install dependencies
@@ -170,7 +170,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: "20"
-      - uses: pnpm/action-setup@v6.0.9
+      - uses: pnpm/action-setup@v6.0.7
         with:
           version: 11.13.0
       - uses: dopplerhq/secrets-fetch-action@v2.0.0
@@ -213,7 +213,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: "20"
-      - uses: pnpm/action-setup@v6.0.9
+      - uses: pnpm/action-setup@v6.0.7
         with:
           version: 11.13.0
       - name: Install dependencies

--- a/.github/workflows/typescript-ci.yml
+++ b/.github/workflows/typescript-ci.yml
@@ -141,7 +141,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "22"
       - uses: pnpm/action-setup@v6.0.7
         with:
           version: 11.13.0
@@ -169,7 +169,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "22"
       - uses: pnpm/action-setup@v6.0.7
         with:
           version: 11.13.0
@@ -212,7 +212,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "22"
       - uses: pnpm/action-setup@v6.0.7
         with:
           version: 11.13.0

--- a/.github/workflows/typescript-publish.yml
+++ b/.github/workflows/typescript-publish.yml
@@ -108,7 +108,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6.0.9
+        uses: pnpm/action-setup@v6.0.7
         with:
           version: 11.13.0
           run_install: false

--- a/.github/workflows/typescript-publish.yml
+++ b/.github/workflows/typescript-publish.yml
@@ -110,7 +110,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v6.0.9
         with:
-          version: 10.14.0
+          version: 11.13.0
           run_install: false
 
       - name: Get pnpm store directory

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -41,21 +41,5 @@
     "vitest": "^4.1.9"
   },
   "prettier": "@solana/prettier-config-solana",
-  "pnpm": {
-    "overrides": {
-      "http-proxy-agent@5.0.0>@tootallnate/once": "3.0.1",
-      "ajv@^6.0.0": "6.14.0",
-      "bn.js@^5.0.0": "5.2.3",
-      "brace-expansion@^1.0.0": "1.1.13",
-      "brace-expansion@^2.0.0": "2.0.3",
-      "fast-xml-parser@^5.0.0": "5.7.3",
-      "flatted@^3.0.0": "3.4.2",
-      "minimatch@^3.0.0": "3.1.4",
-      "minimatch@^9.0.0": "9.0.7",
-      "picomatch@^2.0.0": "2.3.2",
-      "picomatch@^4.0.0": "4.0.4",
-      "vite": "7.3.6"
-    }
-  },
-  "packageManager": "pnpm@10.14.0"
+  "packageManager": "pnpm@11.13.0"
 }

--- a/typescript/pnpm-workspace.yaml
+++ b/typescript/pnpm-workspace.yaml
@@ -1,2 +1,24 @@
 packages:
   - 'packages/*'
+
+allowBuilds:
+  bufferutil: false
+  esbuild: true
+  unrs-resolver: true
+  utf-8-validate: false
+
+auditConfig: {}
+
+overrides:
+  'http-proxy-agent@5.0.0>@tootallnate/once': 3.0.1
+  'ajv@^6.0.0': 6.14.0
+  'bn.js@^5.0.0': 5.2.3
+  'brace-expansion@^1.0.0': 1.1.13
+  'brace-expansion@^2.0.0': 2.0.3
+  'fast-xml-parser@^5.0.0': 5.7.3
+  'flatted@^3.0.0': 3.4.2
+  'minimatch@^3.0.0': 3.1.4
+  'minimatch@^9.0.0': 9.0.7
+  'picomatch@^2.0.0': 2.3.2
+  'picomatch@^4.0.0': 4.0.4
+  vite: 7.3.6


### PR DESCRIPTION
## Summary
- npm retired the legacy audit endpoint, so the scheduled Security workflow's `pnpm-audit` job fails on pnpm 10 with `ERR_PNPM_AUDIT_BAD_RESPONSE ... responded with 410` ([failing run](https://github.com/solana-foundation/solana-keychain/actions/runs/29405303786))
- Pin pnpm 11.13.0 (`packageManager` and all workflow `pnpm/action-setup` pins), which uses npm's bulk advisory endpoint
- Move `pnpm.overrides` from `typescript/package.json` to `typescript/pnpm-workspace.yaml` — pnpm 11 no longer reads the `pnpm` field in package.json
- Add the explicit `allowBuilds` policy pnpm 11 requires (without it `pnpm install` fails with `ERR_PNPM_IGNORED_BUILDS`): esbuild and unrs-resolver allowed, bufferutil and utf-8-validate blocked (prebuilt/optional websocket natives)
- Pin `pnpm/action-setup` to v6.0.7 and bump CI Node to 22: pnpm 11.13.0 requires Node >=22.13, and on older Node the installer falls back to a standalone `@pnpm/exe` that is left as a broken placeholder binary (`pnpm: 1: This: not found`, pnpm/action-setup#277)

Same fix as solana-foundation/subscriptions@d27254a and solana-foundation/kora#612. No lockfile change needed — lockfile v9 is shared between pnpm 10 and 11. The `auditConfig: {}` stub is committed because `pnpm audit --ignore-unfixable` rewrites it on every run.

## Test Plan
- Verified locally with pnpm 11.13.0: `install --frozen-lockfile`, `audit --ignore-unfixable`, `pnpm run build`, and `pnpm run test:unit` (all 18 workspace packages) all pass
- CI on this PR: all checks green, including `pnpm-audit`
