### PR TITLE
feat(python): AWS KMS signer backend

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -23,7 +23,7 @@ library offers a consistent API across all signing methods.
 | **Vault** | Enterprise key management with HashiCorp Vault | `solana_keychain.vault` | ✅ Available |
 | **Privy** | Embedded wallets with Privy infrastructure | — | Planned |
 | **Turnkey** | Non-custodial key management via Turnkey | — | Planned |
-| **AWS KMS** | AWS Key Management Service with Ed25519 signing | — | Planned |
+| **AWS KMS** | AWS Key Management Service with Ed25519 signing | `solana_keychain.aws_kms` | ✅ Available |
 | **Fireblocks** | Fireblocks institutional custody platform | — | Planned |
 | **GCP KMS** | Google Cloud Key Management Service with Ed25519 signing | — | Planned |
 | **Dfns** | Dfns wallet infrastructure with Ed25519 signing | — | Planned |
@@ -36,10 +36,15 @@ library offers a consistent API across all signing methods.
 ## Installation
 
 ```bash
-pip install solana-keychain
+pip install solana-keychain              # memory + vault
+pip install 'solana-keychain[aws-kms]'   # adds the AWS KMS backend
 ```
 
-Requires **Python 3.10+**.
+Requires **Python 3.10+**. Backends built on heavy provider SDKs ship as optional
+extras; importing such a backend without its extra raises an `ImportError` naming
+the extra to install. Extras-gated backends are imported from their submodule
+(e.g. `from solana_keychain.aws_kms import create_aws_kms_signer`), not from the
+package root.
 
 ## Quick Start
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -17,7 +17,9 @@ dependencies = ["httpx>=0.27", "solders>=0.26,<1"]
 Repository = "https://github.com/solana-foundation/solana-keychain"
 
 [project.optional-dependencies]
+aws-kms = ["boto3>=1.35"]
 dev = [
+    "boto3>=1.35",
     "build>=1.2",
     "mypy>=1.14",
     "pytest>=8.3",
@@ -46,3 +48,7 @@ strict = true
 files = ["src", "tests"]
 mypy_path = "src"
 explicit_package_bases = true
+
+[[tool.mypy.overrides]]
+module = ["boto3", "boto3.*", "botocore", "botocore.*"]
+ignore_missing_imports = true

--- a/python/src/solana_keychain/aws_kms/__init__.py
+++ b/python/src/solana_keychain/aws_kms/__init__.py
@@ -1,0 +1,7 @@
+from solana_keychain.aws_kms.signer import (
+    AwsKmsSigner,
+    AwsKmsSignerConfig,
+    create_aws_kms_signer,
+)
+
+__all__ = ["AwsKmsSigner", "AwsKmsSignerConfig", "create_aws_kms_signer"]

--- a/python/src/solana_keychain/aws_kms/signer.py
+++ b/python/src/solana_keychain/aws_kms/signer.py
@@ -1,0 +1,141 @@
+"""AWS KMS signer integration using EdDSA (Ed25519) signing."""
+
+import asyncio
+from dataclasses import dataclass, field
+from typing import Any
+
+try:
+    import boto3
+    from botocore.exceptions import BotoCoreError, ClientError
+except ImportError as error:  # pragma: no cover
+    raise ImportError(
+        "solana_keychain.aws_kms requires the aws-kms extra: pip install 'solana-keychain[aws-kms]'"
+    ) from error
+
+from solders.pubkey import Pubkey
+from solders.signature import Signature
+from solders.transaction import Transaction
+
+from solana_keychain.core.errors import SignerError, SignerErrorCode
+from solana_keychain.core.signer import SignedTransaction, SolanaSigner
+from solana_keychain.core.transaction_util import (
+    add_signature_to_transaction,
+    classify_signed_transaction,
+    serialize_transaction,
+)
+
+AWS_KMS_SIGNING_ALGORITHM = "ED25519_SHA_512"
+AWS_KMS_KEY_SPEC = "ECC_NIST_EDWARDS25519"
+AWS_KMS_KEY_USAGE = "SIGN_VERIFY"
+
+ED25519_SIGNATURE_LENGTH = 64
+
+
+@dataclass
+class AwsKmsSignerConfig:
+    """Configuration for an AWS KMS signer.
+
+    ``key_id`` is a KMS key ID, ARN, or alias and must reference an
+    ``ECC_NIST_EDWARDS25519`` key. ``public_key`` is the base58 Solana public key
+    corresponding to that KMS key. ``region`` falls back to the default AWS config
+    chain when unset. ``client`` accepts a pre-configured KMS client (custom
+    credentials, endpoint, or retry policy); when set, ``region`` is ignored.
+    """
+
+    key_id: str
+    public_key: str
+    region: str | None = None
+    client: Any | None = field(default=None, repr=False)
+
+
+class AwsKmsSigner(SolanaSigner):
+    """Signer backed by an AWS KMS Ed25519 key."""
+
+    def __init__(self, config: AwsKmsSignerConfig) -> None:
+        try:
+            self._pubkey = Pubkey.from_string(config.public_key)
+        except Exception:
+            raise SignerError(SignerErrorCode.INVALID_PUBLIC_KEY, "Invalid public key") from None
+        self._key_id = config.key_id
+        self._region = config.region
+        self._client = (
+            config.client
+            if config.client is not None
+            else boto3.client("kms", region_name=config.region)
+        )
+
+    def __repr__(self) -> str:
+        return f"AwsKmsSigner(key_id={self._key_id}, pubkey={self._pubkey}, region={self._region})"
+
+    @property
+    def key_id(self) -> str:
+        return self._key_id
+
+    @property
+    def pubkey(self) -> Pubkey:
+        return self._pubkey
+
+    async def _sign_bytes(self, message: bytes) -> Signature:
+        def sign_call() -> Any:
+            return self._client.sign(
+                KeyId=self._key_id,
+                Message=message,
+                MessageType="RAW",
+                SigningAlgorithm=AWS_KMS_SIGNING_ALGORITHM,
+            )
+
+        try:
+            response = await asyncio.to_thread(sign_call)
+        except (BotoCoreError, ClientError) as error:
+            raise SignerError(
+                SignerErrorCode.REMOTE_API_ERROR, f"AWS KMS Sign operation failed: {error}"
+            ) from None
+        signature_bytes = response.get("Signature")
+        if not signature_bytes:
+            raise SignerError(SignerErrorCode.SIGNING_FAILED, "No signature in AWS KMS response")
+        if len(signature_bytes) != ED25519_SIGNATURE_LENGTH:
+            raise SignerError(
+                SignerErrorCode.SIGNING_FAILED,
+                f"Invalid signature length: expected {ED25519_SIGNATURE_LENGTH} bytes, "
+                f"got {len(signature_bytes)}",
+            )
+        signature = Signature.from_bytes(signature_bytes)
+        if not signature.verify(self._pubkey, message):
+            raise SignerError(
+                SignerErrorCode.SIGNING_FAILED,
+                "Signature verification failed — the returned signature does not match "
+                "the public key",
+            )
+        return signature
+
+    async def sign_transaction(self, transaction: Transaction) -> SignedTransaction:
+        signature = await self._sign_bytes(transaction.message_data())
+        add_signature_to_transaction(transaction, self._pubkey, signature)
+        return classify_signed_transaction(
+            transaction, serialize_transaction(transaction), signature
+        )
+
+    async def sign_message(self, message: bytes) -> Signature:
+        return await self._sign_bytes(message)
+
+    async def is_available(self) -> bool:
+        def describe_call() -> Any:
+            return self._client.describe_key(KeyId=self._key_id)
+
+        try:
+            response = await asyncio.to_thread(describe_call)
+        except (BotoCoreError, ClientError):
+            return False
+        metadata = response.get("KeyMetadata")
+        if not isinstance(metadata, dict):
+            return False
+        return (
+            metadata.get("KeySpec") == AWS_KMS_KEY_SPEC
+            and metadata.get("Enabled") is True
+            and metadata.get("KeyUsage") == AWS_KMS_KEY_USAGE
+        )
+
+
+async def create_aws_kms_signer(config: AwsKmsSignerConfig) -> AwsKmsSigner:
+    """Create a ready-to-use AWS KMS signer."""
+    return AwsKmsSigner(config)

--- a/python/src/solana_keychain/aws_kms/signer.py
+++ b/python/src/solana_keychain/aws_kms/signer.py
@@ -137,5 +137,9 @@ class AwsKmsSigner(SolanaSigner):
 
 
 async def create_aws_kms_signer(config: AwsKmsSignerConfig) -> AwsKmsSigner:
-    """Create a ready-to-use AWS KMS signer."""
-    return AwsKmsSigner(config)
+    """Create a ready-to-use AWS KMS signer.
+
+    Construction runs in a worker thread: building the client can read AWS config
+    files or query instance metadata, which must not block the event loop.
+    """
+    return await asyncio.to_thread(AwsKmsSigner, config)

--- a/python/tests/test_aws_kms_signer.py
+++ b/python/tests/test_aws_kms_signer.py
@@ -1,0 +1,198 @@
+from typing import Any
+
+import boto3
+import pytest
+from botocore.stub import Stubber
+from solders.keypair import Keypair
+
+from solana_keychain import SignerError, SignerErrorCode
+from solana_keychain.aws_kms import AwsKmsSigner, AwsKmsSignerConfig, create_aws_kms_signer
+from tests.util import create_test_transaction
+
+TEST_KEY_ID = "arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012"
+TEST_REGION = "us-east-1"
+
+
+def make_stubbed_signer(pubkey: str) -> tuple[AwsKmsSigner, Stubber]:
+    client = boto3.client(
+        "kms",
+        region_name=TEST_REGION,
+        aws_access_key_id="testing",
+        aws_secret_access_key="testing",
+    )
+    stubber = Stubber(client)
+    signer = AwsKmsSigner(AwsKmsSignerConfig(key_id=TEST_KEY_ID, public_key=pubkey, client=client))
+    return signer, stubber
+
+
+def expected_sign_params(message: bytes) -> dict[str, Any]:
+    return {
+        "KeyId": TEST_KEY_ID,
+        "Message": message,
+        "MessageType": "RAW",
+        "SigningAlgorithm": "ED25519_SHA_512",
+    }
+
+
+def sign_response(signature: bytes) -> dict[str, Any]:
+    return {"KeyId": TEST_KEY_ID, "Signature": signature, "SigningAlgorithm": "ED25519_SHA_512"}
+
+
+def key_metadata_response(
+    key_spec: str = "ECC_NIST_EDWARDS25519", enabled: bool = True, key_usage: str = "SIGN_VERIFY"
+) -> dict[str, Any]:
+    return {
+        "KeyMetadata": {
+            "KeyId": "12345678-1234-1234-1234-123456789012",
+            "KeySpec": key_spec,
+            "Enabled": enabled,
+            "KeyUsage": key_usage,
+        }
+    }
+
+
+@pytest.mark.parametrize("invalid", ["not-a-valid-pubkey", ""])
+def test_invalid_pubkey_rejected_before_any_aws_call(invalid: str) -> None:
+    with pytest.raises(SignerError) as excinfo:
+        AwsKmsSigner(AwsKmsSignerConfig(key_id=TEST_KEY_ID, public_key=invalid))
+    assert excinfo.value.code == SignerErrorCode.INVALID_PUBLIC_KEY
+
+
+@pytest.mark.parametrize(
+    "key_id",
+    [
+        TEST_KEY_ID,
+        "12345678-1234-1234-1234-123456789012",
+        "alias/my-key",
+    ],
+)
+def test_key_id_variations_accepted(key_id: str) -> None:
+    keypair = Keypair()
+    signer = AwsKmsSigner(
+        AwsKmsSignerConfig(key_id=key_id, public_key=str(keypair.pubkey()), region=TEST_REGION)
+    )
+    assert signer.key_id == key_id
+    assert signer.pubkey == keypair.pubkey()
+
+
+def test_repr_shows_key_id_pubkey_region_only() -> None:
+    keypair = Keypair()
+    signer, _ = make_stubbed_signer(str(keypair.pubkey()))
+    assert (
+        repr(signer)
+        == f"AwsKmsSigner(key_id={TEST_KEY_ID}, pubkey={keypair.pubkey()}, region=None)"
+    )
+
+
+async def test_create_aws_kms_signer_factory() -> None:
+    keypair = Keypair()
+    signer = await create_aws_kms_signer(
+        AwsKmsSignerConfig(key_id=TEST_KEY_ID, public_key=str(keypair.pubkey()), region=TEST_REGION)
+    )
+    assert signer.pubkey == keypair.pubkey()
+
+
+async def test_sign_message_success() -> None:
+    keypair = Keypair()
+    message = b"aws-kms-message"
+    signature = keypair.sign_message(message)
+    signer, stubber = make_stubbed_signer(str(keypair.pubkey()))
+    stubber.add_response("sign", sign_response(bytes(signature)), expected_sign_params(message))
+
+    with stubber:
+        result = await signer.sign_message(message)
+
+    assert result == signature
+
+
+async def test_sign_message_api_error() -> None:
+    keypair = Keypair()
+    signer, stubber = make_stubbed_signer(str(keypair.pubkey()))
+    stubber.add_client_error("sign", service_error_code="AccessDeniedException")
+
+    with stubber:
+        with pytest.raises(SignerError) as excinfo:
+            await signer.sign_message(b"hello")
+    assert excinfo.value.code == SignerErrorCode.REMOTE_API_ERROR
+
+
+async def test_sign_message_wrong_signature_length() -> None:
+    keypair = Keypair()
+    message = b"hello"
+    signer, stubber = make_stubbed_signer(str(keypair.pubkey()))
+    stubber.add_response("sign", sign_response(bytes(32)), expected_sign_params(message))
+
+    with stubber:
+        with pytest.raises(SignerError) as excinfo:
+            await signer.sign_message(message)
+    assert excinfo.value.code == SignerErrorCode.SIGNING_FAILED
+
+
+async def test_sign_message_signature_verification_failure() -> None:
+    signing_keypair = Keypair()
+    other_keypair = Keypair()
+    message = b"aws-kms-message"
+    signature = signing_keypair.sign_message(message)
+    signer, stubber = make_stubbed_signer(str(other_keypair.pubkey()))
+    stubber.add_response("sign", sign_response(bytes(signature)), expected_sign_params(message))
+
+    with stubber:
+        with pytest.raises(SignerError) as excinfo:
+            await signer.sign_message(message)
+    assert excinfo.value.code == SignerErrorCode.SIGNING_FAILED
+
+
+async def test_sign_transaction_success() -> None:
+    keypair = Keypair()
+    transaction = create_test_transaction(keypair.pubkey())
+    signature = keypair.sign_message(transaction.message_data())
+    signer, stubber = make_stubbed_signer(str(keypair.pubkey()))
+    stubber.add_response(
+        "sign",
+        sign_response(bytes(signature)),
+        expected_sign_params(transaction.message_data()),
+    )
+
+    with stubber:
+        result = await signer.sign_transaction(transaction)
+
+    assert result.is_complete
+    assert result.signature == signature
+    assert list(transaction.signatures) == [signature]
+
+
+async def test_is_available_success() -> None:
+    keypair = Keypair()
+    signer, stubber = make_stubbed_signer(str(keypair.pubkey()))
+    stubber.add_response("describe_key", key_metadata_response(), {"KeyId": TEST_KEY_ID})
+
+    with stubber:
+        assert await signer.is_available()
+
+
+@pytest.mark.parametrize(
+    "metadata_kwargs",
+    [
+        {"key_spec": "RSA_2048"},
+        {"enabled": False},
+        {"key_usage": "ENCRYPT_DECRYPT"},
+    ],
+)
+async def test_is_available_false_for_unusable_key(metadata_kwargs: dict[str, Any]) -> None:
+    keypair = Keypair()
+    signer, stubber = make_stubbed_signer(str(keypair.pubkey()))
+    stubber.add_response(
+        "describe_key", key_metadata_response(**metadata_kwargs), {"KeyId": TEST_KEY_ID}
+    )
+
+    with stubber:
+        assert not await signer.is_available()
+
+
+async def test_is_available_false_on_api_error() -> None:
+    keypair = Keypair()
+    signer, stubber = make_stubbed_signer(str(keypair.pubkey()))
+    stubber.add_client_error("describe_key", service_error_code="NotFoundException")
+
+    with stubber:
+        assert not await signer.is_available()


### PR DESCRIPTION
## Summary
- Adds the **AWS KMS** backend (`solana_keychain.aws_kms`). Follows the remote-signer core from #208.
- Signing: KMS `Sign` with `MessageType=RAW` + `SigningAlgorithm=ED25519_SHA_512`; returned signatures are length-checked (64 bytes) and verified locally against the configured pubkey before being accepted.
- Availability: `DescribeKey` gate — key must be `ECC_NIST_EDWARDS25519`, enabled, and `KeyUsage=SIGN_VERIFY`.
- Config: `AwsKmsSignerConfig(key_id, public_key, region=None, client=None)` — pubkey validated at construction before any AWS call; optional pre-configured KMS client for custom credentials/endpoint/retries. Async `create_aws_kms_signer()` factory.

## First extras-gated backend
- `pip install 'solana-keychain[aws-kms]'` — `boto3` stays out of the base install; importing `solana_keychain.aws_kms` without the extra raises an `ImportError` naming it (per the CLAUDE.md import rules). Extras-gated backends import from their submodule, not the package root.
- Sync boto3 calls run through `asyncio.to_thread`, keeping the async contract non-blocking.

## Test Plan
- 131 tests pass (17 new) — KMS client stubbed with `botocore.stub.Stubber`: sign success (request params asserted), API error, wrong-length signature, verification failure against mismatched pubkey, transaction signing, DescribeKey gate (spec/enabled/usage each flipped), API-error availability, pubkey rejected before any AWS call, key-id variations (ARN / raw ID / alias), repr contents
- `ruff` + `mypy --strict` clean (boto3 covered by an `ignore_missing_imports` override), sdist+wheel build clean

