### PR TITLE
feat(python): GCP KMS signer backend

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -25,7 +25,7 @@ library offers a consistent API across all signing methods.
 | **Turnkey** | Non-custodial key management via Turnkey | — | Planned |
 | **AWS KMS** | AWS Key Management Service with Ed25519 signing | `solana_keychain.aws_kms` | ✅ Available |
 | **Fireblocks** | Fireblocks institutional custody platform | — | Planned |
-| **GCP KMS** | Google Cloud Key Management Service with Ed25519 signing | — | Planned |
+| **GCP KMS** | Google Cloud Key Management Service with Ed25519 signing | `solana_keychain.gcp_kms` | ✅ Available |
 | **Dfns** | Dfns wallet infrastructure with Ed25519 signing | — | Planned |
 | **Para** | MPC wallets with Para infrastructure | — | Planned |
 | **CDP** | Coinbase Developer Platform managed wallets | — | Planned |
@@ -38,6 +38,7 @@ library offers a consistent API across all signing methods.
 ```bash
 pip install solana-keychain              # memory + vault
 pip install 'solana-keychain[aws-kms]'   # adds the AWS KMS backend
+pip install 'solana-keychain[gcp-kms]'   # adds the GCP KMS backend
 ```
 
 Requires **Python 3.10+**. Backends built on heavy provider SDKs ship as optional

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -18,9 +18,11 @@ Repository = "https://github.com/solana-foundation/solana-keychain"
 
 [project.optional-dependencies]
 aws-kms = ["boto3>=1.35"]
+gcp-kms = ["google-cloud-kms>=2.24"]
 dev = [
     "boto3>=1.35",
     "build>=1.2",
+    "google-cloud-kms>=2.24",
     "mypy>=1.14",
     "pytest>=8.3",
     "pytest-asyncio>=0.25",
@@ -50,5 +52,9 @@ mypy_path = "src"
 explicit_package_bases = true
 
 [[tool.mypy.overrides]]
-module = ["boto3", "boto3.*", "botocore", "botocore.*"]
+module = ["boto3", "boto3.*", "botocore", "botocore.*", "google.*"]
 ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = ["tests.test_gcp_kms_signer"]
+disallow_untyped_calls = false

--- a/python/src/solana_keychain/gcp_kms/__init__.py
+++ b/python/src/solana_keychain/gcp_kms/__init__.py
@@ -1,0 +1,7 @@
+from solana_keychain.gcp_kms.signer import (
+    GcpKmsSigner,
+    GcpKmsSignerConfig,
+    create_gcp_kms_signer,
+)
+
+__all__ = ["GcpKmsSigner", "GcpKmsSignerConfig", "create_gcp_kms_signer"]

--- a/python/src/solana_keychain/gcp_kms/signer.py
+++ b/python/src/solana_keychain/gcp_kms/signer.py
@@ -1,0 +1,125 @@
+"""Google Cloud KMS signer integration using EdDSA (Ed25519) signing."""
+
+from dataclasses import dataclass, field
+from typing import Any
+
+try:
+    from google.api_core.exceptions import GoogleAPIError
+    from google.auth.exceptions import GoogleAuthError
+    from google.cloud import kms_v1
+except ImportError as error:  # pragma: no cover
+    raise ImportError(
+        "solana_keychain.gcp_kms requires the gcp-kms extra: pip install 'solana-keychain[gcp-kms]'"
+    ) from error
+
+from solders.pubkey import Pubkey
+from solders.signature import Signature
+from solders.transaction import Transaction
+
+from solana_keychain.core.errors import SignerError, SignerErrorCode
+from solana_keychain.core.signer import SignedTransaction, SolanaSigner
+from solana_keychain.core.transaction_util import (
+    add_signature_to_transaction,
+    classify_signed_transaction,
+    serialize_transaction,
+)
+
+EC_SIGN_ED25519 = kms_v1.CryptoKeyVersion.CryptoKeyVersionAlgorithm.EC_SIGN_ED25519
+
+ED25519_SIGNATURE_LENGTH = 64
+
+
+@dataclass
+class GcpKmsSignerConfig:
+    """Configuration for a GCP KMS signer.
+
+    ``key_name`` is the full resource name of the crypto key version, e.g.
+    ``projects/p/locations/l/keyRings/r/cryptoKeys/k/cryptoKeyVersions/1``, and must
+    reference an ``EC_SIGN_ED25519`` key. ``public_key`` is the base58 Solana public
+    key corresponding to that key. ``client`` accepts a pre-configured
+    ``KeyManagementServiceAsyncClient`` (custom credentials, endpoint, or transport).
+    """
+
+    key_name: str
+    public_key: str
+    client: Any | None = field(default=None, repr=False)
+
+
+class GcpKmsSigner(SolanaSigner):
+    """Signer backed by a Google Cloud KMS Ed25519 key."""
+
+    def __init__(self, config: GcpKmsSignerConfig) -> None:
+        try:
+            self._pubkey = Pubkey.from_string(config.public_key)
+        except Exception:
+            raise SignerError(SignerErrorCode.INVALID_PUBLIC_KEY, "Invalid public key") from None
+        self._key_name = config.key_name
+        self._client = (
+            config.client if config.client is not None else kms_v1.KeyManagementServiceAsyncClient()
+        )
+
+    def __repr__(self) -> str:
+        return f"GcpKmsSigner(key_name={self._key_name}, pubkey={self._pubkey})"
+
+    @property
+    def key_name(self) -> str:
+        return self._key_name
+
+    @property
+    def pubkey(self) -> Pubkey:
+        return self._pubkey
+
+    async def _sign_bytes(self, message: bytes) -> Signature:
+        # EC_SIGN_ED25519 operates in PureEdDSA mode: the request carries the raw
+        # data, never a digest.
+        try:
+            response = await self._client.asymmetric_sign(
+                request={"name": self._key_name, "data": message}
+            )
+        except (GoogleAPIError, GoogleAuthError) as error:
+            raise SignerError(
+                SignerErrorCode.REMOTE_API_ERROR, f"GCP KMS Sign operation failed: {error}"
+            ) from None
+        signature_bytes = bytes(response.signature)
+        if not signature_bytes:
+            raise SignerError(SignerErrorCode.SIGNING_FAILED, "No signature in GCP KMS response")
+        if len(signature_bytes) != ED25519_SIGNATURE_LENGTH:
+            raise SignerError(
+                SignerErrorCode.SIGNING_FAILED,
+                f"Invalid signature length: expected {ED25519_SIGNATURE_LENGTH} bytes, "
+                f"got {len(signature_bytes)}",
+            )
+        signature = Signature.from_bytes(signature_bytes)
+        if not signature.verify(self._pubkey, message):
+            raise SignerError(
+                SignerErrorCode.SIGNING_FAILED,
+                "Signature verification failed — the returned signature does not match "
+                "the public key",
+            )
+        return signature
+
+    async def sign_transaction(self, transaction: Transaction) -> SignedTransaction:
+        signature = await self._sign_bytes(transaction.message_data())
+        add_signature_to_transaction(transaction, self._pubkey, signature)
+        return classify_signed_transaction(
+            transaction, serialize_transaction(transaction), signature
+        )
+
+    async def sign_message(self, message: bytes) -> Signature:
+        return await self._sign_bytes(message)
+
+    async def is_available(self) -> bool:
+        try:
+            response = await self._client.get_public_key(request={"name": self._key_name})
+        except (GoogleAPIError, GoogleAuthError):
+            return False
+        return bool(response.algorithm == EC_SIGN_ED25519)
+
+
+async def create_gcp_kms_signer(config: GcpKmsSignerConfig) -> GcpKmsSigner:
+    """Create a ready-to-use GCP KMS signer.
+
+    The client is constructed on the event loop: the gRPC async transport binds to
+    the running loop, so construction must not be moved to a worker thread.
+    """
+    return GcpKmsSigner(config)

--- a/python/tests/test_gcp_kms_signer.py
+++ b/python/tests/test_gcp_kms_signer.py
@@ -1,0 +1,172 @@
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from google.api_core.exceptions import PermissionDenied
+from google.cloud import kms_v1
+from solders.keypair import Keypair
+
+from solana_keychain import SignerError, SignerErrorCode
+from solana_keychain.gcp_kms import GcpKmsSigner, GcpKmsSignerConfig, create_gcp_kms_signer
+from tests.util import create_test_transaction
+
+TEST_KEY_NAME = (
+    "projects/test-project/locations/us-east1/keyRings/test-ring/"
+    "cryptoKeys/test-key/cryptoKeyVersions/1"
+)
+EC_SIGN_ED25519 = kms_v1.CryptoKeyVersion.CryptoKeyVersionAlgorithm.EC_SIGN_ED25519
+RSA_SIGN_PKCS1_2048_SHA256 = (
+    kms_v1.CryptoKeyVersion.CryptoKeyVersionAlgorithm.RSA_SIGN_PKCS1_2048_SHA256
+)
+
+
+class StubKmsClient:
+    def __init__(
+        self,
+        signature: bytes | None = None,
+        sign_error: Exception | None = None,
+        algorithm: Any = EC_SIGN_ED25519,
+        key_error: Exception | None = None,
+    ) -> None:
+        self.signature = signature
+        self.sign_error = sign_error
+        self.algorithm = algorithm
+        self.key_error = key_error
+        self.sign_requests: list[dict[str, Any]] = []
+        self.key_requests: list[dict[str, Any]] = []
+
+    async def asymmetric_sign(self, request: dict[str, Any]) -> Any:
+        self.sign_requests.append(request)
+        if self.sign_error is not None:
+            raise self.sign_error
+        return SimpleNamespace(signature=self.signature)
+
+    async def get_public_key(self, request: dict[str, Any]) -> Any:
+        self.key_requests.append(request)
+        if self.key_error is not None:
+            raise self.key_error
+        return SimpleNamespace(algorithm=self.algorithm)
+
+
+def make_signer(pubkey: str, client: StubKmsClient) -> GcpKmsSigner:
+    return GcpKmsSigner(
+        GcpKmsSignerConfig(key_name=TEST_KEY_NAME, public_key=pubkey, client=client)
+    )
+
+
+@pytest.mark.parametrize("invalid", ["not-a-valid-pubkey", ""])
+def test_invalid_pubkey_rejected_before_any_gcp_call(invalid: str) -> None:
+    with pytest.raises(SignerError) as excinfo:
+        make_signer(invalid, StubKmsClient())
+    assert excinfo.value.code == SignerErrorCode.INVALID_PUBLIC_KEY
+
+
+def test_repr_shows_key_name_and_pubkey() -> None:
+    keypair = Keypair()
+    signer = make_signer(str(keypair.pubkey()), StubKmsClient())
+    assert repr(signer) == f"GcpKmsSigner(key_name={TEST_KEY_NAME}, pubkey={keypair.pubkey()})"
+    assert signer.key_name == TEST_KEY_NAME
+
+
+async def test_create_gcp_kms_signer_factory() -> None:
+    keypair = Keypair()
+    signer = await create_gcp_kms_signer(
+        GcpKmsSignerConfig(
+            key_name=TEST_KEY_NAME, public_key=str(keypair.pubkey()), client=StubKmsClient()
+        )
+    )
+    assert signer.pubkey == keypair.pubkey()
+
+
+async def test_sign_message_sends_raw_data() -> None:
+    keypair = Keypair()
+    message = b"gcp-kms-message"
+    signature = keypair.sign_message(message)
+    client = StubKmsClient(signature=bytes(signature))
+    signer = make_signer(str(keypair.pubkey()), client)
+
+    result = await signer.sign_message(message)
+
+    assert result == signature
+    assert client.sign_requests == [{"name": TEST_KEY_NAME, "data": message}]
+
+
+async def test_sign_message_api_error() -> None:
+    keypair = Keypair()
+    client = StubKmsClient(sign_error=PermissionDenied("denied"))
+    signer = make_signer(str(keypair.pubkey()), client)
+
+    with pytest.raises(SignerError) as excinfo:
+        await signer.sign_message(b"hello")
+    assert excinfo.value.code == SignerErrorCode.REMOTE_API_ERROR
+
+
+async def test_sign_message_empty_signature() -> None:
+    keypair = Keypair()
+    client = StubKmsClient(signature=b"")
+    signer = make_signer(str(keypair.pubkey()), client)
+
+    with pytest.raises(SignerError) as excinfo:
+        await signer.sign_message(b"hello")
+    assert excinfo.value.code == SignerErrorCode.SIGNING_FAILED
+
+
+async def test_sign_message_wrong_signature_length() -> None:
+    keypair = Keypair()
+    client = StubKmsClient(signature=bytes(32))
+    signer = make_signer(str(keypair.pubkey()), client)
+
+    with pytest.raises(SignerError) as excinfo:
+        await signer.sign_message(b"hello")
+    assert excinfo.value.code == SignerErrorCode.SIGNING_FAILED
+
+
+async def test_sign_message_signature_verification_failure() -> None:
+    signing_keypair = Keypair()
+    other_keypair = Keypair()
+    message = b"gcp-kms-message"
+    client = StubKmsClient(signature=bytes(signing_keypair.sign_message(message)))
+    signer = make_signer(str(other_keypair.pubkey()), client)
+
+    with pytest.raises(SignerError) as excinfo:
+        await signer.sign_message(message)
+    assert excinfo.value.code == SignerErrorCode.SIGNING_FAILED
+
+
+async def test_sign_transaction_success() -> None:
+    keypair = Keypair()
+    transaction = create_test_transaction(keypair.pubkey())
+    signature = keypair.sign_message(transaction.message_data())
+    client = StubKmsClient(signature=bytes(signature))
+    signer = make_signer(str(keypair.pubkey()), client)
+
+    result = await signer.sign_transaction(transaction)
+
+    assert result.is_complete
+    assert result.signature == signature
+    assert list(transaction.signatures) == [signature]
+
+
+async def test_is_available_success() -> None:
+    keypair = Keypair()
+    client = StubKmsClient()
+    signer = make_signer(str(keypair.pubkey()), client)
+
+    assert await signer.is_available()
+    assert client.key_requests == [{"name": TEST_KEY_NAME}]
+
+
+async def test_is_available_false_for_non_ed25519_algorithm() -> None:
+    keypair = Keypair()
+    client = StubKmsClient(algorithm=RSA_SIGN_PKCS1_2048_SHA256)
+    signer = make_signer(str(keypair.pubkey()), client)
+
+    assert not await signer.is_available()
+
+
+async def test_is_available_false_on_api_error() -> None:
+    keypair = Keypair()
+    client = StubKmsClient(key_error=PermissionDenied("denied"))
+    signer = make_signer(str(keypair.pubkey()), client)
+
+    assert not await signer.is_available()


### PR DESCRIPTION
## Summary
- Adds the **GCP KMS** backend (`solana_keychain.gcp_kms`). Stacked on #210 — this layer shows only the GCP work.
- Signing: `AsymmetricSign` in PureEdDSA mode — the request carries the **raw data, never a digest**; returned signatures are length-checked (64 bytes) and verified locally against the configured pubkey before being accepted.
- Availability: `GetPublicKey` gate — the key version's algorithm must be `EC_SIGN_ED25519`.
- Config: `GcpKmsSignerConfig(key_name, public_key, client=None)` — `key_name` is the full `cryptoKeyVersions` resource path; pubkey validated at construction before any GCP call; optional pre-configured `KeyManagementServiceAsyncClient` for custom credentials/endpoint/transport. Async `create_gcp_kms_signer()` factory (client stays on the event loop — the gRPC async transport binds to the running loop, so construction must not move to a worker thread).
- `google-cloud-kms` behind the `[gcp-kms]` extra; importing without the extra raises an `ImportError` naming it. Native async client — no thread bridging needed for calls.

## Test Plan
- 144 tests pass (13 new): raw-data request shape asserted, API error, empty/wrong-length signature, verification failure against mismatched pubkey, transaction signing, algorithm gate, availability error path, pubkey rejected before any GCP call, repr contents
- `ruff` + `mypy --strict` + sdist/wheel build clean

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
