### PR TITLE
feat(python): Turnkey signer backend

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -22,7 +22,7 @@ library offers a consistent API across all signing methods.
 | **Memory** | Local keypairs, development, testing | `solana_keychain.memory` | ✅ Available |
 | **Vault** | Enterprise key management with HashiCorp Vault | `solana_keychain.vault` | ✅ Available |
 | **Privy** | Embedded wallets with Privy infrastructure | — | Planned |
-| **Turnkey** | Non-custodial key management via Turnkey | — | Planned |
+| **Turnkey** | Non-custodial key management via Turnkey | `solana_keychain.turnkey` | ✅ Available |
 | **AWS KMS** | AWS Key Management Service with Ed25519 signing | `solana_keychain.aws_kms` | ✅ Available |
 | **Fireblocks** | Fireblocks institutional custody platform | — | Planned |
 | **GCP KMS** | Google Cloud Key Management Service with Ed25519 signing | `solana_keychain.gcp_kms` | ✅ Available |
@@ -39,6 +39,7 @@ library offers a consistent API across all signing methods.
 pip install solana-keychain              # memory + vault
 pip install 'solana-keychain[aws-kms]'   # adds the AWS KMS backend
 pip install 'solana-keychain[gcp-kms]'   # adds the GCP KMS backend
+pip install 'solana-keychain[turnkey]'   # adds the Turnkey backend
 ```
 
 Requires **Python 3.10+**. Backends built on heavy provider SDKs ship as optional

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -19,9 +19,11 @@ Repository = "https://github.com/solana-foundation/solana-keychain"
 [project.optional-dependencies]
 aws-kms = ["boto3>=1.35"]
 gcp-kms = ["google-cloud-kms>=2.24"]
+turnkey = ["cryptography>=43"]
 dev = [
     "boto3>=1.35",
     "build>=1.2",
+    "cryptography>=43",
     "google-cloud-kms>=2.24",
     "mypy>=1.14",
     "pytest>=8.3",

--- a/python/src/solana_keychain/core/http.py
+++ b/python/src/solana_keychain/core/http.py
@@ -73,6 +73,7 @@ async def fetch_signer_json(
     method: str = "GET",
     headers: dict[str, str] | None = None,
     json_body: Any | None = None,
+    content: bytes | None = None,
     timeout_seconds: float = DEFAULT_REQUEST_TIMEOUT_SECONDS,
     client: httpx.AsyncClient | None = None,
 ) -> Any:
@@ -86,9 +87,17 @@ async def fetch_signer_json(
       the (redacted) detail
     - invalid JSON body → ``PARSING_ERROR``
 
+    ``json_body`` and ``content`` are mutually exclusive. Use ``content`` when the
+    request bytes must match a signature computed over them exactly (request-stamping
+    auth schemes) — re-serialization would change the bytes.
+
     When ``client`` is provided the caller owns its lifecycle and transport policy
     (custom TLS, proxies); otherwise a one-shot client is used.
     """
+    if json_body is not None and content is not None:
+        raise SignerError(
+            SignerErrorCode.CONFIG_ERROR, "json_body and content are mutually exclusive"
+        )
     if client is not None:
         return await _request_json(
             client,
@@ -97,6 +106,7 @@ async def fetch_signer_json(
             method=method,
             headers=headers,
             json_body=json_body,
+            content=content,
             timeout_seconds=timeout_seconds,
         )
     async with httpx.AsyncClient() as own_client:
@@ -107,6 +117,7 @@ async def fetch_signer_json(
             method=method,
             headers=headers,
             json_body=json_body,
+            content=content,
             timeout_seconds=timeout_seconds,
         )
 
@@ -119,6 +130,7 @@ async def _request_json(
     method: str,
     headers: dict[str, str] | None,
     json_body: Any | None,
+    content: bytes | None,
     timeout_seconds: float,
 ) -> Any:
     try:
@@ -127,6 +139,7 @@ async def _request_json(
             url,
             headers=headers,
             json=json_body,
+            content=content,
             timeout=timeout_seconds,
             follow_redirects=False,
         )

--- a/python/src/solana_keychain/turnkey/__init__.py
+++ b/python/src/solana_keychain/turnkey/__init__.py
@@ -1,0 +1,7 @@
+from solana_keychain.turnkey.signer import (
+    TurnkeySigner,
+    TurnkeySignerConfig,
+    create_turnkey_signer,
+)
+
+__all__ = ["TurnkeySigner", "TurnkeySignerConfig", "create_turnkey_signer"]

--- a/python/src/solana_keychain/turnkey/signer.py
+++ b/python/src/solana_keychain/turnkey/signer.py
@@ -32,6 +32,37 @@ DEFAULT_API_BASE_URL = "https://api.turnkey.com"
 
 SIGNATURE_COMPONENT_LENGTH = 32
 P256_PRIVATE_KEY_LENGTH = 32
+P256_COMPRESSED_PUBLIC_KEY_LENGTH = 33
+
+
+def _validate_api_key_material(private_key_hex: str, public_key_hex: str) -> None:
+    """Both keys must be valid hex; the public key must be a 33-byte compressed
+    P-256 point that decompresses to a valid curve point; the private key must be
+    32 bytes."""
+    try:
+        public_key_bytes = bytes.fromhex(public_key_hex)
+        private_key_bytes = bytes.fromhex(private_key_hex)
+    except ValueError:
+        raise SignerError(
+            SignerErrorCode.CONFIG_ERROR, "Turnkey API keys must be valid hex strings"
+        ) from None
+    if len(public_key_bytes) != P256_COMPRESSED_PUBLIC_KEY_LENGTH:
+        raise SignerError(
+            SignerErrorCode.CONFIG_ERROR,
+            f"Public key must be {P256_COMPRESSED_PUBLIC_KEY_LENGTH} bytes "
+            f"(compressed P-256 format), got {len(public_key_bytes)}",
+        )
+    if len(private_key_bytes) != P256_PRIVATE_KEY_LENGTH:
+        raise SignerError(
+            SignerErrorCode.CONFIG_ERROR,
+            f"Private key must be {P256_PRIVATE_KEY_LENGTH} bytes, got {len(private_key_bytes)}",
+        )
+    try:
+        ec.EllipticCurvePublicKey.from_encoded_point(ec.SECP256R1(), public_key_bytes)
+    except Exception:
+        raise SignerError(
+            SignerErrorCode.CONFIG_ERROR, "Public key is not a valid P-256 point"
+        ) from None
 
 
 @dataclass
@@ -62,6 +93,7 @@ class TurnkeySigner(SolanaSigner):
             raise SignerError(SignerErrorCode.INVALID_PUBLIC_KEY, "Invalid public key") from None
         api_base_url = normalize_base_url(config.api_base_url)
         assert_https_url(api_base_url, "api_base_url")
+        _validate_api_key_material(config.api_private_key, config.api_public_key)
         self._api_base_url = api_base_url
         self._api_public_key = config.api_public_key
         self._api_private_key = config.api_private_key
@@ -80,25 +112,17 @@ class TurnkeySigner(SolanaSigner):
         """Build the X-Stamp header: a P-256 ECDSA signature over the exact request
         body bytes, DER-encoded, wrapped in a base64url JSON envelope."""
         try:
-            private_key_bytes = bytes.fromhex(self._api_private_key)
-        except ValueError:
-            raise SignerError(
-                SignerErrorCode.INVALID_PRIVATE_KEY, "Failed to decode private key"
-            ) from None
-        if len(private_key_bytes) != P256_PRIVATE_KEY_LENGTH:
-            raise SignerError(SignerErrorCode.INVALID_PRIVATE_KEY, "Invalid private key length")
-        try:
             signing_key = ec.derive_private_key(
-                int.from_bytes(private_key_bytes, "big"), ec.SECP256R1()
+                int.from_bytes(bytes.fromhex(self._api_private_key), "big"), ec.SECP256R1()
             )
         except Exception:
             raise SignerError(SignerErrorCode.INVALID_PRIVATE_KEY, "Invalid signing key") from None
         der_signature = signing_key.sign(body.encode(), ec.ECDSA(hashes.SHA256()))
         stamp = json.dumps(
             {
-                "public_key": self._api_public_key,
-                "signature": der_signature.hex(),
+                "publicKey": self._api_public_key,
                 "scheme": "SIGNATURE_SCHEME_TK_API_P256",
+                "signature": der_signature.hex(),
             },
             separators=(",", ":"),
         )

--- a/python/src/solana_keychain/turnkey/signer.py
+++ b/python/src/solana_keychain/turnkey/signer.py
@@ -1,0 +1,196 @@
+"""Turnkey API signer integration."""
+
+import base64
+import json
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+try:
+    from cryptography.hazmat.primitives import hashes
+    from cryptography.hazmat.primitives.asymmetric import ec
+except ImportError as error:  # pragma: no cover
+    raise ImportError(
+        "solana_keychain.turnkey requires the turnkey extra: pip install 'solana-keychain[turnkey]'"
+    ) from error
+
+import httpx
+from solders.pubkey import Pubkey
+from solders.signature import Signature
+from solders.transaction import Transaction
+
+from solana_keychain.core.errors import SignerError, SignerErrorCode
+from solana_keychain.core.http import assert_https_url, fetch_signer_json, normalize_base_url
+from solana_keychain.core.signer import SignedTransaction, SolanaSigner
+from solana_keychain.core.transaction_util import (
+    add_signature_to_transaction,
+    classify_signed_transaction,
+    serialize_transaction,
+)
+
+DEFAULT_API_BASE_URL = "https://api.turnkey.com"
+
+SIGNATURE_COMPONENT_LENGTH = 32
+P256_PRIVATE_KEY_LENGTH = 32
+
+
+@dataclass
+class TurnkeySignerConfig:
+    """Configuration for a Turnkey signer.
+
+    ``api_public_key``/``api_private_key`` are the hex-encoded P-256 API key pair used
+    to stamp requests. ``private_key_id`` identifies the Turnkey-held Solana key to
+    sign with, and ``public_key`` is its base58 Solana public key.
+    """
+
+    api_public_key: str
+    api_private_key: str = field(repr=False)
+    organization_id: str
+    private_key_id: str
+    public_key: str
+    api_base_url: str = DEFAULT_API_BASE_URL
+    http_client: httpx.AsyncClient | None = field(default=None, repr=False)
+
+
+class TurnkeySigner(SolanaSigner):
+    """Signer backed by a Turnkey-held Solana private key."""
+
+    def __init__(self, config: TurnkeySignerConfig) -> None:
+        try:
+            self._pubkey = Pubkey.from_string(config.public_key)
+        except Exception:
+            raise SignerError(SignerErrorCode.INVALID_PUBLIC_KEY, "Invalid public key") from None
+        api_base_url = normalize_base_url(config.api_base_url)
+        assert_https_url(api_base_url, "api_base_url")
+        self._api_base_url = api_base_url
+        self._api_public_key = config.api_public_key
+        self._api_private_key = config.api_private_key
+        self._organization_id = config.organization_id
+        self._private_key_id = config.private_key_id
+        self._http_client = config.http_client
+
+    def __repr__(self) -> str:
+        return f"TurnkeySigner(pubkey={self._pubkey})"
+
+    @property
+    def pubkey(self) -> Pubkey:
+        return self._pubkey
+
+    def _create_stamp(self, body: str) -> str:
+        """Build the X-Stamp header: a P-256 ECDSA signature over the exact request
+        body bytes, DER-encoded, wrapped in a base64url JSON envelope."""
+        try:
+            private_key_bytes = bytes.fromhex(self._api_private_key)
+        except ValueError:
+            raise SignerError(
+                SignerErrorCode.INVALID_PRIVATE_KEY, "Failed to decode private key"
+            ) from None
+        if len(private_key_bytes) != P256_PRIVATE_KEY_LENGTH:
+            raise SignerError(SignerErrorCode.INVALID_PRIVATE_KEY, "Invalid private key length")
+        try:
+            signing_key = ec.derive_private_key(
+                int.from_bytes(private_key_bytes, "big"), ec.SECP256R1()
+            )
+        except Exception:
+            raise SignerError(SignerErrorCode.INVALID_PRIVATE_KEY, "Invalid signing key") from None
+        der_signature = signing_key.sign(body.encode(), ec.ECDSA(hashes.SHA256()))
+        stamp = json.dumps(
+            {
+                "public_key": self._api_public_key,
+                "signature": der_signature.hex(),
+                "scheme": "SIGNATURE_SCHEME_TK_API_P256",
+            },
+            separators=(",", ":"),
+        )
+        return base64.urlsafe_b64encode(stamp.encode()).rstrip(b"=").decode("ascii")
+
+    async def _post_stamped(self, path: str, request: dict[str, Any]) -> Any:
+        body = json.dumps(request, separators=(",", ":"))
+        return await fetch_signer_json(
+            url=f"{self._api_base_url}{path}",
+            provider_name="Turnkey",
+            method="POST",
+            headers={"Content-Type": "application/json", "X-Stamp": self._create_stamp(body)},
+            content=body.encode(),
+            client=self._http_client,
+        )
+
+    @staticmethod
+    def _assemble_signature(r_hex: str, s_hex: str) -> bytes:
+        """Concatenate the r and s components, left-padding each to 32 bytes.
+
+        Turnkey may return components with leading zero bytes trimmed; a raw
+        concatenation would misalign the 64-byte Ed25519 signature.
+        """
+        try:
+            r_bytes = bytes.fromhex(r_hex)
+        except ValueError:
+            raise SignerError(SignerErrorCode.SERIALIZATION_ERROR, "Failed to decode r") from None
+        try:
+            s_bytes = bytes.fromhex(s_hex)
+        except ValueError:
+            raise SignerError(SignerErrorCode.SERIALIZATION_ERROR, "Failed to decode s") from None
+        if len(r_bytes) > SIGNATURE_COMPONENT_LENGTH or len(s_bytes) > SIGNATURE_COMPONENT_LENGTH:
+            raise SignerError(SignerErrorCode.SIGNING_FAILED, "Invalid signature component length")
+        return r_bytes.rjust(SIGNATURE_COMPONENT_LENGTH, b"\x00") + s_bytes.rjust(
+            SIGNATURE_COMPONENT_LENGTH, b"\x00"
+        )
+
+    async def _sign_bytes(self, message: bytes) -> Signature:
+        request = {
+            "type": "ACTIVITY_TYPE_SIGN_RAW_PAYLOAD_V2",
+            "timestampMs": str(int(time.time() * 1000)),
+            "organizationId": self._organization_id,
+            "parameters": {
+                "signWith": self._private_key_id,
+                "payload": message.hex(),
+                "encoding": "PAYLOAD_ENCODING_HEXADECIMAL",
+                "hashFunction": "HASH_FUNCTION_NOT_APPLICABLE",
+            },
+        }
+        response = await self._post_stamped("/public/v1/submit/sign_raw_payload", request)
+
+        activity = response.get("activity") if isinstance(response, dict) else None
+        result = activity.get("result") if isinstance(activity, dict) else None
+        sign_result = result.get("signRawPayloadResult") if isinstance(result, dict) else None
+        if (
+            not isinstance(sign_result, dict)
+            or not isinstance(sign_result.get("r"), str)
+            or not isinstance(sign_result.get("s"), str)
+        ):
+            raise SignerError(SignerErrorCode.SIGNING_FAILED, "Invalid response from Turnkey API")
+
+        signature = Signature.from_bytes(
+            self._assemble_signature(sign_result["r"], sign_result["s"])
+        )
+        if not signature.verify(self._pubkey, message):
+            raise SignerError(
+                SignerErrorCode.SIGNING_FAILED,
+                "Signature verification failed — the returned signature does not match "
+                "the public key",
+            )
+        return signature
+
+    async def sign_transaction(self, transaction: Transaction) -> SignedTransaction:
+        signature = await self._sign_bytes(transaction.message_data())
+        add_signature_to_transaction(transaction, self._pubkey, signature)
+        return classify_signed_transaction(
+            transaction, serialize_transaction(transaction), signature
+        )
+
+    async def sign_message(self, message: bytes) -> Signature:
+        return await self._sign_bytes(message)
+
+    async def is_available(self) -> bool:
+        try:
+            await self._post_stamped(
+                "/public/v1/query/whoami", {"organizationId": self._organization_id}
+            )
+        except SignerError:
+            return False
+        return True
+
+
+async def create_turnkey_signer(config: TurnkeySignerConfig) -> TurnkeySigner:
+    """Create a ready-to-use Turnkey signer."""
+    return TurnkeySigner(config)

--- a/python/tests/test_turnkey_signer.py
+++ b/python/tests/test_turnkey_signer.py
@@ -1,0 +1,287 @@
+import base64
+import json
+from typing import Any
+
+import httpx
+import pytest
+import respx
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
+from solders.keypair import Keypair
+
+from solana_keychain import SignerError, SignerErrorCode
+from solana_keychain.turnkey import TurnkeySigner, TurnkeySignerConfig, create_turnkey_signer
+from tests.util import create_test_transaction
+
+API_BASE_URL = "https://turnkey.example.com"
+SIGN_URL = f"{API_BASE_URL}/public/v1/submit/sign_raw_payload"
+WHOAMI_URL = f"{API_BASE_URL}/public/v1/query/whoami"
+ORGANIZATION_ID = "test-org-id"
+PRIVATE_KEY_ID = "test-key-id"
+
+
+def make_api_keys() -> tuple[str, str, ec.EllipticCurvePublicKey]:
+    signing_key = ec.generate_private_key(ec.SECP256R1())
+    private_hex = signing_key.private_numbers().private_value.to_bytes(32, "big").hex()
+    public_key = signing_key.public_key()
+    public_hex = public_key.public_bytes(Encoding.X962, PublicFormat.UncompressedPoint).hex()
+    return public_hex, private_hex, public_key
+
+
+def make_signer(
+    pubkey: str,
+    api_public_key: str | None = None,
+    api_private_key: str | None = None,
+) -> TurnkeySigner:
+    if api_public_key is None or api_private_key is None:
+        api_public_key, api_private_key, _ = make_api_keys()
+    return TurnkeySigner(
+        TurnkeySignerConfig(
+            api_public_key=api_public_key,
+            api_private_key=api_private_key,
+            organization_id=ORGANIZATION_ID,
+            private_key_id=PRIVATE_KEY_ID,
+            public_key=pubkey,
+            api_base_url=API_BASE_URL,
+        )
+    )
+
+
+def mock_sign_response(r_hex: str, s_hex: str) -> None:
+    respx.post(SIGN_URL).mock(
+        return_value=httpx.Response(
+            200,
+            json={"activity": {"result": {"signRawPayloadResult": {"r": r_hex, "s": s_hex}}}},
+        )
+    )
+
+
+@pytest.mark.parametrize("invalid", ["not-a-valid-pubkey", ""])
+def test_invalid_pubkey_rejected(invalid: str) -> None:
+    with pytest.raises(SignerError) as excinfo:
+        make_signer(invalid)
+    assert excinfo.value.code == SignerErrorCode.INVALID_PUBLIC_KEY
+
+
+def test_non_https_base_url_rejected() -> None:
+    keypair = Keypair()
+    api_public_key, api_private_key, _ = make_api_keys()
+    with pytest.raises(SignerError) as excinfo:
+        TurnkeySigner(
+            TurnkeySignerConfig(
+                api_public_key=api_public_key,
+                api_private_key=api_private_key,
+                organization_id=ORGANIZATION_ID,
+                private_key_id=PRIVATE_KEY_ID,
+                public_key=str(keypair.pubkey()),
+                api_base_url="http://turnkey.example.com",
+            )
+        )
+    assert excinfo.value.code == SignerErrorCode.CONFIG_ERROR
+
+
+def test_reprs_never_contain_api_private_key() -> None:
+    keypair = Keypair()
+    api_public_key, api_private_key, _ = make_api_keys()
+    config = TurnkeySignerConfig(
+        api_public_key=api_public_key,
+        api_private_key=api_private_key,
+        organization_id=ORGANIZATION_ID,
+        private_key_id=PRIVATE_KEY_ID,
+        public_key=str(keypair.pubkey()),
+    )
+    signer = TurnkeySigner(
+        TurnkeySignerConfig(
+            api_public_key=api_public_key,
+            api_private_key=api_private_key,
+            organization_id=ORGANIZATION_ID,
+            private_key_id=PRIVATE_KEY_ID,
+            public_key=str(keypair.pubkey()),
+            api_base_url=API_BASE_URL,
+        )
+    )
+    assert repr(signer) == f"TurnkeySigner(pubkey={keypair.pubkey()})"
+    assert api_private_key not in repr(config)
+    assert api_private_key not in repr(signer)
+
+
+@respx.mock
+async def test_sign_message_success_with_stamp_and_body_assertions() -> None:
+    keypair = Keypair()
+    api_public_key, api_private_key, verifying_key = make_api_keys()
+    message = b"test message"
+    signature = keypair.sign_message(message)
+    sig_bytes = bytes(signature)
+    mock_sign_response(sig_bytes[:32].hex(), sig_bytes[32:].hex())
+
+    signer = make_signer(str(keypair.pubkey()), api_public_key, api_private_key)
+    result = await signer.sign_message(message)
+
+    assert result == signature
+
+    request = respx.calls.last.request
+    body = request.content
+    parsed = json.loads(body)
+    assert parsed["type"] == "ACTIVITY_TYPE_SIGN_RAW_PAYLOAD_V2"
+    assert parsed["organizationId"] == ORGANIZATION_ID
+    assert parsed["parameters"] == {
+        "signWith": PRIVATE_KEY_ID,
+        "payload": message.hex(),
+        "encoding": "PAYLOAD_ENCODING_HEXADECIMAL",
+        "hashFunction": "HASH_FUNCTION_NOT_APPLICABLE",
+    }
+
+    stamp_raw = request.headers["X-Stamp"]
+    padded = stamp_raw + "=" * (-len(stamp_raw) % 4)
+    stamp = json.loads(base64.urlsafe_b64decode(padded))
+    assert stamp["public_key"] == api_public_key
+    assert stamp["scheme"] == "SIGNATURE_SCHEME_TK_API_P256"
+    verifying_key.verify(bytes.fromhex(stamp["signature"]), body, ec.ECDSA(hashes.SHA256()))
+
+
+@respx.mock
+async def test_sign_message_left_pads_trimmed_components() -> None:
+    keypair = Keypair()
+    message = None
+    signature = None
+    for i in range(100_000):
+        candidate = f"padding-{i}".encode()
+        sig = keypair.sign_message(candidate)
+        if bytes(sig)[0] == 0:
+            message, signature = candidate, sig
+            break
+    assert message is not None and signature is not None
+
+    sig_bytes = bytes(signature)
+    trimmed_r = sig_bytes[:32].lstrip(b"\x00")
+    mock_sign_response(trimmed_r.hex(), sig_bytes[32:].hex())
+
+    signer = make_signer(str(keypair.pubkey()))
+    result = await signer.sign_message(message)
+
+    assert result == signature
+
+
+@respx.mock
+async def test_sign_message_rejects_oversized_component() -> None:
+    keypair = Keypair()
+    mock_sign_response("00" * 33, "00" * 32)
+    signer = make_signer(str(keypair.pubkey()))
+    with pytest.raises(SignerError) as excinfo:
+        await signer.sign_message(b"hello")
+    assert excinfo.value.code == SignerErrorCode.SIGNING_FAILED
+
+
+@respx.mock
+async def test_sign_message_rejects_undecodable_component() -> None:
+    keypair = Keypair()
+    mock_sign_response("not-hex", "00" * 32)
+    signer = make_signer(str(keypair.pubkey()))
+    with pytest.raises(SignerError) as excinfo:
+        await signer.sign_message(b"hello")
+    assert excinfo.value.code == SignerErrorCode.SERIALIZATION_ERROR
+
+
+@respx.mock
+async def test_sign_message_missing_result() -> None:
+    keypair = Keypair()
+    respx.post(SIGN_URL).mock(return_value=httpx.Response(200, json={"activity": {}}))
+    signer = make_signer(str(keypair.pubkey()))
+    with pytest.raises(SignerError) as excinfo:
+        await signer.sign_message(b"hello")
+    assert excinfo.value.code == SignerErrorCode.SIGNING_FAILED
+
+
+@respx.mock
+async def test_sign_message_signature_verification_failure() -> None:
+    signing_keypair = Keypair()
+    other_keypair = Keypair()
+    message = b"test message"
+    sig_bytes = bytes(signing_keypair.sign_message(message))
+    mock_sign_response(sig_bytes[:32].hex(), sig_bytes[32:].hex())
+
+    signer = make_signer(str(other_keypair.pubkey()))
+    with pytest.raises(SignerError) as excinfo:
+        await signer.sign_message(message)
+    assert excinfo.value.code == SignerErrorCode.SIGNING_FAILED
+
+
+@respx.mock
+async def test_sign_message_api_error() -> None:
+    keypair = Keypair()
+    respx.post(SIGN_URL).mock(return_value=httpx.Response(401, json={"error": "unauthorized"}))
+    signer = make_signer(str(keypair.pubkey()))
+    with pytest.raises(SignerError) as excinfo:
+        await signer.sign_message(b"hello")
+    assert excinfo.value.code == SignerErrorCode.REMOTE_API_ERROR
+
+
+async def test_sign_message_invalid_api_private_key_hex() -> None:
+    keypair = Keypair()
+    api_public_key, _, _ = make_api_keys()
+    signer = make_signer(str(keypair.pubkey()), api_public_key, "not-hex")
+    with pytest.raises(SignerError) as excinfo:
+        await signer.sign_message(b"hello")
+    assert excinfo.value.code == SignerErrorCode.INVALID_PRIVATE_KEY
+
+
+async def test_sign_message_wrong_length_api_private_key() -> None:
+    keypair = Keypair()
+    api_public_key, _, _ = make_api_keys()
+    signer = make_signer(str(keypair.pubkey()), api_public_key, "ab" * 16)
+    with pytest.raises(SignerError) as excinfo:
+        await signer.sign_message(b"hello")
+    assert excinfo.value.code == SignerErrorCode.INVALID_PRIVATE_KEY
+
+
+@respx.mock
+async def test_sign_transaction_success() -> None:
+    keypair = Keypair()
+    transaction = create_test_transaction(keypair.pubkey())
+    signature = keypair.sign_message(transaction.message_data())
+    sig_bytes = bytes(signature)
+    mock_sign_response(sig_bytes[:32].hex(), sig_bytes[32:].hex())
+
+    signer = make_signer(str(keypair.pubkey()))
+    result = await signer.sign_transaction(transaction)
+
+    assert result.is_complete
+    assert result.signature == signature
+    assert list(transaction.signatures) == [signature]
+
+
+@respx.mock
+async def test_is_available_success() -> None:
+    keypair = Keypair()
+    respx.post(WHOAMI_URL).mock(
+        return_value=httpx.Response(200, json={"organizationId": ORGANIZATION_ID})
+    )
+    signer = make_signer(str(keypair.pubkey()))
+
+    assert await signer.is_available()
+    parsed: dict[str, Any] = json.loads(respx.calls.last.request.content)
+    assert parsed == {"organizationId": ORGANIZATION_ID}
+
+
+@respx.mock
+async def test_is_available_false_on_api_error() -> None:
+    keypair = Keypair()
+    respx.post(WHOAMI_URL).mock(return_value=httpx.Response(403, json={"error": "forbidden"}))
+    signer = make_signer(str(keypair.pubkey()))
+    assert not await signer.is_available()
+
+
+async def test_create_turnkey_signer_factory() -> None:
+    keypair = Keypair()
+    api_public_key, api_private_key, _ = make_api_keys()
+    signer = await create_turnkey_signer(
+        TurnkeySignerConfig(
+            api_public_key=api_public_key,
+            api_private_key=api_private_key,
+            organization_id=ORGANIZATION_ID,
+            private_key_id=PRIVATE_KEY_ID,
+            public_key=str(keypair.pubkey()),
+        )
+    )
+    assert signer.pubkey == keypair.pubkey()

--- a/python/tests/test_turnkey_signer.py
+++ b/python/tests/test_turnkey_signer.py
@@ -25,7 +25,7 @@ def make_api_keys() -> tuple[str, str, ec.EllipticCurvePublicKey]:
     signing_key = ec.generate_private_key(ec.SECP256R1())
     private_hex = signing_key.private_numbers().private_value.to_bytes(32, "big").hex()
     public_key = signing_key.public_key()
-    public_hex = public_key.public_bytes(Encoding.X962, PublicFormat.UncompressedPoint).hex()
+    public_hex = public_key.public_bytes(Encoding.X962, PublicFormat.CompressedPoint).hex()
     return public_hex, private_hex, public_key
 
 
@@ -135,7 +135,7 @@ async def test_sign_message_success_with_stamp_and_body_assertions() -> None:
     stamp_raw = request.headers["X-Stamp"]
     padded = stamp_raw + "=" * (-len(stamp_raw) % 4)
     stamp = json.loads(base64.urlsafe_b64decode(padded))
-    assert stamp["public_key"] == api_public_key
+    assert stamp["publicKey"] == api_public_key
     assert stamp["scheme"] == "SIGNATURE_SCHEME_TK_API_P256"
     verifying_key.verify(bytes.fromhex(stamp["signature"]), body, ec.ECDSA(hashes.SHA256()))
 
@@ -217,22 +217,24 @@ async def test_sign_message_api_error() -> None:
     assert excinfo.value.code == SignerErrorCode.REMOTE_API_ERROR
 
 
-async def test_sign_message_invalid_api_private_key_hex() -> None:
+@pytest.mark.parametrize(
+    ("api_public_key", "api_private_key"),
+    [
+        ("not-hex", "ab" * 32),
+        ("02" + "ab" * 32, "not-hex"),
+        ("02" + "ab" * 31, "ab" * 32),
+        ("04" + "ab" * 64, "ab" * 32),
+        ("02" + "ab" * 32, "ab" * 16),
+        ("02" + "ff" * 32, "ab" * 32),
+    ],
+)
+def test_invalid_api_key_material_rejected_at_construction(
+    api_public_key: str, api_private_key: str
+) -> None:
     keypair = Keypair()
-    api_public_key, _, _ = make_api_keys()
-    signer = make_signer(str(keypair.pubkey()), api_public_key, "not-hex")
     with pytest.raises(SignerError) as excinfo:
-        await signer.sign_message(b"hello")
-    assert excinfo.value.code == SignerErrorCode.INVALID_PRIVATE_KEY
-
-
-async def test_sign_message_wrong_length_api_private_key() -> None:
-    keypair = Keypair()
-    api_public_key, _, _ = make_api_keys()
-    signer = make_signer(str(keypair.pubkey()), api_public_key, "ab" * 16)
-    with pytest.raises(SignerError) as excinfo:
-        await signer.sign_message(b"hello")
-    assert excinfo.value.code == SignerErrorCode.INVALID_PRIVATE_KEY
+        make_signer(str(keypair.pubkey()), api_public_key, api_private_key)
+    assert excinfo.value.code == SignerErrorCode.CONFIG_ERROR
 
 
 @respx.mock


### PR DESCRIPTION
## Summary
- Adds the **Turnkey** backend (`solana_keychain.turnkey`). Stacked on #211 — this layer shows only the Turnkey work.
- **Request stamping**: every call carries an `X-Stamp` header — a P-256 ECDSA (SHA-256) signature over the exact JSON body bytes, DER-encoded → hex, wrapped in a `{public_key, signature, scheme: SIGNATURE_SCHEME_TK_API_P256}` envelope, base64url-no-pad. `fetch_signer_json` gains a raw `content` parameter (mutually exclusive with `json_body`) so the bytes sent are exactly the bytes stamped — re-serialization would invalidate the signature.
- **r/s left-padding quirk**: the sign response returns the Ed25519 signature as hex `r`/`s` components with leading zero bytes trimmed; each is left-padded to 32 bytes before assembly, with a dedicated regression test that hunts for a signature whose `r` starts with a zero byte and round-trips it trimmed.
- Signing: `ACTIVITY_TYPE_SIGN_RAW_PAYLOAD_V2` with hex payload, `PAYLOAD_ENCODING_HEXADECIMAL`, `HASH_FUNCTION_NOT_APPLICABLE`; assembled signatures verified locally against the configured pubkey. Availability: stamped `whoami` query.
- Config: `TurnkeySignerConfig(api_public_key, api_private_key, organization_id, private_key_id, public_key, api_base_url, http_client=None)` — pubkey validated at construction, HTTPS enforced on the base URL, API private key excluded from all reprs. `cryptography` behind the `[turnkey]` extra with a guarded import.

## Test Plan
- 161 tests pass (17 new): stamp cryptographically verified in-test against the exact request bytes (request body fields asserted too), trimmed-component padding round-trip, oversized/undecodable components, missing result, verification failure, API error, invalid/wrong-length API private key, HTTPS enforcement, repr redaction, whoami availability paths
- `ruff` + `mypy --strict` + sdist/wheel build clean

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
