### PR TITLE
feat(python): Privy signer backend

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -21,7 +21,7 @@ library offers a consistent API across all signing methods.
 | --- | --- | --- | --- |
 | **Memory** | Local keypairs, development, testing | `solana_keychain.memory` | ✅ Available |
 | **Vault** | Enterprise key management with HashiCorp Vault | `solana_keychain.vault` | ✅ Available |
-| **Privy** | Embedded wallets with Privy infrastructure | — | Planned |
+| **Privy** | Embedded wallets with Privy infrastructure | `solana_keychain.privy` | ✅ Available |
 | **Turnkey** | Non-custodial key management via Turnkey | `solana_keychain.turnkey` | ✅ Available |
 | **AWS KMS** | AWS Key Management Service with Ed25519 signing | `solana_keychain.aws_kms` | ✅ Available |
 | **Fireblocks** | Fireblocks institutional custody platform | — | Planned |
@@ -39,6 +39,7 @@ library offers a consistent API across all signing methods.
 pip install solana-keychain              # memory + vault
 pip install 'solana-keychain[aws-kms]'   # adds the AWS KMS backend
 pip install 'solana-keychain[gcp-kms]'   # adds the GCP KMS backend
+pip install 'solana-keychain[privy]'     # adds the Privy backend
 pip install 'solana-keychain[turnkey]'   # adds the Turnkey backend
 ```
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -19,6 +19,7 @@ Repository = "https://github.com/solana-foundation/solana-keychain"
 [project.optional-dependencies]
 aws-kms = ["boto3>=1.35"]
 gcp-kms = ["google-cloud-kms>=2.24"]
+privy = ["cryptography>=43"]
 turnkey = ["cryptography>=43"]
 dev = [
     "boto3>=1.35",

--- a/python/src/solana_keychain/privy/__init__.py
+++ b/python/src/solana_keychain/privy/__init__.py
@@ -1,0 +1,23 @@
+from solana_keychain.privy.authorization import (
+    DEFAULT_AUTHORIZATION_REQUEST_EXPIRY_MS,
+    PrivyAuthorizationConfig,
+    PrivyAuthorizationContext,
+    PrivyAuthorizationContextProvider,
+    PrivyAuthorizationSignFn,
+    format_authorization_signature_payload,
+    generate_authorization_signatures,
+)
+from solana_keychain.privy.signer import PrivySigner, PrivySignerConfig, create_privy_signer
+
+__all__ = [
+    "DEFAULT_AUTHORIZATION_REQUEST_EXPIRY_MS",
+    "PrivyAuthorizationConfig",
+    "PrivyAuthorizationContext",
+    "PrivyAuthorizationContextProvider",
+    "PrivyAuthorizationSignFn",
+    "PrivySigner",
+    "PrivySignerConfig",
+    "create_privy_signer",
+    "format_authorization_signature_payload",
+    "generate_authorization_signatures",
+]

--- a/python/src/solana_keychain/privy/authorization.py
+++ b/python/src/solana_keychain/privy/authorization.py
@@ -1,0 +1,158 @@
+"""Privy wallet-authorization signatures."""
+
+import base64
+import json
+import time
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+try:
+    from cryptography.hazmat.primitives import hashes
+    from cryptography.hazmat.primitives.asymmetric import ec
+    from cryptography.hazmat.primitives.serialization import (
+        load_der_private_key,
+        load_pem_private_key,
+    )
+except ImportError as error:  # pragma: no cover
+    raise ImportError(
+        "solana_keychain.privy requires the privy extra: pip install 'solana-keychain[privy]'"
+    ) from error
+
+from solana_keychain.core.errors import SignerError, SignerErrorCode
+
+DEFAULT_AUTHORIZATION_REQUEST_EXPIRY_MS = 15 * 60 * 1000
+
+PrivyAuthorizationSignFn = Callable[[bytes], str]
+
+
+@dataclass
+class PrivyAuthorizationContext:
+    """Key material for Privy wallet-authorization signatures.
+
+    ``authorization_private_keys`` are base64 PKCS8 P-256 private keys exported by
+    Privy (``wallet-auth:`` and ``wallet-api:`` prefixes accepted, PEM supported).
+    ``signatures`` are precomputed base64 authorization signatures for the exact
+    request. ``sign_fns`` are external signers that receive the canonical payload
+    bytes and return a base64 signature.
+    """
+
+    authorization_private_keys: list[str] = field(default_factory=list, repr=False)
+    signatures: list[str] = field(default_factory=list, repr=False)
+    sign_fns: list[PrivyAuthorizationSignFn] = field(default_factory=list, repr=False)
+
+
+PrivyAuthorizationContextProvider = Callable[[dict[str, Any]], PrivyAuthorizationContext | None]
+PrivyAuthorizationConfig = PrivyAuthorizationContext | PrivyAuthorizationContextProvider
+
+
+def format_authorization_signature_payload(request: dict[str, Any]) -> bytes:
+    """Serialize the authorization request to its canonical signed form: recursively
+    sorted keys, compact separators, and an empty ``body`` object replaced by ``""``."""
+    value = dict(request)
+    body = value.get("body")
+    if isinstance(body, dict) and not body:
+        value["body"] = ""
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode()
+
+
+def _parse_p256_private_key(authorization_private_key: str) -> ec.EllipticCurvePrivateKey:
+    normalized = authorization_private_key
+    for prefix in ("wallet-auth:", "wallet-api:"):
+        if normalized.startswith(prefix):
+            normalized = normalized[len(prefix) :]
+            break
+    normalized = normalized.strip()
+
+    if "-----BEGIN" in normalized:
+        pem = normalized.replace("\\n", "\n")
+        try:
+            key = load_pem_private_key(pem.encode(), password=None)
+        except Exception:
+            raise SignerError(
+                SignerErrorCode.INVALID_PRIVATE_KEY, "Invalid Privy authorization private key"
+            ) from None
+    else:
+        compact = "".join(normalized.split())
+        try:
+            der = base64.b64decode(compact, validate=True)
+        except Exception:
+            raise SignerError(
+                SignerErrorCode.INVALID_PRIVATE_KEY,
+                "Invalid Privy authorization private key encoding",
+            ) from None
+        try:
+            key = load_der_private_key(der, password=None)
+        except Exception:
+            raise SignerError(
+                SignerErrorCode.INVALID_PRIVATE_KEY, "Invalid Privy authorization private key"
+            ) from None
+
+    if not isinstance(key, ec.EllipticCurvePrivateKey) or not isinstance(key.curve, ec.SECP256R1):
+        raise SignerError(
+            SignerErrorCode.INVALID_PRIVATE_KEY, "Invalid Privy authorization private key"
+        )
+    return key
+
+
+def generate_authorization_signatures(
+    request: dict[str, Any], authorization_context: PrivyAuthorizationContext
+) -> list[str]:
+    """Produce base64 DER ECDSA signatures over the canonical payload, preserving
+    the order: precomputed signatures, then private keys, then sign functions."""
+    payload = format_authorization_signature_payload(request)
+    signatures = list(authorization_context.signatures)
+    for private_key in authorization_context.authorization_private_keys:
+        signing_key = _parse_p256_private_key(private_key)
+        der_signature = signing_key.sign(payload, ec.ECDSA(hashes.SHA256()))
+        signatures.append(base64.b64encode(der_signature).decode("ascii"))
+    for sign_fn in authorization_context.sign_fns:
+        signatures.append(sign_fn(payload))
+    return signatures
+
+
+def prepare_authorization_headers(
+    *,
+    app_id: str,
+    authorization_config: PrivyAuthorizationConfig | None,
+    method: str,
+    url: str,
+    body: dict[str, Any],
+    request_expiry_ms: int | None,
+) -> tuple[str | None, str | None]:
+    """Build the (``privy-authorization-signature``, ``privy-request-expiry``) header
+    values, or ``(None, None)`` when no authorization context is configured."""
+    if authorization_config is None:
+        return (None, None)
+
+    request_expiry = (
+        str(int(time.time() * 1000) + request_expiry_ms) if request_expiry_ms is not None else None
+    )
+    headers = {"privy-app-id": app_id}
+    if request_expiry is not None:
+        headers["privy-request-expiry"] = request_expiry
+
+    request: dict[str, Any] = {
+        "version": 1,
+        "method": method,
+        "url": url,
+        "body": body,
+        "headers": headers,
+    }
+
+    context = (
+        authorization_config
+        if isinstance(authorization_config, PrivyAuthorizationContext)
+        else authorization_config(request)
+    )
+    if context is None:
+        return (None, None)
+
+    signatures = generate_authorization_signatures(request, context)
+    if not signatures:
+        raise SignerError(
+            SignerErrorCode.CONFIG_ERROR,
+            "authorization_context must include authorization_private_keys, signatures, "
+            "or sign_fns",
+        )
+    return (",".join(signatures), request_expiry)

--- a/python/src/solana_keychain/privy/signer.py
+++ b/python/src/solana_keychain/privy/signer.py
@@ -1,0 +1,191 @@
+"""Privy API signer integration."""
+
+import base64
+from dataclasses import dataclass, field
+from urllib.parse import quote
+
+import httpx
+from solders.pubkey import Pubkey
+from solders.signature import Signature
+from solders.transaction import Transaction
+
+from solana_keychain.core.errors import SignerError, SignerErrorCode
+from solana_keychain.core.http import assert_https_url, fetch_signer_json, normalize_base_url
+from solana_keychain.core.signer import SignedTransaction, SolanaSigner
+from solana_keychain.core.transaction_util import (
+    add_signature_to_transaction,
+    classify_signed_transaction,
+    serialize_transaction,
+)
+from solana_keychain.privy.authorization import (
+    DEFAULT_AUTHORIZATION_REQUEST_EXPIRY_MS,
+    PrivyAuthorizationConfig,
+    prepare_authorization_headers,
+)
+
+DEFAULT_API_BASE_URL = "https://api.privy.io/v1"
+
+
+@dataclass
+class PrivySignerConfig:
+    """Configuration for a Privy signer.
+
+    ``authorization_request_expiry_ms`` defaults to 15 minutes; set it to ``None``
+    to omit ``privy-request-expiry`` from signed payloads and request headers.
+    """
+
+    app_id: str
+    app_secret: str = field(repr=False)
+    wallet_id: str
+    api_base_url: str = DEFAULT_API_BASE_URL
+    authorization_context: PrivyAuthorizationConfig | None = field(default=None, repr=False)
+    authorization_request_expiry_ms: int | None = DEFAULT_AUTHORIZATION_REQUEST_EXPIRY_MS
+    http_client: httpx.AsyncClient | None = field(default=None, repr=False)
+
+
+class PrivySigner(SolanaSigner):
+    """Signer backed by a Privy-held wallet.
+
+    ``init()`` must be awaited before use — it resolves the wallet's public key.
+    ``create_privy_signer()`` does this for you.
+    """
+
+    def __init__(self, config: PrivySignerConfig) -> None:
+        api_base_url = normalize_base_url(config.api_base_url)
+        assert_https_url(api_base_url, "api_base_url")
+        self._api_base_url = api_base_url
+        self._app_id = config.app_id
+        self._app_secret = config.app_secret
+        self._wallet_id = config.wallet_id
+        self._authorization_context = config.authorization_context
+        self._authorization_request_expiry_ms = config.authorization_request_expiry_ms
+        self._http_client = config.http_client
+        self._public_key: Pubkey | None = None
+
+    def __repr__(self) -> str:
+        return f"PrivySigner(pubkey={self._public_key})"
+
+    async def init(self) -> None:
+        """Resolve the wallet's public key. Must be awaited before signing."""
+        self._public_key = await self._fetch_public_key()
+
+    def _initialized_pubkey(self) -> Pubkey:
+        if self._public_key is None:
+            raise SignerError(
+                SignerErrorCode.NOT_INITIALIZED,
+                "PrivySigner is not initialized; call init() before signing",
+            )
+        return self._public_key
+
+    @property
+    def pubkey(self) -> Pubkey:
+        return self._initialized_pubkey()
+
+    def _base_headers(self) -> dict[str, str]:
+        credentials = base64.b64encode(f"{self._app_id}:{self._app_secret}".encode()).decode(
+            "ascii"
+        )
+        return {"Authorization": f"Basic {credentials}", "privy-app-id": self._app_id}
+
+    async def _fetch_public_key(self) -> Pubkey:
+        url = f"{self._api_base_url}/wallets/{quote(self._wallet_id, safe='')}"
+        wallet = await fetch_signer_json(
+            url=url,
+            provider_name="Privy",
+            headers=self._base_headers(),
+            client=self._http_client,
+        )
+        if not isinstance(wallet, dict):
+            raise SignerError(SignerErrorCode.REMOTE_API_ERROR, "Invalid Privy wallet response")
+        chain_type = wallet.get("chain_type")
+        if chain_type != "solana":
+            raise SignerError(
+                SignerErrorCode.REMOTE_API_ERROR,
+                f"Expected Solana wallet, got chain_type={chain_type}",
+            )
+        try:
+            return Pubkey.from_string(wallet.get("address", ""))
+        except Exception:
+            raise SignerError(
+                SignerErrorCode.INVALID_PUBLIC_KEY, "Invalid public key from Privy API"
+            ) from None
+
+    async def _sign_bytes(self, message: bytes) -> Signature:
+        public_key = self._initialized_pubkey()
+        url = f"{self._api_base_url}/wallets/{quote(self._wallet_id, safe='')}/rpc"
+        request = {
+            "method": "signMessage",
+            "chain_type": "solana",
+            "params": {"message": base64.b64encode(message).decode("ascii"), "encoding": "base64"},
+        }
+        authorization_signature, request_expiry = prepare_authorization_headers(
+            app_id=self._app_id,
+            authorization_config=self._authorization_context,
+            method="POST",
+            url=url,
+            body=request,
+            request_expiry_ms=self._authorization_request_expiry_ms,
+        )
+        headers = self._base_headers()
+        headers["Content-Type"] = "application/json"
+        if authorization_signature is not None:
+            headers["privy-authorization-signature"] = authorization_signature
+        if request_expiry is not None:
+            headers["privy-request-expiry"] = request_expiry
+
+        response = await fetch_signer_json(
+            url=url,
+            provider_name="Privy",
+            method="POST",
+            headers=headers,
+            json_body=request,
+            client=self._http_client,
+        )
+
+        data = response.get("data") if isinstance(response, dict) else None
+        signature_b64 = data.get("signature") if isinstance(data, dict) else None
+        if not isinstance(signature_b64, str):
+            raise SignerError(SignerErrorCode.REMOTE_API_ERROR, "No signature in Privy response")
+        try:
+            signature_bytes = base64.b64decode(signature_b64, validate=True)
+        except Exception:
+            raise SignerError(
+                SignerErrorCode.SERIALIZATION_ERROR,
+                "Failed to decode base64 signature from Privy",
+            ) from None
+        try:
+            signature = Signature.from_bytes(signature_bytes)
+        except Exception:
+            raise SignerError(SignerErrorCode.SIGNING_FAILED, "Failed to parse signature") from None
+        if not signature.verify(public_key, message):
+            raise SignerError(
+                SignerErrorCode.SIGNING_FAILED,
+                "Signature verification failed — the returned signature does not match "
+                "the public key",
+            )
+        return signature
+
+    async def sign_transaction(self, transaction: Transaction) -> SignedTransaction:
+        signature = await self._sign_bytes(transaction.message_data())
+        add_signature_to_transaction(transaction, self._initialized_pubkey(), signature)
+        return classify_signed_transaction(
+            transaction, serialize_transaction(transaction), signature
+        )
+
+    async def sign_message(self, message: bytes) -> Signature:
+        return await self._sign_bytes(message)
+
+    async def is_available(self) -> bool:
+        if self._public_key is None:
+            return False
+        try:
+            return await self._fetch_public_key() == self._public_key
+        except SignerError:
+            return False
+
+
+async def create_privy_signer(config: PrivySignerConfig) -> PrivySigner:
+    """Create a ready-to-use Privy signer (awaits ``init()``)."""
+    signer = PrivySigner(config)
+    await signer.init()
+    return signer

--- a/python/tests/test_privy_signer.py
+++ b/python/tests/test_privy_signer.py
@@ -1,0 +1,405 @@
+import base64
+import json
+from typing import Any
+
+import httpx
+import pytest
+import respx
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives.serialization import load_pem_private_key
+from solders.keypair import Keypair
+
+from solana_keychain import SignerError, SignerErrorCode
+from solana_keychain.privy import (
+    PrivyAuthorizationContext,
+    PrivySigner,
+    PrivySignerConfig,
+    create_privy_signer,
+    format_authorization_signature_payload,
+    generate_authorization_signatures,
+)
+from solana_keychain.privy.authorization import _parse_p256_private_key
+from tests.util import create_test_transaction
+
+API_BASE_URL = "https://privy.example.com/v1"
+APP_ID = "test-app-id"
+APP_SECRET = "test-app-secret"
+WALLET_ID = "test-wallet-id"
+WALLET_URL = f"{API_BASE_URL}/wallets/{WALLET_ID}"
+RPC_URL = f"{API_BASE_URL}/wallets/{WALLET_ID}/rpc"
+
+TEST_P256_PKCS8_PEM = (
+    "-----BEGIN PRIVATE KEY-----\n"
+    "MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgNVGLQN9VkU26M2JG\n"
+    "3hbSFACbGLXkQlB69ZxAhXGqf/mhRANCAATjr6H28PJiFSlRz9kfkzu9Fy6vt1uY\n"
+    "9Egu4yP/e2qnDZ+SjpcQo1hpF6Cb1h6S1a2b7qi3IEEnh+d/vzlOHAaf\n"
+    "-----END PRIVATE KEY-----"
+)
+TEST_P256_PKCS8_BASE64 = (
+    "MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgNVGLQN9VkU26M2JG"
+    "3hbSFACbGLXkQlB69ZxAhXGqf/mhRANCAATjr6H28PJiFSlRz9kfkzu9Fy6vt1uY"
+    "9Egu4yP/e2qnDZ+SjpcQo1hpF6Cb1h6S1a2b7qi3IEEnh+d/vzlOHAaf"
+)
+
+
+def make_signer(
+    authorization_context: PrivyAuthorizationContext | None = None,
+    authorization_request_expiry_ms: int | None = 15 * 60 * 1000,
+) -> PrivySigner:
+    return PrivySigner(
+        PrivySignerConfig(
+            app_id=APP_ID,
+            app_secret=APP_SECRET,
+            wallet_id=WALLET_ID,
+            api_base_url=API_BASE_URL,
+            authorization_context=authorization_context,
+            authorization_request_expiry_ms=authorization_request_expiry_ms,
+        )
+    )
+
+
+def mock_wallet_response(address: str, chain_type: str = "solana") -> None:
+    respx.get(WALLET_URL).mock(
+        return_value=httpx.Response(
+            200, json={"id": WALLET_ID, "address": address, "chain_type": chain_type}
+        )
+    )
+
+
+def mock_sign_response(signature_b64: str) -> None:
+    respx.post(RPC_URL).mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "method": "signMessage",
+                "data": {"signature": signature_b64, "encoding": "base64"},
+            },
+        )
+    )
+
+
+async def initialized_signer(
+    keypair: Keypair, authorization_context: PrivyAuthorizationContext | None = None
+) -> PrivySigner:
+    mock_wallet_response(str(keypair.pubkey()))
+    signer = make_signer(authorization_context)
+    await signer.init()
+    return signer
+
+
+def authorization_request(body: Any) -> dict[str, Any]:
+    return {
+        "version": 1,
+        "method": "POST",
+        "url": "https://api.privy.test/wallets/test-wallet-id/rpc",
+        "body": body,
+        "headers": {
+            "privy-app-id": "test-app-id",
+            "privy-request-expiry": "1900000",
+        },
+    }
+
+
+def test_formats_empty_authorization_request_bodies_canonically() -> None:
+    payload = format_authorization_signature_payload(authorization_request({}))
+    assert payload.decode() == (
+        '{"body":"","headers":{"privy-app-id":"test-app-id",'
+        '"privy-request-expiry":"1900000"},"method":"POST",'
+        '"url":"https://api.privy.test/wallets/test-wallet-id/rpc","version":1}'
+    )
+
+
+def test_generates_base64_der_authorization_signatures() -> None:
+    request = authorization_request(
+        {
+            "chain_type": "solana",
+            "method": "signMessage",
+            "params": {"encoding": "base64", "message": "AQIDBA=="},
+        }
+    )
+    context = PrivyAuthorizationContext(
+        authorization_private_keys=[f"wallet-auth:{TEST_P256_PKCS8_BASE64}"]
+    )
+
+    signatures = generate_authorization_signatures(request, context)
+
+    payload = format_authorization_signature_payload(request)
+    private_key = load_pem_private_key(TEST_P256_PKCS8_PEM.encode(), password=None)
+    assert isinstance(private_key, ec.EllipticCurvePrivateKey)
+    private_key.public_key().verify(
+        base64.b64decode(signatures[0]), payload, ec.ECDSA(hashes.SHA256())
+    )
+
+
+def test_preserves_signature_order() -> None:
+    request = authorization_request({"method": "signMessage"})
+    context = PrivyAuthorizationContext(
+        signatures=["provided"], sign_fns=[lambda _payload: "sign-fn"]
+    )
+    assert generate_authorization_signatures(request, context) == ["provided", "sign-fn"]
+
+
+@pytest.mark.parametrize(
+    "invalid_key",
+    [
+        "wallet-auth:not-secret-but-sensitive",
+        "-----BEGIN PRIVATE KEY-----\nnot-secret-but-sensitive\n-----END PRIVATE KEY-----",
+        base64.b64encode(b"not-secret-but-sensitive").decode(),
+    ],
+)
+def test_invalid_authorization_keys_never_leak(invalid_key: str) -> None:
+    with pytest.raises(SignerError) as excinfo:
+        _parse_p256_private_key(invalid_key)
+    error = excinfo.value
+    assert error.code == SignerErrorCode.INVALID_PRIVATE_KEY
+    for channel in (str(error), repr(error), repr(error.args)):
+        assert "not-secret-but-sensitive" not in channel
+
+
+@respx.mock
+async def test_init_resolves_wallet_pubkey() -> None:
+    keypair = Keypair()
+    signer = await initialized_signer(keypair)
+    assert signer.pubkey == keypair.pubkey()
+    request = respx.calls.last.request
+    expected = base64.b64encode(f"{APP_ID}:{APP_SECRET}".encode()).decode()
+    assert request.headers["Authorization"] == f"Basic {expected}"
+    assert request.headers["privy-app-id"] == APP_ID
+
+
+@respx.mock
+async def test_init_rejects_non_solana_wallet() -> None:
+    mock_wallet_response("0xabc", chain_type="ethereum")
+    signer = make_signer()
+    with pytest.raises(SignerError) as excinfo:
+        await signer.init()
+    assert excinfo.value.code == SignerErrorCode.REMOTE_API_ERROR
+
+
+@respx.mock
+async def test_init_rejects_invalid_address() -> None:
+    mock_wallet_response("not-a-pubkey")
+    signer = make_signer()
+    with pytest.raises(SignerError) as excinfo:
+        await signer.init()
+    assert excinfo.value.code == SignerErrorCode.INVALID_PUBLIC_KEY
+
+
+@respx.mock
+async def test_init_api_error() -> None:
+    respx.get(WALLET_URL).mock(return_value=httpx.Response(401, json={"error": "unauthorized"}))
+    signer = make_signer()
+    with pytest.raises(SignerError) as excinfo:
+        await signer.init()
+    assert excinfo.value.code == SignerErrorCode.REMOTE_API_ERROR
+
+
+def test_uninitialized_signer_raises_not_initialized() -> None:
+    signer = make_signer()
+    with pytest.raises(SignerError) as excinfo:
+        _ = signer.pubkey
+    assert excinfo.value.code == SignerErrorCode.NOT_INITIALIZED
+
+
+async def test_uninitialized_sign_raises_not_initialized() -> None:
+    signer = make_signer()
+    with pytest.raises(SignerError) as excinfo:
+        await signer.sign_message(b"hello")
+    assert excinfo.value.code == SignerErrorCode.NOT_INITIALIZED
+
+
+async def test_uninitialized_is_available_false() -> None:
+    assert not await make_signer().is_available()
+
+
+@respx.mock
+async def test_sign_message_success() -> None:
+    keypair = Keypair()
+    message = b"privy-message"
+    signature = keypair.sign_message(message)
+    signer = await initialized_signer(keypair)
+    mock_sign_response(base64.b64encode(bytes(signature)).decode())
+
+    result = await signer.sign_message(message)
+
+    assert result == signature
+    request = respx.calls.last.request
+    assert "privy-authorization-signature" not in request.headers
+    parsed = json.loads(request.content)
+    assert parsed == {
+        "method": "signMessage",
+        "chain_type": "solana",
+        "params": {"message": base64.b64encode(message).decode(), "encoding": "base64"},
+    }
+
+
+@respx.mock
+async def test_sign_message_with_authorization_context() -> None:
+    keypair = Keypair()
+    message = b"privy-message"
+    signature = keypair.sign_message(message)
+    context = PrivyAuthorizationContext(
+        authorization_private_keys=[f"wallet-auth:{TEST_P256_PKCS8_BASE64}"]
+    )
+    signer = await initialized_signer(keypair, context)
+    mock_sign_response(base64.b64encode(bytes(signature)).decode())
+
+    result = await signer.sign_message(message)
+
+    assert result == signature
+    request = respx.calls.last.request
+    expiry = request.headers["privy-request-expiry"]
+    payload = format_authorization_signature_payload(
+        {
+            "version": 1,
+            "method": "POST",
+            "url": RPC_URL,
+            "body": json.loads(request.content),
+            "headers": {"privy-app-id": APP_ID, "privy-request-expiry": expiry},
+        }
+    )
+    private_key = load_pem_private_key(TEST_P256_PKCS8_PEM.encode(), password=None)
+    assert isinstance(private_key, ec.EllipticCurvePrivateKey)
+    private_key.public_key().verify(
+        base64.b64decode(request.headers["privy-authorization-signature"]),
+        payload,
+        ec.ECDSA(hashes.SHA256()),
+    )
+
+
+@respx.mock
+async def test_sign_message_omits_expiry_when_disabled() -> None:
+    keypair = Keypair()
+    message = b"privy-message"
+    signature = keypair.sign_message(message)
+    context = PrivyAuthorizationContext(
+        authorization_private_keys=[f"wallet-auth:{TEST_P256_PKCS8_BASE64}"]
+    )
+    mock_wallet_response(str(keypair.pubkey()))
+    signer = make_signer(context, authorization_request_expiry_ms=None)
+    await signer.init()
+    mock_sign_response(base64.b64encode(bytes(signature)).decode())
+
+    await signer.sign_message(message)
+
+    request = respx.calls.last.request
+    assert "privy-request-expiry" not in request.headers
+    assert "privy-authorization-signature" in request.headers
+
+
+@respx.mock
+async def test_empty_authorization_context_is_config_error() -> None:
+    keypair = Keypair()
+    signer = await initialized_signer(keypair, PrivyAuthorizationContext())
+    with pytest.raises(SignerError) as excinfo:
+        await signer.sign_message(b"hello")
+    assert excinfo.value.code == SignerErrorCode.CONFIG_ERROR
+
+
+@respx.mock
+async def test_sign_message_undecodable_signature() -> None:
+    keypair = Keypair()
+    signer = await initialized_signer(keypair)
+    mock_sign_response("!!!not-base64!!!")
+    with pytest.raises(SignerError) as excinfo:
+        await signer.sign_message(b"hello")
+    assert excinfo.value.code == SignerErrorCode.SERIALIZATION_ERROR
+
+
+@respx.mock
+async def test_sign_message_signature_verification_failure() -> None:
+    keypair = Keypair()
+    other = Keypair()
+    message = b"privy-message"
+    signer = await initialized_signer(keypair)
+    mock_sign_response(base64.b64encode(bytes(other.sign_message(message))).decode())
+    with pytest.raises(SignerError) as excinfo:
+        await signer.sign_message(message)
+    assert excinfo.value.code == SignerErrorCode.SIGNING_FAILED
+
+
+@respx.mock
+async def test_sign_message_api_error() -> None:
+    keypair = Keypair()
+    signer = await initialized_signer(keypair)
+    respx.post(RPC_URL).mock(return_value=httpx.Response(500, json={"error": "boom"}))
+    with pytest.raises(SignerError) as excinfo:
+        await signer.sign_message(b"hello")
+    assert excinfo.value.code == SignerErrorCode.REMOTE_API_ERROR
+
+
+@respx.mock
+async def test_sign_transaction_success() -> None:
+    keypair = Keypair()
+    signer = await initialized_signer(keypair)
+    transaction = create_test_transaction(keypair.pubkey())
+    signature = keypair.sign_message(transaction.message_data())
+    mock_sign_response(base64.b64encode(bytes(signature)).decode())
+
+    result = await signer.sign_transaction(transaction)
+
+    assert result.is_complete
+    assert result.signature == signature
+    assert list(transaction.signatures) == [signature]
+
+
+@respx.mock
+async def test_is_available_true_when_wallet_matches() -> None:
+    keypair = Keypair()
+    signer = await initialized_signer(keypair)
+    assert await signer.is_available()
+
+
+@respx.mock
+async def test_is_available_false_when_wallet_changed() -> None:
+    keypair = Keypair()
+    signer = await initialized_signer(keypair)
+    mock_wallet_response(str(Keypair().pubkey()))
+    assert not await signer.is_available()
+
+
+@respx.mock
+async def test_is_available_false_on_api_error() -> None:
+    keypair = Keypair()
+    signer = await initialized_signer(keypair)
+    respx.get(WALLET_URL).mock(return_value=httpx.Response(403, json={"error": "forbidden"}))
+    assert not await signer.is_available()
+
+
+@respx.mock
+async def test_create_privy_signer_factory_initializes() -> None:
+    keypair = Keypair()
+    mock_wallet_response(str(keypair.pubkey()))
+    signer = await create_privy_signer(
+        PrivySignerConfig(
+            app_id=APP_ID,
+            app_secret=APP_SECRET,
+            wallet_id=WALLET_ID,
+            api_base_url=API_BASE_URL,
+        )
+    )
+    assert signer.pubkey == keypair.pubkey()
+
+
+def test_reprs_never_contain_app_secret() -> None:
+    config = PrivySignerConfig(
+        app_id=APP_ID, app_secret=APP_SECRET, wallet_id=WALLET_ID, api_base_url=API_BASE_URL
+    )
+    signer = make_signer()
+    assert APP_SECRET not in repr(config)
+    assert APP_SECRET not in repr(signer)
+    assert repr(signer) == "PrivySigner(pubkey=None)"
+
+
+def test_non_https_base_url_rejected() -> None:
+    with pytest.raises(SignerError) as excinfo:
+        PrivySigner(
+            PrivySignerConfig(
+                app_id=APP_ID,
+                app_secret=APP_SECRET,
+                wallet_id=WALLET_ID,
+                api_base_url="http://privy.example.com",
+            )
+        )
+    assert excinfo.value.code == SignerErrorCode.CONFIG_ERROR


### PR DESCRIPTION
## Summary
- Adds the **Privy** backend (`solana_keychain.privy`). Stacked on #213 — this layer shows only the Privy work.
- **Init-required backend**: the wallet lookup resolves the pubkey during `init()` (the `create_privy_signer` factory awaits it), guards `chain_type == solana`, and validates the returned address. Signing/`pubkey` before init raise `SIGNER_NOT_INITIALIZED`; `is_available()` re-fetches the wallet and compares pubkeys.
- **Auth**: every request carries `Authorization: Basic b64(app_id:app_secret)` + `privy-app-id`.
- **Wallet-authorization signatures** (optional): P-256 ECDSA (SHA-256, DER, base64) over a canonical JSON payload — recursively sorted keys, compact separators, empty body object serialized as `""` — of `{version, method, url, body, headers}`. Supports base64-PKCS8 keys (`wallet-auth:`/`wallet-api:` prefixes, PEM with escaped newlines), precomputed signatures, external sign callables, and a per-request context provider; signature order is preserved. `privy-request-expiry` defaults to a 15-minute window, customizable or omissible (`None`).
- Signing: `signMessage` RPC with base64 payload; returned signatures base64-decoded, parsed, and verified against the wallet pubkey. `cryptography` behind the `[privy]` extra.

## Test Plan
- 192 tests pass (28 new): canonical-payload golden literal, authorization signatures cryptographically verified (unit + end-to-end against the captured request/expiry header), signature-order preservation, invalid-key redaction across all output channels, chain-type guard, invalid address, not-initialized paths (pubkey/sign/is_available), expiry omission, empty-context `CONFIG_ERROR`, verification failure, API errors, wallet-changed availability, factory init, Basic-auth header assertion, repr redaction, HTTPS enforcement
- `ruff` + `mypy --strict` + sdist/wheel build clean

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
