### PR TITLE
feat(python): Para signer backend

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -27,7 +27,7 @@ library offers a consistent API across all signing methods.
 | **Fireblocks** | Fireblocks institutional custody platform | — | Planned |
 | **GCP KMS** | Google Cloud Key Management Service with Ed25519 signing | `solana_keychain.gcp_kms` | ✅ Available |
 | **Dfns** | Dfns wallet infrastructure with Ed25519 signing | — | Planned |
-| **Para** | MPC wallets with Para infrastructure | — | Planned |
+| **Para** | MPC wallets with Para infrastructure | `solana_keychain.para` | ✅ Available |
 | **CDP** | Coinbase Developer Platform managed wallets | — | Planned |
 | **Crossmint** | Crossmint managed wallets | — | Planned |
 | **Openfort** | Openfort backend wallets with TEE-stored keys | — | Planned |

--- a/python/src/solana_keychain/__init__.py
+++ b/python/src/solana_keychain/__init__.py
@@ -5,16 +5,20 @@ from solana_keychain.core import (
     SolanaSigner,
 )
 from solana_keychain.memory import MemorySigner, MemorySignerConfig
+from solana_keychain.para import ParaSigner, ParaSignerConfig, create_para_signer
 from solana_keychain.vault import VaultSigner, VaultSignerConfig, create_vault_signer
 
 __all__ = [
     "MemorySigner",
     "MemorySignerConfig",
+    "ParaSigner",
+    "ParaSignerConfig",
     "SignedTransaction",
     "SignerError",
     "SignerErrorCode",
     "SolanaSigner",
     "VaultSigner",
     "VaultSignerConfig",
+    "create_para_signer",
     "create_vault_signer",
 ]

--- a/python/src/solana_keychain/para/__init__.py
+++ b/python/src/solana_keychain/para/__init__.py
@@ -1,0 +1,3 @@
+from solana_keychain.para.signer import ParaSigner, ParaSignerConfig, create_para_signer
+
+__all__ = ["ParaSigner", "ParaSignerConfig", "create_para_signer"]

--- a/python/src/solana_keychain/para/signer.py
+++ b/python/src/solana_keychain/para/signer.py
@@ -187,7 +187,9 @@ class ParaSigner(SolanaSigner):
         if frequent checks are needed."""
         try:
             wallet = await asyncio.wait_for(self._fetch_wallet(), AVAILABILITY_TIMEOUT_SECONDS)
-        except (SignerError, TimeoutError):
+        except (SignerError, asyncio.TimeoutError):
+            # asyncio.TimeoutError: on 3.10 wait_for raises this distinct class;
+            # from 3.11 it aliases the builtin, so one except covers both.
             return False
         wallet_type = str(wallet.get("type", ""))
         status = str(wallet.get("status", ""))

--- a/python/src/solana_keychain/para/signer.py
+++ b/python/src/solana_keychain/para/signer.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import logging
+import re
 from dataclasses import dataclass, field
 from urllib.parse import quote
 
@@ -28,13 +29,16 @@ SIGNATURE_HEX_LENGTH = 128
 _logger = logging.getLogger("solana_keychain")
 
 
+# uuid.UUID is too lenient here: it strips dashes anywhere before parsing, so a
+# 36-char id with misplaced dashes would be accepted. The API requires the
+# canonical dashed form.
+_CANONICAL_UUID = re.compile(
+    r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"
+)
+
+
 def _is_valid_uuid(value: str) -> bool:
-    if len(value) != 36:
-        return False
-    if any(value[position] != "-" for position in (8, 13, 18, 23)):
-        return False
-    hex_chars = value.replace("-", "")
-    return len(hex_chars) == 32 and all(c in "0123456789abcdefABCDEF" for c in hex_chars)
+    return _CANONICAL_UUID.fullmatch(value) is not None
 
 
 @dataclass

--- a/python/src/solana_keychain/para/signer.py
+++ b/python/src/solana_keychain/para/signer.py
@@ -1,0 +1,201 @@
+"""Para API signer integration."""
+
+import asyncio
+import logging
+from dataclasses import dataclass, field
+from urllib.parse import quote
+
+import httpx
+from solders.pubkey import Pubkey
+from solders.signature import Signature
+from solders.transaction import Transaction
+
+from solana_keychain.core.errors import SignerError, SignerErrorCode
+from solana_keychain.core.http import assert_https_url, fetch_signer_json, normalize_base_url
+from solana_keychain.core.signer import SignedTransaction, SolanaSigner
+from solana_keychain.core.transaction_util import (
+    add_signature_to_transaction,
+    classify_signed_transaction,
+    serialize_transaction,
+)
+
+DEFAULT_API_BASE_URL = "https://api.getpara.com"
+REQUEST_TIMEOUT_SECONDS = 30.0
+AVAILABILITY_TIMEOUT_SECONDS = 5.0
+
+SIGNATURE_HEX_LENGTH = 128
+
+_logger = logging.getLogger("solana_keychain")
+
+
+def _is_valid_uuid(value: str) -> bool:
+    if len(value) != 36:
+        return False
+    if any(value[position] != "-" for position in (8, 13, 18, 23)):
+        return False
+    hex_chars = value.replace("-", "")
+    return len(hex_chars) == 32 and all(c in "0123456789abcdefABCDEF" for c in hex_chars)
+
+
+@dataclass
+class ParaSignerConfig:
+    """Configuration for a Para signer.
+
+    ``api_key`` must be a Para secret key (``sk_`` prefix); ``wallet_id`` must be a
+    canonical dashed UUID.
+    """
+
+    api_key: str = field(repr=False)
+    wallet_id: str
+    api_base_url: str = DEFAULT_API_BASE_URL
+    http_client: httpx.AsyncClient | None = field(default=None, repr=False)
+
+
+class ParaSigner(SolanaSigner):
+    """Signer backed by a Para-held wallet.
+
+    ``init()`` must be awaited before use — it resolves the wallet's public key.
+    ``create_para_signer()`` does this for you.
+    """
+
+    def __init__(self, config: ParaSignerConfig) -> None:
+        if not config.api_key or not config.wallet_id:
+            raise SignerError(
+                SignerErrorCode.CONFIG_ERROR, "api_key and wallet_id must not be empty"
+            )
+        if not config.api_key.startswith("sk_"):
+            raise SignerError(
+                SignerErrorCode.CONFIG_ERROR, "api_key must be a Para secret key (starts with sk_)"
+            )
+        if not _is_valid_uuid(config.wallet_id):
+            raise SignerError(SignerErrorCode.CONFIG_ERROR, "wallet_id must be a valid UUID")
+        api_base_url = normalize_base_url(config.api_base_url)
+        assert_https_url(api_base_url, "api_base_url")
+        self._api_base_url = api_base_url
+        self._api_key = config.api_key
+        self._wallet_id = config.wallet_id
+        self._http_client = config.http_client
+        self._public_key: Pubkey | None = None
+
+    def __repr__(self) -> str:
+        return f"ParaSigner(pubkey={self._public_key})"
+
+    async def init(self) -> None:
+        """Resolve the wallet's public key. Must be awaited before signing."""
+        wallet = await self._fetch_wallet()
+        wallet_type = str(wallet.get("type", ""))
+        if wallet_type.upper() != "SOLANA":
+            raise SignerError(
+                SignerErrorCode.CONFIG_ERROR, f"Expected SOLANA wallet, got: {wallet_type}"
+            )
+        status = str(wallet.get("status", ""))
+        if status.upper() not in ("ACTIVE", "READY"):
+            _logger.warning("Para wallet status is %r — signing may fail", status)
+        address = wallet.get("address")
+        if not isinstance(address, str) or not address:
+            raise SignerError(
+                SignerErrorCode.CONFIG_ERROR,
+                "Wallet does not have an address (may still be creating)",
+            )
+        try:
+            self._public_key = Pubkey.from_string(address)
+        except Exception:
+            raise SignerError(
+                SignerErrorCode.INVALID_PUBLIC_KEY, "Invalid Solana public key from Para API"
+            ) from None
+
+    def _initialized_pubkey(self) -> Pubkey:
+        if self._public_key is None:
+            raise SignerError(
+                SignerErrorCode.NOT_INITIALIZED,
+                "ParaSigner is not initialized; call init() before signing",
+            )
+        return self._public_key
+
+    @property
+    def pubkey(self) -> Pubkey:
+        return self._initialized_pubkey()
+
+    async def _fetch_wallet(self) -> dict[str, object]:
+        url = f"{self._api_base_url}/v1/wallets/{quote(self._wallet_id, safe='')}"
+        wallet = await fetch_signer_json(
+            url=url,
+            provider_name="Para",
+            headers={"X-API-Key": self._api_key},
+            timeout_seconds=REQUEST_TIMEOUT_SECONDS,
+            client=self._http_client,
+        )
+        if not isinstance(wallet, dict):
+            raise SignerError(SignerErrorCode.REMOTE_API_ERROR, "Invalid Para wallet response")
+        return wallet
+
+    @staticmethod
+    def _decode_hex_signature(hex_signature: str) -> Signature:
+        stripped = hex_signature.removeprefix("0x")
+        if len(stripped) != SIGNATURE_HEX_LENGTH:
+            raise SignerError(
+                SignerErrorCode.SIGNING_FAILED,
+                f"Expected {SIGNATURE_HEX_LENGTH} hex chars (64 bytes), got {len(stripped)} chars",
+            )
+        try:
+            signature_bytes = bytes.fromhex(stripped)
+        except ValueError:
+            raise SignerError(
+                SignerErrorCode.SIGNING_FAILED, "Failed to decode hex signature"
+            ) from None
+        try:
+            return Signature.from_bytes(signature_bytes)
+        except Exception:
+            raise SignerError(SignerErrorCode.SIGNING_FAILED, "Failed to parse signature") from None
+
+    async def _sign_bytes(self, data: bytes) -> Signature:
+        public_key = self._initialized_pubkey()
+        url = f"{self._api_base_url}/v1/wallets/{quote(self._wallet_id, safe='')}/sign-raw"
+        response = await fetch_signer_json(
+            url=url,
+            provider_name="Para",
+            method="POST",
+            headers={"X-API-Key": self._api_key},
+            json_body={"data": data.hex(), "encoding": "hex"},
+            timeout_seconds=REQUEST_TIMEOUT_SECONDS,
+            client=self._http_client,
+        )
+        hex_signature = response.get("signature") if isinstance(response, dict) else None
+        if not isinstance(hex_signature, str):
+            raise SignerError(SignerErrorCode.SIGNING_FAILED, "Missing signature in response")
+        signature = self._decode_hex_signature(hex_signature)
+        if not signature.verify(public_key, data):
+            raise SignerError(
+                SignerErrorCode.SIGNING_FAILED,
+                "Signature verification failed — the returned signature does not match "
+                "the public key",
+            )
+        return signature
+
+    async def sign_transaction(self, transaction: Transaction) -> SignedTransaction:
+        signature = await self._sign_bytes(transaction.message_data())
+        add_signature_to_transaction(transaction, self._initialized_pubkey(), signature)
+        return classify_signed_transaction(
+            transaction, serialize_transaction(transaction), signature
+        )
+
+    async def sign_message(self, message: bytes) -> Signature:
+        return await self._sign_bytes(message)
+
+    async def is_available(self) -> bool:
+        """Availability makes a network call bounded to 5 seconds; cache the result
+        if frequent checks are needed."""
+        try:
+            wallet = await asyncio.wait_for(self._fetch_wallet(), AVAILABILITY_TIMEOUT_SECONDS)
+        except (SignerError, TimeoutError):
+            return False
+        wallet_type = str(wallet.get("type", ""))
+        status = str(wallet.get("status", ""))
+        return wallet_type.upper() == "SOLANA" and status.upper() in ("ACTIVE", "READY")
+
+
+async def create_para_signer(config: ParaSignerConfig) -> ParaSigner:
+    """Create a ready-to-use Para signer (awaits ``init()``)."""
+    signer = ParaSigner(config)
+    await signer.init()
+    return signer

--- a/python/tests/test_para_signer.py
+++ b/python/tests/test_para_signer.py
@@ -1,0 +1,297 @@
+import asyncio
+import json
+import logging
+from typing import Any
+
+import httpx
+import pytest
+import respx
+from solders.keypair import Keypair
+
+from solana_keychain import ParaSigner, ParaSignerConfig, SignerError, SignerErrorCode
+from solana_keychain.para import create_para_signer
+from tests.util import create_test_transaction
+
+API_BASE_URL = "https://para.example.com"
+API_KEY = "sk_test-key"
+WALLET_ID = "12345678-1234-1234-1234-123456789abc"
+WALLET_URL = f"{API_BASE_URL}/v1/wallets/{WALLET_ID}"
+SIGN_URL = f"{API_BASE_URL}/v1/wallets/{WALLET_ID}/sign-raw"
+
+
+def make_signer() -> ParaSigner:
+    return ParaSigner(
+        ParaSignerConfig(api_key=API_KEY, wallet_id=WALLET_ID, api_base_url=API_BASE_URL)
+    )
+
+
+def mock_wallet_response(
+    address: str | None, wallet_type: str = "SOLANA", status: str = "ACTIVE"
+) -> None:
+    body: dict[str, Any] = {"id": WALLET_ID, "type": wallet_type, "status": status}
+    if address is not None:
+        body["address"] = address
+    respx.get(WALLET_URL).mock(return_value=httpx.Response(200, json=body))
+
+
+def mock_sign_response(hex_signature: str) -> None:
+    respx.post(SIGN_URL).mock(return_value=httpx.Response(200, json={"signature": hex_signature}))
+
+
+async def initialized_signer(keypair: Keypair) -> ParaSigner:
+    mock_wallet_response(str(keypair.pubkey()))
+    signer = make_signer()
+    await signer.init()
+    return signer
+
+
+@pytest.mark.parametrize(
+    ("api_key", "wallet_id"),
+    [
+        ("bad-key", WALLET_ID),
+        ("sk_test-key", "not-a-uuid"),
+        ("", WALLET_ID),
+        ("sk_test-key", ""),
+        ("sk_test-key", "12345678-1234-1234-1234-123456789abg"),
+        ("sk_test-key", "123456781234-1234-1234-123456789abcd"),
+    ],
+)
+def test_invalid_config_rejected(api_key: str, wallet_id: str) -> None:
+    with pytest.raises(SignerError) as excinfo:
+        ParaSigner(
+            ParaSignerConfig(api_key=api_key, wallet_id=wallet_id, api_base_url=API_BASE_URL)
+        )
+    assert excinfo.value.code == SignerErrorCode.CONFIG_ERROR
+
+
+def test_non_https_base_url_rejected() -> None:
+    with pytest.raises(SignerError) as excinfo:
+        ParaSigner(
+            ParaSignerConfig(
+                api_key=API_KEY, wallet_id=WALLET_ID, api_base_url="http://para.example.com"
+            )
+        )
+    assert excinfo.value.code == SignerErrorCode.CONFIG_ERROR
+
+
+def test_reprs_never_contain_api_key() -> None:
+    config = ParaSignerConfig(api_key=API_KEY, wallet_id=WALLET_ID, api_base_url=API_BASE_URL)
+    signer = make_signer()
+    assert API_KEY not in repr(config)
+    assert API_KEY not in repr(signer)
+    assert repr(signer) == "ParaSigner(pubkey=None)"
+
+
+@respx.mock
+async def test_init_resolves_wallet_pubkey() -> None:
+    keypair = Keypair()
+    signer = await initialized_signer(keypair)
+    assert signer.pubkey == keypair.pubkey()
+    assert respx.calls.last.request.headers["X-API-Key"] == API_KEY
+
+
+@respx.mock
+async def test_init_rejects_non_solana_wallet() -> None:
+    mock_wallet_response("0xabc", wallet_type="ETHEREUM")
+    signer = make_signer()
+    with pytest.raises(SignerError) as excinfo:
+        await signer.init()
+    assert excinfo.value.code == SignerErrorCode.CONFIG_ERROR
+
+
+@respx.mock
+async def test_init_accepts_lowercase_wallet_type() -> None:
+    keypair = Keypair()
+    mock_wallet_response(str(keypair.pubkey()), wallet_type="solana")
+    signer = make_signer()
+    await signer.init()
+    assert signer.pubkey == keypair.pubkey()
+
+
+@respx.mock
+async def test_init_warns_on_unusual_status(caplog: pytest.LogCaptureFixture) -> None:
+    keypair = Keypair()
+    mock_wallet_response(str(keypair.pubkey()), status="CREATING")
+    signer = make_signer()
+    with caplog.at_level(logging.WARNING, logger="solana_keychain"):
+        await signer.init()
+    assert any("signing may fail" in record.message for record in caplog.records)
+
+
+@respx.mock
+async def test_init_rejects_missing_address() -> None:
+    mock_wallet_response(None)
+    signer = make_signer()
+    with pytest.raises(SignerError) as excinfo:
+        await signer.init()
+    assert excinfo.value.code == SignerErrorCode.CONFIG_ERROR
+
+
+@respx.mock
+async def test_init_rejects_invalid_address() -> None:
+    mock_wallet_response("not-a-pubkey")
+    signer = make_signer()
+    with pytest.raises(SignerError) as excinfo:
+        await signer.init()
+    assert excinfo.value.code == SignerErrorCode.INVALID_PUBLIC_KEY
+
+
+@respx.mock
+async def test_init_api_error() -> None:
+    respx.get(WALLET_URL).mock(return_value=httpx.Response(401, json={"error": "unauthorized"}))
+    signer = make_signer()
+    with pytest.raises(SignerError) as excinfo:
+        await signer.init()
+    assert excinfo.value.code == SignerErrorCode.REMOTE_API_ERROR
+
+
+async def test_uninitialized_sign_raises_not_initialized() -> None:
+    signer = make_signer()
+    with pytest.raises(SignerError) as excinfo:
+        await signer.sign_message(b"hello")
+    assert excinfo.value.code == SignerErrorCode.NOT_INITIALIZED
+
+
+@respx.mock
+async def test_sign_message_success() -> None:
+    keypair = Keypair()
+    message = b"para-message"
+    signature = keypair.sign_message(message)
+    signer = await initialized_signer(keypair)
+    mock_sign_response(bytes(signature).hex())
+
+    result = await signer.sign_message(message)
+
+    assert result == signature
+    parsed = json.loads(respx.calls.last.request.content)
+    assert parsed == {"data": message.hex(), "encoding": "hex"}
+
+
+@respx.mock
+async def test_sign_message_accepts_0x_prefixed_signature() -> None:
+    keypair = Keypair()
+    message = b"para-message"
+    signature = keypair.sign_message(message)
+    signer = await initialized_signer(keypair)
+    mock_sign_response(f"0x{bytes(signature).hex()}")
+
+    assert await signer.sign_message(message) == signature
+
+
+@respx.mock
+async def test_sign_message_missing_signature() -> None:
+    keypair = Keypair()
+    signer = await initialized_signer(keypair)
+    respx.post(SIGN_URL).mock(return_value=httpx.Response(200, json={}))
+    with pytest.raises(SignerError) as excinfo:
+        await signer.sign_message(b"hello")
+    assert excinfo.value.code == SignerErrorCode.SIGNING_FAILED
+
+
+@respx.mock
+async def test_sign_message_wrong_length_signature() -> None:
+    keypair = Keypair()
+    signer = await initialized_signer(keypair)
+    mock_sign_response("ab" * 32)
+    with pytest.raises(SignerError) as excinfo:
+        await signer.sign_message(b"hello")
+    assert excinfo.value.code == SignerErrorCode.SIGNING_FAILED
+
+
+@respx.mock
+async def test_sign_message_undecodable_signature() -> None:
+    keypair = Keypair()
+    signer = await initialized_signer(keypair)
+    mock_sign_response("zz" * 64)
+    with pytest.raises(SignerError) as excinfo:
+        await signer.sign_message(b"hello")
+    assert excinfo.value.code == SignerErrorCode.SIGNING_FAILED
+
+
+@respx.mock
+async def test_sign_message_signature_verification_failure() -> None:
+    keypair = Keypair()
+    other = Keypair()
+    message = b"para-message"
+    signer = await initialized_signer(keypair)
+    mock_sign_response(bytes(other.sign_message(message)).hex())
+    with pytest.raises(SignerError) as excinfo:
+        await signer.sign_message(message)
+    assert excinfo.value.code == SignerErrorCode.SIGNING_FAILED
+
+
+@respx.mock
+async def test_sign_message_api_error() -> None:
+    keypair = Keypair()
+    signer = await initialized_signer(keypair)
+    respx.post(SIGN_URL).mock(return_value=httpx.Response(500, json={"error": "boom"}))
+    with pytest.raises(SignerError) as excinfo:
+        await signer.sign_message(b"hello")
+    assert excinfo.value.code == SignerErrorCode.REMOTE_API_ERROR
+
+
+@respx.mock
+async def test_sign_transaction_success() -> None:
+    keypair = Keypair()
+    signer = await initialized_signer(keypair)
+    transaction = create_test_transaction(keypair.pubkey())
+    signature = keypair.sign_message(transaction.message_data())
+    mock_sign_response(bytes(signature).hex())
+
+    result = await signer.sign_transaction(transaction)
+
+    assert result.is_complete
+    assert result.signature == signature
+    assert list(transaction.signatures) == [signature]
+
+
+@respx.mock
+@pytest.mark.parametrize(
+    ("wallet_type", "status", "expected"),
+    [
+        ("SOLANA", "ACTIVE", True),
+        ("SOLANA", "READY", True),
+        ("solana", "ready", True),
+        ("ETHEREUM", "ACTIVE", False),
+        ("SOLANA", "CREATING", False),
+    ],
+)
+async def test_is_available_gates_type_and_status(
+    wallet_type: str, status: str, expected: bool
+) -> None:
+    keypair = Keypair()
+    signer = await initialized_signer(keypair)
+    mock_wallet_response(str(keypair.pubkey()), wallet_type=wallet_type, status=status)
+    assert await signer.is_available() is expected
+
+
+@respx.mock
+async def test_is_available_false_on_api_error() -> None:
+    keypair = Keypair()
+    signer = await initialized_signer(keypair)
+    respx.get(WALLET_URL).mock(return_value=httpx.Response(403, json={"error": "forbidden"}))
+    assert not await signer.is_available()
+
+
+@respx.mock
+async def test_is_available_false_on_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    keypair = Keypair()
+    signer = await initialized_signer(keypair)
+    monkeypatch.setattr("solana_keychain.para.signer.AVAILABILITY_TIMEOUT_SECONDS", 0.05)
+
+    async def slow_response(_request: httpx.Request) -> httpx.Response:
+        await asyncio.sleep(0.5)
+        return httpx.Response(200, json={})
+
+    respx.get(WALLET_URL).mock(side_effect=slow_response)
+    assert not await signer.is_available()
+
+
+@respx.mock
+async def test_create_para_signer_factory_initializes() -> None:
+    keypair = Keypair()
+    mock_wallet_response(str(keypair.pubkey()))
+    signer = await create_para_signer(
+        ParaSignerConfig(api_key=API_KEY, wallet_id=WALLET_ID, api_base_url=API_BASE_URL)
+    )
+    assert signer.pubkey == keypair.pubkey()


### PR DESCRIPTION
## Summary
- Adds the **Para** backend (`solana_keychain.para`). Stacked on #214 — this layer shows only the Para work.
- **Construction validation**: `api_key` must carry the `sk_` secret-key prefix, `wallet_id` must be a canonical dashed UUID (8-4-4-4-12), base URL HTTPS-enforced — all `SIGNER_CONFIG_ERROR` before any network call.
- **Init-required**: `init()` (awaited by `create_para_signer`) fetches the wallet with `X-API-Key`, requires `type == SOLANA` (case-insensitive), warns when status isn't `ACTIVE`/`READY`, and resolves the address into the pubkey. Pre-init signing raises `SIGNER_NOT_INITIALIZED`.
- **Signing**: `sign-raw` with hex-encoded data; responses accept optional `0x` prefixes and must decode to exactly 64 bytes; signatures verified locally against the wallet pubkey.
- **Availability**: wallet fetch bounded to 5 seconds (`asyncio.wait_for`), gating on wallet type and `ACTIVE`/`READY` status.
- Pure-httpx backend — no optional extra; exported from the package root like memory/vault. Requests use a 30s timeout.

## Test Plan
- 224 tests pass (32 new): config validation matrix (prefix, UUID shapes, empties, HTTP URL), wallet-type gate incl. case-insensitivity, status warning, missing/invalid address, `0x`-prefixed signatures, wrong-length/undecodable signatures, verification failure, API errors, availability matrix (type/status combinations), real timeout path (patched window + slow mock), not-initialized paths, factory init, repr redaction
- `ruff` + `mypy --strict` + sdist/wheel build clean

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
