### PR TITLE
feat(python): Fireblocks signer backend

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -24,7 +24,7 @@ library offers a consistent API across all signing methods.
 | **Privy** | Embedded wallets with Privy infrastructure | `solana_keychain.privy` | ✅ Available |
 | **Turnkey** | Non-custodial key management via Turnkey | `solana_keychain.turnkey` | ✅ Available |
 | **AWS KMS** | AWS Key Management Service with Ed25519 signing | `solana_keychain.aws_kms` | ✅ Available |
-| **Fireblocks** | Fireblocks institutional custody platform | — | Planned |
+| **Fireblocks** | Fireblocks institutional custody platform | `solana_keychain.fireblocks` | ✅ Available |
 | **GCP KMS** | Google Cloud Key Management Service with Ed25519 signing | `solana_keychain.gcp_kms` | ✅ Available |
 | **Dfns** | Dfns wallet infrastructure with Ed25519 signing | — | Planned |
 | **Para** | MPC wallets with Para infrastructure | `solana_keychain.para` | ✅ Available |
@@ -38,6 +38,7 @@ library offers a consistent API across all signing methods.
 ```bash
 pip install solana-keychain              # memory + vault
 pip install 'solana-keychain[aws-kms]'   # adds the AWS KMS backend
+pip install 'solana-keychain[fireblocks]' # adds the Fireblocks backend
 pip install 'solana-keychain[gcp-kms]'   # adds the GCP KMS backend
 pip install 'solana-keychain[privy]'     # adds the Privy backend
 pip install 'solana-keychain[turnkey]'   # adds the Turnkey backend

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -18,6 +18,7 @@ Repository = "https://github.com/solana-foundation/solana-keychain"
 
 [project.optional-dependencies]
 aws-kms = ["boto3>=1.35"]
+fireblocks = ["cryptography>=43", "pyjwt>=2.8"]
 gcp-kms = ["google-cloud-kms>=2.24"]
 privy = ["cryptography>=43"]
 turnkey = ["cryptography>=43"]
@@ -26,6 +27,7 @@ dev = [
     "build>=1.2",
     "cryptography>=43",
     "google-cloud-kms>=2.24",
+    "pyjwt>=2.8",
     "mypy>=1.14",
     "pytest>=8.3",
     "pytest-asyncio>=0.25",

--- a/python/src/solana_keychain/fireblocks/__init__.py
+++ b/python/src/solana_keychain/fireblocks/__init__.py
@@ -1,0 +1,7 @@
+from solana_keychain.fireblocks.signer import (
+    FireblocksSigner,
+    FireblocksSignerConfig,
+    create_fireblocks_signer,
+)
+
+__all__ = ["FireblocksSigner", "FireblocksSignerConfig", "create_fireblocks_signer"]

--- a/python/src/solana_keychain/fireblocks/jwt.py
+++ b/python/src/solana_keychain/fireblocks/jwt.py
@@ -1,0 +1,53 @@
+"""Fireblocks JWT authentication helper."""
+
+import hashlib
+import time
+import uuid
+from typing import Any
+
+try:
+    import jwt as pyjwt
+    from cryptography.hazmat.primitives.asymmetric import rsa
+    from cryptography.hazmat.primitives.serialization import load_pem_private_key
+except ImportError as error:  # pragma: no cover
+    raise ImportError(
+        "solana_keychain.fireblocks requires the fireblocks extra: "
+        "pip install 'solana-keychain[fireblocks]'"
+    ) from error
+
+from solana_keychain.core.errors import SignerError, SignerErrorCode
+
+JWT_TTL_SECONDS = 120
+JWT_SKEW_LEEWAY_SECONDS = 60
+
+
+def parse_signing_key(private_key_pem: str) -> rsa.RSAPrivateKey:
+    """Parse the Fireblocks RSA private key once for token reuse."""
+    try:
+        key = load_pem_private_key(private_key_pem.encode(), password=None)
+    except Exception:
+        raise SignerError(SignerErrorCode.INVALID_PRIVATE_KEY, "Failed to parse RSA key") from None
+    if not isinstance(key, rsa.RSAPrivateKey):
+        raise SignerError(SignerErrorCode.INVALID_PRIVATE_KEY, "Failed to parse RSA key")
+    return key
+
+
+def create_jwt(api_key: str, signing_key: rsa.RSAPrivateKey, uri: str, body: str) -> str:
+    """Create an RS256 request JWT: ``uri``, a fresh nonce, an issued-at backdated by
+    the skew leeway, and ``bodyHash`` = SHA-256 hex of the exact request body (empty
+    string for GET requests)."""
+    now = int(time.time())
+    issued_at = now - JWT_SKEW_LEEWAY_SECONDS
+    claims: dict[str, Any] = {
+        "uri": uri,
+        "nonce": str(uuid.uuid4()),
+        "iat": issued_at,
+        "nbf": issued_at,
+        "exp": now + JWT_TTL_SECONDS,
+        "sub": api_key,
+        "bodyHash": hashlib.sha256(body.encode()).hexdigest(),
+    }
+    try:
+        return pyjwt.encode(claims, signing_key, algorithm="RS256")
+    except Exception:
+        raise SignerError(SignerErrorCode.SIGNING_FAILED, "Failed to create JWT") from None

--- a/python/src/solana_keychain/fireblocks/signer.py
+++ b/python/src/solana_keychain/fireblocks/signer.py
@@ -1,0 +1,259 @@
+"""Fireblocks API signer integration."""
+
+import asyncio
+import json
+from dataclasses import dataclass, field
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+from solders.pubkey import Pubkey
+from solders.signature import Signature
+from solders.transaction import Transaction
+
+from solana_keychain.core.errors import SignerError, SignerErrorCode
+from solana_keychain.core.http import assert_https_url, fetch_signer_json, normalize_base_url
+from solana_keychain.core.signer import SignedTransaction, SolanaSigner
+from solana_keychain.core.transaction_util import (
+    add_signature_to_transaction,
+    classify_signed_transaction,
+    serialize_transaction,
+)
+from solana_keychain.fireblocks.jwt import create_jwt, parse_signing_key
+
+DEFAULT_API_BASE_URL = "https://api.fireblocks.io"
+DEFAULT_ASSET_ID = "SOL"
+DEFAULT_POLL_INTERVAL_MS = 1000
+DEFAULT_MAX_POLL_ATTEMPTS = 300
+
+ED25519_SIGNATURE_LENGTH = 64
+
+_TERMINAL_FAILURE_STATUSES = frozenset({"FAILED", "CANCELLED", "REJECTED", "BLOCKED"})
+
+
+@dataclass
+class FireblocksSignerConfig:
+    """Configuration for a Fireblocks signer.
+
+    ``asset_id`` defaults to ``SOL`` (use ``SOL_TEST`` for devnet).
+
+    ``use_program_call`` is unsupported: PROGRAM_CALL signing broadcasts the
+    transaction on-chain and only returns a broadcast transaction id, not a
+    reusable signer-bound signature over the local message bytes — that violates
+    the signing contract and risks duplicate spends. Setting it to ``True`` makes
+    ``init()`` fail before any network call; the signer always uses RAW signing
+    (signs message bytes only; the caller broadcasts).
+    """
+
+    api_key: str = field(repr=False)
+    private_key_pem: str = field(repr=False)
+    vault_account_id: str
+    asset_id: str = DEFAULT_ASSET_ID
+    api_base_url: str = DEFAULT_API_BASE_URL
+    poll_interval_ms: int = DEFAULT_POLL_INTERVAL_MS
+    max_poll_attempts: int = DEFAULT_MAX_POLL_ATTEMPTS
+    use_program_call: bool = False
+    http_client: httpx.AsyncClient | None = field(default=None, repr=False)
+
+
+class FireblocksSigner(SolanaSigner):
+    """Signer backed by a Fireblocks vault account using RAW signing.
+
+    ``init()`` must be awaited before use — it resolves the vault's public key.
+    ``create_fireblocks_signer()`` does this for you.
+    """
+
+    def __init__(self, config: FireblocksSignerConfig) -> None:
+        api_base_url = normalize_base_url(config.api_base_url)
+        assert_https_url(api_base_url, "api_base_url")
+        self._api_base_url = api_base_url
+        self._api_key = config.api_key
+        self._private_key_pem = config.private_key_pem
+        self._signing_key = None
+        try:
+            self._signing_key = parse_signing_key(config.private_key_pem)
+        except SignerError:
+            pass
+        self._vault_account_id = config.vault_account_id
+        self._asset_id = config.asset_id
+        self._poll_interval_ms = config.poll_interval_ms
+        self._max_poll_attempts = config.max_poll_attempts
+        self._use_program_call = config.use_program_call
+        self._http_client = config.http_client
+        self._public_key: Pubkey | None = None
+
+    def __repr__(self) -> str:
+        return (
+            f"FireblocksSigner(pubkey={self._public_key}, "
+            f"vault_account_id={self._vault_account_id}, asset_id={self._asset_id})"
+        )
+
+    async def init(self) -> None:
+        """Resolve the vault's public key. Must be awaited before signing.
+
+        Fails fast when ``use_program_call`` is set — see the config docstring.
+        """
+        if self._use_program_call:
+            raise SignerError(
+                SignerErrorCode.CONFIG_ERROR,
+                "use_program_call (Fireblocks PROGRAM_CALL signing) is not supported: it "
+                "broadcasts the transaction on-chain without producing a reusable "
+                "signer-bound signature, which violates the signing contract and risks "
+                "duplicate spends. Use RAW signing (the default, omit use_program_call) "
+                "instead.",
+            )
+        self._public_key = await self._fetch_public_key()
+
+    def _initialized_pubkey(self) -> Pubkey:
+        if self._public_key is None:
+            raise SignerError(
+                SignerErrorCode.NOT_INITIALIZED,
+                "FireblocksSigner is not initialized; call init() before signing",
+            )
+        return self._public_key
+
+    @property
+    def pubkey(self) -> Pubkey:
+        return self._initialized_pubkey()
+
+    def _auth_headers(self, uri: str, body: str) -> dict[str, str]:
+        if self._signing_key is None:
+            raise SignerError(SignerErrorCode.INVALID_PRIVATE_KEY, "Failed to parse RSA key")
+        token = create_jwt(self._api_key, self._signing_key, uri, body)
+        return {"X-API-Key": self._api_key, "Authorization": f"Bearer {token}"}
+
+    async def _get_json(self, uri: str) -> Any:
+        return await fetch_signer_json(
+            url=f"{self._api_base_url}{uri}",
+            provider_name="Fireblocks",
+            headers=self._auth_headers(uri, ""),
+            client=self._http_client,
+        )
+
+    async def _fetch_public_key(self) -> Pubkey:
+        uri = (
+            f"/v1/vault/accounts/{quote(self._vault_account_id, safe='')}/"
+            f"{quote(self._asset_id, safe='')}/addresses_paginated"
+        )
+        response = await self._get_json(uri)
+        addresses = response.get("addresses") if isinstance(response, dict) else None
+        first = addresses[0] if isinstance(addresses, list) and addresses else None
+        address = first.get("address") if isinstance(first, dict) else None
+        if not isinstance(address, str):
+            raise SignerError(
+                SignerErrorCode.INVALID_PUBLIC_KEY, "Invalid public key from Fireblocks"
+            )
+        try:
+            return Pubkey.from_string(address)
+        except Exception:
+            raise SignerError(
+                SignerErrorCode.INVALID_PUBLIC_KEY, "Invalid public key from Fireblocks"
+            ) from None
+
+    async def _create_transaction(self, message: bytes) -> str:
+        uri = "/v1/transactions"
+        request = {
+            "assetId": self._asset_id,
+            "operation": "RAW",
+            "source": {"type": "VAULT_ACCOUNT", "id": self._vault_account_id},
+            "extraParameters": {"rawMessageData": {"messages": [{"content": message.hex()}]}},
+        }
+        body = json.dumps(request, separators=(",", ":"))
+        headers = self._auth_headers(uri, body)
+        headers["Content-Type"] = "application/json"
+        response = await fetch_signer_json(
+            url=f"{self._api_base_url}{uri}",
+            provider_name="Fireblocks",
+            method="POST",
+            headers=headers,
+            content=body.encode(),
+            client=self._http_client,
+        )
+        transaction_id = response.get("id") if isinstance(response, dict) else None
+        if not isinstance(transaction_id, str):
+            raise SignerError(SignerErrorCode.SERIALIZATION_ERROR, "Failed to parse response")
+        return transaction_id
+
+    async def _poll_for_signature(self, transaction_id: str) -> dict[str, Any]:
+        for _ in range(self._max_poll_attempts):
+            response = await self._get_json(f"/v1/transactions/{quote(transaction_id, safe='')}")
+            if not isinstance(response, dict):
+                raise SignerError(SignerErrorCode.SERIALIZATION_ERROR, "Failed to parse response")
+            status = response.get("status")
+            if status == "COMPLETED":
+                return response
+            if status in _TERMINAL_FAILURE_STATUSES:
+                raise SignerError(
+                    SignerErrorCode.SIGNING_FAILED, f"Transaction {status}: {transaction_id}"
+                )
+            await asyncio.sleep(self._poll_interval_ms / 1000)
+        raise SignerError(
+            SignerErrorCode.REMOTE_API_ERROR,
+            f"Transaction polling timeout after {self._max_poll_attempts} attempts - "
+            "signing request may still complete",
+        )
+
+    @staticmethod
+    def _extract_signature(response: dict[str, Any]) -> Signature:
+        signed_messages = response.get("signedMessages")
+        first = (
+            signed_messages[0] if isinstance(signed_messages, list) and signed_messages else None
+        )
+        signature_data = first.get("signature") if isinstance(first, dict) else None
+        full_sig = signature_data.get("fullSig") if isinstance(signature_data, dict) else None
+        if not isinstance(full_sig, str):
+            raise SignerError(
+                SignerErrorCode.SIGNING_FAILED,
+                "No reusable signature found in response (no signed_messages)",
+            )
+        try:
+            signature_bytes = bytes.fromhex(full_sig)
+        except ValueError:
+            raise SignerError(
+                SignerErrorCode.SERIALIZATION_ERROR, "Failed to decode hex signature"
+            ) from None
+        if len(signature_bytes) != ED25519_SIGNATURE_LENGTH:
+            raise SignerError(
+                SignerErrorCode.SIGNING_FAILED,
+                f"Invalid signature length (expected {ED25519_SIGNATURE_LENGTH} bytes)",
+            )
+        return Signature.from_bytes(signature_bytes)
+
+    async def _sign_bytes(self, message: bytes) -> Signature:
+        public_key = self._initialized_pubkey()
+        transaction_id = await self._create_transaction(message)
+        response = await self._poll_for_signature(transaction_id)
+        signature = self._extract_signature(response)
+        if not signature.verify(public_key, message):
+            raise SignerError(
+                SignerErrorCode.SIGNING_FAILED,
+                "Signature verification failed — the returned signature does not match "
+                "the public key",
+            )
+        return signature
+
+    async def sign_transaction(self, transaction: Transaction) -> SignedTransaction:
+        signature = await self._sign_bytes(transaction.message_data())
+        add_signature_to_transaction(transaction, self._initialized_pubkey(), signature)
+        return classify_signed_transaction(
+            transaction, serialize_transaction(transaction), signature
+        )
+
+    async def sign_message(self, message: bytes) -> Signature:
+        return await self._sign_bytes(message)
+
+    async def is_available(self) -> bool:
+        if self._public_key is None:
+            return False
+        try:
+            await self._get_json(f"/v1/vault/accounts/{quote(self._vault_account_id, safe='')}")
+        except SignerError:
+            return False
+        return True
+
+
+async def create_fireblocks_signer(config: FireblocksSignerConfig) -> FireblocksSigner:
+    """Create a ready-to-use Fireblocks signer (awaits ``init()``)."""
+    signer = FireblocksSigner(config)
+    await signer.init()
+    return signer

--- a/python/tests/test_fireblocks_signer.py
+++ b/python/tests/test_fireblocks_signer.py
@@ -1,0 +1,341 @@
+import hashlib
+import json
+from typing import Any
+
+import httpx
+import jwt as pyjwt
+import pytest
+import respx
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives.serialization import (
+    Encoding,
+    NoEncryption,
+    PrivateFormat,
+)
+from solders.keypair import Keypair
+
+from solana_keychain import SignerError, SignerErrorCode
+from solana_keychain.fireblocks import (
+    FireblocksSigner,
+    FireblocksSignerConfig,
+    create_fireblocks_signer,
+)
+from solana_keychain.fireblocks.jwt import (
+    JWT_SKEW_LEEWAY_SECONDS,
+    JWT_TTL_SECONDS,
+    create_jwt,
+    parse_signing_key,
+)
+from tests.util import create_test_transaction
+
+API_BASE_URL = "https://fireblocks.example.com"
+API_KEY = "test-api-key"
+VAULT_ACCOUNT_ID = "7"
+ADDRESSES_URL = f"{API_BASE_URL}/v1/vault/accounts/{VAULT_ACCOUNT_ID}/SOL/addresses_paginated"
+TRANSACTIONS_URL = f"{API_BASE_URL}/v1/transactions"
+ACCOUNT_URL = f"{API_BASE_URL}/v1/vault/accounts/{VAULT_ACCOUNT_ID}"
+
+_RSA_KEY = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+RSA_PRIVATE_PEM = _RSA_KEY.private_bytes(Encoding.PEM, PrivateFormat.PKCS8, NoEncryption()).decode()
+RSA_PUBLIC_KEY = _RSA_KEY.public_key()
+
+
+def make_signer(**overrides: Any) -> FireblocksSigner:
+    config = FireblocksSignerConfig(
+        api_key=API_KEY,
+        private_key_pem=overrides.pop("private_key_pem", RSA_PRIVATE_PEM),
+        vault_account_id=VAULT_ACCOUNT_ID,
+        api_base_url=API_BASE_URL,
+        poll_interval_ms=0,
+        **overrides,
+    )
+    return FireblocksSigner(config)
+
+
+def mock_addresses_response(address: str) -> None:
+    respx.get(ADDRESSES_URL).mock(
+        return_value=httpx.Response(200, json={"addresses": [{"address": address}]})
+    )
+
+
+def transaction_response(
+    status: str, full_sig: str | None = None, tx_id: str = "tx-1"
+) -> dict[str, Any]:
+    body: dict[str, Any] = {"id": tx_id, "status": status}
+    if full_sig is not None:
+        body["signedMessages"] = [{"signature": {"fullSig": full_sig}}]
+    return body
+
+
+def mock_sign_flow(full_sig: str, intermediate_statuses: list[str] | None = None) -> None:
+    respx.post(TRANSACTIONS_URL).mock(
+        return_value=httpx.Response(200, json={"id": "tx-1", "status": "SUBMITTED"})
+    )
+    poll_responses = [
+        httpx.Response(200, json=transaction_response(status))
+        for status in (intermediate_statuses or [])
+    ]
+    poll_responses.append(
+        httpx.Response(200, json=transaction_response("COMPLETED", full_sig=full_sig))
+    )
+    respx.get(f"{TRANSACTIONS_URL}/tx-1").mock(side_effect=poll_responses)
+
+
+async def initialized_signer(keypair: Keypair, **overrides: Any) -> FireblocksSigner:
+    mock_addresses_response(str(keypair.pubkey()))
+    signer = make_signer(**overrides)
+    await signer.init()
+    return signer
+
+
+def decode_bearer_claims(request: httpx.Request) -> dict[str, Any]:
+    token = request.headers["Authorization"].removeprefix("Bearer ")
+    return pyjwt.decode(token, RSA_PUBLIC_KEY, algorithms=["RS256"])
+
+
+def test_create_jwt_claims_shape() -> None:
+    signing_key = parse_signing_key(RSA_PRIVATE_PEM)
+    body = '{"test": "body"}'
+    token = create_jwt(API_KEY, signing_key, "/v1/transactions", body)
+
+    claims = pyjwt.decode(token, RSA_PUBLIC_KEY, algorithms=["RS256"])
+    assert claims["uri"] == "/v1/transactions"
+    assert claims["sub"] == API_KEY
+    assert claims["iat"] == claims["nbf"]
+    assert claims["exp"] - claims["iat"] == JWT_TTL_SECONDS + JWT_SKEW_LEEWAY_SECONDS
+    assert claims["bodyHash"] == hashlib.sha256(body.encode()).hexdigest()
+    assert claims["nonce"]
+
+
+def test_parse_signing_key_invalid() -> None:
+    with pytest.raises(SignerError) as excinfo:
+        parse_signing_key("invalid-key")
+    assert excinfo.value.code == SignerErrorCode.INVALID_PRIVATE_KEY
+
+
+@respx.mock
+async def test_use_program_call_rejected_before_any_network_call() -> None:
+    signer = make_signer(use_program_call=True)
+    with pytest.raises(SignerError) as excinfo:
+        await signer.init()
+    assert excinfo.value.code == SignerErrorCode.CONFIG_ERROR
+    assert not respx.calls
+
+
+@respx.mock
+async def test_init_resolves_vault_pubkey_with_stamped_jwt() -> None:
+    keypair = Keypair()
+    signer = await initialized_signer(keypair)
+    assert signer.pubkey == keypair.pubkey()
+
+    request = respx.calls.last.request
+    assert request.headers["X-API-Key"] == API_KEY
+    claims = decode_bearer_claims(request)
+    assert claims["uri"] == f"/v1/vault/accounts/{VAULT_ACCOUNT_ID}/SOL/addresses_paginated"
+    assert claims["bodyHash"] == hashlib.sha256(b"").hexdigest()
+
+
+@respx.mock
+async def test_init_rejects_empty_addresses() -> None:
+    respx.get(ADDRESSES_URL).mock(return_value=httpx.Response(200, json={"addresses": []}))
+    signer = make_signer()
+    with pytest.raises(SignerError) as excinfo:
+        await signer.init()
+    assert excinfo.value.code == SignerErrorCode.INVALID_PUBLIC_KEY
+
+
+@respx.mock
+async def test_init_rejects_invalid_address() -> None:
+    mock_addresses_response("not-a-pubkey")
+    signer = make_signer()
+    with pytest.raises(SignerError) as excinfo:
+        await signer.init()
+    assert excinfo.value.code == SignerErrorCode.INVALID_PUBLIC_KEY
+
+
+@respx.mock
+async def test_init_api_error() -> None:
+    respx.get(ADDRESSES_URL).mock(return_value=httpx.Response(401, json={"error": "denied"}))
+    signer = make_signer()
+    with pytest.raises(SignerError) as excinfo:
+        await signer.init()
+    assert excinfo.value.code == SignerErrorCode.REMOTE_API_ERROR
+
+
+async def test_invalid_rsa_key_surfaces_on_use() -> None:
+    signer = make_signer(private_key_pem="not-a-pem")
+    with pytest.raises(SignerError) as excinfo:
+        await signer.init()
+    assert excinfo.value.code == SignerErrorCode.INVALID_PRIVATE_KEY
+
+
+async def test_uninitialized_sign_raises_not_initialized() -> None:
+    signer = make_signer()
+    with pytest.raises(SignerError) as excinfo:
+        await signer.sign_message(b"hello")
+    assert excinfo.value.code == SignerErrorCode.NOT_INITIALIZED
+
+
+@respx.mock
+async def test_sign_message_success_with_polling() -> None:
+    keypair = Keypair()
+    message = b"fireblocks-message"
+    signature = keypair.sign_message(message)
+    signer = await initialized_signer(keypair)
+    mock_sign_flow(bytes(signature).hex(), intermediate_statuses=["SUBMITTED", "SIGNING"])
+
+    result = await signer.sign_message(message)
+
+    assert result == signature
+    create_request = respx.calls[1].request
+    body = json.loads(create_request.content)
+    assert body == {
+        "assetId": "SOL",
+        "operation": "RAW",
+        "source": {"type": "VAULT_ACCOUNT", "id": VAULT_ACCOUNT_ID},
+        "extraParameters": {"rawMessageData": {"messages": [{"content": message.hex()}]}},
+    }
+    claims = decode_bearer_claims(create_request)
+    assert claims["uri"] == "/v1/transactions"
+    assert claims["bodyHash"] == hashlib.sha256(create_request.content).hexdigest()
+
+
+@respx.mock
+@pytest.mark.parametrize("status", ["FAILED", "CANCELLED", "REJECTED", "BLOCKED"])
+async def test_sign_message_terminal_failure_status(status: str) -> None:
+    keypair = Keypair()
+    signer = await initialized_signer(keypair)
+    respx.post(TRANSACTIONS_URL).mock(
+        return_value=httpx.Response(200, json={"id": "tx-1", "status": "SUBMITTED"})
+    )
+    respx.get(f"{TRANSACTIONS_URL}/tx-1").mock(
+        return_value=httpx.Response(200, json=transaction_response(status))
+    )
+    with pytest.raises(SignerError) as excinfo:
+        await signer.sign_message(b"hello")
+    assert excinfo.value.code == SignerErrorCode.SIGNING_FAILED
+
+
+@respx.mock
+async def test_sign_message_polling_timeout() -> None:
+    keypair = Keypair()
+    signer = await initialized_signer(keypair, max_poll_attempts=3)
+    respx.post(TRANSACTIONS_URL).mock(
+        return_value=httpx.Response(200, json={"id": "tx-1", "status": "SUBMITTED"})
+    )
+    respx.get(f"{TRANSACTIONS_URL}/tx-1").mock(
+        return_value=httpx.Response(200, json=transaction_response("SUBMITTED"))
+    )
+    with pytest.raises(SignerError) as excinfo:
+        await signer.sign_message(b"hello")
+    assert excinfo.value.code == SignerErrorCode.REMOTE_API_ERROR
+
+
+@respx.mock
+async def test_sign_message_missing_signed_messages() -> None:
+    keypair = Keypair()
+    signer = await initialized_signer(keypair)
+    respx.post(TRANSACTIONS_URL).mock(
+        return_value=httpx.Response(200, json={"id": "tx-1", "status": "SUBMITTED"})
+    )
+    respx.get(f"{TRANSACTIONS_URL}/tx-1").mock(
+        return_value=httpx.Response(200, json=transaction_response("COMPLETED"))
+    )
+    with pytest.raises(SignerError) as excinfo:
+        await signer.sign_message(b"hello")
+    assert excinfo.value.code == SignerErrorCode.SIGNING_FAILED
+
+
+@respx.mock
+async def test_sign_message_undecodable_signature() -> None:
+    keypair = Keypair()
+    signer = await initialized_signer(keypair)
+    mock_sign_flow("zz" * 64)
+    with pytest.raises(SignerError) as excinfo:
+        await signer.sign_message(b"hello")
+    assert excinfo.value.code == SignerErrorCode.SERIALIZATION_ERROR
+
+
+@respx.mock
+async def test_sign_message_wrong_length_signature() -> None:
+    keypair = Keypair()
+    signer = await initialized_signer(keypair)
+    mock_sign_flow("ab" * 32)
+    with pytest.raises(SignerError) as excinfo:
+        await signer.sign_message(b"hello")
+    assert excinfo.value.code == SignerErrorCode.SIGNING_FAILED
+
+
+@respx.mock
+async def test_sign_message_signature_verification_failure() -> None:
+    keypair = Keypair()
+    other = Keypair()
+    message = b"fireblocks-message"
+    signer = await initialized_signer(keypair)
+    mock_sign_flow(bytes(other.sign_message(message)).hex())
+    with pytest.raises(SignerError) as excinfo:
+        await signer.sign_message(message)
+    assert excinfo.value.code == SignerErrorCode.SIGNING_FAILED
+
+
+@respx.mock
+async def test_sign_transaction_success() -> None:
+    keypair = Keypair()
+    signer = await initialized_signer(keypair)
+    transaction = create_test_transaction(keypair.pubkey())
+    signature = keypair.sign_message(transaction.message_data())
+    mock_sign_flow(bytes(signature).hex())
+
+    result = await signer.sign_transaction(transaction)
+
+    assert result.is_complete
+    assert result.signature == signature
+    assert list(transaction.signatures) == [signature]
+
+
+async def test_uninitialized_is_available_false() -> None:
+    assert not await make_signer().is_available()
+
+
+@respx.mock
+async def test_is_available_success() -> None:
+    keypair = Keypair()
+    signer = await initialized_signer(keypair)
+    respx.get(ACCOUNT_URL).mock(return_value=httpx.Response(200, json={"id": VAULT_ACCOUNT_ID}))
+    assert await signer.is_available()
+
+
+@respx.mock
+async def test_is_available_false_on_api_error() -> None:
+    keypair = Keypair()
+    signer = await initialized_signer(keypair)
+    respx.get(ACCOUNT_URL).mock(return_value=httpx.Response(403, json={"error": "forbidden"}))
+    assert not await signer.is_available()
+
+
+@respx.mock
+async def test_create_fireblocks_signer_factory_initializes() -> None:
+    keypair = Keypair()
+    mock_addresses_response(str(keypair.pubkey()))
+    signer = await create_fireblocks_signer(
+        FireblocksSignerConfig(
+            api_key=API_KEY,
+            private_key_pem=RSA_PRIVATE_PEM,
+            vault_account_id=VAULT_ACCOUNT_ID,
+            api_base_url=API_BASE_URL,
+        )
+    )
+    assert signer.pubkey == keypair.pubkey()
+
+
+def test_reprs_never_contain_secrets() -> None:
+    config = FireblocksSignerConfig(
+        api_key=API_KEY,
+        private_key_pem=RSA_PRIVATE_PEM,
+        vault_account_id=VAULT_ACCOUNT_ID,
+        api_base_url=API_BASE_URL,
+    )
+    signer = make_signer()
+    for text in (repr(config), repr(signer)):
+        assert API_KEY not in text
+        assert "PRIVATE KEY" not in text


### PR DESCRIPTION
## Summary
- Adds the **Fireblocks** backend (`solana_keychain.fireblocks`). Stacked on #215 — this layer shows only the Fireblocks work.
- **RAW signing with polling**: `POST /v1/transactions` (RAW operation, hex message content, VAULT_ACCOUNT source) then poll `GET /v1/transactions/{id}` until `COMPLETED`; `FAILED`/`CANCELLED`/`REJECTED`/`BLOCKED` are terminal `SIGNING_FAILED`; attempt cap surfaces a polling-timeout `REMOTE_API_ERROR` noting the request may still complete. Interval (default 1s) and attempts (default 300) configurable.
- **RS256 request JWTs**: claims carry `uri`, a fresh UUID `nonce`, `iat`/`nbf` backdated by a 60s skew leeway, 120s TTL, `sub = api_key`, and `bodyHash` = SHA-256 of the exact body bytes — sent via `fetch_signer_json(content=…)` so stamped and wire bytes are identical. Headers: `X-API-Key` + `Authorization: Bearer`.
- **`use_program_call` rejected at `init()` before any network call** (`CONFIG_ERROR`): PROGRAM_CALL broadcasts the transaction on-chain and returns no reusable signer-bound signature — a duplicate-spend risk that violates the signing contract. The signer always uses RAW.
- Signature extraction from `signedMessages[0].signature.fullSig`: hex-decoded, 64-byte length check, verified locally against the vault pubkey. Init resolves the pubkey from `addresses_paginated`. `cryptography` + `pyjwt` behind the `[fireblocks]` extra.

## Test Plan
- 249 tests pass (25 new): JWT claims shape (iat==nbf, exp window, bodyHash) and cryptographic verification of the Bearer token against captured request bytes, PROGRAM_CALL rejection with zero network calls asserted, polling through intermediate statuses, all four terminal statuses, polling timeout, missing/undecodable/wrong-length signatures, verification failure, empty/invalid addresses, RSA-key failure surfaced on use, not-initialized paths, availability paths, factory init, repr redaction (API key + PEM)
- `ruff` + `mypy --strict` + sdist/wheel build clean

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
