### PR TITLE
feat(python): CDP signer backend

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -28,7 +28,7 @@ library offers a consistent API across all signing methods.
 | **GCP KMS** | Google Cloud Key Management Service with Ed25519 signing | `solana_keychain.gcp_kms` | ✅ Available |
 | **Dfns** | Dfns wallet infrastructure with Ed25519 signing | — | Planned |
 | **Para** | MPC wallets with Para infrastructure | `solana_keychain.para` | ✅ Available |
-| **CDP** | Coinbase Developer Platform managed wallets | — | Planned |
+| **CDP** | Coinbase Developer Platform managed wallets | `solana_keychain.cdp` | ✅ Available |
 | **Crossmint** | Crossmint managed wallets | — | Planned |
 | **Openfort** | Openfort backend wallets with TEE-stored keys | — | Planned |
 | **Utila** | Utila MPC wallet integration | — | Planned |
@@ -38,6 +38,7 @@ library offers a consistent API across all signing methods.
 ```bash
 pip install solana-keychain              # memory + vault
 pip install 'solana-keychain[aws-kms]'   # adds the AWS KMS backend
+pip install 'solana-keychain[cdp]'       # adds the CDP backend
 pip install 'solana-keychain[fireblocks]' # adds the Fireblocks backend
 pip install 'solana-keychain[gcp-kms]'   # adds the GCP KMS backend
 pip install 'solana-keychain[privy]'     # adds the Privy backend

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -18,6 +18,7 @@ Repository = "https://github.com/solana-foundation/solana-keychain"
 
 [project.optional-dependencies]
 aws-kms = ["boto3>=1.35"]
+cdp = ["cryptography>=43", "pyjwt>=2.8"]
 fireblocks = ["cryptography>=43", "pyjwt>=2.8"]
 gcp-kms = ["google-cloud-kms>=2.24"]
 privy = ["cryptography>=43"]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -18,12 +18,13 @@ Repository = "https://github.com/solana-foundation/solana-keychain"
 
 [project.optional-dependencies]
 aws-kms = ["boto3>=1.35"]
-cdp = ["cryptography>=43", "pyjwt>=2.8"]
+cdp = ["base58>=2.1", "cryptography>=43", "pyjwt>=2.8"]
 fireblocks = ["cryptography>=43", "pyjwt>=2.8"]
 gcp-kms = ["google-cloud-kms>=2.24"]
 privy = ["cryptography>=43"]
 turnkey = ["cryptography>=43"]
 dev = [
+    "base58>=2.1",
     "boto3>=1.35",
     "build>=1.2",
     "cryptography>=43",

--- a/python/src/solana_keychain/cdp/__init__.py
+++ b/python/src/solana_keychain/cdp/__init__.py
@@ -1,0 +1,3 @@
+from solana_keychain.cdp.signer import CdpSigner, CdpSignerConfig, create_cdp_signer
+
+__all__ = ["CdpSigner", "CdpSignerConfig", "create_cdp_signer"]

--- a/python/src/solana_keychain/cdp/jwt.py
+++ b/python/src/solana_keychain/cdp/jwt.py
@@ -1,0 +1,156 @@
+"""CDP JWT authentication helpers: an EdDSA bearer token for every request and an
+ES256 wallet token for write endpoints."""
+
+import base64
+import hashlib
+import json
+import time
+import uuid
+from typing import Any
+from urllib.parse import urlsplit
+
+try:
+    import jwt as pyjwt
+    from cryptography.hazmat.primitives.asymmetric import ec
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+    from cryptography.hazmat.primitives.serialization import load_der_private_key
+except ImportError as error:  # pragma: no cover
+    raise ImportError(
+        "solana_keychain.cdp requires the cdp extra: pip install 'solana-keychain[cdp]'"
+    ) from error
+
+from solders.keypair import Keypair
+
+from solana_keychain.core.errors import SignerError, SignerErrorCode
+
+JWT_TTL_SECONDS = 120
+
+ED25519_KEYPAIR_LENGTH = 64
+
+
+def jwt_uri(host: str, method: str, path: str) -> str:
+    return f"{method} {host}{path}"
+
+
+def extract_host(base_url: str) -> str:
+    """Extract the request host (including port if present) from a base URL."""
+    try:
+        parsed = urlsplit(base_url)
+        hostname = parsed.hostname
+        port = parsed.port
+    except ValueError:
+        raise SignerError(
+            SignerErrorCode.CONFIG_ERROR, f"Invalid CDP base URL: {base_url}"
+        ) from None
+    if not hostname:
+        raise SignerError(SignerErrorCode.CONFIG_ERROR, f"Missing host in CDP base URL: {base_url}")
+    return f"{hostname}:{port}" if port is not None else hostname
+
+
+def compute_req_hash(body: Any | None) -> str | None:
+    """SHA-256 hex of the request body serialized with recursively sorted keys and
+    compact separators; ``None`` for absent, null, or empty-object bodies."""
+    if body is None or body == {}:
+        return None
+    serialized = json.dumps(body, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return hashlib.sha256(serialized.encode()).hexdigest()
+
+
+def _parse_ed25519_signing_key(api_key_secret: str) -> Ed25519PrivateKey:
+    if api_key_secret.startswith("-----BEGIN"):
+        raise SignerError(
+            SignerErrorCode.INVALID_PRIVATE_KEY,
+            "PEM EC keys are not supported; use base64 Ed25519 key",
+        )
+    try:
+        key_bytes = base64.b64decode(api_key_secret, validate=True)
+    except Exception:
+        raise SignerError(
+            SignerErrorCode.INVALID_PRIVATE_KEY,
+            "Failed to decode Ed25519 private key from base64",
+        ) from None
+    if len(key_bytes) != ED25519_KEYPAIR_LENGTH:
+        raise SignerError(
+            SignerErrorCode.INVALID_PRIVATE_KEY,
+            f"Invalid Ed25519 key length: expected {ED25519_KEYPAIR_LENGTH} bytes, "
+            f"got {len(key_bytes)}",
+        )
+    seed, provided_pubkey = key_bytes[:32], key_bytes[32:]
+    try:
+        derived_pubkey = bytes(Keypair.from_seed(seed).pubkey())
+    except Exception:
+        raise SignerError(SignerErrorCode.INVALID_PRIVATE_KEY, "Invalid Ed25519 seed") from None
+    if derived_pubkey != provided_pubkey:
+        raise SignerError(
+            SignerErrorCode.INVALID_PRIVATE_KEY, "Ed25519 public key does not match seed"
+        )
+    return Ed25519PrivateKey.from_private_bytes(seed)
+
+
+def create_auth_jwt(api_key_id: str, api_key_secret: str, host: str, method: str, path: str) -> str:
+    """Create the main CDP API authentication JWT (EdDSA over the request URI), with
+    ``kid`` and a fresh ``nonce`` in the protected header for replay prevention."""
+    signing_key = _parse_ed25519_signing_key(api_key_secret)
+    now = int(time.time())
+    claims = {
+        "sub": api_key_id,
+        "iss": "cdp",
+        "iat": now,
+        "nbf": now,
+        "exp": now + JWT_TTL_SECONDS,
+        "uris": [jwt_uri(host, method, path)],
+    }
+    try:
+        return pyjwt.encode(
+            claims,
+            signing_key,
+            algorithm="EdDSA",
+            headers={"kid": api_key_id, "nonce": uuid.uuid4().hex, "typ": "JWT"},
+        )
+    except Exception:
+        raise SignerError(
+            SignerErrorCode.SIGNING_FAILED, "Failed to create CDP authentication JWT"
+        ) from None
+
+
+def create_wallet_jwt(
+    wallet_secret: str, host: str, method: str, path: str, request_body: Any | None
+) -> str:
+    """Create the CDP wallet authentication JWT (``X-Wallet-Auth``, ES256), carrying
+    ``reqHash`` over the sorted request body when one is present."""
+    try:
+        der_bytes = base64.b64decode(wallet_secret, validate=True)
+    except Exception:
+        raise SignerError(
+            SignerErrorCode.INVALID_PRIVATE_KEY, "Failed to decode walletSecret from base64"
+        ) from None
+    try:
+        signing_key = load_der_private_key(der_bytes, password=None)
+    except Exception:
+        raise SignerError(
+            SignerErrorCode.INVALID_PRIVATE_KEY,
+            "Failed to parse walletSecret as EC private key",
+        ) from None
+    if not isinstance(signing_key, ec.EllipticCurvePrivateKey):
+        raise SignerError(
+            SignerErrorCode.INVALID_PRIVATE_KEY,
+            "Failed to parse walletSecret as EC private key",
+        )
+
+    now = int(time.time())
+    claims: dict[str, Any] = {
+        "uris": [jwt_uri(host, method, path)],
+        "iat": now,
+        "nbf": now,
+        "exp": now + JWT_TTL_SECONDS,
+        "jti": str(uuid.uuid4()),
+    }
+    req_hash = compute_req_hash(request_body)
+    if req_hash is not None:
+        claims["reqHash"] = req_hash
+    try:
+        return pyjwt.encode(claims, signing_key, algorithm="ES256", headers={"typ": "JWT"})
+    except Exception:
+        raise SignerError(
+            SignerErrorCode.SIGNING_FAILED, "Failed to create CDP wallet JWT"
+        ) from None

--- a/python/src/solana_keychain/cdp/signer.py
+++ b/python/src/solana_keychain/cdp/signer.py
@@ -1,0 +1,217 @@
+"""CDP (Coinbase Developer Platform) signer integration."""
+
+import base64
+from dataclasses import dataclass, field
+from typing import Any
+
+import httpx
+from solders.pubkey import Pubkey
+from solders.signature import Signature
+from solders.transaction import Transaction
+
+from solana_keychain.cdp.jwt import create_auth_jwt, create_wallet_jwt, extract_host
+from solana_keychain.core.errors import SignerError, SignerErrorCode
+from solana_keychain.core.http import assert_https_url, fetch_signer_json, normalize_base_url
+from solana_keychain.core.signer import SignedTransaction, SolanaSigner
+from solana_keychain.core.transaction_util import (
+    add_signature_to_transaction,
+    classify_signed_transaction,
+    get_signing_keypair_position,
+    serialize_transaction,
+)
+
+DEFAULT_API_BASE_URL = "https://api.cdp.coinbase.com"
+BASE_PATH = "/platform/v2/solana/accounts"
+
+ED25519_SIGNATURE_LENGTH = 64
+
+_B58_ALPHABET = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
+
+
+def _b58decode(encoded: str) -> bytes:
+    number = 0
+    for char in encoded:
+        number = number * 58 + _B58_ALPHABET.index(char)
+    decoded = number.to_bytes((number.bit_length() + 7) // 8, "big")
+    leading_zeroes = len(encoded) - len(encoded.lstrip("1"))
+    return b"\x00" * leading_zeroes + decoded
+
+
+@dataclass
+class CdpSignerConfig:
+    """Configuration for a CDP signer.
+
+    ``api_key_secret`` is the base64 Ed25519 API private key (seed ‖ pubkey);
+    ``wallet_secret`` is the base64 PKCS8 DER P-256 wallet key used for the
+    ``X-Wallet-Auth`` token on write endpoints; ``address`` is the base58 Solana
+    account address managed by CDP.
+    """
+
+    api_key_id: str
+    api_key_secret: str = field(repr=False)
+    wallet_secret: str = field(repr=False)
+    address: str
+    api_base_url: str = DEFAULT_API_BASE_URL
+    http_client: httpx.AsyncClient | None = field(default=None, repr=False)
+
+
+class CdpSigner(SolanaSigner):
+    """Signer backed by a CDP-managed Solana account.
+
+    ``sign_message`` requires UTF-8 payloads — the sign-message endpoint takes a
+    string, so arbitrary non-UTF-8 bytes are rejected.
+    """
+
+    def __init__(self, config: CdpSignerConfig) -> None:
+        for name, value in (
+            ("api_key_id", config.api_key_id),
+            ("api_key_secret", config.api_key_secret),
+            ("wallet_secret", config.wallet_secret),
+            ("address", config.address),
+        ):
+            if not value:
+                raise SignerError(SignerErrorCode.CONFIG_ERROR, f"{name} must not be empty")
+        try:
+            self._pubkey = Pubkey.from_string(config.address)
+        except Exception:
+            raise SignerError(
+                SignerErrorCode.INVALID_PUBLIC_KEY, f"Invalid Solana address: {config.address}"
+            ) from None
+        api_base_url = normalize_base_url(config.api_base_url)
+        assert_https_url(api_base_url, "api_base_url")
+        self._api_base_url = api_base_url
+        self._api_host = extract_host(api_base_url)
+        self._api_key_id = config.api_key_id
+        self._api_key_secret = config.api_key_secret
+        self._wallet_secret = config.wallet_secret
+        self._http_client = config.http_client
+
+    def __repr__(self) -> str:
+        return f"CdpSigner(pubkey={self._pubkey}, api_base_url={self._api_base_url})"
+
+    @property
+    def pubkey(self) -> Pubkey:
+        return self._pubkey
+
+    async def _post_signed(self, path: str, body: dict[str, Any]) -> Any:
+        auth_token = create_auth_jwt(
+            self._api_key_id, self._api_key_secret, self._api_host, "POST", path
+        )
+        wallet_token = create_wallet_jwt(self._wallet_secret, self._api_host, "POST", path, body)
+        return await fetch_signer_json(
+            url=f"{self._api_base_url}{path}",
+            provider_name="CDP",
+            method="POST",
+            headers={
+                "Authorization": f"Bearer {auth_token}",
+                "Content-Type": "application/json",
+                "X-Wallet-Auth": wallet_token,
+            },
+            json_body=body,
+            client=self._http_client,
+        )
+
+    async def sign_message(self, message: bytes) -> Signature:
+        try:
+            message_str = message.decode("utf-8")
+        except UnicodeDecodeError:
+            raise SignerError(
+                SignerErrorCode.SERIALIZATION_ERROR,
+                "CDP signMessage requires UTF-8; non-UTF-8 bytes are not supported",
+            ) from None
+        path = f"{BASE_PATH}/{self._pubkey}/sign/message"
+        response = await self._post_signed(path, {"message": message_str})
+        signature_b58 = response.get("signature") if isinstance(response, dict) else None
+        if not isinstance(signature_b58, str):
+            raise SignerError(
+                SignerErrorCode.SERIALIZATION_ERROR, "Failed to parse CDP sign_message response"
+            )
+        try:
+            signature_bytes = _b58decode(signature_b58)
+        except ValueError:
+            raise SignerError(
+                SignerErrorCode.SERIALIZATION_ERROR,
+                "Failed to decode base58 signature from CDP",
+            ) from None
+        if len(signature_bytes) != ED25519_SIGNATURE_LENGTH:
+            raise SignerError(
+                SignerErrorCode.SIGNING_FAILED,
+                f"Invalid signature length from CDP (expected {ED25519_SIGNATURE_LENGTH} bytes)",
+            )
+        signature = Signature.from_bytes(signature_bytes)
+        if not signature.verify(self._pubkey, message):
+            raise SignerError(
+                SignerErrorCode.SIGNING_FAILED,
+                "Signature verification failed — the returned signature does not match "
+                "the public key",
+            )
+        return signature
+
+    async def sign_transaction(self, transaction: Transaction) -> SignedTransaction:
+        message_data = transaction.message_data()
+        position = get_signing_keypair_position(transaction, self._pubkey)
+
+        path = f"{BASE_PATH}/{self._pubkey}/sign/transaction"
+        encoded_tx = base64.b64encode(bytes(transaction)).decode("ascii")
+        response = await self._post_signed(path, {"transaction": encoded_tx})
+
+        signed_b64 = response.get("signedTransaction") if isinstance(response, dict) else None
+        if not isinstance(signed_b64, str):
+            raise SignerError(
+                SignerErrorCode.SERIALIZATION_ERROR,
+                "Failed to parse CDP sign_transaction response",
+            )
+        try:
+            signed_bytes = base64.b64decode(signed_b64, validate=True)
+        except Exception:
+            raise SignerError(
+                SignerErrorCode.SERIALIZATION_ERROR,
+                "Failed to decode base64 signed transaction from CDP",
+            ) from None
+        try:
+            signed_transaction = Transaction.from_bytes(signed_bytes)
+        except Exception:
+            raise SignerError(
+                SignerErrorCode.SERIALIZATION_ERROR,
+                "Failed to deserialize signed transaction from CDP",
+            ) from None
+
+        signatures = list(signed_transaction.signatures)
+        if position >= len(signatures):
+            raise SignerError(
+                SignerErrorCode.SIGNING_FAILED,
+                "Signature not found at expected position in CDP response",
+            )
+        signature = signatures[position]
+        if not signature.verify(self._pubkey, message_data):
+            raise SignerError(
+                SignerErrorCode.SIGNING_FAILED,
+                "Signature verification failed — the returned signature does not match "
+                "the public key",
+            )
+
+        add_signature_to_transaction(transaction, self._pubkey, signature)
+        return classify_signed_transaction(
+            transaction, serialize_transaction(transaction), signature
+        )
+
+    async def is_available(self) -> bool:
+        path = f"{BASE_PATH}/{self._pubkey}"
+        try:
+            auth_token = create_auth_jwt(
+                self._api_key_id, self._api_key_secret, self._api_host, "GET", path
+            )
+            await fetch_signer_json(
+                url=f"{self._api_base_url}{path}",
+                provider_name="CDP",
+                headers={"Authorization": f"Bearer {auth_token}"},
+                client=self._http_client,
+            )
+        except SignerError:
+            return False
+        return True
+
+
+async def create_cdp_signer(config: CdpSignerConfig) -> CdpSigner:
+    """Create a ready-to-use CDP signer."""
+    return CdpSigner(config)

--- a/python/src/solana_keychain/cdp/signer.py
+++ b/python/src/solana_keychain/cdp/signer.py
@@ -4,6 +4,13 @@ import base64
 from dataclasses import dataclass, field
 from typing import Any
 
+try:
+    import base58
+except ImportError as error:  # pragma: no cover
+    raise ImportError(
+        "solana_keychain.cdp requires the cdp extra: pip install 'solana-keychain[cdp]'"
+    ) from error
+
 import httpx
 from solders.pubkey import Pubkey
 from solders.signature import Signature
@@ -24,17 +31,6 @@ DEFAULT_API_BASE_URL = "https://api.cdp.coinbase.com"
 BASE_PATH = "/platform/v2/solana/accounts"
 
 ED25519_SIGNATURE_LENGTH = 64
-
-_B58_ALPHABET = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
-
-
-def _b58decode(encoded: str) -> bytes:
-    number = 0
-    for char in encoded:
-        number = number * 58 + _B58_ALPHABET.index(char)
-    decoded = number.to_bytes((number.bit_length() + 7) // 8, "big")
-    leading_zeroes = len(encoded) - len(encoded.lstrip("1"))
-    return b"\x00" * leading_zeroes + decoded
 
 
 @dataclass
@@ -127,7 +123,7 @@ class CdpSigner(SolanaSigner):
                 SignerErrorCode.SERIALIZATION_ERROR, "Failed to parse CDP sign_message response"
             )
         try:
-            signature_bytes = _b58decode(signature_b58)
+            signature_bytes = base58.b58decode(signature_b58)
         except ValueError:
             raise SignerError(
                 SignerErrorCode.SERIALIZATION_ERROR,

--- a/python/tests/test_cdp_signer.py
+++ b/python/tests/test_cdp_signer.py
@@ -1,0 +1,364 @@
+import base64
+from typing import Any
+
+import httpx
+import jwt as pyjwt
+import pytest
+import respx
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+from cryptography.hazmat.primitives.serialization import (
+    Encoding,
+    NoEncryption,
+    PrivateFormat,
+)
+from solders.keypair import Keypair
+from solders.transaction import Transaction
+
+from solana_keychain import SignerError, SignerErrorCode
+from solana_keychain.cdp import CdpSigner, CdpSignerConfig, create_cdp_signer
+from solana_keychain.cdp.jwt import (
+    compute_req_hash,
+    create_auth_jwt,
+    create_wallet_jwt,
+    extract_host,
+)
+from tests.util import create_test_transaction
+
+API_BASE_URL = "https://cdp.example.com"
+API_HOST = "cdp.example.com"
+API_KEY_ID = "test-key-id"
+
+_API_KEYPAIR = Keypair()
+API_KEY_SECRET = base64.b64encode(bytes(_API_KEYPAIR)).decode()
+API_PUBLIC_KEY = Ed25519PublicKey.from_public_bytes(bytes(_API_KEYPAIR.pubkey()))
+
+_WALLET_EC_KEY = ec.generate_private_key(ec.SECP256R1())
+WALLET_SECRET = base64.b64encode(
+    _WALLET_EC_KEY.private_bytes(Encoding.DER, PrivateFormat.PKCS8, NoEncryption())
+).decode()
+
+_ACCOUNT_KEYPAIR = Keypair()
+ADDRESS = str(_ACCOUNT_KEYPAIR.pubkey())
+BASE_PATH = f"/platform/v2/solana/accounts/{ADDRESS}"
+
+
+def make_signer() -> CdpSigner:
+    return CdpSigner(
+        CdpSignerConfig(
+            api_key_id=API_KEY_ID,
+            api_key_secret=API_KEY_SECRET,
+            wallet_secret=WALLET_SECRET,
+            address=ADDRESS,
+            api_base_url=API_BASE_URL,
+        )
+    )
+
+
+def decode_auth_claims(request: httpx.Request) -> tuple[dict[str, Any], dict[str, Any]]:
+    token = request.headers["Authorization"].removeprefix("Bearer ")
+    header = pyjwt.get_unverified_header(token)
+    claims = pyjwt.decode(token, API_PUBLIC_KEY, algorithms=["EdDSA"])
+    return header, claims
+
+
+def decode_wallet_claims(request: httpx.Request) -> dict[str, Any]:
+    token = request.headers["X-Wallet-Auth"]
+    return pyjwt.decode(token, _WALLET_EC_KEY.public_key(), algorithms=["ES256"])
+
+
+def test_extract_host() -> None:
+    assert extract_host("https://api.cdp.coinbase.com") == "api.cdp.coinbase.com"
+    assert extract_host("https://cdp.example.com:8443/base") == "cdp.example.com:8443"
+    with pytest.raises(SignerError) as excinfo:
+        extract_host("not a url")
+    assert excinfo.value.code == SignerErrorCode.CONFIG_ERROR
+
+
+def test_compute_req_hash_rules() -> None:
+    assert compute_req_hash(None) is None
+    assert compute_req_hash({}) is None
+    ordered = compute_req_hash({"a": 1, "b": {"c": 2, "d": 3}})
+    reordered = compute_req_hash({"b": {"d": 3, "c": 2}, "a": 1})
+    assert ordered == reordered
+    assert ordered is not None
+
+
+def test_create_auth_jwt_shape() -> None:
+    token = create_auth_jwt(API_KEY_ID, API_KEY_SECRET, API_HOST, "GET", "/path")
+    header = pyjwt.get_unverified_header(token)
+    assert header["alg"] == "EdDSA"
+    assert header["kid"] == API_KEY_ID
+    assert len(header["nonce"]) == 32
+    claims = pyjwt.decode(token, API_PUBLIC_KEY, algorithms=["EdDSA"])
+    assert claims["sub"] == API_KEY_ID
+    assert claims["iss"] == "cdp"
+    assert claims["uris"] == [f"GET {API_HOST}/path"]
+    assert claims["exp"] - claims["iat"] == 120
+
+
+@pytest.mark.parametrize(
+    "secret",
+    [
+        "-----BEGIN PRIVATE KEY-----\nabc\n-----END PRIVATE KEY-----",
+        "!!!not-base64!!!",
+        base64.b64encode(bytes(32)).decode(),
+        base64.b64encode(bytes(_API_KEYPAIR)[:32] + bytes(32)).decode(),
+    ],
+)
+def test_create_auth_jwt_rejects_invalid_secrets(secret: str) -> None:
+    with pytest.raises(SignerError) as excinfo:
+        create_auth_jwt(API_KEY_ID, secret, API_HOST, "GET", "/path")
+    assert excinfo.value.code == SignerErrorCode.INVALID_PRIVATE_KEY
+
+
+def test_create_wallet_jwt_shape() -> None:
+    body = {"transaction": "abc"}
+    token = create_wallet_jwt(WALLET_SECRET, API_HOST, "POST", "/path", body)
+    claims = pyjwt.decode(token, _WALLET_EC_KEY.public_key(), algorithms=["ES256"])
+    assert claims["uris"] == [f"POST {API_HOST}/path"]
+    assert claims["jti"]
+    assert claims["reqHash"] == compute_req_hash(body)
+
+
+def test_create_wallet_jwt_omits_req_hash_for_empty_body() -> None:
+    token = create_wallet_jwt(WALLET_SECRET, API_HOST, "POST", "/path", None)
+    claims = pyjwt.decode(token, _WALLET_EC_KEY.public_key(), algorithms=["ES256"])
+    assert "reqHash" not in claims
+
+
+@pytest.mark.parametrize(
+    "secret",
+    ["!!!not-base64!!!", base64.b64encode(b"not-der").decode()],
+)
+def test_create_wallet_jwt_rejects_invalid_secrets(secret: str) -> None:
+    with pytest.raises(SignerError) as excinfo:
+        create_wallet_jwt(secret, API_HOST, "POST", "/path", None)
+    assert excinfo.value.code == SignerErrorCode.INVALID_PRIVATE_KEY
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"api_key_id": ""},
+        {"api_key_secret": ""},
+        {"wallet_secret": ""},
+        {"address": ""},
+    ],
+)
+def test_empty_config_fields_rejected(overrides: dict[str, str]) -> None:
+    kwargs: dict[str, Any] = {
+        "api_key_id": API_KEY_ID,
+        "api_key_secret": API_KEY_SECRET,
+        "wallet_secret": WALLET_SECRET,
+        "address": ADDRESS,
+        "api_base_url": API_BASE_URL,
+    }
+    kwargs.update(overrides)
+    with pytest.raises(SignerError) as excinfo:
+        CdpSigner(CdpSignerConfig(**kwargs))
+    assert excinfo.value.code == SignerErrorCode.CONFIG_ERROR
+
+
+def test_invalid_address_rejected() -> None:
+    with pytest.raises(SignerError) as excinfo:
+        CdpSigner(
+            CdpSignerConfig(
+                api_key_id=API_KEY_ID,
+                api_key_secret=API_KEY_SECRET,
+                wallet_secret=WALLET_SECRET,
+                address="not-a-pubkey",
+                api_base_url=API_BASE_URL,
+            )
+        )
+    assert excinfo.value.code == SignerErrorCode.INVALID_PUBLIC_KEY
+
+
+def test_reprs_never_contain_secrets() -> None:
+    config = CdpSignerConfig(
+        api_key_id=API_KEY_ID,
+        api_key_secret=API_KEY_SECRET,
+        wallet_secret=WALLET_SECRET,
+        address=ADDRESS,
+        api_base_url=API_BASE_URL,
+    )
+    signer = make_signer()
+    for text in (repr(config), repr(signer)):
+        assert API_KEY_SECRET not in text
+        assert WALLET_SECRET not in text
+
+
+@respx.mock
+async def test_sign_message_success_with_both_jwts() -> None:
+    message = b"cdp-message"
+    signature = _ACCOUNT_KEYPAIR.sign_message(message)
+    respx.post(f"{API_BASE_URL}{BASE_PATH}/sign/message").mock(
+        return_value=httpx.Response(200, json={"signature": str(signature)})
+    )
+
+    result = await make_signer().sign_message(message)
+
+    assert result == signature
+    request = respx.calls.last.request
+    header, auth_claims = decode_auth_claims(request)
+    assert header["kid"] == API_KEY_ID
+    assert auth_claims["uris"] == [f"POST {API_HOST}{BASE_PATH}/sign/message"]
+    wallet_claims = decode_wallet_claims(request)
+    assert wallet_claims["uris"] == [f"POST {API_HOST}{BASE_PATH}/sign/message"]
+    assert wallet_claims["reqHash"] == compute_req_hash({"message": message.decode()})
+
+
+async def test_sign_message_rejects_non_utf8() -> None:
+    with pytest.raises(SignerError) as excinfo:
+        await make_signer().sign_message(b"\xff\xfe")
+    assert excinfo.value.code == SignerErrorCode.SERIALIZATION_ERROR
+
+
+@respx.mock
+async def test_sign_message_undecodable_signature() -> None:
+    respx.post(f"{API_BASE_URL}{BASE_PATH}/sign/message").mock(
+        return_value=httpx.Response(200, json={"signature": "0OIl-not-base58"})
+    )
+    with pytest.raises(SignerError) as excinfo:
+        await make_signer().sign_message(b"hello")
+    assert excinfo.value.code == SignerErrorCode.SERIALIZATION_ERROR
+
+
+@respx.mock
+async def test_sign_message_wrong_length_signature() -> None:
+    short = str(Keypair().pubkey())
+    respx.post(f"{API_BASE_URL}{BASE_PATH}/sign/message").mock(
+        return_value=httpx.Response(200, json={"signature": short})
+    )
+    with pytest.raises(SignerError) as excinfo:
+        await make_signer().sign_message(b"hello")
+    assert excinfo.value.code == SignerErrorCode.SIGNING_FAILED
+
+
+@respx.mock
+async def test_sign_message_signature_verification_failure() -> None:
+    message = b"cdp-message"
+    other_signature = Keypair().sign_message(message)
+    respx.post(f"{API_BASE_URL}{BASE_PATH}/sign/message").mock(
+        return_value=httpx.Response(200, json={"signature": str(other_signature)})
+    )
+    with pytest.raises(SignerError) as excinfo:
+        await make_signer().sign_message(message)
+    assert excinfo.value.code == SignerErrorCode.SIGNING_FAILED
+
+
+@respx.mock
+async def test_sign_message_api_error() -> None:
+    respx.post(f"{API_BASE_URL}{BASE_PATH}/sign/message").mock(
+        return_value=httpx.Response(401, json={"error": "unauthorized"})
+    )
+    with pytest.raises(SignerError) as excinfo:
+        await make_signer().sign_message(b"hello")
+    assert excinfo.value.code == SignerErrorCode.REMOTE_API_ERROR
+
+
+def signed_transaction_b64(transaction: Transaction) -> str:
+    signature = _ACCOUNT_KEYPAIR.sign_message(transaction.message_data())
+    signed = Transaction.from_bytes(bytes(transaction))
+    signed.signatures = [signature]
+    return base64.b64encode(bytes(signed)).decode()
+
+
+@respx.mock
+async def test_sign_transaction_success() -> None:
+    transaction = create_test_transaction(_ACCOUNT_KEYPAIR.pubkey())
+    expected_signature = _ACCOUNT_KEYPAIR.sign_message(transaction.message_data())
+    respx.post(f"{API_BASE_URL}{BASE_PATH}/sign/transaction").mock(
+        return_value=httpx.Response(
+            200, json={"signedTransaction": signed_transaction_b64(transaction)}
+        )
+    )
+
+    result = await make_signer().sign_transaction(transaction)
+
+    assert result.is_complete
+    assert result.signature == expected_signature
+    assert list(transaction.signatures) == [expected_signature]
+    request = respx.calls.last.request
+    wallet_claims = decode_wallet_claims(request)
+    assert wallet_claims["reqHash"] is not None
+
+
+@respx.mock
+async def test_sign_transaction_rejects_tx_where_signer_is_not_required() -> None:
+    transaction = create_test_transaction(Keypair().pubkey())
+    with pytest.raises(SignerError) as excinfo:
+        await make_signer().sign_transaction(transaction)
+    assert excinfo.value.code == SignerErrorCode.SIGNING_FAILED
+    assert not respx.calls
+
+
+@respx.mock
+async def test_sign_transaction_undecodable_response() -> None:
+    transaction = create_test_transaction(_ACCOUNT_KEYPAIR.pubkey())
+    respx.post(f"{API_BASE_URL}{BASE_PATH}/sign/transaction").mock(
+        return_value=httpx.Response(200, json={"signedTransaction": "!!!not-base64!!!"})
+    )
+    with pytest.raises(SignerError) as excinfo:
+        await make_signer().sign_transaction(transaction)
+    assert excinfo.value.code == SignerErrorCode.SERIALIZATION_ERROR
+
+
+@respx.mock
+async def test_sign_transaction_undeserializable_response() -> None:
+    transaction = create_test_transaction(_ACCOUNT_KEYPAIR.pubkey())
+    respx.post(f"{API_BASE_URL}{BASE_PATH}/sign/transaction").mock(
+        return_value=httpx.Response(
+            200, json={"signedTransaction": base64.b64encode(b"junk").decode()}
+        )
+    )
+    with pytest.raises(SignerError) as excinfo:
+        await make_signer().sign_transaction(transaction)
+    assert excinfo.value.code == SignerErrorCode.SERIALIZATION_ERROR
+
+
+@respx.mock
+async def test_sign_transaction_unsigned_response_fails_verification() -> None:
+    transaction = create_test_transaction(_ACCOUNT_KEYPAIR.pubkey())
+    respx.post(f"{API_BASE_URL}{BASE_PATH}/sign/transaction").mock(
+        return_value=httpx.Response(
+            200,
+            json={"signedTransaction": base64.b64encode(bytes(transaction)).decode()},
+        )
+    )
+    with pytest.raises(SignerError) as excinfo:
+        await make_signer().sign_transaction(transaction)
+    assert excinfo.value.code == SignerErrorCode.SIGNING_FAILED
+
+
+@respx.mock
+async def test_is_available_uses_bearer_only() -> None:
+    respx.get(f"{API_BASE_URL}{BASE_PATH}").mock(
+        return_value=httpx.Response(200, json={"address": ADDRESS})
+    )
+    assert await make_signer().is_available()
+    request = respx.calls.last.request
+    assert "X-Wallet-Auth" not in request.headers
+    _, claims = decode_auth_claims(request)
+    assert claims["uris"] == [f"GET {API_HOST}{BASE_PATH}"]
+
+
+@respx.mock
+async def test_is_available_false_on_api_error() -> None:
+    respx.get(f"{API_BASE_URL}{BASE_PATH}").mock(
+        return_value=httpx.Response(403, json={"error": "forbidden"})
+    )
+    assert not await make_signer().is_available()
+
+
+async def test_create_cdp_signer_factory() -> None:
+    signer = await create_cdp_signer(
+        CdpSignerConfig(
+            api_key_id=API_KEY_ID,
+            api_key_secret=API_KEY_SECRET,
+            wallet_secret=WALLET_SECRET,
+            address=ADDRESS,
+            api_base_url=API_BASE_URL,
+        )
+    )
+    assert str(signer.pubkey) == ADDRESS


### PR DESCRIPTION
## Summary
- Adds the **CDP** backend (`solana_keychain.cdp`). Stacked on #216 — this layer shows only the CDP work.
- **Dual JWT auth**: every request carries an EdDSA bearer token (protected header: `kid` = API key id, fresh `nonce`; claims: `sub`, `iss=cdp`, 120s window, `uris = ["METHOD host/path"]`). Write endpoints add an ES256 `X-Wallet-Auth` token whose `reqHash` is SHA-256 over the request body serialized with recursively sorted keys — omitted for empty bodies. API key secret is a validated base64 Ed25519 keypair (pubkey half must match the seed-derived key; PEM keys rejected); wallet secret is base64 PKCS8 DER P-256.
- **`sign_message` is UTF-8-only** — the endpoint takes a string, so non-UTF-8 bytes raise `SIGNER_SERIALIZATION_ERROR`. Returned signatures are base58, length-checked, and verified locally.
- **`sign_transaction` flow differs from other backends**: submits the full base64 serialized transaction, decodes the returned signed transaction, extracts this signer's signature at its required-signer position, verifies it against the message bytes, then applies it to the caller's transaction. Non-signer transactions fail before any network call.
- Availability: bearer-only GET of the account resource. No init needed — the address is supplied in config and validated at construction. `cryptography` + `pyjwt` behind the `[cdp]` extra.

## Test Plan
- 280 tests pass (31 new): both JWTs cryptographically verified against captured requests (kid/nonce/uris/reqHash), reqHash key-order independence and empty-body omission, invalid API/wallet secrets (PEM, bad base64, wrong length, mismatched pubkey half, non-EC DER), UTF-8 rejection, base58/length/verification failures, full signed-transaction round-trip incl. undecodable/undeserializable/unsigned responses, non-signer fast-fail with zero network calls asserted, bearer-only availability, empty-config matrix, repr redaction
- `ruff` + `mypy --strict` + sdist/wheel build clean

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
