### PR TITLE
feat(python): Dfns signer backend

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -26,7 +26,7 @@ library offers a consistent API across all signing methods.
 | **AWS KMS** | AWS Key Management Service with Ed25519 signing | `solana_keychain.aws_kms` | ✅ Available |
 | **Fireblocks** | Fireblocks institutional custody platform | `solana_keychain.fireblocks` | ✅ Available |
 | **GCP KMS** | Google Cloud Key Management Service with Ed25519 signing | `solana_keychain.gcp_kms` | ✅ Available |
-| **Dfns** | Dfns wallet infrastructure with Ed25519 signing | — | Planned |
+| **Dfns** | Dfns wallet infrastructure with Ed25519 signing | `solana_keychain.dfns` | ✅ Available |
 | **Para** | MPC wallets with Para infrastructure | `solana_keychain.para` | ✅ Available |
 | **CDP** | Coinbase Developer Platform managed wallets | `solana_keychain.cdp` | ✅ Available |
 | **Crossmint** | Crossmint managed wallets | — | Planned |
@@ -39,6 +39,7 @@ library offers a consistent API across all signing methods.
 pip install solana-keychain              # memory + vault
 pip install 'solana-keychain[aws-kms]'   # adds the AWS KMS backend
 pip install 'solana-keychain[cdp]'       # adds the CDP backend
+pip install 'solana-keychain[dfns]'      # adds the Dfns backend
 pip install 'solana-keychain[fireblocks]' # adds the Fireblocks backend
 pip install 'solana-keychain[gcp-kms]'   # adds the GCP KMS backend
 pip install 'solana-keychain[privy]'     # adds the Privy backend

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -19,6 +19,7 @@ Repository = "https://github.com/solana-foundation/solana-keychain"
 [project.optional-dependencies]
 aws-kms = ["boto3>=1.35"]
 cdp = ["base58>=2.1", "cryptography>=43", "pyjwt>=2.8"]
+dfns = ["cryptography>=43"]
 fireblocks = ["cryptography>=43", "pyjwt>=2.8"]
 gcp-kms = ["google-cloud-kms>=2.24"]
 privy = ["cryptography>=43"]

--- a/python/src/solana_keychain/dfns/__init__.py
+++ b/python/src/solana_keychain/dfns/__init__.py
@@ -1,0 +1,3 @@
+from solana_keychain.dfns.signer import DfnsSigner, DfnsSignerConfig, create_dfns_signer
+
+__all__ = ["DfnsSigner", "DfnsSignerConfig", "create_dfns_signer"]

--- a/python/src/solana_keychain/dfns/auth.py
+++ b/python/src/solana_keychain/dfns/auth.py
@@ -1,0 +1,131 @@
+"""Dfns User Action Signing flow: mutating API requests require a challenge to be
+signed with a registered credential key and exchanged for a one-time user-action
+token."""
+
+import base64
+import json
+from typing import Any
+
+try:
+    from cryptography.hazmat.primitives import hashes
+    from cryptography.hazmat.primitives.asymmetric import ec, padding, rsa
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+    from cryptography.hazmat.primitives.serialization import load_pem_private_key
+except ImportError as error:  # pragma: no cover
+    raise ImportError(
+        "solana_keychain.dfns requires the dfns extra: pip install 'solana-keychain[dfns]'"
+    ) from error
+
+import httpx
+
+from solana_keychain.core.errors import SignerError, SignerErrorCode
+from solana_keychain.core.http import fetch_signer_json
+
+
+def sign_challenge(private_key_pem: str, data: bytes) -> bytes:
+    """Sign challenge data with an Ed25519, P-256, or RSA private key in PEM format
+    (PKCS8 or SEC1). Ed25519 yields the raw 64-byte signature, P-256 a DER-encoded
+    ECDSA-SHA256 signature, RSA a PKCS1v15-SHA256 signature."""
+    invalid = SignerError(
+        SignerErrorCode.INVALID_PRIVATE_KEY,
+        "Unsupported PEM key type (expected Ed25519, P256, or RSA)",
+    )
+    try:
+        key = load_pem_private_key(private_key_pem.encode(), password=None)
+    except Exception:
+        raise invalid from None
+    if isinstance(key, Ed25519PrivateKey):
+        return key.sign(data)
+    if isinstance(key, ec.EllipticCurvePrivateKey):
+        if not isinstance(key.curve, ec.SECP256R1):
+            raise invalid
+        return key.sign(data, ec.ECDSA(hashes.SHA256()))
+    if isinstance(key, rsa.RSAPrivateKey):
+        return key.sign(data, padding.PKCS1v15(), hashes.SHA256())
+    raise invalid
+
+
+def _b64url_no_pad(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def format_client_data(challenge: str) -> bytes:
+    """The exact bytes signed for a key credential assertion: a compact JSON object
+    with ``challenge`` before ``type``. The byte layout is part of the assertion —
+    the server verifies the signature over precisely these bytes."""
+    return json.dumps({"challenge": challenge, "type": "key.get"}, separators=(",", ":")).encode()
+
+
+async def sign_user_action(
+    *,
+    api_base_url: str,
+    auth_token: str,
+    cred_id: str,
+    private_key_pem: str,
+    http_method: str,
+    http_path: str,
+    body: str,
+    client: httpx.AsyncClient | None,
+) -> str:
+    """Perform the User Action Signing flow and return the token for the
+    ``x-dfns-useraction`` header."""
+    headers = {"Authorization": f"Bearer {auth_token}", "Content-Type": "application/json"}
+
+    challenge_response = await fetch_signer_json(
+        url=f"{api_base_url}/auth/action/init",
+        provider_name="Dfns",
+        method="POST",
+        headers=headers,
+        json_body={
+            "userActionPayload": body,
+            "userActionHttpMethod": http_method,
+            "userActionHttpPath": http_path,
+            "userActionServerKind": "Api",
+        },
+        client=client,
+    )
+    if not isinstance(challenge_response, dict):
+        raise SignerError(
+            SignerErrorCode.SERIALIZATION_ERROR, "Failed to parse action init response"
+        )
+    challenge = challenge_response.get("challenge")
+    challenge_identifier = challenge_response.get("challengeIdentifier")
+    if not isinstance(challenge, str) or not isinstance(challenge_identifier, str):
+        raise SignerError(
+            SignerErrorCode.SERIALIZATION_ERROR, "Failed to parse action init response"
+        )
+
+    allowed: list[Any] = []
+    allow_credentials = challenge_response.get("allowCredentials")
+    if isinstance(allow_credentials, dict) and isinstance(allow_credentials.get("key"), list):
+        allowed = allow_credentials["key"]
+    if not any(isinstance(c, dict) and c.get("id") == cred_id for c in allowed):
+        raise SignerError(
+            SignerErrorCode.CONFIG_ERROR, f"Credential {cred_id} not in allowed credentials"
+        )
+
+    client_data = format_client_data(challenge)
+    signature = sign_challenge(private_key_pem, client_data)
+
+    action_response = await fetch_signer_json(
+        url=f"{api_base_url}/auth/action",
+        provider_name="Dfns",
+        method="POST",
+        headers=headers,
+        json_body={
+            "challengeIdentifier": challenge_identifier,
+            "firstFactor": {
+                "kind": "Key",
+                "credentialAssertion": {
+                    "credId": cred_id,
+                    "clientData": _b64url_no_pad(client_data),
+                    "signature": _b64url_no_pad(signature),
+                },
+            },
+        },
+        client=client,
+    )
+    user_action = action_response.get("userAction") if isinstance(action_response, dict) else None
+    if not isinstance(user_action, str):
+        raise SignerError(SignerErrorCode.SERIALIZATION_ERROR, "Failed to parse action response")
+    return user_action

--- a/python/src/solana_keychain/dfns/signer.py
+++ b/python/src/solana_keychain/dfns/signer.py
@@ -1,0 +1,259 @@
+"""Dfns Keys API signer integration."""
+
+import json
+from dataclasses import dataclass, field
+from urllib.parse import quote
+
+import httpx
+from solders.pubkey import Pubkey
+from solders.signature import Signature
+from solders.transaction import Transaction
+
+from solana_keychain.core.errors import SignerError, SignerErrorCode
+from solana_keychain.core.http import assert_https_url, fetch_signer_json, normalize_base_url
+from solana_keychain.core.signer import SignedTransaction, SolanaSigner
+from solana_keychain.core.transaction_util import (
+    add_signature_to_transaction,
+    classify_signed_transaction,
+    serialize_transaction,
+)
+from solana_keychain.dfns.auth import sign_user_action
+
+DEFAULT_API_BASE_URL = "https://api.dfns.io"
+
+ED25519_SIGNATURE_LENGTH = 64
+
+
+@dataclass
+class DfnsSignerConfig:
+    """Configuration for a Dfns signer.
+
+    ``auth_token`` is a service-account or personal access token; ``cred_id`` and
+    ``private_key_pem`` (Ed25519, P-256, or RSA) identify the credential used for
+    User Action Signing.
+    """
+
+    auth_token: str = field(repr=False)
+    cred_id: str
+    private_key_pem: str = field(repr=False)
+    wallet_id: str
+    api_base_url: str = DEFAULT_API_BASE_URL
+    http_client: httpx.AsyncClient | None = field(default=None, repr=False)
+
+
+class DfnsSigner(SolanaSigner):
+    """Signer backed by a Dfns-held wallet.
+
+    ``init()`` must be awaited before signing — it resolves the wallet's signing-key
+    id and public key. ``create_dfns_signer()`` does this for you.
+    """
+
+    def __init__(self, config: DfnsSignerConfig) -> None:
+        api_base_url = normalize_base_url(config.api_base_url)
+        assert_https_url(api_base_url, "api_base_url")
+        self._api_base_url = api_base_url
+        self._auth_token = config.auth_token
+        self._cred_id = config.cred_id
+        self._private_key_pem = config.private_key_pem
+        self._wallet_id = config.wallet_id
+        self._http_client = config.http_client
+        self._key_id: str | None = None
+        self._public_key: Pubkey | None = None
+
+    def __repr__(self) -> str:
+        return (
+            f"DfnsSigner(pubkey={self._public_key}, wallet_id={self._wallet_id}, "
+            f"key_id={self._key_id})"
+        )
+
+    async def _get_wallet(self) -> dict[str, object]:
+        wallet = await fetch_signer_json(
+            url=f"{self._api_base_url}/wallets/{quote(self._wallet_id, safe='')}",
+            provider_name="Dfns",
+            headers={"Authorization": f"Bearer {self._auth_token}"},
+            client=self._http_client,
+        )
+        if not isinstance(wallet, dict):
+            raise SignerError(
+                SignerErrorCode.SERIALIZATION_ERROR, "Failed to parse wallet response"
+            )
+        return wallet
+
+    @staticmethod
+    def _signing_key_fields(wallet: dict[str, object]) -> tuple[str, str, str, str]:
+        signing_key = wallet.get("signingKey")
+        if not isinstance(signing_key, dict):
+            raise SignerError(
+                SignerErrorCode.SERIALIZATION_ERROR, "Failed to parse wallet response"
+            )
+        return (
+            str(signing_key.get("id", "")),
+            str(signing_key.get("scheme", "")),
+            str(signing_key.get("curve", "")),
+            str(signing_key.get("publicKey", "")),
+        )
+
+    async def init(self) -> None:
+        """Resolve the wallet's signing-key id and public key. Must be awaited
+        before signing."""
+        wallet = await self._get_wallet()
+        status = str(wallet.get("status", ""))
+        if status != "Active":
+            raise SignerError(SignerErrorCode.CONFIG_ERROR, f"Wallet is not active: {status}")
+        key_id, scheme, curve, public_key_hex = self._signing_key_fields(wallet)
+        if scheme != "EdDSA":
+            raise SignerError(
+                SignerErrorCode.CONFIG_ERROR, f"Unsupported key scheme: {scheme} (expected EdDSA)"
+            )
+        if curve != "ed25519":
+            raise SignerError(
+                SignerErrorCode.CONFIG_ERROR, f"Unsupported key curve: {curve} (expected ed25519)"
+            )
+        try:
+            pubkey_bytes = bytes.fromhex(public_key_hex)
+        except ValueError:
+            raise SignerError(
+                SignerErrorCode.INVALID_PUBLIC_KEY, "Failed to decode hex public key"
+            ) from None
+        if len(pubkey_bytes) != 32:
+            raise SignerError(
+                SignerErrorCode.INVALID_PUBLIC_KEY,
+                "Invalid public key length (expected 32 bytes)",
+            )
+        self._public_key = Pubkey.from_bytes(pubkey_bytes)
+        self._key_id = key_id
+
+    def _initialized(self) -> tuple[Pubkey, str]:
+        if self._public_key is None or self._key_id is None:
+            raise SignerError(
+                SignerErrorCode.NOT_INITIALIZED,
+                "DfnsSigner is not initialized; call init() before signing",
+            )
+        return self._public_key, self._key_id
+
+    @property
+    def pubkey(self) -> Pubkey:
+        return self._initialized()[0]
+
+    @staticmethod
+    def _combine_signature(r_hex: str, s_hex: str) -> Signature:
+        try:
+            r_bytes = bytes.fromhex(r_hex.removeprefix("0x"))
+        except ValueError:
+            raise SignerError(
+                SignerErrorCode.SERIALIZATION_ERROR, "Failed to decode signature r"
+            ) from None
+        try:
+            s_bytes = bytes.fromhex(s_hex.removeprefix("0x"))
+        except ValueError:
+            raise SignerError(
+                SignerErrorCode.SERIALIZATION_ERROR, "Failed to decode signature s"
+            ) from None
+        signature_bytes = r_bytes + s_bytes
+        if len(signature_bytes) != ED25519_SIGNATURE_LENGTH:
+            raise SignerError(
+                SignerErrorCode.SIGNING_FAILED,
+                f"Invalid signature length (expected {ED25519_SIGNATURE_LENGTH} bytes)",
+            )
+        return Signature.from_bytes(signature_bytes)
+
+    async def _send_signature_request(self, request: dict[str, str]) -> Signature:
+        _, key_id = self._initialized()
+        http_path = f"/keys/{quote(key_id, safe='')}/signatures"
+        body = json.dumps(request, separators=(",", ":"))
+
+        user_action = await sign_user_action(
+            api_base_url=self._api_base_url,
+            auth_token=self._auth_token,
+            cred_id=self._cred_id,
+            private_key_pem=self._private_key_pem,
+            http_method="POST",
+            http_path=http_path,
+            body=body,
+            client=self._http_client,
+        )
+
+        response = await fetch_signer_json(
+            url=f"{self._api_base_url}{http_path}",
+            provider_name="Dfns",
+            method="POST",
+            headers={
+                "Authorization": f"Bearer {self._auth_token}",
+                "Content-Type": "application/json",
+                "x-dfns-useraction": user_action,
+            },
+            content=body.encode(),
+            client=self._http_client,
+        )
+        if not isinstance(response, dict):
+            raise SignerError(
+                SignerErrorCode.SERIALIZATION_ERROR, "Failed to parse signature response"
+            )
+        status = response.get("status")
+        if status == "Failed":
+            raise SignerError(SignerErrorCode.SIGNING_FAILED, "Dfns signing failed")
+        if status != "Signed":
+            raise SignerError(
+                SignerErrorCode.SIGNING_FAILED,
+                f"Unexpected signature status: {status} (may require policy approval)",
+            )
+        components = response.get("signature")
+        if (
+            not isinstance(components, dict)
+            or not isinstance(components.get("r"), str)
+            or not isinstance(components.get("s"), str)
+        ):
+            raise SignerError(
+                SignerErrorCode.SIGNING_FAILED, "Signature components missing from response"
+            )
+        return self._combine_signature(components["r"], components["s"])
+
+    async def sign_message(self, message: bytes) -> Signature:
+        public_key, _ = self._initialized()
+        signature = await self._send_signature_request(
+            {"kind": "Message", "message": f"0x{message.hex()}"}
+        )
+        if not signature.verify(public_key, message):
+            raise SignerError(
+                SignerErrorCode.SIGNING_FAILED,
+                "Signature verification failed — the returned signature does not match "
+                "the public key",
+            )
+        return signature
+
+    async def sign_transaction(self, transaction: Transaction) -> SignedTransaction:
+        public_key, _ = self._initialized()
+        signature = await self._send_signature_request(
+            {
+                "kind": "Transaction",
+                "transaction": f"0x{bytes(transaction).hex()}",
+                "blockchainKind": "Solana",
+            }
+        )
+        if not signature.verify(public_key, transaction.message_data()):
+            raise SignerError(
+                SignerErrorCode.SIGNING_FAILED,
+                "Signature verification failed — the returned signature does not match "
+                "the public key",
+            )
+        add_signature_to_transaction(transaction, public_key, signature)
+        return classify_signed_transaction(
+            transaction, serialize_transaction(transaction), signature
+        )
+
+    async def is_available(self) -> bool:
+        try:
+            wallet = await self._get_wallet()
+            _, scheme, curve, _ = self._signing_key_fields(wallet)
+        except SignerError:
+            return False
+        return (
+            str(wallet.get("status", "")) == "Active" and scheme == "EdDSA" and curve == "ed25519"
+        )
+
+
+async def create_dfns_signer(config: DfnsSignerConfig) -> DfnsSigner:
+    """Create a ready-to-use Dfns signer (awaits ``init()``)."""
+    signer = DfnsSigner(config)
+    await signer.init()
+    return signer

--- a/python/tests/test_dfns_signer.py
+++ b/python/tests/test_dfns_signer.py
@@ -1,0 +1,420 @@
+import base64
+import json
+from typing import Any
+
+import httpx
+import pytest
+import respx
+from cryptography.hazmat.primitives.serialization import load_pem_private_key
+from solders.keypair import Keypair
+
+from solana_keychain import SignerError, SignerErrorCode
+from solana_keychain.dfns import DfnsSigner, DfnsSignerConfig, create_dfns_signer
+from solana_keychain.dfns.auth import format_client_data, sign_challenge
+from tests.util import create_test_transaction
+
+API_BASE_URL = "https://dfns.example.com"
+AUTH_TOKEN = "test-auth-token"
+CRED_ID = "test-cred-id"
+WALLET_ID = "test-wallet-id"
+KEY_ID = "test-key-id"
+
+WALLET_URL = f"{API_BASE_URL}/wallets/{WALLET_ID}"
+ACTION_INIT_URL = f"{API_BASE_URL}/auth/action/init"
+ACTION_URL = f"{API_BASE_URL}/auth/action"
+SIGNATURES_URL = f"{API_BASE_URL}/keys/{KEY_ID}/signatures"
+
+ED25519_PEM = (
+    "-----BEGIN PRIVATE KEY-----\n"
+    "MC4CAQAwBQYDK2VwBCIEIJ+DYvh6SEqVTm50DFtMDoQikUmifl1yiWd+IiYyoHBD\n"
+    "-----END PRIVATE KEY-----"
+)
+P256_PKCS8_PEM = (
+    "-----BEGIN PRIVATE KEY-----\n"
+    "MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgNVGLQN9VkU26M2JG\n"
+    "3hbSFACbGLXkQlB69ZxAhXGqf/mhRANCAATjr6H28PJiFSlRz9kfkzu9Fy6vt1uY\n"
+    "9Egu4yP/e2qnDZ+SjpcQo1hpF6Cb1h6S1a2b7qi3IEEnh+d/vzlOHAaf\n"
+    "-----END PRIVATE KEY-----"
+)
+P256_SEC1_PEM = (
+    "-----BEGIN EC PRIVATE KEY-----\n"
+    "MHcCAQEEIGa93+PpxzDlIywW+Al/cpIAGzLKwGwIDWpgwrJ+ht9ZoAoGCCqGSM49\n"
+    "AwEHoUQDQgAE0Mi+Kw78tyVMPAGb6a6Nwn/yiz65gKVBS+nT171vqgLzoHwf51iU\n"
+    "TLWfftn3ZyCvKLzTN5pd1Up982TKelcbFw==\n"
+    "-----END EC PRIVATE KEY-----"
+)
+
+
+def make_signer() -> DfnsSigner:
+    return DfnsSigner(
+        DfnsSignerConfig(
+            auth_token=AUTH_TOKEN,
+            cred_id=CRED_ID,
+            private_key_pem=ED25519_PEM,
+            wallet_id=WALLET_ID,
+            api_base_url=API_BASE_URL,
+        )
+    )
+
+
+def wallet_response(
+    pubkey_hex: str,
+    status: str = "Active",
+    scheme: str = "EdDSA",
+    curve: str = "ed25519",
+) -> dict[str, Any]:
+    return {
+        "id": WALLET_ID,
+        "status": status,
+        "signingKey": {
+            "id": KEY_ID,
+            "scheme": scheme,
+            "curve": curve,
+            "publicKey": pubkey_hex,
+        },
+    }
+
+
+def mock_wallet(keypair: Keypair, **overrides: str) -> None:
+    respx.get(WALLET_URL).mock(
+        return_value=httpx.Response(
+            200, json=wallet_response(bytes(keypair.pubkey()).hex(), **overrides)
+        )
+    )
+
+
+def mock_user_action_flow(challenge: str = "test-challenge") -> None:
+    respx.post(ACTION_INIT_URL).mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "challenge": challenge,
+                "challengeIdentifier": "challenge-id-1",
+                "allowCredentials": {"key": [{"id": CRED_ID}], "webauthn": []},
+            },
+        )
+    )
+    respx.post(ACTION_URL).mock(
+        return_value=httpx.Response(200, json={"userAction": "user-action-token"})
+    )
+
+
+def mock_signature_response(signature: bytes, prefix: str = "") -> None:
+    respx.post(SIGNATURES_URL).mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "id": "sig-1",
+                "status": "Signed",
+                "signature": {
+                    "r": f"{prefix}{signature[:32].hex()}",
+                    "s": f"{prefix}{signature[32:].hex()}",
+                },
+            },
+        )
+    )
+
+
+async def initialized_signer(keypair: Keypair) -> DfnsSigner:
+    mock_wallet(keypair)
+    signer = make_signer()
+    await signer.init()
+    return signer
+
+
+def test_sign_challenge_ed25519_is_raw_64_bytes() -> None:
+    assert len(sign_challenge(ED25519_PEM, b"test challenge data")) == 64
+
+
+@pytest.mark.parametrize("pem", [P256_PKCS8_PEM, P256_SEC1_PEM])
+def test_sign_challenge_p256_is_der(pem: str) -> None:
+    signature = sign_challenge(pem, b"test challenge data")
+    assert 68 <= len(signature) <= 72
+    assert signature[0] == 0x30
+
+
+def test_sign_challenge_invalid_key() -> None:
+    with pytest.raises(SignerError) as excinfo:
+        sign_challenge("not-a-pem-key", b"test")
+    assert excinfo.value.code == SignerErrorCode.INVALID_PRIVATE_KEY
+
+
+def test_client_data_bytes_are_exact() -> None:
+    assert format_client_data("abc") == b'{"challenge":"abc","type":"key.get"}'
+
+
+@respx.mock
+async def test_init_resolves_signing_key() -> None:
+    keypair = Keypair()
+    signer = await initialized_signer(keypair)
+    assert signer.pubkey == keypair.pubkey()
+    assert respx.calls.last.request.headers["Authorization"] == f"Bearer {AUTH_TOKEN}"
+
+
+@respx.mock
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"status": "Archived"},
+        {"scheme": "ECDSA"},
+        {"curve": "secp256k1"},
+    ],
+)
+async def test_init_rejects_unusable_wallet(overrides: dict[str, str]) -> None:
+    mock_wallet(Keypair(), **overrides)
+    signer = make_signer()
+    with pytest.raises(SignerError) as excinfo:
+        await signer.init()
+    assert excinfo.value.code == SignerErrorCode.CONFIG_ERROR
+
+
+@respx.mock
+@pytest.mark.parametrize("pubkey_hex", ["not-hex", "abcd"])
+async def test_init_rejects_bad_public_key(pubkey_hex: str) -> None:
+    respx.get(WALLET_URL).mock(return_value=httpx.Response(200, json=wallet_response(pubkey_hex)))
+    signer = make_signer()
+    with pytest.raises(SignerError) as excinfo:
+        await signer.init()
+    assert excinfo.value.code == SignerErrorCode.INVALID_PUBLIC_KEY
+
+
+@respx.mock
+async def test_init_api_error() -> None:
+    respx.get(WALLET_URL).mock(return_value=httpx.Response(401, json={"error": "denied"}))
+    signer = make_signer()
+    with pytest.raises(SignerError) as excinfo:
+        await signer.init()
+    assert excinfo.value.code == SignerErrorCode.REMOTE_API_ERROR
+
+
+async def test_uninitialized_sign_raises_not_initialized() -> None:
+    with pytest.raises(SignerError) as excinfo:
+        await make_signer().sign_message(b"hello")
+    assert excinfo.value.code == SignerErrorCode.NOT_INITIALIZED
+
+
+@respx.mock
+async def test_sign_message_full_user_action_flow() -> None:
+    keypair = Keypair()
+    message = b"dfns-message"
+    signature = keypair.sign_message(message)
+    signer = await initialized_signer(keypair)
+    mock_user_action_flow()
+    mock_signature_response(bytes(signature))
+
+    result = await signer.sign_message(message)
+
+    assert result == signature
+
+    init_request = json.loads(respx.calls[1].request.content)
+    expected_body = json.dumps(
+        {"kind": "Message", "message": f"0x{message.hex()}"}, separators=(",", ":")
+    )
+    assert init_request == {
+        "userActionPayload": expected_body,
+        "userActionHttpMethod": "POST",
+        "userActionHttpPath": f"/keys/{KEY_ID}/signatures",
+        "userActionServerKind": "Api",
+    }
+
+    action_request = json.loads(respx.calls[2].request.content)
+    assertion = action_request["firstFactor"]["credentialAssertion"]
+    assert action_request["challengeIdentifier"] == "challenge-id-1"
+    assert action_request["firstFactor"]["kind"] == "Key"
+    assert assertion["credId"] == CRED_ID
+    padded = assertion["clientData"] + "=" * (-len(assertion["clientData"]) % 4)
+    client_data = base64.urlsafe_b64decode(padded)
+    assert client_data == format_client_data("test-challenge")
+    credential_key = load_pem_private_key(ED25519_PEM.encode(), password=None)
+    signature_padded = assertion["signature"] + "=" * (-len(assertion["signature"]) % 4)
+    credential_key.public_key().verify(  # type: ignore[union-attr, call-arg]
+        base64.urlsafe_b64decode(signature_padded), client_data
+    )
+
+    sign_request = respx.calls[3].request
+    assert sign_request.headers["x-dfns-useraction"] == "user-action-token"
+    assert sign_request.content == expected_body.encode()
+
+
+@respx.mock
+async def test_sign_message_rejects_disallowed_credential() -> None:
+    keypair = Keypair()
+    signer = await initialized_signer(keypair)
+    respx.post(ACTION_INIT_URL).mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "challenge": "c",
+                "challengeIdentifier": "ci",
+                "allowCredentials": {"key": [{"id": "other-cred"}]},
+            },
+        )
+    )
+    with pytest.raises(SignerError) as excinfo:
+        await signer.sign_message(b"hello")
+    assert excinfo.value.code == SignerErrorCode.CONFIG_ERROR
+
+
+@respx.mock
+async def test_sign_message_accepts_0x_prefixed_components() -> None:
+    keypair = Keypair()
+    message = b"dfns-message"
+    signature = keypair.sign_message(message)
+    signer = await initialized_signer(keypair)
+    mock_user_action_flow()
+    mock_signature_response(bytes(signature), prefix="0x")
+
+    assert await signer.sign_message(message) == signature
+
+
+@respx.mock
+@pytest.mark.parametrize(
+    ("status", "signature"),
+    [
+        ("Failed", None),
+        ("Pending", None),
+        ("Signed", None),
+    ],
+)
+async def test_sign_message_bad_status_or_missing_components(
+    status: str, signature: dict[str, str] | None
+) -> None:
+    keypair = Keypair()
+    signer = await initialized_signer(keypair)
+    mock_user_action_flow()
+    respx.post(SIGNATURES_URL).mock(
+        return_value=httpx.Response(
+            200, json={"id": "sig-1", "status": status, "signature": signature}
+        )
+    )
+    with pytest.raises(SignerError) as excinfo:
+        await signer.sign_message(b"hello")
+    assert excinfo.value.code == SignerErrorCode.SIGNING_FAILED
+
+
+@respx.mock
+async def test_sign_message_undecodable_component() -> None:
+    keypair = Keypair()
+    signer = await initialized_signer(keypair)
+    mock_user_action_flow()
+    respx.post(SIGNATURES_URL).mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "id": "sig-1",
+                "status": "Signed",
+                "signature": {"r": "not-hex", "s": "00" * 32},
+            },
+        )
+    )
+    with pytest.raises(SignerError) as excinfo:
+        await signer.sign_message(b"hello")
+    assert excinfo.value.code == SignerErrorCode.SERIALIZATION_ERROR
+
+
+@respx.mock
+async def test_sign_message_wrong_length_signature() -> None:
+    keypair = Keypair()
+    signer = await initialized_signer(keypair)
+    mock_user_action_flow()
+    respx.post(SIGNATURES_URL).mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "id": "sig-1",
+                "status": "Signed",
+                "signature": {"r": "00" * 16, "s": "00" * 16},
+            },
+        )
+    )
+    with pytest.raises(SignerError) as excinfo:
+        await signer.sign_message(b"hello")
+    assert excinfo.value.code == SignerErrorCode.SIGNING_FAILED
+
+
+@respx.mock
+async def test_sign_message_signature_verification_failure() -> None:
+    keypair = Keypair()
+    message = b"dfns-message"
+    signer = await initialized_signer(keypair)
+    mock_user_action_flow()
+    mock_signature_response(bytes(Keypair().sign_message(message)))
+    with pytest.raises(SignerError) as excinfo:
+        await signer.sign_message(message)
+    assert excinfo.value.code == SignerErrorCode.SIGNING_FAILED
+
+
+@respx.mock
+async def test_sign_transaction_success() -> None:
+    keypair = Keypair()
+    signer = await initialized_signer(keypair)
+    transaction = create_test_transaction(keypair.pubkey())
+    signature = keypair.sign_message(transaction.message_data())
+    mock_user_action_flow()
+    mock_signature_response(bytes(signature))
+
+    result = await signer.sign_transaction(transaction)
+
+    assert result.is_complete
+    assert result.signature == signature
+    assert list(transaction.signatures) == [signature]
+
+    sign_request = json.loads(respx.calls[3].request.content)
+    assert sign_request["kind"] == "Transaction"
+    assert sign_request["blockchainKind"] == "Solana"
+    assert sign_request["transaction"].startswith("0x")
+
+
+@respx.mock
+@pytest.mark.parametrize(
+    ("overrides", "expected"),
+    [
+        ({}, True),
+        ({"status": "Archived"}, False),
+        ({"scheme": "ECDSA"}, False),
+        ({"curve": "secp256k1"}, False),
+    ],
+)
+async def test_is_available_gates_wallet_health(overrides: dict[str, str], expected: bool) -> None:
+    keypair = Keypair()
+    signer = await initialized_signer(keypair)
+    mock_wallet(keypair, **overrides)
+    assert await signer.is_available() is expected
+
+
+@respx.mock
+async def test_is_available_false_on_api_error() -> None:
+    keypair = Keypair()
+    signer = await initialized_signer(keypair)
+    respx.get(WALLET_URL).mock(return_value=httpx.Response(403, json={"error": "forbidden"}))
+    assert not await signer.is_available()
+
+
+@respx.mock
+async def test_create_dfns_signer_factory_initializes() -> None:
+    keypair = Keypair()
+    mock_wallet(keypair)
+    signer = await create_dfns_signer(
+        DfnsSignerConfig(
+            auth_token=AUTH_TOKEN,
+            cred_id=CRED_ID,
+            private_key_pem=ED25519_PEM,
+            wallet_id=WALLET_ID,
+            api_base_url=API_BASE_URL,
+        )
+    )
+    assert signer.pubkey == keypair.pubkey()
+
+
+def test_reprs_never_contain_secrets() -> None:
+    config = DfnsSignerConfig(
+        auth_token=AUTH_TOKEN,
+        cred_id=CRED_ID,
+        private_key_pem=ED25519_PEM,
+        wallet_id=WALLET_ID,
+        api_base_url=API_BASE_URL,
+    )
+    signer = make_signer()
+    for text in (repr(config), repr(signer)):
+        assert AUTH_TOKEN not in text
+        assert "PRIVATE KEY" not in text


### PR DESCRIPTION
## Summary
- Adds the **Dfns** backend (`solana_keychain.dfns`). Stacked on #217 — this layer shows only the Dfns work.
- **User Action Signing** on every mutating request: `POST /auth/action/init` (the exact signing-request body is the `userActionPayload`), configured credential must appear in `allowCredentials.key`, the credential key signs the **byte-exact** `clientData` JSON (`{"challenge":…,"type":"key.get"}`, compact, challenge-first — the server verifies the signature over precisely these bytes), assertion exchanged at `POST /auth/action` for the `x-dfns-useraction` token. The final signing request is sent with raw `content=` so its bytes equal the signed payload.
- **Credential keys**: Ed25519 (raw 64-byte signature), P-256 from PKCS8 *or* SEC1 PEM (ECDSA-SHA256, DER), RSA (PKCS1v15-SHA256) — all via `cryptography`, dispatched by parsed key type.
- **Init gate**: wallet must be `Active` with an `EdDSA`/`ed25519` signing key; hex pubkey decoded and length-checked (explicitly — wrong-length `Pubkey.from_bytes` panics in native code rather than raising). Signing before `init()` raises `SIGNER_NOT_INITIALIZED`.
- Signatures return as hex `r`/`s` (0x-tolerant), concatenated to exactly 64 bytes (no padding — unlike Turnkey), verified against the wallet pubkey. `Failed` status → signing failed; any non-`Signed` status surfaces the may-require-policy-approval case. `cryptography` behind the `[dfns]` extra.

## Test Plan
- 310 tests pass (30 new): full four-request flow with the credential assertion **cryptographically verified** against the decoded `clientData` bytes and the byte-exact body asserted at each hop, golden `clientData` literal, all three key types (incl. SEC1), disallowed credential, wallet gates (status/scheme/curve), bad pubkey hex/length, 0x-prefixed components, undecodable/wrong-length signatures, non-Signed statuses, verification failure, availability matrix, not-initialized paths, factory init, repr redaction
- `ruff` + `mypy --strict` + sdist/wheel build clean

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
