### PR TITLE
feat(python): Crossmint signer backend

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -29,7 +29,7 @@ library offers a consistent API across all signing methods.
 | **Dfns** | Dfns wallet infrastructure with Ed25519 signing | `solana_keychain.dfns` | ✅ Available |
 | **Para** | MPC wallets with Para infrastructure | `solana_keychain.para` | ✅ Available |
 | **CDP** | Coinbase Developer Platform managed wallets | `solana_keychain.cdp` | ✅ Available |
-| **Crossmint** | Crossmint managed wallets | — | Planned |
+| **Crossmint** | Crossmint managed wallets | `solana_keychain.crossmint` | ✅ Available |
 | **Openfort** | Openfort backend wallets with TEE-stored keys | — | Planned |
 | **Utila** | Utila MPC wallet integration | — | Planned |
 
@@ -39,6 +39,7 @@ library offers a consistent API across all signing methods.
 pip install solana-keychain              # memory + vault
 pip install 'solana-keychain[aws-kms]'   # adds the AWS KMS backend
 pip install 'solana-keychain[cdp]'       # adds the CDP backend
+pip install 'solana-keychain[crossmint]' # adds the Crossmint backend
 pip install 'solana-keychain[dfns]'      # adds the Dfns backend
 pip install 'solana-keychain[fireblocks]' # adds the Fireblocks backend
 pip install 'solana-keychain[gcp-kms]'   # adds the GCP KMS backend

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -19,6 +19,7 @@ Repository = "https://github.com/solana-foundation/solana-keychain"
 [project.optional-dependencies]
 aws-kms = ["boto3>=1.35"]
 cdp = ["base58>=2.1", "cryptography>=43", "pyjwt>=2.8"]
+crossmint = ["base58>=2.1", "cryptography>=43"]
 dfns = ["cryptography>=43"]
 fireblocks = ["cryptography>=43", "pyjwt>=2.8"]
 gcp-kms = ["google-cloud-kms>=2.24"]

--- a/python/src/solana_keychain/crossmint/__init__.py
+++ b/python/src/solana_keychain/crossmint/__init__.py
@@ -1,0 +1,7 @@
+from solana_keychain.crossmint.signer import (
+    CrossmintSigner,
+    CrossmintSignerConfig,
+    create_crossmint_signer,
+)
+
+__all__ = ["CrossmintSigner", "CrossmintSignerConfig", "create_crossmint_signer"]

--- a/python/src/solana_keychain/crossmint/derive.py
+++ b/python/src/solana_keychain/crossmint/derive.py
@@ -1,0 +1,62 @@
+"""Crossmint delegated-signer key derivation."""
+
+try:
+    import base58
+    from cryptography.hazmat.primitives import hashes
+    from cryptography.hazmat.primitives.kdf.hkdf import HKDF
+except ImportError as error:  # pragma: no cover
+    raise ImportError(
+        "solana_keychain.crossmint requires the crossmint extra: "
+        "pip install 'solana-keychain[crossmint]'"
+    ) from error
+
+from solders.keypair import Keypair
+
+from solana_keychain.core.errors import SignerError, SignerErrorCode
+
+SIGNER_SECRET_HEX_LENGTH = 64
+
+
+def parse_api_key(api_key: str) -> tuple[str, str]:
+    """Extract ``(project_id, environment)`` from a Crossmint API key of the form
+    ``{ck|sk}_{environment}_{base58data}`` where the base58 data decodes to UTF-8
+    ``projectId:nacl_signature``."""
+    parts = api_key.split("_", 2)
+    if len(parts) != 3:
+        raise SignerError(SignerErrorCode.CONFIG_ERROR, "Invalid API key format")
+    environment, base58_data = parts[1], parts[2]
+    try:
+        decoded = base58.b58decode(base58_data).decode("utf-8")
+    except (ValueError, UnicodeDecodeError):
+        raise SignerError(SignerErrorCode.CONFIG_ERROR, "Failed to decode API key data") from None
+    project_id = decoded.split(":", 1)[0]
+    if not project_id:
+        raise SignerError(SignerErrorCode.CONFIG_ERROR, "Could not extract projectId from API key")
+    return project_id, environment
+
+
+def derive_signing_key(secret: str, api_key: str) -> Keypair:
+    """Derive the server delegated-signer Ed25519 keypair from an ``xmsk1_``-prefixed
+    64-hex-char secret via HKDF-SHA256 (salt ``crossmint``, info
+    ``{projectId}:{environment}:solana-ed25519``)."""
+    project_id, environment = parse_api_key(api_key)
+
+    raw_secret = secret.removeprefix("xmsk1_")
+    if len(raw_secret) != SIGNER_SECRET_HEX_LENGTH:
+        raise SignerError(
+            SignerErrorCode.CONFIG_ERROR,
+            f"signer_secret must be a {SIGNER_SECRET_HEX_LENGTH}-char hex string "
+            f"(got {len(raw_secret)})",
+        )
+    try:
+        ikm = bytes.fromhex(raw_secret)
+    except ValueError:
+        raise SignerError(SignerErrorCode.CONFIG_ERROR, "signer_secret is not valid hex") from None
+
+    hkdf = HKDF(
+        algorithm=hashes.SHA256(),
+        length=32,
+        salt=b"crossmint",
+        info=f"{project_id}:{environment}:solana-ed25519".encode(),
+    )
+    return Keypair.from_seed(hkdf.derive(ikm))

--- a/python/src/solana_keychain/crossmint/signer.py
+++ b/python/src/solana_keychain/crossmint/signer.py
@@ -1,0 +1,423 @@
+"""Crossmint Wallets API signer integration."""
+
+import asyncio
+import json
+from dataclasses import dataclass, field
+from typing import Any
+from urllib.parse import quote
+
+import base58
+import httpx
+from solders.keypair import Keypair
+from solders.pubkey import Pubkey
+from solders.signature import Signature
+from solders.transaction import Transaction, VersionedTransaction
+
+from solana_keychain.core.errors import SignerError, SignerErrorCode
+from solana_keychain.core.http import assert_https_url, fetch_signer_json, normalize_base_url
+from solana_keychain.core.signer import SignedTransaction, SolanaSigner
+from solana_keychain.core.transaction_util import (
+    add_signature_to_transaction,
+    classify_signed_transaction,
+    serialize_transaction,
+)
+from solana_keychain.crossmint.derive import derive_signing_key
+
+DEFAULT_API_BASE_URL = "https://www.crossmint.com/api"
+API_VERSION_PATH = "2025-06-09"
+DEFAULT_POLL_INTERVAL_MS = 1000
+DEFAULT_MAX_POLL_ATTEMPTS = 60
+AVAILABILITY_TIMEOUT_SECONDS = 5.0
+
+ED25519_SIGNATURE_LENGTH = 64
+
+_AWAITING_APPROVAL_ERROR = (
+    "Crossmint transaction is awaiting approval; additional signer approvals are required"
+)
+
+_ENCODE_URI_COMPONENT_SAFE = "-_.!~*'()"
+
+
+def _encode_uri_component(value: str) -> str:
+    return quote(value, safe=_ENCODE_URI_COMPONENT_SAFE)
+
+
+@dataclass
+class CrossmintSignerConfig:
+    """Configuration for a Crossmint signer.
+
+    ``signer_secret`` is an optional server delegated-signer secret
+    (``xmsk1_<64hex>``); when provided, an Ed25519 keypair is derived from it and
+    ``awaiting-approval`` transactions are approved automatically. ``signer``
+    overrides the delegated-signer locator (default ``server:<derived pubkey>``).
+    """
+
+    api_key: str = field(repr=False)
+    wallet_locator: str
+    signer_secret: str | None = field(default=None, repr=False)
+    signer: str | None = None
+    api_base_url: str = DEFAULT_API_BASE_URL
+    poll_interval_ms: int = DEFAULT_POLL_INTERVAL_MS
+    max_poll_attempts: int = DEFAULT_MAX_POLL_ATTEMPTS
+    http_client: httpx.AsyncClient | None = field(default=None, repr=False)
+
+
+class CrossmintSigner(SolanaSigner):
+    """Signer backed by a Crossmint smart or MPC wallet.
+
+    ``init()`` must be awaited before signing — it resolves the wallet address.
+    ``create_crossmint_signer()`` does this for you. ``sign_message`` is
+    intentionally unsupported: the Wallets API signs transactions only.
+    """
+
+    def __init__(self, config: CrossmintSignerConfig) -> None:
+        if not config.api_key:
+            raise SignerError(SignerErrorCode.CONFIG_ERROR, "api_key must not be empty")
+        if not config.wallet_locator:
+            raise SignerError(SignerErrorCode.CONFIG_ERROR, "wallet_locator must not be empty")
+        if config.poll_interval_ms <= 0:
+            raise SignerError(
+                SignerErrorCode.CONFIG_ERROR, "poll_interval_ms must be greater than 0"
+            )
+        if config.max_poll_attempts <= 0:
+            raise SignerError(
+                SignerErrorCode.CONFIG_ERROR, "max_poll_attempts must be greater than 0"
+            )
+        api_base_url = normalize_base_url(config.api_base_url)
+        assert_https_url(api_base_url, "api_base_url")
+        self._api_base_url = api_base_url
+        self._api_key = config.api_key
+        self._wallet_locator = config.wallet_locator
+        self._poll_interval_ms = config.poll_interval_ms
+        self._max_poll_attempts = config.max_poll_attempts
+        self._http_client = config.http_client
+        self._public_key: Pubkey | None = None
+
+        self._signing_key: Keypair | None = None
+        self._signer: str | None = config.signer
+        if config.signer_secret is not None:
+            self._signing_key = derive_signing_key(config.signer_secret, config.api_key)
+            self._signer = config.signer or f"server:{self._signing_key.pubkey()}"
+
+    def __repr__(self) -> str:
+        return f"CrossmintSigner(pubkey={self._public_key}, wallet_locator={self._wallet_locator})"
+
+    def _wallets_url(self, *segments: str) -> str:
+        url = (
+            f"{self._api_base_url}/{API_VERSION_PATH}/wallets/"
+            f"{_encode_uri_component(self._wallet_locator)}"
+        )
+        for segment in segments:
+            url += f"/{_encode_uri_component(segment)}"
+        return url
+
+    @staticmethod
+    def _extract_error_message(value: Any) -> str | None:
+        if not isinstance(value, dict):
+            return None
+        message = value.get("message")
+        if isinstance(message, str):
+            return message
+        error = value.get("error")
+        if isinstance(error, str):
+            return error
+        if isinstance(error, dict) and isinstance(error.get("message"), str):
+            return str(error["message"])
+        return None
+
+    async def _request_with_required_field(
+        self,
+        *,
+        method: str,
+        url: str,
+        required_field: str,
+        context: str,
+        json_body: Any | None = None,
+    ) -> dict[str, Any]:
+        headers = {"X-API-KEY": self._api_key}
+        if json_body is not None:
+            headers["Content-Type"] = "application/json"
+        response = await fetch_signer_json(
+            url=url,
+            provider_name="Crossmint",
+            method=method,
+            headers=headers,
+            json_body=json_body,
+            client=self._http_client,
+        )
+        if not isinstance(response, dict) or response.get(required_field) is None:
+            message = self._extract_error_message(response)
+            if message is not None:
+                raise SignerError(SignerErrorCode.REMOTE_API_ERROR, f"{context}: {message}")
+            raise SignerError(
+                SignerErrorCode.SERIALIZATION_ERROR,
+                f"{context}: missing expected field '{required_field}' in response",
+            )
+        return response
+
+    async def _fetch_wallet(self) -> dict[str, Any]:
+        return await self._request_with_required_field(
+            method="GET",
+            url=self._wallets_url(),
+            required_field="address",
+            context="fetch_wallet",
+        )
+
+    async def init(self) -> None:
+        """Resolve the wallet address. Must be awaited before signing."""
+        wallet = await self._fetch_wallet()
+        chain_type = str(wallet.get("chainType", ""))
+        if chain_type.lower() != "solana":
+            raise SignerError(
+                SignerErrorCode.CONFIG_ERROR, f"Expected Solana wallet, got chainType={chain_type}"
+            )
+        wallet_type = str(wallet.get("type", ""))
+        if wallet_type.lower() not in ("smart", "mpc"):
+            raise SignerError(
+                SignerErrorCode.CONFIG_ERROR, f"Unsupported Crossmint wallet type: {wallet_type}"
+            )
+        try:
+            self._public_key = Pubkey.from_string(str(wallet.get("address", "")))
+        except Exception:
+            raise SignerError(
+                SignerErrorCode.INVALID_PUBLIC_KEY,
+                "Invalid Solana public key returned by Crossmint wallet",
+            ) from None
+
+    def _initialized_pubkey(self) -> Pubkey:
+        if self._public_key is None:
+            raise SignerError(
+                SignerErrorCode.NOT_INITIALIZED,
+                "CrossmintSigner is not initialized; call init() before signing",
+            )
+        return self._public_key
+
+    @property
+    def pubkey(self) -> Pubkey:
+        return self._initialized_pubkey()
+
+    async def _create_transaction(self, transaction_b58: str) -> dict[str, Any]:
+        params: dict[str, Any] = {"transaction": transaction_b58}
+        if self._signer is not None:
+            params["signer"] = self._signer
+        return await self._request_with_required_field(
+            method="POST",
+            url=self._wallets_url("transactions"),
+            required_field="id",
+            context="create_transaction",
+            json_body={"params": params},
+        )
+
+    async def _get_transaction(self, transaction_id: str) -> dict[str, Any]:
+        return await self._request_with_required_field(
+            method="GET",
+            url=self._wallets_url("transactions", transaction_id),
+            required_field="id",
+            context="get_transaction",
+        )
+
+    @staticmethod
+    def _failure_detail(response: dict[str, Any]) -> str:
+        error = response.get("error")
+        return json.dumps(error) if error is not None else "unknown error"
+
+    async def _poll_transaction(self, response: dict[str, Any]) -> dict[str, Any]:
+        approval_submitted = False
+        for _ in range(self._max_poll_attempts):
+            status = response.get("status")
+            if status == "success":
+                return response
+            if status == "failed":
+                raise SignerError(
+                    SignerErrorCode.SIGNING_FAILED,
+                    f"Crossmint transaction failed: {self._failure_detail(response)}",
+                )
+            if status == "awaiting-approval" and not approval_submitted:
+                # Approve at most once; the approval may register asynchronously,
+                # so afterwards awaiting-approval re-polls like any other
+                # in-flight status.
+                response = await self._handle_awaiting_approval(response)
+                approval_submitted = True
+                continue
+            await asyncio.sleep(self._poll_interval_ms / 1000)
+            response = await self._get_transaction(str(response.get("id")))
+
+        status = response.get("status")
+        if status == "success":
+            return response
+        if status == "failed":
+            raise SignerError(
+                SignerErrorCode.SIGNING_FAILED,
+                f"Crossmint transaction failed: {self._failure_detail(response)}",
+            )
+        if status == "awaiting-approval" and not approval_submitted:
+            raise SignerError(SignerErrorCode.SIGNING_FAILED, _AWAITING_APPROVAL_ERROR)
+        raise SignerError(
+            SignerErrorCode.REMOTE_API_ERROR,
+            f"Crossmint transaction polling timed out after {self._max_poll_attempts} attempts",
+        )
+
+    async def _handle_awaiting_approval(self, response: dict[str, Any]) -> dict[str, Any]:
+        if self._signing_key is None or self._signer is None:
+            raise SignerError(SignerErrorCode.SIGNING_FAILED, _AWAITING_APPROVAL_ERROR)
+
+        # A multi-approver wallet may list challenges for other approvers; signing
+        # one of those with our key yields a vendor 4xx, so only the entry matching
+        # our signer locator is ours to approve.
+        approvals = response.get("approvals")
+        pending_entries = approvals.get("pending", []) if isinstance(approvals, dict) else []
+        our_entry = next(
+            (
+                entry
+                for entry in pending_entries
+                if isinstance(entry, dict)
+                and isinstance(entry.get("signer"), dict)
+                and entry["signer"].get("locator") == self._signer
+            ),
+            None,
+        )
+        if our_entry is None:
+            raise SignerError(SignerErrorCode.SIGNING_FAILED, _AWAITING_APPROVAL_ERROR)
+
+        message = our_entry.get("message")
+        if not isinstance(message, str):
+            raise SignerError(
+                SignerErrorCode.SIGNING_FAILED,
+                "Crossmint transaction awaiting approval but no pending message found",
+            )
+
+        try:
+            message_bytes = base58.b58decode(message)
+        except ValueError:
+            raise SignerError(
+                SignerErrorCode.SIGNING_FAILED,
+                "Failed to decode approval message as base58",
+            ) from None
+        signature = self._signing_key.sign_message(message_bytes)
+
+        return await self._request_with_required_field(
+            method="POST",
+            url=self._wallets_url("transactions", str(response.get("id")), "approvals"),
+            required_field="id",
+            context="submit_approval",
+            json_body={"approvals": [{"signer": self._signer, "signature": str(signature)}]},
+        )
+
+    def _verify_signature_matches_message(self, signature: Signature, message: bytes) -> None:
+        if not signature.verify(self._initialized_pubkey(), message):
+            raise SignerError(
+                SignerErrorCode.SIGNING_FAILED,
+                "Crossmint returned a signature for different bytes",
+            )
+
+    def _extract_signature_from_serialized_transaction(
+        self, serialized_transaction: str
+    ) -> Signature:
+        try:
+            transaction_bytes = base58.b58decode(serialized_transaction)
+        except ValueError:
+            raise SignerError(
+                SignerErrorCode.SERIALIZATION_ERROR,
+                "Failed to decode Crossmint onChain.transaction as base58",
+            ) from None
+        try:
+            transaction = VersionedTransaction.from_bytes(transaction_bytes)
+        except Exception:
+            raise SignerError(
+                SignerErrorCode.SERIALIZATION_ERROR,
+                "Failed to deserialize Crossmint onChain.transaction",
+            ) from None
+
+        message = transaction.message
+        num_required = message.header.num_required_signatures
+        account_keys = list(message.account_keys)
+        if len(account_keys) < num_required:
+            raise SignerError(
+                SignerErrorCode.SIGNING_FAILED, "Invalid account index: not enough account keys"
+            )
+        public_key = self._initialized_pubkey()
+        try:
+            position = account_keys[:num_required].index(public_key)
+        except ValueError:
+            raise SignerError(
+                SignerErrorCode.SIGNING_FAILED,
+                "Failed to locate signer pubkey in Crossmint transaction",
+            ) from None
+
+        signatures = list(transaction.signatures)
+        if position >= len(signatures) or signatures[position] == Signature.default():
+            raise SignerError(
+                SignerErrorCode.SIGNING_FAILED,
+                "Crossmint onChain.transaction did not contain a signer signature",
+            )
+        signature = signatures[position]
+        self._verify_signature_matches_message(signature, bytes(message))
+        return signature
+
+    def _extract_signature_from_response(
+        self, response: dict[str, Any], expected_message: bytes
+    ) -> Signature:
+        on_chain = response.get("onChain")
+        if isinstance(on_chain, dict):
+            serialized_transaction = on_chain.get("transaction")
+            if isinstance(serialized_transaction, str):
+                try:
+                    return self._extract_signature_from_serialized_transaction(
+                        serialized_transaction
+                    )
+                except SignerError:
+                    pass
+
+            tx_id = on_chain.get("txId")
+            if isinstance(tx_id, str):
+                try:
+                    signature_bytes = base58.b58decode(tx_id)
+                    if len(signature_bytes) != ED25519_SIGNATURE_LENGTH:
+                        raise ValueError
+                    signature = Signature.from_bytes(signature_bytes)
+                except Exception:
+                    raise SignerError(
+                        SignerErrorCode.SIGNING_FAILED,
+                        "Crossmint onChain.txId was not a valid Solana signature",
+                    ) from None
+                self._verify_signature_matches_message(signature, expected_message)
+                return signature
+
+        raise SignerError(
+            SignerErrorCode.SIGNING_FAILED,
+            "Unable to extract signature from Crossmint transaction response",
+        )
+
+    async def sign_transaction(self, transaction: Transaction) -> SignedTransaction:
+        public_key = self._initialized_pubkey()
+        expected_message = transaction.message_data()
+        transaction_b58 = base58.b58encode(bytes(transaction)).decode("ascii")
+
+        create_response = await self._create_transaction(transaction_b58)
+        final_response = await self._poll_transaction(create_response)
+        signature = self._extract_signature_from_response(final_response, expected_message)
+
+        add_signature_to_transaction(transaction, public_key, signature)
+        return classify_signed_transaction(
+            transaction, serialize_transaction(transaction), signature
+        )
+
+    async def sign_message(self, message: bytes) -> Signature:
+        raise SignerError(
+            SignerErrorCode.SIGNING_FAILED,
+            "Crossmint sign_message is not supported for Solana wallets in this signer",
+        )
+
+    async def is_available(self) -> bool:
+        try:
+            await asyncio.wait_for(self._fetch_wallet(), AVAILABILITY_TIMEOUT_SECONDS)
+        except (SignerError, asyncio.TimeoutError):
+            return False
+        return True
+
+
+async def create_crossmint_signer(config: CrossmintSignerConfig) -> CrossmintSigner:
+    """Create a ready-to-use Crossmint signer (awaits ``init()``)."""
+    signer = CrossmintSigner(config)
+    await signer.init()
+    return signer

--- a/python/src/solana_keychain/crossmint/signer.py
+++ b/python/src/solana_keychain/crossmint/signer.py
@@ -311,7 +311,7 @@ class CrossmintSigner(SolanaSigner):
             )
 
     def _extract_signature_from_serialized_transaction(
-        self, serialized_transaction: str
+        self, serialized_transaction: str, expected_message: bytes
     ) -> Signature:
         try:
             transaction_bytes = base58.b58decode(serialized_transaction)
@@ -351,7 +351,10 @@ class CrossmintSigner(SolanaSigner):
                 "Crossmint onChain.transaction did not contain a signer signature",
             )
         signature = signatures[position]
-        self._verify_signature_matches_message(signature, bytes(message))
+        # Verify against the caller's message bytes, not the returned ones: if the
+        # service rewrote the transaction (blockhash, wrapping), its signature does
+        # not sign the caller's transaction and must not be attached to it.
+        self._verify_signature_matches_message(signature, expected_message)
         return signature
 
     def _extract_signature_from_response(
@@ -363,7 +366,7 @@ class CrossmintSigner(SolanaSigner):
             if isinstance(serialized_transaction, str):
                 try:
                     return self._extract_signature_from_serialized_transaction(
-                        serialized_transaction
+                        serialized_transaction, expected_message
                     )
                 except SignerError:
                     pass

--- a/python/tests/test_crossmint_signer.py
+++ b/python/tests/test_crossmint_signer.py
@@ -347,6 +347,33 @@ async def test_awaiting_approval_with_no_matching_entry_fails() -> None:
 
 
 @respx.mock
+async def test_rewritten_transaction_signature_is_rejected() -> None:
+    keypair = Keypair()
+    signer = await initialized_signer(keypair)
+    transaction = create_test_transaction(keypair.pubkey())
+
+    # The service returns a validly-signed transaction whose message differs from
+    # the one the caller submitted (same payer, rewritten contents).
+    rewritten = create_test_transaction(keypair.pubkey())
+    assert rewritten.message_data() != transaction.message_data()
+    rewritten.signatures = [keypair.sign_message(rewritten.message_data())]
+
+    respx.post(TRANSACTIONS_URL).mock(
+        return_value=httpx.Response(
+            200,
+            json=tx_response(
+                "success",
+                onChain={"transaction": base58.b58encode(bytes(rewritten)).decode()},
+            ),
+        )
+    )
+
+    with pytest.raises(SignerError) as excinfo:
+        await signer.sign_transaction(transaction)
+    assert excinfo.value.code == SignerErrorCode.SIGNING_FAILED
+
+
+@respx.mock
 async def test_embedded_transaction_without_signer_signature_falls_through() -> None:
     keypair = Keypair()
     signer = await initialized_signer(keypair)

--- a/python/tests/test_crossmint_signer.py
+++ b/python/tests/test_crossmint_signer.py
@@ -1,0 +1,397 @@
+import json
+from typing import Any
+
+import base58
+import httpx
+import pytest
+import respx
+from solders.keypair import Keypair
+from solders.signature import Signature
+
+from solana_keychain import SignerError, SignerErrorCode
+from solana_keychain.crossmint import (
+    CrossmintSigner,
+    CrossmintSignerConfig,
+    create_crossmint_signer,
+)
+from solana_keychain.crossmint.derive import derive_signing_key, parse_api_key
+from tests.util import create_test_transaction
+
+API_BASE_URL = "https://crossmint.example.com/api"
+API_KEY = "sk_staging_" + base58.b58encode(b"project-123:nacl-sig").decode()
+SIGNER_SECRET = "xmsk1_" + "ab" * 32
+WALLET_LOCATOR = "email:user@test.com:solana"
+ENCODED_LOCATOR = "email%3Auser%40test.com%3Asolana"
+WALLET_URL = f"{API_BASE_URL}/2025-06-09/wallets/{ENCODED_LOCATOR}"
+TRANSACTIONS_URL = f"{WALLET_URL}/transactions"
+
+
+def make_signer(**overrides: Any) -> CrossmintSigner:
+    config = CrossmintSignerConfig(
+        api_key=overrides.pop("api_key", API_KEY),
+        wallet_locator=overrides.pop("wallet_locator", WALLET_LOCATOR),
+        api_base_url=overrides.pop("api_base_url", API_BASE_URL),
+        poll_interval_ms=overrides.pop("poll_interval_ms", 1),
+        **overrides,
+    )
+    return CrossmintSigner(config)
+
+
+def mock_wallet(address: str, chain_type: str = "solana", wallet_type: str = "smart") -> None:
+    respx.get(WALLET_URL).mock(
+        return_value=httpx.Response(
+            200, json={"chainType": chain_type, "type": wallet_type, "address": address}
+        )
+    )
+
+
+async def initialized_signer(keypair: Keypair, **overrides: Any) -> CrossmintSigner:
+    mock_wallet(str(keypair.pubkey()))
+    signer = make_signer(**overrides)
+    await signer.init()
+    return signer
+
+
+def signed_transaction_b58(keypair: Keypair, transaction: Any) -> str:
+    from solders.transaction import Transaction
+
+    signed = Transaction.from_bytes(bytes(transaction))
+    signed.signatures = [keypair.sign_message(transaction.message_data())]
+    return base58.b58encode(bytes(signed)).decode()
+
+
+def tx_response(status: str, tx_id: str = "tx-1", **extra: Any) -> dict[str, Any]:
+    return {"id": tx_id, "status": status, **extra}
+
+
+def test_parse_api_key() -> None:
+    assert parse_api_key(API_KEY) == ("project-123", "staging")
+    with pytest.raises(SignerError) as excinfo:
+        parse_api_key("sk_missing-data")
+    assert excinfo.value.code == SignerErrorCode.CONFIG_ERROR
+
+
+def test_derive_signing_key_is_deterministic_and_env_scoped() -> None:
+    key_one = derive_signing_key(SIGNER_SECRET, API_KEY)
+    key_two = derive_signing_key(SIGNER_SECRET, API_KEY)
+    assert key_one.pubkey() == key_two.pubkey()
+
+    production_key = API_KEY.replace("_staging_", "_production_")
+    assert derive_signing_key(SIGNER_SECRET, production_key).pubkey() != key_one.pubkey()
+
+
+@pytest.mark.parametrize(
+    "secret",
+    ["xmsk1_" + "ab" * 16, "xmsk1_" + "zz" * 32],
+)
+def test_derive_signing_key_rejects_bad_secret(secret: str) -> None:
+    with pytest.raises(SignerError) as excinfo:
+        derive_signing_key(secret, API_KEY)
+    assert excinfo.value.code == SignerErrorCode.CONFIG_ERROR
+
+
+def test_signer_secret_default_locator() -> None:
+    signer = make_signer(signer_secret=SIGNER_SECRET)
+    derived = derive_signing_key(SIGNER_SECRET, API_KEY)
+    assert signer._signer == f"server:{derived.pubkey()}"
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"api_key": ""},
+        {"wallet_locator": ""},
+        {"api_base_url": "http://crossmint.example.com"},
+        {"poll_interval_ms": 0},
+        {"max_poll_attempts": 0},
+    ],
+)
+def test_invalid_config_rejected(overrides: dict[str, Any]) -> None:
+    with pytest.raises(SignerError) as excinfo:
+        make_signer(**overrides)
+    assert excinfo.value.code == SignerErrorCode.CONFIG_ERROR
+
+
+@respx.mock
+async def test_init_resolves_wallet_with_encoded_locator() -> None:
+    keypair = Keypair()
+    signer = await initialized_signer(keypair)
+    assert signer.pubkey == keypair.pubkey()
+    request = respx.calls.last.request
+    assert ENCODED_LOCATOR in str(request.url)
+    assert request.headers["X-API-KEY"] == API_KEY
+
+
+@respx.mock
+@pytest.mark.parametrize(
+    ("chain_type", "wallet_type"),
+    [("ethereum", "smart"), ("solana", "custodial")],
+)
+async def test_init_rejects_unusable_wallet(chain_type: str, wallet_type: str) -> None:
+    mock_wallet(str(Keypair().pubkey()), chain_type=chain_type, wallet_type=wallet_type)
+    signer = make_signer()
+    with pytest.raises(SignerError) as excinfo:
+        await signer.init()
+    assert excinfo.value.code == SignerErrorCode.CONFIG_ERROR
+
+
+@respx.mock
+async def test_init_accepts_mpc_wallet() -> None:
+    keypair = Keypair()
+    mock_wallet(str(keypair.pubkey()), wallet_type="MPC")
+    signer = make_signer()
+    await signer.init()
+    assert signer.pubkey == keypair.pubkey()
+
+
+@respx.mock
+async def test_init_surfaces_api_error_message() -> None:
+    respx.get(WALLET_URL).mock(
+        return_value=httpx.Response(404, json={"message": "wallet not found"})
+    )
+    signer = make_signer()
+    with pytest.raises(SignerError) as excinfo:
+        await signer.init()
+    assert excinfo.value.code == SignerErrorCode.REMOTE_API_ERROR
+
+
+@respx.mock
+async def test_init_missing_field_is_serialization_error() -> None:
+    respx.get(WALLET_URL).mock(return_value=httpx.Response(200, json={"unexpected": True}))
+    signer = make_signer()
+    with pytest.raises(SignerError) as excinfo:
+        await signer.init()
+    assert excinfo.value.code == SignerErrorCode.SERIALIZATION_ERROR
+
+
+async def test_sign_message_is_unsupported() -> None:
+    signer = make_signer()
+    with pytest.raises(SignerError) as excinfo:
+        await signer.sign_message(b"hello")
+    assert excinfo.value.code == SignerErrorCode.SIGNING_FAILED
+
+
+async def test_uninitialized_sign_transaction_raises_not_initialized() -> None:
+    signer = make_signer()
+    with pytest.raises(SignerError) as excinfo:
+        await signer.sign_transaction(create_test_transaction(Keypair().pubkey()))
+    assert excinfo.value.code == SignerErrorCode.NOT_INITIALIZED
+
+
+@respx.mock
+async def test_sign_transaction_success_from_embedded_transaction() -> None:
+    keypair = Keypair()
+    signer = await initialized_signer(keypair)
+    transaction = create_test_transaction(keypair.pubkey())
+    unsigned_bytes = bytes(transaction)
+    expected_signature = keypair.sign_message(transaction.message_data())
+
+    respx.post(TRANSACTIONS_URL).mock(return_value=httpx.Response(200, json=tx_response("pending")))
+    respx.get(f"{TRANSACTIONS_URL}/tx-1").mock(
+        return_value=httpx.Response(
+            200,
+            json=tx_response(
+                "success",
+                onChain={"transaction": signed_transaction_b58(keypair, transaction)},
+            ),
+        )
+    )
+
+    result = await signer.sign_transaction(transaction)
+
+    assert result.is_complete
+    assert result.signature == expected_signature
+    create_body = json.loads(respx.calls[1].request.content)
+    assert "signer" not in create_body["params"]
+    assert base58.b58decode(create_body["params"]["transaction"]) == unsigned_bytes
+
+
+@respx.mock
+async def test_sign_transaction_falls_back_to_tx_id() -> None:
+    keypair = Keypair()
+    signer = await initialized_signer(keypair)
+    transaction = create_test_transaction(keypair.pubkey())
+    signature = keypair.sign_message(transaction.message_data())
+
+    respx.post(TRANSACTIONS_URL).mock(
+        return_value=httpx.Response(
+            200, json=tx_response("success", onChain={"txId": str(signature)})
+        )
+    )
+
+    result = await signer.sign_transaction(transaction)
+    assert result.signature == signature
+
+
+@respx.mock
+async def test_sign_transaction_rejects_tx_id_for_different_bytes() -> None:
+    keypair = Keypair()
+    signer = await initialized_signer(keypair)
+    transaction = create_test_transaction(keypair.pubkey())
+    other_signature = keypair.sign_message(b"different bytes")
+
+    respx.post(TRANSACTIONS_URL).mock(
+        return_value=httpx.Response(
+            200, json=tx_response("success", onChain={"txId": str(other_signature)})
+        )
+    )
+
+    with pytest.raises(SignerError) as excinfo:
+        await signer.sign_transaction(transaction)
+    assert excinfo.value.code == SignerErrorCode.SIGNING_FAILED
+
+
+@respx.mock
+async def test_sign_transaction_failed_status() -> None:
+    keypair = Keypair()
+    signer = await initialized_signer(keypair)
+    respx.post(TRANSACTIONS_URL).mock(
+        return_value=httpx.Response(200, json=tx_response("failed", error={"reason": "boom"}))
+    )
+    with pytest.raises(SignerError) as excinfo:
+        await signer.sign_transaction(create_test_transaction(keypair.pubkey()))
+    assert excinfo.value.code == SignerErrorCode.SIGNING_FAILED
+
+
+@respx.mock
+async def test_sign_transaction_polling_timeout() -> None:
+    keypair = Keypair()
+    signer = await initialized_signer(keypair, max_poll_attempts=2)
+    respx.post(TRANSACTIONS_URL).mock(return_value=httpx.Response(200, json=tx_response("pending")))
+    respx.get(f"{TRANSACTIONS_URL}/tx-1").mock(
+        return_value=httpx.Response(200, json=tx_response("pending"))
+    )
+    with pytest.raises(SignerError) as excinfo:
+        await signer.sign_transaction(create_test_transaction(keypair.pubkey()))
+    assert excinfo.value.code == SignerErrorCode.REMOTE_API_ERROR
+
+
+@respx.mock
+async def test_awaiting_approval_without_signer_key_fails() -> None:
+    keypair = Keypair()
+    signer = await initialized_signer(keypair)
+    respx.post(TRANSACTIONS_URL).mock(
+        return_value=httpx.Response(200, json=tx_response("awaiting-approval"))
+    )
+    with pytest.raises(SignerError) as excinfo:
+        await signer.sign_transaction(create_test_transaction(keypair.pubkey()))
+    assert excinfo.value.code == SignerErrorCode.SIGNING_FAILED
+
+
+@respx.mock
+async def test_awaiting_approval_signs_only_our_pending_entry() -> None:
+    keypair = Keypair()
+    signer = await initialized_signer(keypair, signer_secret=SIGNER_SECRET)
+    transaction = create_test_transaction(keypair.pubkey())
+    expected_signature = keypair.sign_message(transaction.message_data())
+    delegated = derive_signing_key(SIGNER_SECRET, API_KEY)
+    locator = f"server:{delegated.pubkey()}"
+    challenge = b"approval-challenge-bytes"
+
+    respx.post(TRANSACTIONS_URL).mock(
+        return_value=httpx.Response(
+            200,
+            json=tx_response(
+                "awaiting-approval",
+                approvals={
+                    "pending": [
+                        {"signer": {"locator": "other:approver"}, "message": "111"},
+                        {
+                            "signer": {"locator": locator},
+                            "message": base58.b58encode(challenge).decode(),
+                        },
+                    ]
+                },
+            ),
+        )
+    )
+    respx.post(f"{TRANSACTIONS_URL}/tx-1/approvals").mock(
+        return_value=httpx.Response(200, json=tx_response("pending"))
+    )
+    respx.get(f"{TRANSACTIONS_URL}/tx-1").mock(
+        return_value=httpx.Response(
+            200,
+            json=tx_response(
+                "success",
+                onChain={"transaction": signed_transaction_b58(keypair, transaction)},
+            ),
+        )
+    )
+
+    result = await signer.sign_transaction(transaction)
+
+    assert result.signature == expected_signature
+    approval_body = json.loads(respx.calls[2].request.content)
+    approval = approval_body["approvals"][0]
+    assert approval["signer"] == locator
+    approval_signature = Signature.from_bytes(base58.b58decode(approval["signature"]))
+    assert approval_signature.verify(delegated.pubkey(), challenge)
+
+
+@respx.mock
+async def test_awaiting_approval_with_no_matching_entry_fails() -> None:
+    keypair = Keypair()
+    signer = await initialized_signer(keypair, signer_secret=SIGNER_SECRET)
+    respx.post(TRANSACTIONS_URL).mock(
+        return_value=httpx.Response(
+            200,
+            json=tx_response(
+                "awaiting-approval",
+                approvals={"pending": [{"signer": {"locator": "other:approver"}}]},
+            ),
+        )
+    )
+    with pytest.raises(SignerError) as excinfo:
+        await signer.sign_transaction(create_test_transaction(keypair.pubkey()))
+    assert excinfo.value.code == SignerErrorCode.SIGNING_FAILED
+
+
+@respx.mock
+async def test_embedded_transaction_without_signer_signature_falls_through() -> None:
+    keypair = Keypair()
+    signer = await initialized_signer(keypair)
+    transaction = create_test_transaction(keypair.pubkey())
+    unsigned_b58 = base58.b58encode(bytes(transaction)).decode()
+
+    respx.post(TRANSACTIONS_URL).mock(
+        return_value=httpx.Response(
+            200, json=tx_response("success", onChain={"transaction": unsigned_b58})
+        )
+    )
+    with pytest.raises(SignerError) as excinfo:
+        await signer.sign_transaction(transaction)
+    assert excinfo.value.code == SignerErrorCode.SIGNING_FAILED
+
+
+@respx.mock
+async def test_is_available_true_and_false() -> None:
+    keypair = Keypair()
+    signer = await initialized_signer(keypair)
+    assert await signer.is_available()
+    respx.get(WALLET_URL).mock(return_value=httpx.Response(403, json={"error": "forbidden"}))
+    assert not await signer.is_available()
+
+
+@respx.mock
+async def test_create_crossmint_signer_factory_initializes() -> None:
+    keypair = Keypair()
+    mock_wallet(str(keypair.pubkey()))
+    signer = await create_crossmint_signer(
+        CrossmintSignerConfig(
+            api_key=API_KEY, wallet_locator=WALLET_LOCATOR, api_base_url=API_BASE_URL
+        )
+    )
+    assert signer.pubkey == keypair.pubkey()
+
+
+def test_reprs_never_contain_secrets() -> None:
+    config = CrossmintSignerConfig(
+        api_key=API_KEY,
+        wallet_locator=WALLET_LOCATOR,
+        signer_secret=SIGNER_SECRET,
+        api_base_url=API_BASE_URL,
+    )
+    signer = make_signer(signer_secret=SIGNER_SECRET)
+    for text in (repr(config), repr(signer)):
+        assert API_KEY not in text
+        assert SIGNER_SECRET not in text


### PR DESCRIPTION
## Summary
- Adds the **Crossmint** backend (`solana_keychain.crossmint`). Stacked on #218 — this layer shows only the Crossmint work.
- **Delegated-signer derivation**: an optional `xmsk1_<64hex>` secret derives an Ed25519 keypair via HKDF-SHA256 (salt `crossmint`, info `{projectId}:{environment}:solana-ed25519`, both parsed from the API key's base58 payload); the signer locator defaults to `server:<derived pubkey>`.
- **Create → poll → approve flow**: transactions are submitted base58-encoded and polled to `success`. `awaiting-approval` is approved **at most once** and only for the pending challenge matching our signer locator (signing another approver's challenge yields a vendor 4xx); afterwards it re-polls like any in-flight status. Without a delegated signer, awaiting-approval fails with the approvals-required error.
- **Signature extraction**: from the returned serialized transaction (parsed as a versioned transaction, our signature at the required-signer position, verified over the returned message bytes), falling back to `onChain.txId` verified against the originally-requested message bytes. Both paths reject signatures over different bytes.
- **`sign_message` intentionally unsupported** — the Wallets API signs transactions only; rejects with `SIGNER_SIGNING_FAILED`.
- Wallet locators URL-encoded with the exact `encodeURIComponent` character set (via `urllib.parse.quote` + matching safe-set); init gates on solana-chain `smart`/`mpc` wallets; API error bodies surface their `message`/`error` fields into (redacted) error detail. `base58` + `cryptography` behind the `[crossmint]` extra.

## Test Plan
- 340 tests pass (30 new): HKDF determinism + environment scoping, secret validation, API-key parsing, default locator, locator encoding asserted in URLs, wallet gates (chain/type incl. MPC case-insensitivity), the approval flow with the approval signature **cryptographically verified** against the challenge and locator-matching asserted (other approvers' challenges skipped), approvals-required failures (no key / no matching entry), embedded-transaction extraction + unsigned-fallthrough, txId fallback + wrong-bytes rejection, failed status, polling timeout, sign_message rejection, config validation matrix, availability, factory init, repr redaction
- `ruff` + `mypy --strict` + sdist/wheel build clean

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
