### PR TITLE
feat(python): Openfort signer backend

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -30,7 +30,7 @@ library offers a consistent API across all signing methods.
 | **Para** | MPC wallets with Para infrastructure | `solana_keychain.para` | ✅ Available |
 | **CDP** | Coinbase Developer Platform managed wallets | `solana_keychain.cdp` | ✅ Available |
 | **Crossmint** | Crossmint managed wallets | `solana_keychain.crossmint` | ✅ Available |
-| **Openfort** | Openfort backend wallets with TEE-stored keys | — | Planned |
+| **Openfort** | Openfort backend wallets with TEE-stored keys | `solana_keychain.openfort` | ✅ Available |
 | **Utila** | Utila MPC wallet integration | — | Planned |
 
 ## Installation
@@ -43,6 +43,7 @@ pip install 'solana-keychain[crossmint]' # adds the Crossmint backend
 pip install 'solana-keychain[dfns]'      # adds the Dfns backend
 pip install 'solana-keychain[fireblocks]' # adds the Fireblocks backend
 pip install 'solana-keychain[gcp-kms]'   # adds the GCP KMS backend
+pip install 'solana-keychain[openfort]'  # adds the Openfort backend
 pip install 'solana-keychain[privy]'     # adds the Privy backend
 pip install 'solana-keychain[turnkey]'   # adds the Turnkey backend
 ```

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -23,6 +23,7 @@ crossmint = ["base58>=2.1", "cryptography>=43"]
 dfns = ["cryptography>=43"]
 fireblocks = ["cryptography>=43", "pyjwt>=2.8"]
 gcp-kms = ["google-cloud-kms>=2.24"]
+openfort = ["cryptography>=43", "pyjwt>=2.8"]
 privy = ["cryptography>=43"]
 turnkey = ["cryptography>=43"]
 dev = [

--- a/python/src/solana_keychain/openfort/__init__.py
+++ b/python/src/solana_keychain/openfort/__init__.py
@@ -1,0 +1,7 @@
+from solana_keychain.openfort.signer import (
+    OpenfortSigner,
+    OpenfortSignerConfig,
+    create_openfort_signer,
+)
+
+__all__ = ["OpenfortSigner", "OpenfortSignerConfig", "create_openfort_signer"]

--- a/python/src/solana_keychain/openfort/jwt.py
+++ b/python/src/solana_keychain/openfort/jwt.py
@@ -1,0 +1,94 @@
+"""Openfort wallet-auth JWT: an ES256 token signed by the project's wallet secret,
+carrying a hash of the exact request body."""
+
+import hashlib
+import json
+import time
+import uuid
+from typing import Any
+from urllib.parse import urlsplit
+
+try:
+    import jwt as pyjwt
+    from cryptography.hazmat.primitives.asymmetric import ec
+    from cryptography.hazmat.primitives.serialization import load_pem_private_key
+except ImportError as error:  # pragma: no cover
+    raise ImportError(
+        "solana_keychain.openfort requires the openfort extra: "
+        "pip install 'solana-keychain[openfort]'"
+    ) from error
+
+from solana_keychain.core.errors import SignerError, SignerErrorCode
+
+JWT_LIFETIME_SECONDS = 120
+
+
+def extract_host(base_url: str) -> str:
+    """Extract the request host (including port if present) from a base URL."""
+    try:
+        parsed = urlsplit(base_url)
+        hostname = parsed.hostname
+        port = parsed.port
+    except ValueError:
+        raise SignerError(
+            SignerErrorCode.CONFIG_ERROR, f"Invalid Openfort base URL: {base_url}"
+        ) from None
+    if not hostname:
+        raise SignerError(
+            SignerErrorCode.CONFIG_ERROR, f"Missing host in Openfort base URL: {base_url}"
+        )
+    return f"{hostname}:{port}" if port is not None else hostname
+
+
+def compute_req_hash(body: Any) -> str:
+    """SHA-256 hex of the request body serialized with recursively sorted keys and
+    compact separators."""
+    serialized = json.dumps(body, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return hashlib.sha256(serialized.encode()).hexdigest()
+
+
+def _wallet_secret_to_pem(wallet_secret: str) -> str:
+    """Accept either a full PEM (passed through) or a bare base64 PKCS8 DER body
+    (the env-var-friendly single-line form), which gets whitespace-stripped and
+    wrapped in PEM headers."""
+    if wallet_secret.lstrip().startswith("-----BEGIN"):
+        return wallet_secret
+    stripped = "".join(wallet_secret.split())
+    return f"-----BEGIN PRIVATE KEY-----\n{stripped}\n-----END PRIVATE KEY-----\n"
+
+
+def create_wallet_jwt(
+    wallet_secret: str, host: str, method: str, path: str, request_body: Any
+) -> str:
+    """Build the ``x-wallet-auth`` JWT for an Openfort backend wallet request."""
+    pem = _wallet_secret_to_pem(wallet_secret)
+    try:
+        signing_key = load_pem_private_key(pem.encode(), password=None)
+    except Exception:
+        raise SignerError(
+            SignerErrorCode.INVALID_PRIVATE_KEY,
+            "Failed to parse Openfort wallet secret as EC P-256 private key "
+            "(expected base64 PKCS#8 DER or PEM)",
+        ) from None
+    if not isinstance(signing_key, ec.EllipticCurvePrivateKey):
+        raise SignerError(
+            SignerErrorCode.INVALID_PRIVATE_KEY,
+            "Failed to parse Openfort wallet secret as EC P-256 private key "
+            "(expected base64 PKCS#8 DER or PEM)",
+        )
+
+    now = int(time.time())
+    claims = {
+        "uris": [f"{method} {host}{path}"],
+        "iat": now,
+        "nbf": now,
+        "exp": now + JWT_LIFETIME_SECONDS,
+        "jti": str(uuid.uuid4()),
+        "reqHash": compute_req_hash(request_body),
+    }
+    try:
+        return pyjwt.encode(claims, signing_key, algorithm="ES256", headers={"typ": "JWT"})
+    except Exception:
+        raise SignerError(
+            SignerErrorCode.SIGNING_FAILED, "Failed to create Openfort wallet JWT"
+        ) from None

--- a/python/src/solana_keychain/openfort/signer.py
+++ b/python/src/solana_keychain/openfort/signer.py
@@ -1,0 +1,187 @@
+"""Openfort backend wallet signer. The private key lives in Openfort's TEE and is
+never exposed; message bytes are signed as-is (no hashing) and returned as a 64-byte
+Ed25519 signature."""
+
+from dataclasses import dataclass, field
+from urllib.parse import quote
+
+import httpx
+from solders.pubkey import Pubkey
+from solders.signature import Signature
+from solders.transaction import Transaction
+
+from solana_keychain.core.errors import SignerError, SignerErrorCode
+from solana_keychain.core.http import assert_https_url, fetch_signer_json, normalize_base_url
+from solana_keychain.core.signer import SignedTransaction, SolanaSigner
+from solana_keychain.core.transaction_util import (
+    add_signature_to_transaction,
+    classify_signed_transaction,
+    serialize_transaction,
+)
+from solana_keychain.openfort.jwt import create_wallet_jwt, extract_host
+
+DEFAULT_API_BASE_URL = "https://api.openfort.io"
+ACCOUNTS_PATH = "/v2/accounts"
+BACKEND_PATH = "/v2/accounts/backend"
+
+ED25519_SIGNATURE_LENGTH = 64
+
+
+@dataclass
+class OpenfortSignerConfig:
+    """Configuration for an Openfort signer.
+
+    ``secret_key`` is the project secret key (``sk_live_*``/``sk_test_*``);
+    ``account_id`` the backend wallet account id (``acc_<uuid>``);
+    ``wallet_secret`` the dashboard-issued ECDSA P-256 key that signs the
+    ``x-wallet-auth`` JWT, as bare base64 PKCS8 DER or full PEM.
+    """
+
+    secret_key: str = field(repr=False)
+    account_id: str
+    wallet_secret: str = field(repr=False)
+    api_base_url: str = DEFAULT_API_BASE_URL
+    http_client: httpx.AsyncClient | None = field(default=None, repr=False)
+
+
+class OpenfortSigner(SolanaSigner):
+    """Signer backed by an Openfort backend wallet.
+
+    ``init()`` must be awaited before signing — it resolves the wallet's Solana
+    address. ``create_openfort_signer()`` does this for you.
+    """
+
+    def __init__(self, config: OpenfortSignerConfig) -> None:
+        for name, value in (
+            ("secret_key", config.secret_key),
+            ("account_id", config.account_id),
+            ("wallet_secret", config.wallet_secret),
+        ):
+            if not value:
+                raise SignerError(SignerErrorCode.CONFIG_ERROR, f"{name} must not be empty")
+        api_base_url = normalize_base_url(config.api_base_url)
+        assert_https_url(api_base_url, "api_base_url")
+        self._api_base_url = api_base_url
+        self._api_host = extract_host(api_base_url)
+        self._secret_key = config.secret_key
+        self._account_id = config.account_id
+        self._wallet_secret = config.wallet_secret
+        self._http_client = config.http_client
+        self._public_key: Pubkey | None = None
+
+    def __repr__(self) -> str:
+        return (
+            f"OpenfortSigner(account_id={self._account_id}, pubkey={self._public_key}, "
+            f"api_base_url={self._api_base_url})"
+        )
+
+    def _account_path(self) -> str:
+        return f"{ACCOUNTS_PATH}/{quote(self._account_id, safe='')}"
+
+    def _sign_path(self) -> str:
+        return f"{BACKEND_PATH}/{quote(self._account_id, safe='')}/sign"
+
+    async def _fetch_public_key(self) -> Pubkey:
+        response = await fetch_signer_json(
+            url=f"{self._api_base_url}{self._account_path()}",
+            provider_name="Openfort",
+            headers={"Authorization": f"Bearer {self._secret_key}"},
+            client=self._http_client,
+        )
+        address = response.get("address") if isinstance(response, dict) else None
+        if not isinstance(address, str):
+            raise SignerError(
+                SignerErrorCode.SERIALIZATION_ERROR, "Failed to parse Openfort account response"
+            )
+        try:
+            return Pubkey.from_string(address)
+        except Exception:
+            raise SignerError(
+                SignerErrorCode.INVALID_PUBLIC_KEY,
+                f"Openfort returned non-Solana address for {self._account_id}: "
+                "ensure the account is on an SVM chain",
+            ) from None
+
+    async def init(self) -> None:
+        """Resolve the wallet's Solana address. Must be awaited before signing."""
+        self._public_key = await self._fetch_public_key()
+
+    def _initialized_pubkey(self) -> Pubkey:
+        if self._public_key is None:
+            raise SignerError(
+                SignerErrorCode.NOT_INITIALIZED,
+                "OpenfortSigner is not initialized; call init() before signing",
+            )
+        return self._public_key
+
+    @property
+    def pubkey(self) -> Pubkey:
+        return self._initialized_pubkey()
+
+    async def _sign_bytes(self, message: bytes) -> Signature:
+        public_key = self._initialized_pubkey()
+        path = self._sign_path()
+        body = {"data": f"0x{message.hex()}"}
+        wallet_token = create_wallet_jwt(self._wallet_secret, self._api_host, "POST", path, body)
+        response = await fetch_signer_json(
+            url=f"{self._api_base_url}{path}",
+            provider_name="Openfort",
+            method="POST",
+            headers={
+                "Authorization": f"Bearer {self._secret_key}",
+                "Content-Type": "application/json",
+                "x-wallet-auth": wallet_token,
+            },
+            json_body=body,
+            client=self._http_client,
+        )
+        signature_hex = response.get("signature") if isinstance(response, dict) else None
+        if not isinstance(signature_hex, str):
+            raise SignerError(
+                SignerErrorCode.SERIALIZATION_ERROR, "Failed to parse Openfort sign response"
+            )
+        try:
+            signature_bytes = bytes.fromhex(signature_hex.removeprefix("0x"))
+        except ValueError:
+            raise SignerError(
+                SignerErrorCode.SERIALIZATION_ERROR, "Failed to hex-decode Openfort signature"
+            ) from None
+        if len(signature_bytes) != ED25519_SIGNATURE_LENGTH:
+            raise SignerError(
+                SignerErrorCode.SIGNING_FAILED,
+                f"Invalid signature length from Openfort "
+                f"(expected {ED25519_SIGNATURE_LENGTH} bytes)",
+            )
+        signature = Signature.from_bytes(signature_bytes)
+        if not signature.verify(public_key, message):
+            raise SignerError(
+                SignerErrorCode.SIGNING_FAILED,
+                "Signature verification failed — the returned signature does not match "
+                "the public key",
+            )
+        return signature
+
+    async def sign_transaction(self, transaction: Transaction) -> SignedTransaction:
+        signature = await self._sign_bytes(transaction.message_data())
+        add_signature_to_transaction(transaction, self._initialized_pubkey(), signature)
+        return classify_signed_transaction(
+            transaction, serialize_transaction(transaction), signature
+        )
+
+    async def sign_message(self, message: bytes) -> Signature:
+        return await self._sign_bytes(message)
+
+    async def is_available(self) -> bool:
+        if self._public_key is None:
+            return False
+        try:
+            return await self._fetch_public_key() == self._public_key
+        except SignerError:
+            return False
+
+
+async def create_openfort_signer(config: OpenfortSignerConfig) -> OpenfortSigner:
+    """Create a ready-to-use Openfort signer (awaits ``init()``)."""
+    signer = OpenfortSigner(config)
+    await signer.init()
+    return signer

--- a/python/tests/test_openfort_signer.py
+++ b/python/tests/test_openfort_signer.py
@@ -1,0 +1,336 @@
+import base64
+import hashlib
+import json
+from typing import Any
+
+import httpx
+import jwt as pyjwt
+import pytest
+import respx
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives.serialization import (
+    Encoding,
+    NoEncryption,
+    PrivateFormat,
+)
+from solders.keypair import Keypair
+
+from solana_keychain import SignerError, SignerErrorCode
+from solana_keychain.openfort import (
+    OpenfortSigner,
+    OpenfortSignerConfig,
+    create_openfort_signer,
+)
+from solana_keychain.openfort.jwt import compute_req_hash, create_wallet_jwt, extract_host
+from tests.util import create_test_transaction
+
+API_BASE_URL = "https://openfort.example.com"
+API_HOST = "openfort.example.com"
+SECRET_KEY = "sk_test_secret-key-value"
+ACCOUNT_ID = "acc_12345678-1234-1234-1234-123456789abc"
+ACCOUNT_URL = f"{API_BASE_URL}/v2/accounts/{ACCOUNT_ID}"
+SIGN_URL = f"{API_BASE_URL}/v2/accounts/backend/{ACCOUNT_ID}/sign"
+
+_WALLET_EC_KEY = ec.generate_private_key(ec.SECP256R1())
+_WALLET_DER = _WALLET_EC_KEY.private_bytes(Encoding.DER, PrivateFormat.PKCS8, NoEncryption())
+WALLET_SECRET = base64.b64encode(_WALLET_DER).decode()
+WALLET_SECRET_PEM = _WALLET_EC_KEY.private_bytes(
+    Encoding.PEM, PrivateFormat.PKCS8, NoEncryption()
+).decode()
+
+
+def make_signer(**overrides: Any) -> OpenfortSigner:
+    config = OpenfortSignerConfig(
+        secret_key=overrides.pop("secret_key", SECRET_KEY),
+        account_id=overrides.pop("account_id", ACCOUNT_ID),
+        wallet_secret=overrides.pop("wallet_secret", WALLET_SECRET),
+        api_base_url=overrides.pop("api_base_url", API_BASE_URL),
+        **overrides,
+    )
+    return OpenfortSigner(config)
+
+
+def mock_account(address: str) -> None:
+    respx.get(ACCOUNT_URL).mock(
+        return_value=httpx.Response(
+            200, json={"id": ACCOUNT_ID, "address": address, "chainId": 101}
+        )
+    )
+
+
+def mock_sign_response(signature_hex: str) -> None:
+    respx.post(SIGN_URL).mock(
+        return_value=httpx.Response(
+            200,
+            json={"object": "signature", "account": ACCOUNT_ID, "signature": signature_hex},
+        )
+    )
+
+
+async def initialized_signer(keypair: Keypair, **overrides: Any) -> OpenfortSigner:
+    mock_account(str(keypair.pubkey()))
+    signer = make_signer(**overrides)
+    await signer.init()
+    return signer
+
+
+def test_extract_host() -> None:
+    assert extract_host("https://api.openfort.io") == "api.openfort.io"
+    assert extract_host("https://openfort.example.com:8443") == "openfort.example.com:8443"
+    with pytest.raises(SignerError) as excinfo:
+        extract_host("not a url")
+    assert excinfo.value.code == SignerErrorCode.CONFIG_ERROR
+
+
+@pytest.mark.parametrize(
+    "wallet_secret",
+    [
+        WALLET_SECRET,
+        WALLET_SECRET_PEM,
+        WALLET_SECRET[:32] + " \n" + WALLET_SECRET[32:],
+    ],
+)
+def test_create_wallet_jwt_accepts_der_and_pem_forms(wallet_secret: str) -> None:
+    body = {"data": "0xabcd"}
+    token = create_wallet_jwt(wallet_secret, API_HOST, "POST", "/path", body)
+    claims = pyjwt.decode(token, _WALLET_EC_KEY.public_key(), algorithms=["ES256"])
+    assert claims["uris"] == [f"POST {API_HOST}/path"]
+    assert claims["jti"]
+    assert claims["exp"] - claims["iat"] == 120
+    assert claims["reqHash"] == compute_req_hash(body)
+
+
+def test_compute_req_hash_is_key_order_independent() -> None:
+    body_hash = compute_req_hash({"b": 2, "a": {"d": 4, "c": 3}})
+    assert body_hash == compute_req_hash({"a": {"c": 3, "d": 4}, "b": 2})
+    assert body_hash == hashlib.sha256(b'{"a":{"c":3,"d":4},"b":2}').hexdigest()
+
+
+@pytest.mark.parametrize("secret", ["!!!not-a-key!!!", base64.b64encode(b"junk").decode()])
+def test_create_wallet_jwt_rejects_invalid_secret(secret: str) -> None:
+    with pytest.raises(SignerError) as excinfo:
+        create_wallet_jwt(secret, API_HOST, "POST", "/path", {})
+    assert excinfo.value.code == SignerErrorCode.INVALID_PRIVATE_KEY
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [{"secret_key": ""}, {"account_id": ""}, {"wallet_secret": ""}],
+)
+def test_empty_config_fields_rejected(overrides: dict[str, str]) -> None:
+    with pytest.raises(SignerError) as excinfo:
+        make_signer(**overrides)
+    assert excinfo.value.code == SignerErrorCode.CONFIG_ERROR
+
+
+def test_non_https_base_url_rejected() -> None:
+    with pytest.raises(SignerError) as excinfo:
+        make_signer(api_base_url="http://openfort.example.com")
+    assert excinfo.value.code == SignerErrorCode.CONFIG_ERROR
+
+
+@respx.mock
+async def test_init_resolves_account_address() -> None:
+    keypair = Keypair()
+    signer = await initialized_signer(keypair)
+    assert signer.pubkey == keypair.pubkey()
+    request = respx.calls.last.request
+    assert request.headers["Authorization"] == f"Bearer {SECRET_KEY}"
+    assert "x-wallet-auth" not in request.headers
+
+
+@respx.mock
+async def test_init_rejects_non_solana_address() -> None:
+    mock_account("0xE5f4d1a9B23c")
+    signer = make_signer()
+    with pytest.raises(SignerError) as excinfo:
+        await signer.init()
+    assert excinfo.value.code == SignerErrorCode.INVALID_PUBLIC_KEY
+
+
+@respx.mock
+async def test_init_api_error() -> None:
+    respx.get(ACCOUNT_URL).mock(return_value=httpx.Response(401, json={"error": "denied"}))
+    signer = make_signer()
+    with pytest.raises(SignerError) as excinfo:
+        await signer.init()
+    assert excinfo.value.code == SignerErrorCode.REMOTE_API_ERROR
+
+
+async def test_uninitialized_sign_raises_not_initialized() -> None:
+    with pytest.raises(SignerError) as excinfo:
+        await make_signer().sign_message(b"hello")
+    assert excinfo.value.code == SignerErrorCode.NOT_INITIALIZED
+
+
+@respx.mock
+async def test_sign_message_success_with_wallet_jwt() -> None:
+    keypair = Keypair()
+    message = b"openfort-message"
+    signature = keypair.sign_message(message)
+    signer = await initialized_signer(keypair)
+    mock_sign_response(f"0x{bytes(signature).hex()}")
+
+    result = await signer.sign_message(message)
+
+    assert result == signature
+    request = respx.calls.last.request
+    assert request.headers["Authorization"] == f"Bearer {SECRET_KEY}"
+    body = json.loads(request.content)
+    assert body == {"data": f"0x{message.hex()}"}
+    claims = pyjwt.decode(
+        request.headers["x-wallet-auth"], _WALLET_EC_KEY.public_key(), algorithms=["ES256"]
+    )
+    assert claims["uris"] == [f"POST {API_HOST}/v2/accounts/backend/{ACCOUNT_ID}/sign"]
+    assert claims["reqHash"] == compute_req_hash(body)
+
+
+@respx.mock
+async def test_sign_message_accepts_unprefixed_hex_signature() -> None:
+    keypair = Keypair()
+    message = b"openfort-message"
+    signature = keypair.sign_message(message)
+    signer = await initialized_signer(keypair)
+    mock_sign_response(bytes(signature).hex())
+
+    assert await signer.sign_message(message) == signature
+
+
+@respx.mock
+async def test_sign_message_undecodable_signature() -> None:
+    keypair = Keypair()
+    signer = await initialized_signer(keypair)
+    mock_sign_response("0xzz")
+    with pytest.raises(SignerError) as excinfo:
+        await signer.sign_message(b"hello")
+    assert excinfo.value.code == SignerErrorCode.SERIALIZATION_ERROR
+
+
+@respx.mock
+async def test_sign_message_wrong_length_signature() -> None:
+    keypair = Keypair()
+    signer = await initialized_signer(keypair)
+    mock_sign_response("0x" + "ab" * 32)
+    with pytest.raises(SignerError) as excinfo:
+        await signer.sign_message(b"hello")
+    assert excinfo.value.code == SignerErrorCode.SIGNING_FAILED
+
+
+@respx.mock
+async def test_sign_message_signature_verification_failure() -> None:
+    keypair = Keypair()
+    message = b"openfort-message"
+    signer = await initialized_signer(keypair)
+    mock_sign_response(f"0x{bytes(Keypair().sign_message(message)).hex()}")
+    with pytest.raises(SignerError) as excinfo:
+        await signer.sign_message(message)
+    assert excinfo.value.code == SignerErrorCode.SIGNING_FAILED
+
+
+@respx.mock
+async def test_sign_message_api_error() -> None:
+    keypair = Keypair()
+    signer = await initialized_signer(keypair)
+    respx.post(SIGN_URL).mock(return_value=httpx.Response(500, json={"error": "boom"}))
+    with pytest.raises(SignerError) as excinfo:
+        await signer.sign_message(b"hello")
+    assert excinfo.value.code == SignerErrorCode.REMOTE_API_ERROR
+
+
+@respx.mock
+async def test_sign_transaction_success() -> None:
+    keypair = Keypair()
+    signer = await initialized_signer(keypair)
+    transaction = create_test_transaction(keypair.pubkey())
+    signature = keypair.sign_message(transaction.message_data())
+    mock_sign_response(f"0x{bytes(signature).hex()}")
+
+    result = await signer.sign_transaction(transaction)
+
+    assert result.is_complete
+    assert result.signature == signature
+    assert list(transaction.signatures) == [signature]
+
+
+async def test_uninitialized_is_available_false() -> None:
+    assert not await make_signer().is_available()
+
+
+@respx.mock
+async def test_is_available_true_when_address_matches() -> None:
+    keypair = Keypair()
+    signer = await initialized_signer(keypair)
+    assert await signer.is_available()
+
+
+@respx.mock
+async def test_is_available_false_when_address_changed() -> None:
+    keypair = Keypair()
+    signer = await initialized_signer(keypair)
+    mock_account(str(Keypair().pubkey()))
+    assert not await signer.is_available()
+
+
+@respx.mock
+async def test_is_available_false_on_api_error() -> None:
+    keypair = Keypair()
+    signer = await initialized_signer(keypair)
+    respx.get(ACCOUNT_URL).mock(return_value=httpx.Response(403, json={"error": "forbidden"}))
+    assert not await signer.is_available()
+
+
+@respx.mock
+async def test_create_openfort_signer_factory_initializes() -> None:
+    keypair = Keypair()
+    mock_account(str(keypair.pubkey()))
+    signer = await create_openfort_signer(
+        OpenfortSignerConfig(
+            secret_key=SECRET_KEY,
+            account_id=ACCOUNT_ID,
+            wallet_secret=WALLET_SECRET,
+            api_base_url=API_BASE_URL,
+        )
+    )
+    assert signer.pubkey == keypair.pubkey()
+
+
+def _assert_channels_clean(error: SignerError) -> None:
+    for channel in (str(error), repr(error), repr(error.args)):
+        assert SECRET_KEY not in channel
+        assert WALLET_SECRET not in channel
+
+
+@respx.mock
+async def test_redaction_across_failure_modes() -> None:
+    keypair = Keypair()
+
+    respx.get(ACCOUNT_URL).mock(return_value=httpx.Response(401, json={"error": SECRET_KEY}))
+    signer = make_signer()
+    with pytest.raises(SignerError) as init_error:
+        await signer.init()
+    _assert_channels_clean(init_error.value)
+
+    signer = await initialized_signer(keypair)
+    respx.post(SIGN_URL).mock(
+        return_value=httpx.Response(500, text=f"boom {SECRET_KEY} {WALLET_SECRET}")
+    )
+    with pytest.raises(SignerError) as sign_error:
+        await signer.sign_message(b"hello")
+    _assert_channels_clean(sign_error.value)
+
+    with pytest.raises(SignerError) as jwt_error:
+        create_wallet_jwt("!!!bad!!!", API_HOST, "POST", "/p", {})
+    _assert_channels_clean(jwt_error.value)
+
+
+def test_reprs_never_contain_secrets() -> None:
+    config = OpenfortSignerConfig(
+        secret_key=SECRET_KEY,
+        account_id=ACCOUNT_ID,
+        wallet_secret=WALLET_SECRET,
+        api_base_url=API_BASE_URL,
+    )
+    signer = make_signer()
+    for text in (repr(config), repr(signer)):
+        assert SECRET_KEY not in text
+        assert WALLET_SECRET not in text


### PR DESCRIPTION
## Summary
- Adds the **Openfort** backend (`solana_keychain.openfort`). Stacked on #219 — this layer shows only the Openfort work.
- **Auth**: every request carries `Authorization: Bearer <secret_key>`; signing requests add an ES256 `x-wallet-auth` JWT (`uris`, 120s window, fresh `jti`, `reqHash` = SHA-256 over the sorted-key request body — always present). The wallet secret is accepted as bare base64 PKCS8 DER (whitespace-tolerant, env-var-friendly) or full PEM.
- **Signing**: message bytes sent hex-encoded (`0x` prefix) in `data` and signed as-is in the TEE (no hashing); returned `0x`-hex signatures (prefix optional) are length-checked and verified locally against the address resolved at `init()`.
- **Init**: `GET /v2/accounts/{id}` (bearer-only) resolves the Solana address; non-Solana addresses rejected with a message pointing at SVM-chain configuration. Availability re-fetches and compares addresses.
- **Dedicated redaction suite**: sweeps `secret_key`/`wallet_secret` across init failures (secret echoed in the error body), signing failures (secrets in the response text), JWT failures, and both reprs — no channel may leak. `cryptography` + `pyjwt` behind the `[openfort]` extra.

## Test Plan
- 370 tests pass (30 new): wallet JWT cryptographically verified against captured requests (uris/reqHash), DER/PEM/whitespace secret forms, reqHash key-order independence pinned to a golden hash, invalid secrets, config validation, non-Solana address, 0x-optional signatures, undecodable/wrong-length signatures, verification failure, API errors, not-initialized paths, availability matrix (match/changed/error/uninit), factory init, the redaction sweep
- `ruff` + `mypy --strict` + sdist/wheel build clean

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
