### PR TITLE
feat(python): Utila signer backend

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -31,7 +31,7 @@ library offers a consistent API across all signing methods.
 | **CDP** | Coinbase Developer Platform managed wallets | `solana_keychain.cdp` | ✅ Available |
 | **Crossmint** | Crossmint managed wallets | `solana_keychain.crossmint` | ✅ Available |
 | **Openfort** | Openfort backend wallets with TEE-stored keys | `solana_keychain.openfort` | ✅ Available |
-| **Utila** | Utila MPC wallet integration | — | Planned |
+| **Utila** | Utila MPC wallet integration | `solana_keychain.utila` | ✅ Available |
 
 ## Installation
 
@@ -46,6 +46,7 @@ pip install 'solana-keychain[gcp-kms]'   # adds the GCP KMS backend
 pip install 'solana-keychain[openfort]'  # adds the Openfort backend
 pip install 'solana-keychain[privy]'     # adds the Privy backend
 pip install 'solana-keychain[turnkey]'   # adds the Turnkey backend
+pip install 'solana-keychain[utila]'     # adds the Utila backend
 ```
 
 Requires **Python 3.10+**. Backends built on heavy provider SDKs ship as optional

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -26,6 +26,7 @@ gcp-kms = ["google-cloud-kms>=2.24"]
 openfort = ["cryptography>=43", "pyjwt>=2.8"]
 privy = ["cryptography>=43"]
 turnkey = ["cryptography>=43"]
+utila = ["cryptography>=43", "pyjwt>=2.8"]
 dev = [
     "base58>=2.1",
     "boto3>=1.35",

--- a/python/src/solana_keychain/utila/__init__.py
+++ b/python/src/solana_keychain/utila/__init__.py
@@ -1,0 +1,3 @@
+from solana_keychain.utila.signer import UtilaSigner, UtilaSignerConfig, create_utila_signer
+
+__all__ = ["UtilaSigner", "UtilaSignerConfig", "create_utila_signer"]

--- a/python/src/solana_keychain/utila/signer.py
+++ b/python/src/solana_keychain/utila/signer.py
@@ -1,0 +1,392 @@
+"""Utila API signer integration."""
+
+import asyncio
+import base64
+import time
+from dataclasses import dataclass, field
+from typing import Any
+from urllib.parse import quote
+
+try:
+    import jwt as pyjwt
+    from cryptography.hazmat.primitives.asymmetric import rsa
+    from cryptography.hazmat.primitives.serialization import load_pem_private_key
+except ImportError as error:  # pragma: no cover
+    raise ImportError(
+        "solana_keychain.utila requires the utila extra: pip install 'solana-keychain[utila]'"
+    ) from error
+
+import httpx
+from solders.pubkey import Pubkey
+from solders.signature import Signature
+from solders.transaction import Transaction, VersionedTransaction
+
+from solana_keychain.core.errors import SignerError, SignerErrorCode
+from solana_keychain.core.http import assert_https_url, fetch_signer_json, normalize_base_url
+from solana_keychain.core.signer import SignedTransaction, SolanaSigner
+from solana_keychain.core.transaction_util import (
+    add_signature_to_transaction,
+    classify_signed_transaction,
+    serialize_transaction,
+)
+
+DEFAULT_API_BASE_URL = "https://api.utila.io"
+API_AUDIENCE = "https://api.utila.io/"
+TOKEN_TTL_SECONDS = 55 * 60
+DEFAULT_POLL_INTERVAL_MS = 1000
+DEFAULT_MAX_POLL_ATTEMPTS = 60
+AVAILABILITY_TIMEOUT_SECONDS = 5.0
+
+_TERMINAL_FAILURE_STATES = frozenset(
+    {
+        "DECLINED_BY_AML_POLICY",
+        "MINED_FAILED",
+        "FAILED",
+        "DECLINED",
+        "REPLACED",
+        "CANCELED",
+        "DROPPED",
+        "EXPIRED",
+    }
+)
+
+_ENCODE_URI_COMPONENT_SAFE = "-_.!~*'()"
+
+
+def _encode_uri_component(value: str) -> str:
+    return quote(value, safe=_ENCODE_URI_COMPONENT_SAFE)
+
+
+def _trim_vault_id(value: str) -> str:
+    return value.removeprefix("vaults/")
+
+
+def _trim_wallet_id(value: str) -> str:
+    _, separator, wallet_id = value.rpartition("/wallets/")
+    return wallet_id if separator else value
+
+
+@dataclass
+class UtilaSignerConfig:
+    """Configuration for a Utila signer.
+
+    ``service_account_private_key_pem`` is the service account's RSA key
+    (literal ``\\n`` escapes tolerated). ``network`` is a Utila network resource
+    name, e.g. ``networks/solana-devnet``. ``designated_signers`` defaults to
+    ``["users/{service_account_email}"]``.
+    """
+
+    service_account_email: str
+    service_account_private_key_pem: str = field(repr=False)
+    vault_id: str
+    wallet_id: str
+    network: str
+    api_base_url: str = DEFAULT_API_BASE_URL
+    poll_interval_ms: int = DEFAULT_POLL_INTERVAL_MS
+    max_poll_attempts: int = DEFAULT_MAX_POLL_ATTEMPTS
+    designated_signers: list[str] | None = None
+    http_client: httpx.AsyncClient | None = field(default=None, repr=False)
+
+
+class UtilaSigner(SolanaSigner):
+    """Signer backed by a Utila MPC vault wallet.
+
+    ``init()`` must be awaited before signing — it resolves the wallet's Solana
+    address. ``create_utila_signer()`` does this for you. ``sign_message`` is
+    intentionally unsupported: the API signs transactions only.
+    """
+
+    def __init__(self, config: UtilaSignerConfig) -> None:
+        for name, value in (
+            ("service_account_email", config.service_account_email),
+            ("service_account_private_key_pem", config.service_account_private_key_pem),
+            ("vault_id", config.vault_id),
+            ("wallet_id", config.wallet_id),
+            ("network", config.network),
+        ):
+            if not value.strip():
+                raise SignerError(SignerErrorCode.CONFIG_ERROR, f"{name} must not be empty")
+        if config.poll_interval_ms <= 0:
+            raise SignerError(
+                SignerErrorCode.CONFIG_ERROR, "poll_interval_ms must be greater than 0"
+            )
+        if config.max_poll_attempts <= 0:
+            raise SignerError(
+                SignerErrorCode.CONFIG_ERROR, "max_poll_attempts must be greater than 0"
+            )
+        api_base_url = normalize_base_url(config.api_base_url)
+        assert_https_url(api_base_url, "api_base_url")
+
+        pem = config.service_account_private_key_pem.replace("\\n", "\n").replace("\r", "")
+        try:
+            signing_key = load_pem_private_key(pem.strip().encode(), password=None)
+        except Exception:
+            raise SignerError(
+                SignerErrorCode.INVALID_PRIVATE_KEY,
+                "Failed to parse Utila service account RSA private key",
+            ) from None
+        if not isinstance(signing_key, rsa.RSAPrivateKey):
+            raise SignerError(
+                SignerErrorCode.INVALID_PRIVATE_KEY,
+                "Failed to parse Utila service account RSA private key",
+            )
+
+        self._api_base_url = api_base_url
+        self._service_account_email = config.service_account_email
+        self._signing_key = signing_key
+        self._vault_id = _trim_vault_id(config.vault_id)
+        self._wallet_id = _trim_wallet_id(config.wallet_id)
+        self._network = config.network
+        self._poll_interval_ms = config.poll_interval_ms
+        self._max_poll_attempts = config.max_poll_attempts
+        self._designated_signers = (
+            config.designated_signers
+            if config.designated_signers is not None
+            else [f"users/{config.service_account_email}"]
+        )
+        self._http_client = config.http_client
+        self._public_key: Pubkey | None = None
+
+    def __repr__(self) -> str:
+        return (
+            f"UtilaSigner(pubkey={self._public_key}, vault_id={self._vault_id}, "
+            f"wallet_id={self._wallet_id}, network={self._network})"
+        )
+
+    def _create_access_token(self) -> str:
+        claims = {
+            "sub": self._service_account_email,
+            "aud": API_AUDIENCE,
+            "exp": int(time.time()) + TOKEN_TTL_SECONDS,
+        }
+        try:
+            return pyjwt.encode(claims, self._signing_key, algorithm="RS256")
+        except Exception:
+            raise SignerError(
+                SignerErrorCode.SIGNING_FAILED, "Failed to create Utila access token"
+            ) from None
+
+    async def _request(self, *, method: str, path: str, json_body: Any | None = None) -> Any:
+        return await fetch_signer_json(
+            url=f"{self._api_base_url}{path}",
+            provider_name="Utila",
+            method=method,
+            headers={"Authorization": f"Bearer {self._create_access_token()}"},
+            json_body=json_body,
+            client=self._http_client,
+        )
+
+    async def _fetch_wallet(self) -> dict[str, Any]:
+        path = (
+            f"/v2/vaults/{_encode_uri_component(self._vault_id)}"
+            f"/wallets/{_encode_uri_component(self._wallet_id)}"
+        )
+        response = await self._request(method="GET", path=path)
+        wallet = response.get("wallet") if isinstance(response, dict) else None
+        if not isinstance(wallet, dict):
+            raise SignerError(
+                SignerErrorCode.SERIALIZATION_ERROR, "Failed to parse Utila fetch_wallet response"
+            )
+        return wallet
+
+    async def init(self) -> None:
+        """Resolve the wallet's Solana address. Must be awaited before signing."""
+        wallet = await self._fetch_wallet()
+        solana_details = wallet.get("solanaDetails")
+        address = solana_details.get("address") if isinstance(solana_details, dict) else None
+        if not isinstance(address, str):
+            raise SignerError(
+                SignerErrorCode.INVALID_PUBLIC_KEY,
+                "Utila wallet response did not include solanaDetails",
+            )
+        try:
+            self._public_key = Pubkey.from_string(address)
+        except Exception:
+            raise SignerError(
+                SignerErrorCode.INVALID_PUBLIC_KEY,
+                "Invalid Solana address returned by Utila wallet",
+            ) from None
+
+    def _initialized_pubkey(self) -> Pubkey:
+        if self._public_key is None:
+            raise SignerError(
+                SignerErrorCode.NOT_INITIALIZED,
+                "UtilaSigner is not initialized; call init() before signing",
+            )
+        return self._public_key
+
+    @property
+    def pubkey(self) -> Pubkey:
+        return self._initialized_pubkey()
+
+    @staticmethod
+    def _transaction_envelope(response: Any, context: str) -> dict[str, Any]:
+        transaction = response.get("transaction") if isinstance(response, dict) else None
+        if not isinstance(transaction, dict):
+            raise SignerError(
+                SignerErrorCode.SERIALIZATION_ERROR, f"Failed to parse Utila {context} response"
+            )
+        return transaction
+
+    async def _initiate_transaction(self, raw_transaction: str) -> dict[str, Any]:
+        path = f"/v2/vaults/{_encode_uri_component(self._vault_id)}/transactions:initiate"
+        request: dict[str, Any] = {
+            "details": {
+                "solanaSerializedTransaction": {
+                    "network": self._network,
+                    "rawTransaction": raw_transaction,
+                    "publish": False,
+                    "replaceBlockhash": False,
+                    "tryReplaceBlockhash": False,
+                }
+            }
+        }
+        if self._designated_signers:
+            request["designatedSigners"] = self._designated_signers
+        response = await self._request(method="POST", path=path, json_body=request)
+        return self._transaction_envelope(response, "initiate_transaction")
+
+    async def _get_transaction(self, transaction_id: str) -> dict[str, Any]:
+        path = (
+            f"/v2/vaults/{_encode_uri_component(self._vault_id)}"
+            f"/transactions/{_encode_uri_component(transaction_id)}?view=FULL"
+        )
+        response = await self._request(method="GET", path=path)
+        return self._transaction_envelope(response, "get_transaction")
+
+    @staticmethod
+    def _extract_transaction_id(name: str) -> str:
+        transaction_id = name.rsplit("/", 1)[-1]
+        if not transaction_id:
+            raise SignerError(
+                SignerErrorCode.SERIALIZATION_ERROR,
+                "Utila transaction response missing transaction id",
+            )
+        return transaction_id
+
+    async def _poll_signed_transaction(self, transaction: dict[str, Any]) -> dict[str, Any]:
+        for _ in range(self._max_poll_attempts):
+            state = transaction.get("state")
+            if state == "SIGNED":
+                return transaction
+            if state in _TERMINAL_FAILURE_STATES:
+                raise SignerError(
+                    SignerErrorCode.SIGNING_FAILED,
+                    f"Utila transaction reached terminal state {state}",
+                )
+            await asyncio.sleep(self._poll_interval_ms / 1000)
+            transaction_id = self._extract_transaction_id(str(transaction.get("name", "")))
+            transaction = await self._get_transaction(transaction_id)
+
+        state = transaction.get("state")
+        if state == "SIGNED":
+            return transaction
+        if state in _TERMINAL_FAILURE_STATES:
+            raise SignerError(
+                SignerErrorCode.SIGNING_FAILED,
+                f"Utila transaction reached terminal state {state}",
+            )
+        raise SignerError(
+            SignerErrorCode.REMOTE_API_ERROR,
+            f"Utila transaction polling timed out after {self._max_poll_attempts} attempts",
+        )
+
+    def _extract_signature_from_raw_transaction(
+        self, raw_transaction: str, expected_message: bytes
+    ) -> Signature:
+        public_key = self._initialized_pubkey()
+        try:
+            transaction_bytes = base64.b64decode(raw_transaction, validate=True)
+        except Exception:
+            raise SignerError(
+                SignerErrorCode.SERIALIZATION_ERROR,
+                "Failed to decode Utila rawTransaction as base64",
+            ) from None
+        try:
+            transaction = VersionedTransaction.from_bytes(transaction_bytes)
+        except Exception:
+            raise SignerError(
+                SignerErrorCode.SERIALIZATION_ERROR,
+                "Failed to deserialize Utila rawTransaction",
+            ) from None
+
+        message = transaction.message
+        if bytes(message) != expected_message:
+            raise SignerError(
+                SignerErrorCode.SIGNING_FAILED,
+                "Utila returned a signed transaction with different message bytes",
+            )
+
+        num_required = message.header.num_required_signatures
+        account_keys = list(message.account_keys)
+        if len(account_keys) < num_required:
+            raise SignerError(
+                SignerErrorCode.SIGNING_FAILED, "Invalid account index: not enough account keys"
+            )
+        try:
+            position = account_keys[:num_required].index(public_key)
+        except ValueError:
+            raise SignerError(
+                SignerErrorCode.SIGNING_FAILED,
+                "Failed to locate signer pubkey in Utila transaction",
+            ) from None
+
+        signatures = list(transaction.signatures)
+        if position >= len(signatures) or signatures[position] == Signature.default():
+            raise SignerError(
+                SignerErrorCode.SIGNING_FAILED,
+                "Utila rawTransaction did not contain a signer signature",
+            )
+        signature = signatures[position]
+        if not signature.verify(public_key, expected_message):
+            raise SignerError(
+                SignerErrorCode.SIGNING_FAILED,
+                "Signature verification failed for Utila rawTransaction",
+            )
+        return signature
+
+    async def sign_transaction(self, transaction: Transaction) -> SignedTransaction:
+        public_key = self._initialized_pubkey()
+        expected_message = transaction.message_data()
+        raw_transaction = base64.b64encode(bytes(transaction)).decode("ascii")
+
+        initiated = await self._initiate_transaction(raw_transaction)
+        signed = await self._poll_signed_transaction(initiated)
+
+        solana_transaction = signed.get("solanaTransaction")
+        raw_signed = (
+            solana_transaction.get("rawTransaction")
+            if isinstance(solana_transaction, dict)
+            else None
+        )
+        if not isinstance(raw_signed, str):
+            raise SignerError(
+                SignerErrorCode.SIGNING_FAILED,
+                "Utila signed transaction response missing solanaTransaction.rawTransaction",
+            )
+        signature = self._extract_signature_from_raw_transaction(raw_signed, expected_message)
+
+        add_signature_to_transaction(transaction, public_key, signature)
+        return classify_signed_transaction(
+            transaction, serialize_transaction(transaction), signature
+        )
+
+    async def sign_message(self, message: bytes) -> Signature:
+        raise SignerError(
+            SignerErrorCode.SIGNING_FAILED,
+            "Utila sign_message is not supported for Solana wallets in this signer",
+        )
+
+    async def is_available(self) -> bool:
+        try:
+            await asyncio.wait_for(self._fetch_wallet(), AVAILABILITY_TIMEOUT_SECONDS)
+        except (SignerError, asyncio.TimeoutError):
+            return False
+        return True
+
+
+async def create_utila_signer(config: UtilaSignerConfig) -> UtilaSigner:
+    """Create a ready-to-use Utila signer (awaits ``init()``)."""
+    signer = UtilaSigner(config)
+    await signer.init()
+    return signer

--- a/python/tests/test_utila_signer.py
+++ b/python/tests/test_utila_signer.py
@@ -1,0 +1,383 @@
+import base64
+import json
+import time
+from typing import Any
+
+import httpx
+import jwt as pyjwt
+import pytest
+import respx
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives.serialization import (
+    Encoding,
+    NoEncryption,
+    PrivateFormat,
+)
+from solders.keypair import Keypair
+from solders.transaction import Transaction
+
+from solana_keychain import SignerError, SignerErrorCode
+from solana_keychain.utila import UtilaSigner, UtilaSignerConfig, create_utila_signer
+from tests.util import create_test_transaction
+
+API_BASE_URL = "https://utila.example.com"
+EMAIL = "service-account@vault.utilaserviceaccount.io"
+VAULT_ID = "vault-test"
+WALLET_ID = "wallet-test"
+NETWORK = "networks/solana-devnet"
+
+WALLET_URL = f"{API_BASE_URL}/v2/vaults/{VAULT_ID}/wallets/{WALLET_ID}"
+INITIATE_URL = f"{API_BASE_URL}/v2/vaults/{VAULT_ID}/transactions:initiate"
+GET_TX_URL = f"{API_BASE_URL}/v2/vaults/{VAULT_ID}/transactions/tx-1"
+
+_RSA_KEY = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+RSA_PRIVATE_PEM = _RSA_KEY.private_bytes(Encoding.PEM, PrivateFormat.PKCS8, NoEncryption()).decode()
+RSA_PUBLIC_KEY = _RSA_KEY.public_key()
+
+
+def make_signer(**overrides: Any) -> UtilaSigner:
+    config = UtilaSignerConfig(
+        service_account_email=overrides.pop("service_account_email", EMAIL),
+        service_account_private_key_pem=overrides.pop(
+            "service_account_private_key_pem", RSA_PRIVATE_PEM
+        ),
+        vault_id=overrides.pop("vault_id", VAULT_ID),
+        wallet_id=overrides.pop("wallet_id", WALLET_ID),
+        network=overrides.pop("network", NETWORK),
+        api_base_url=overrides.pop("api_base_url", API_BASE_URL),
+        poll_interval_ms=overrides.pop("poll_interval_ms", 1),
+        **overrides,
+    )
+    return UtilaSigner(config)
+
+
+def mock_wallet(address: str | None) -> None:
+    wallet: dict[str, Any] = {"name": f"vaults/{VAULT_ID}/wallets/{WALLET_ID}"}
+    if address is not None:
+        wallet["solanaDetails"] = {"address": address}
+    respx.get(WALLET_URL).mock(return_value=httpx.Response(200, json={"wallet": wallet}))
+
+
+def utila_transaction(state: str, raw_transaction: str | None = None) -> dict[str, Any]:
+    transaction: dict[str, Any] = {
+        "name": f"vaults/{VAULT_ID}/transactions/tx-1",
+        "state": state,
+    }
+    if raw_transaction is not None:
+        transaction["solanaTransaction"] = {"rawTransaction": raw_transaction}
+    return transaction
+
+
+def signed_raw_transaction(keypair: Keypair, transaction: Transaction) -> str:
+    signed = Transaction.from_bytes(bytes(transaction))
+    signed.signatures = [keypair.sign_message(transaction.message_data())]
+    return base64.b64encode(bytes(signed)).decode()
+
+
+async def initialized_signer(keypair: Keypair, **overrides: Any) -> UtilaSigner:
+    mock_wallet(str(keypair.pubkey()))
+    signer = make_signer(**overrides)
+    await signer.init()
+    return signer
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"service_account_email": "  "},
+        {"service_account_private_key_pem": ""},
+        {"vault_id": ""},
+        {"wallet_id": ""},
+        {"network": ""},
+        {"poll_interval_ms": 0},
+        {"max_poll_attempts": 0},
+        {"api_base_url": "http://utila.example.com"},
+    ],
+)
+def test_invalid_config_rejected(overrides: dict[str, Any]) -> None:
+    with pytest.raises(SignerError) as excinfo:
+        make_signer(**overrides)
+    assert excinfo.value.code == SignerErrorCode.CONFIG_ERROR
+
+
+def test_invalid_rsa_key_rejected_at_construction() -> None:
+    with pytest.raises(SignerError) as excinfo:
+        make_signer(service_account_private_key_pem="not-a-pem")
+    assert excinfo.value.code == SignerErrorCode.INVALID_PRIVATE_KEY
+
+
+def test_pem_with_escaped_newlines_accepted() -> None:
+    escaped = RSA_PRIVATE_PEM.replace("\n", "\\n")
+    signer = make_signer(service_account_private_key_pem=escaped)
+    assert isinstance(signer, UtilaSigner)
+
+
+@respx.mock
+async def test_resource_name_prefixes_are_trimmed() -> None:
+    keypair = Keypair()
+    mock_wallet(str(keypair.pubkey()))
+    signer = make_signer(
+        vault_id=f"vaults/{VAULT_ID}",
+        wallet_id=f"vaults/{VAULT_ID}/wallets/{WALLET_ID}",
+    )
+    await signer.init()
+    assert signer.pubkey == keypair.pubkey()
+    assert str(respx.calls.last.request.url) == WALLET_URL
+
+
+@respx.mock
+async def test_access_token_claims() -> None:
+    await initialized_signer(Keypair())
+    token = respx.calls.last.request.headers["Authorization"].removeprefix("Bearer ")
+    claims = pyjwt.decode(
+        token, RSA_PUBLIC_KEY, algorithms=["RS256"], audience="https://api.utila.io/"
+    )
+    assert claims["sub"] == EMAIL
+    assert claims["aud"] == "https://api.utila.io/"
+    assert 0 < claims["exp"] - int(time.time()) <= 55 * 60
+
+
+@respx.mock
+async def test_init_rejects_missing_solana_details() -> None:
+    mock_wallet(None)
+    signer = make_signer()
+    with pytest.raises(SignerError) as excinfo:
+        await signer.init()
+    assert excinfo.value.code == SignerErrorCode.INVALID_PUBLIC_KEY
+
+
+@respx.mock
+async def test_init_rejects_invalid_address() -> None:
+    mock_wallet("not-a-pubkey")
+    signer = make_signer()
+    with pytest.raises(SignerError) as excinfo:
+        await signer.init()
+    assert excinfo.value.code == SignerErrorCode.INVALID_PUBLIC_KEY
+
+
+@respx.mock
+async def test_init_api_error() -> None:
+    respx.get(WALLET_URL).mock(return_value=httpx.Response(401, json={"error": "denied"}))
+    signer = make_signer()
+    with pytest.raises(SignerError) as excinfo:
+        await signer.init()
+    assert excinfo.value.code == SignerErrorCode.REMOTE_API_ERROR
+
+
+async def test_sign_message_is_unsupported() -> None:
+    with pytest.raises(SignerError) as excinfo:
+        await make_signer().sign_message(b"hello")
+    assert excinfo.value.code == SignerErrorCode.SIGNING_FAILED
+
+
+async def test_uninitialized_sign_transaction_raises_not_initialized() -> None:
+    with pytest.raises(SignerError) as excinfo:
+        await make_signer().sign_transaction(create_test_transaction(Keypair().pubkey()))
+    assert excinfo.value.code == SignerErrorCode.NOT_INITIALIZED
+
+
+@respx.mock
+async def test_sign_transaction_success_with_polling() -> None:
+    keypair = Keypair()
+    signer = await initialized_signer(keypair)
+    transaction = create_test_transaction(keypair.pubkey())
+    unsigned_b64 = base64.b64encode(bytes(transaction)).decode()
+    expected_signature = keypair.sign_message(transaction.message_data())
+
+    respx.post(INITIATE_URL).mock(
+        return_value=httpx.Response(
+            200, json={"transaction": utila_transaction("AWAITING_SIGNATURE")}
+        )
+    )
+    respx.get(f"{GET_TX_URL}?view=FULL").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "transaction": utila_transaction(
+                    "SIGNED", raw_transaction=signed_raw_transaction(keypair, transaction)
+                )
+            },
+        )
+    )
+
+    result = await signer.sign_transaction(transaction)
+
+    assert result.is_complete
+    assert result.signature == expected_signature
+    assert list(transaction.signatures) == [expected_signature]
+
+    initiate_body = json.loads(respx.calls[1].request.content)
+    assert initiate_body == {
+        "details": {
+            "solanaSerializedTransaction": {
+                "network": NETWORK,
+                "rawTransaction": unsigned_b64,
+                "publish": False,
+                "replaceBlockhash": False,
+                "tryReplaceBlockhash": False,
+            }
+        },
+        "designatedSigners": [f"users/{EMAIL}"],
+    }
+
+
+@respx.mock
+async def test_custom_designated_signers() -> None:
+    keypair = Keypair()
+    signer = await initialized_signer(keypair, designated_signers=["users/other@example.com"])
+    transaction = create_test_transaction(keypair.pubkey())
+    respx.post(INITIATE_URL).mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "transaction": utila_transaction(
+                    "SIGNED", raw_transaction=signed_raw_transaction(keypair, transaction)
+                )
+            },
+        )
+    )
+
+    await signer.sign_transaction(transaction)
+
+    initiate_body = json.loads(respx.calls[1].request.content)
+    assert initiate_body["designatedSigners"] == ["users/other@example.com"]
+
+
+@respx.mock
+@pytest.mark.parametrize("state", ["FAILED", "DECLINED", "CANCELED", "EXPIRED", "DROPPED"])
+async def test_sign_transaction_terminal_failure(state: str) -> None:
+    keypair = Keypair()
+    signer = await initialized_signer(keypair)
+    respx.post(INITIATE_URL).mock(
+        return_value=httpx.Response(200, json={"transaction": utila_transaction(state)})
+    )
+    with pytest.raises(SignerError) as excinfo:
+        await signer.sign_transaction(create_test_transaction(keypair.pubkey()))
+    assert excinfo.value.code == SignerErrorCode.SIGNING_FAILED
+
+
+@respx.mock
+async def test_sign_transaction_polling_timeout() -> None:
+    keypair = Keypair()
+    signer = await initialized_signer(keypair, max_poll_attempts=2)
+    respx.post(INITIATE_URL).mock(
+        return_value=httpx.Response(
+            200, json={"transaction": utila_transaction("AWAITING_APPROVAL")}
+        )
+    )
+    respx.get(f"{GET_TX_URL}?view=FULL").mock(
+        return_value=httpx.Response(
+            200, json={"transaction": utila_transaction("AWAITING_APPROVAL")}
+        )
+    )
+    with pytest.raises(SignerError) as excinfo:
+        await signer.sign_transaction(create_test_transaction(keypair.pubkey()))
+    assert excinfo.value.code == SignerErrorCode.REMOTE_API_ERROR
+
+
+@respx.mock
+async def test_sign_transaction_missing_raw_transaction() -> None:
+    keypair = Keypair()
+    signer = await initialized_signer(keypair)
+    respx.post(INITIATE_URL).mock(
+        return_value=httpx.Response(200, json={"transaction": utila_transaction("SIGNED")})
+    )
+    with pytest.raises(SignerError) as excinfo:
+        await signer.sign_transaction(create_test_transaction(keypair.pubkey()))
+    assert excinfo.value.code == SignerErrorCode.SIGNING_FAILED
+
+
+@respx.mock
+async def test_rewritten_message_bytes_are_rejected() -> None:
+    keypair = Keypair()
+    signer = await initialized_signer(keypair)
+    transaction = create_test_transaction(keypair.pubkey())
+    rewritten = create_test_transaction(keypair.pubkey())
+    assert rewritten.message_data() != transaction.message_data()
+
+    respx.post(INITIATE_URL).mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "transaction": utila_transaction(
+                    "SIGNED", raw_transaction=signed_raw_transaction(keypair, rewritten)
+                )
+            },
+        )
+    )
+    with pytest.raises(SignerError) as excinfo:
+        await signer.sign_transaction(transaction)
+    assert excinfo.value.code == SignerErrorCode.SIGNING_FAILED
+
+
+@respx.mock
+async def test_unsigned_raw_transaction_is_rejected() -> None:
+    keypair = Keypair()
+    signer = await initialized_signer(keypair)
+    transaction = create_test_transaction(keypair.pubkey())
+    unsigned_b64 = base64.b64encode(bytes(transaction)).decode()
+
+    respx.post(INITIATE_URL).mock(
+        return_value=httpx.Response(
+            200,
+            json={"transaction": utila_transaction("SIGNED", raw_transaction=unsigned_b64)},
+        )
+    )
+    with pytest.raises(SignerError) as excinfo:
+        await signer.sign_transaction(transaction)
+    assert excinfo.value.code == SignerErrorCode.SIGNING_FAILED
+
+
+@respx.mock
+async def test_undecodable_raw_transaction() -> None:
+    keypair = Keypair()
+    signer = await initialized_signer(keypair)
+    respx.post(INITIATE_URL).mock(
+        return_value=httpx.Response(
+            200,
+            json={"transaction": utila_transaction("SIGNED", raw_transaction="!!!")},
+        )
+    )
+    with pytest.raises(SignerError) as excinfo:
+        await signer.sign_transaction(create_test_transaction(keypair.pubkey()))
+    assert excinfo.value.code == SignerErrorCode.SERIALIZATION_ERROR
+
+
+@respx.mock
+async def test_is_available_true_and_false() -> None:
+    keypair = Keypair()
+    signer = await initialized_signer(keypair)
+    assert await signer.is_available()
+    respx.get(WALLET_URL).mock(return_value=httpx.Response(403, json={"error": "forbidden"}))
+    assert not await signer.is_available()
+
+
+@respx.mock
+async def test_create_utila_signer_factory_initializes() -> None:
+    keypair = Keypair()
+    mock_wallet(str(keypair.pubkey()))
+    signer = await create_utila_signer(
+        UtilaSignerConfig(
+            service_account_email=EMAIL,
+            service_account_private_key_pem=RSA_PRIVATE_PEM,
+            vault_id=VAULT_ID,
+            wallet_id=WALLET_ID,
+            network=NETWORK,
+            api_base_url=API_BASE_URL,
+        )
+    )
+    assert signer.pubkey == keypair.pubkey()
+
+
+def test_reprs_never_contain_private_key() -> None:
+    config = UtilaSignerConfig(
+        service_account_email=EMAIL,
+        service_account_private_key_pem=RSA_PRIVATE_PEM,
+        vault_id=VAULT_ID,
+        wallet_id=WALLET_ID,
+        network=NETWORK,
+        api_base_url=API_BASE_URL,
+    )
+    signer = make_signer()
+    for text in (repr(config), repr(signer)):
+        assert "PRIVATE KEY" not in text


### PR DESCRIPTION
## Summary
- Adds the **Utila** backend (`solana_keychain.utila`) — the thirteenth and final backend. Stacked on #220 — this layer shows only the Utila work.
- **Auth**: fresh RS256 access token per request (`sub` = service-account email, fixed audience `https://api.utila.io/`, 55-minute TTL); the service-account RSA key is parsed at construction and tolerates escaped-newline PEM.
- **Signing flow**: `transactions:initiate` with the base64 transaction, `publish: false` and blockhash replacement disabled, `designatedSigners` defaulting to `users/{email}`; polled until `SIGNED`, with the full terminal-failure state set (`DECLINED_BY_AML_POLICY`, `MINED_FAILED`, `FAILED`, `DECLINED`, `REPLACED`, `CANCELED`, `DROPPED`, `EXPIRED`) surfacing as `SIGNING_FAILED` and an attempt cap surfacing a polling-timeout `REMOTE_API_ERROR`.
- **Strict message binding**: the returned `rawTransaction` must carry **byte-identical** message bytes to the caller's transaction (rewrites rejected outright), then this signer's signature is taken at its required-signer position and verified before being applied.
- Vault (`vaults/` prefix) and wallet (`…/wallets/` path) resource names are trimmed; path segments use exact `encodeURIComponent` encoding. `sign_message` is intentionally unsupported. `init()` resolves the wallet's `solanaDetails.address`. `cryptography` + `pyjwt` behind the `[utila]` extra.

## Test Plan
- 402 tests pass (32 new): access-token claims cryptographically verified (sub/aud/TTL), escaped-newline PEM, resource-name trimming asserted in URLs, initiate body pinned exactly (flags + designated signers), custom designated signers, polling through intermediate states, five terminal states, timeout, rewritten-message rejection, unsigned/undecodable/missing rawTransaction, config validation matrix, sign_message rejection, not-initialized paths, availability, factory init, repr redaction
- `ruff` + `mypy --strict` + sdist/wheel build clean

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
