### PR TITLE
feat(python): keychain umbrella factory and integration test suite

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -130,6 +130,7 @@ jobs:
       run:
         working-directory: python
     strategy:
+      fail-fast: false
       matrix:
         backend: ${{ fromJSON(needs.resolve-signers.outputs.python_integration_backends_json) }}
     steps:

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -164,4 +164,5 @@ jobs:
         env:
           SOLANA_RPC_URL: https://api.devnet.solana.com
           KEYCHAIN_INTEGRATION_REQUIRE_RUN: '1'
-        run: pytest -m integration tests/integration/test_live_signers.py -k "$(echo '${{ matrix.backend }}' | tr '-' '_')"
+          KEYCHAIN_INTEGRATION_BACKEND: ${{ matrix.backend }}
+        run: pytest -m integration tests/integration/test_live_signers.py

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -163,4 +163,5 @@ jobs:
       - name: Run ${{ matrix.backend }} integration tests
         env:
           SOLANA_RPC_URL: https://api.devnet.solana.com
+          KEYCHAIN_INTEGRATION_REQUIRE_RUN: '1'
         run: pytest -m integration tests/integration/test_live_signers.py -k "$(echo '${{ matrix.backend }}' | tr '-' '_')"

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -10,6 +10,59 @@ on:
       - '.github/workflows/python-ci.yml'
 
 jobs:
+  resolve-signers:
+    runs-on: ubuntu-latest
+    outputs:
+      python_integration_backends_json: ${{ steps.resolve.outputs.python_integration_backends_json }}
+      python_integration_backend_count: ${{ steps.resolve.outputs.python_integration_backend_count }}
+    steps:
+      - name: Resolve enabled signers from repository variables
+        id: resolve
+        uses: actions/github-script@v9
+        env:
+          CI_SIGNER_PRIVY_ENABLED: ${{ vars.CI_SIGNER_PRIVY_ENABLED || 'true' }}
+          CI_SIGNER_TURNKEY_ENABLED: ${{ vars.CI_SIGNER_TURNKEY_ENABLED || 'true' }}
+          CI_SIGNER_FIREBLOCKS_ENABLED: ${{ vars.CI_SIGNER_FIREBLOCKS_ENABLED || 'true' }}
+          CI_SIGNER_AWS_KMS_ENABLED: ${{ vars.CI_SIGNER_AWS_KMS_ENABLED || 'true' }}
+          CI_SIGNER_GCP_KMS_ENABLED: ${{ vars.CI_SIGNER_GCP_KMS_ENABLED || 'true' }}
+          CI_SIGNER_PARA_ENABLED: ${{ vars.CI_SIGNER_PARA_ENABLED || 'true' }}
+          CI_SIGNER_CDP_ENABLED: ${{ vars.CI_SIGNER_CDP_ENABLED || 'true' }}
+          CI_SIGNER_DFNS_ENABLED: ${{ vars.CI_SIGNER_DFNS_ENABLED || 'true' }}
+          CI_SIGNER_CROSSMINT_ENABLED: ${{ vars.CI_SIGNER_CROSSMINT_ENABLED || 'true' }}
+          CI_SIGNER_OPENFORT_ENABLED: ${{ vars.CI_SIGNER_OPENFORT_ENABLED || 'true' }}
+        with:
+          script: |
+            const parseVar = (name) => {
+              const raw = process.env[name];
+              if (raw !== 'true' && raw !== 'false') {
+                const message = `${name} must be set to the string 'true' or 'false' in repository Actions variables. Received: ${raw ?? 'undefined'}`;
+                core.setFailed(message);
+                throw new Error(message);
+              }
+              return raw === 'true';
+            };
+
+            // Same live-credential set as the other language CIs (utila and
+            // vault run locally via `just py-test-integration`).
+            const integrationOrder = [
+              ['privy', 'CI_SIGNER_PRIVY_ENABLED'],
+              ['turnkey', 'CI_SIGNER_TURNKEY_ENABLED'],
+              ['fireblocks', 'CI_SIGNER_FIREBLOCKS_ENABLED'],
+              ['aws-kms', 'CI_SIGNER_AWS_KMS_ENABLED'],
+              ['gcp-kms', 'CI_SIGNER_GCP_KMS_ENABLED'],
+              ['para', 'CI_SIGNER_PARA_ENABLED'],
+              ['cdp', 'CI_SIGNER_CDP_ENABLED'],
+              ['dfns', 'CI_SIGNER_DFNS_ENABLED'],
+              ['crossmint', 'CI_SIGNER_CROSSMINT_ENABLED'],
+              ['openfort', 'CI_SIGNER_OPENFORT_ENABLED'],
+            ];
+            const backends = integrationOrder
+              .filter(([, variable]) => parseVar(variable))
+              .map(([backend]) => backend);
+
+            core.setOutput('python_integration_backends_json', JSON.stringify(backends));
+            core.setOutput('python_integration_backend_count', String(backends.length));
+
   python-test:
     runs-on: ubuntu-latest
     defaults:
@@ -65,3 +118,49 @@ jobs:
         run: |
           pip install build
           python -m build
+
+  python-integration-test:
+    needs: resolve-signers
+    if: ${{ (github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork) && needs.resolve-signers.outputs.python_integration_backend_count != '0' }}
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    defaults:
+      run:
+        working-directory: python
+    strategy:
+      matrix:
+        backend: ${{ fromJSON(needs.resolve-signers.outputs.python_integration_backends_json) }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
+          cache: pip
+          cache-dependency-path: python/pyproject.toml
+      - uses: dopplerhq/secrets-fetch-action@v2.0.0
+        id: doppler
+        with:
+          auth-method: oidc
+          doppler-identity-id: ${{ vars.DOPPLER_SERVICE_IDENTITY_ID }}
+          doppler-project: ${{ vars.DOPPLER_PROJECT || 'keychain' }}
+          doppler-config: ${{ vars.DOPPLER_CONFIG_CI || 'stg_github' }}
+          inject-env-vars: true
+      - name: Setup GCP credentials
+        if: matrix.backend == 'gcp-kms'
+        uses: google-github-actions/auth@v3
+        with:
+          credentials_json: ${{ steps.doppler.outputs.GCP_SERVICE_ACCOUNT_KEY }}
+      - name: Configure AWS credentials
+        if: matrix.backend == 'aws-kms'
+        uses: aws-actions/configure-aws-credentials@v6.2.0
+        with:
+          role-to-assume: ${{ steps.doppler.outputs.AWS_ROLE_ARN }}
+          aws-region: ${{ steps.doppler.outputs.AWS_KMS_REGION }}
+      - name: Install
+        run: pip install -e '.[dev]'
+      - name: Run ${{ matrix.backend }} integration tests
+        env:
+          SOLANA_RPC_URL: https://api.devnet.solana.com
+        run: pytest -m integration tests/integration/test_live_signers.py -k "$(echo '${{ matrix.backend }}' | tr '-' '_')"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,7 @@ Per-side recipes (use these to scope work to one language):
 | Build | `just rust-build` | `just ts-build` | `just py-build` |
 | Unit tests | `just rust-test` | `just ts-test` | `just py-test` |
 | Format + lint | `just rust-fmt` | `just ts-fmt` | `just py-fmt` |
-| Integration tests | `just rust-test-integration` | `just ts-test-integration` | — |
+| Integration tests | `just rust-test-integration` | `just ts-test-integration` | `just py-test-integration` |
 | Other | — | `just ts-treeshake` (verifies `@solana/keychain` umbrella + per-pkg tree-shakability) | — |
 
 Integration recipes auto-spawn a local `vault server -dev` and load `.env` from the repo root — do not run vault yourself or pass secrets via shell.
@@ -124,6 +124,8 @@ Single package under [python/](python/) (PyPI `solana-keychain`, import `solana_
 - **Serialization**: built on `solders`; golden wire-format vectors pinned in `python/tests/test_parity.py` — never regenerate them to make the suite pass.
 - **Remote API calls** go through `fetch_signer_json()` from `solana_keychain.core` — it owns the HTTP_ERROR/REMOTE_API_ERROR/PARSING_ERROR pipeline, response sanitization, redirect rejection, and a default 60s timeout. Base URLs must pass `assert_https_url()`. Unit tests mock HTTP with `respx`; no live API calls in unit tests.
 - **Backend imports/extras rules**: the root `__init__.py` must never eagerly import a backend whose dependencies live behind an optional extra (use lazy `__getattr__` or leave it to submodule imports), and such backends must raise a clear "install `solana-keychain[<extra>]`" error when imported without their extra. Backends with only base deps (`solders`, `httpx`) may be exported eagerly.
+- **Umbrella factory**: `create_keychain_signer(backend, config)` in `solana_keychain/keychain.py` dispatches by backend name with lazy imports; new backends must be added to its `_BACKENDS` table.
+- **Integration tests**: `python/tests/integration/`, gated by the `integration` pytest marker (excluded by default via `addopts`), env-var-driven with the same variable names as the other integration suites; each backend skips itself when unconfigured. `just py-test-integration` runs the local Vault flow.
 
 ## Branch Workflow
 

--- a/justfile
+++ b/justfile
@@ -260,7 +260,7 @@ py-test-integration: _py-install
     export VAULT_KEY_NAME="${VAULT_KEY_NAME:-solana-test-key}"
 
     echo "Running Python integration tests..."
-    .venv/bin/pytest -m integration tests/integration
+    KEYCHAIN_INTEGRATION_REQUIRE_RUN=1 .venv/bin/pytest -m integration tests/integration
 
 # ===========================================================
 # ========================= Release =========================

--- a/justfile
+++ b/justfile
@@ -21,7 +21,7 @@ build: rust-build ts-build py-build
 test: rust-test ts-test py-test
 
 # Integration tests
-test-integration: rust-test-integration ts-test-integration
+test-integration: rust-test-integration ts-test-integration py-test-integration
 
 # All tests
 test-all: test test-integration
@@ -210,6 +210,57 @@ py-build: _py-install
 [working-directory: 'python']
 py-test: _py-install
     .venv/bin/pytest
+
+[working-directory: 'python']
+py-test-integration: _py-install
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    VAULT_PID=""
+
+    cleanup() {
+        if [ -n "$VAULT_PID" ]; then
+            echo "Stopping Vault dev server..."
+            kill "$VAULT_PID" 2>/dev/null || true
+            wait "$VAULT_PID" 2>/dev/null || true
+        fi
+        pkill -f "vault server -dev" 2>/dev/null || true
+    }
+    trap cleanup EXIT
+
+    pkill -f "vault server -dev" 2>/dev/null || true
+
+    # Load env vars from .env file (shared across all languages)
+    if [ -f ../.env ]; then
+        set -a
+        source ../.env
+        set +a
+    fi
+
+    echo "Starting Vault dev server..."
+    vault server -dev -dev-root-token-id="root" &
+    VAULT_PID=$!
+
+    export VAULT_ADDR='http://127.0.0.1:8200'
+    export VAULT_TOKEN='root'
+
+    echo "Waiting for Vault to be ready..."
+    for i in {1..10}; do
+        if vault status > /dev/null 2>&1; then
+            echo "Vault is ready!"
+            break
+        fi
+        [[ $i -eq 10 ]] && { echo "Error: Vault not available"; exit 1; }
+        sleep 1
+    done
+
+    # Restore the SAME shared transit test key used by the other integration suites.
+    vault secrets enable transit >/dev/null 2>&1 || true
+    vault write transit/restore/solana-test-key backup=@"../rust/src/tests/vault-test-key.b64" >/dev/null 2>&1 || true
+    export VAULT_KEY_NAME="${VAULT_KEY_NAME:-solana-test-key}"
+
+    echo "Running Python integration tests..."
+    .venv/bin/pytest -m integration tests/integration
 
 # ===========================================================
 # ========================= Release =========================

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -48,6 +48,10 @@ packages = ["src/solana_keychain"]
 asyncio_mode = "auto"
 testpaths = ["tests"]
 pythonpath = ["src", "."]
+addopts = "-m 'not integration'"
+markers = [
+    "integration: live external-service tests, gated by environment variables",
+]
 
 [tool.ruff]
 line-length = 100

--- a/python/src/solana_keychain/__init__.py
+++ b/python/src/solana_keychain/__init__.py
@@ -4,11 +4,13 @@ from solana_keychain.core import (
     SignerErrorCode,
     SolanaSigner,
 )
-from solana_keychain.memory import MemorySigner, MemorySignerConfig
+from solana_keychain.keychain import SUPPORTED_BACKENDS, create_keychain_signer
+from solana_keychain.memory import MemorySigner, MemorySignerConfig, create_memory_signer
 from solana_keychain.para import ParaSigner, ParaSignerConfig, create_para_signer
 from solana_keychain.vault import VaultSigner, VaultSignerConfig, create_vault_signer
 
 __all__ = [
+    "SUPPORTED_BACKENDS",
     "MemorySigner",
     "MemorySignerConfig",
     "ParaSigner",
@@ -19,6 +21,8 @@ __all__ = [
     "SolanaSigner",
     "VaultSigner",
     "VaultSignerConfig",
+    "create_keychain_signer",
+    "create_memory_signer",
     "create_para_signer",
     "create_vault_signer",
 ]

--- a/python/src/solana_keychain/core/__init__.py
+++ b/python/src/solana_keychain/core/__init__.py
@@ -13,6 +13,7 @@ from solana_keychain.core.transaction_util import (
     get_signing_keypair_position,
     has_all_required_signatures,
     serialize_transaction,
+    signed_message_bytes,
 )
 
 __all__ = [
@@ -30,4 +31,5 @@ __all__ = [
     "normalize_base_url",
     "sanitize_remote_error_response",
     "serialize_transaction",
+    "signed_message_bytes",
 ]

--- a/python/src/solana_keychain/core/transaction_util.py
+++ b/python/src/solana_keychain/core/transaction_util.py
@@ -2,12 +2,15 @@
 
 import base64
 
+from solders.message import Message, MessageV0
 from solders.pubkey import Pubkey
 from solders.signature import Signature
 from solders.transaction import Transaction
 
 from solana_keychain.core.errors import SignerError, SignerErrorCode
 from solana_keychain.core.signer import SignedTransaction
+
+MESSAGE_VERSION_PREFIX = b"\x80"
 
 
 def serialize_transaction(transaction: Transaction) -> str:
@@ -19,6 +22,18 @@ def serialize_transaction(transaction: Transaction) -> str:
             SignerErrorCode.SERIALIZATION_ERROR, f"Failed to serialize transaction: {error}"
         ) from None
     return base64.b64encode(raw).decode("ascii")
+
+
+def signed_message_bytes(message: Message | MessageV0) -> bytes:
+    """The bytes a signature over ``message`` actually covers.
+
+    A v0 message is signed with a ``0x80`` version prefix that its serialization
+    omits; a legacy message is signed as-is.
+    """
+    serialized = bytes(message)
+    if isinstance(message, MessageV0):
+        return MESSAGE_VERSION_PREFIX + serialized
+    return serialized
 
 
 def get_signing_keypair_position(transaction: Transaction, pubkey: Pubkey) -> int:

--- a/python/src/solana_keychain/crossmint/signer.py
+++ b/python/src/solana_keychain/crossmint/signer.py
@@ -20,6 +20,7 @@ from solana_keychain.core.transaction_util import (
     add_signature_to_transaction,
     classify_signed_transaction,
     serialize_transaction,
+    signed_message_bytes,
 )
 from solana_keychain.crossmint.derive import derive_signing_key
 
@@ -360,7 +361,7 @@ class CrossmintSigner(SolanaSigner):
         # (gas sponsorship, priority fee, its own blockhash) and broadcasts
         # server-side, so a strict check against caller bytes rejects legitimately
         # landed transactions.
-        self._verify_signature_matches_message(signature, bytes(message))
+        self._verify_signature_matches_message(signature, signed_message_bytes(message))
         return signature
 
     def _extract_signature_from_response(

--- a/python/src/solana_keychain/crossmint/signer.py
+++ b/python/src/solana_keychain/crossmint/signer.py
@@ -65,6 +65,10 @@ class CrossmintSignerConfig:
 class CrossmintSigner(SolanaSigner):
     """Signer backed by a Crossmint smart or MPC wallet.
 
+    Crossmint is a broadcast-managed signer: it rewrites the transaction (gas
+    sponsorship, priority fee, its own blockhash) and broadcasts server-side, so
+    returned signatures cover Crossmint's bytes rather than the caller's.
+
     ``init()`` must be awaited before signing — it resolves the wallet address.
     ``create_crossmint_signer()`` does this for you. ``sign_message`` is
     intentionally unsupported: the Wallets API signs transactions only.
@@ -311,7 +315,7 @@ class CrossmintSigner(SolanaSigner):
             )
 
     def _extract_signature_from_serialized_transaction(
-        self, serialized_transaction: str, expected_message: bytes
+        self, serialized_transaction: str
     ) -> Signature:
         try:
             transaction_bytes = base58.b58decode(serialized_transaction)
@@ -351,10 +355,12 @@ class CrossmintSigner(SolanaSigner):
                 "Crossmint onChain.transaction did not contain a signer signature",
             )
         signature = signatures[position]
-        # Verify against the caller's message bytes, not the returned ones: if the
-        # service rewrote the transaction (blockhash, wrapping), its signature does
-        # not sign the caller's transaction and must not be attached to it.
-        self._verify_signature_matches_message(signature, expected_message)
+        # Verify against the bytes Crossmint actually signed, not the caller's:
+        # Crossmint is a broadcast-managed signer that rewrites the transaction
+        # (gas sponsorship, priority fee, its own blockhash) and broadcasts
+        # server-side, so a strict check against caller bytes rejects legitimately
+        # landed transactions.
+        self._verify_signature_matches_message(signature, bytes(message))
         return signature
 
     def _extract_signature_from_response(
@@ -366,7 +372,7 @@ class CrossmintSigner(SolanaSigner):
             if isinstance(serialized_transaction, str):
                 try:
                     return self._extract_signature_from_serialized_transaction(
-                        serialized_transaction, expected_message
+                        serialized_transaction
                     )
                 except SignerError:
                     pass

--- a/python/src/solana_keychain/keychain.py
+++ b/python/src/solana_keychain/keychain.py
@@ -1,0 +1,63 @@
+"""Unified factory: create any backend's signer from a backend name and its config.
+
+Backends are imported lazily, so backends whose dependencies live behind an
+optional extra only load when requested.
+"""
+
+import importlib
+from typing import Any
+
+from solana_keychain.core.errors import SignerError, SignerErrorCode
+from solana_keychain.core.signer import SolanaSigner
+
+_BACKENDS: dict[str, tuple[str, str, str]] = {
+    "aws-kms": ("solana_keychain.aws_kms", "AwsKmsSignerConfig", "create_aws_kms_signer"),
+    "cdp": ("solana_keychain.cdp", "CdpSignerConfig", "create_cdp_signer"),
+    "crossmint": (
+        "solana_keychain.crossmint",
+        "CrossmintSignerConfig",
+        "create_crossmint_signer",
+    ),
+    "dfns": ("solana_keychain.dfns", "DfnsSignerConfig", "create_dfns_signer"),
+    "fireblocks": (
+        "solana_keychain.fireblocks",
+        "FireblocksSignerConfig",
+        "create_fireblocks_signer",
+    ),
+    "gcp-kms": ("solana_keychain.gcp_kms", "GcpKmsSignerConfig", "create_gcp_kms_signer"),
+    "memory": ("solana_keychain.memory", "MemorySignerConfig", "create_memory_signer"),
+    "openfort": ("solana_keychain.openfort", "OpenfortSignerConfig", "create_openfort_signer"),
+    "para": ("solana_keychain.para", "ParaSignerConfig", "create_para_signer"),
+    "privy": ("solana_keychain.privy", "PrivySignerConfig", "create_privy_signer"),
+    "turnkey": ("solana_keychain.turnkey", "TurnkeySignerConfig", "create_turnkey_signer"),
+    "utila": ("solana_keychain.utila", "UtilaSignerConfig", "create_utila_signer"),
+    "vault": ("solana_keychain.vault", "VaultSignerConfig", "create_vault_signer"),
+}
+
+SUPPORTED_BACKENDS = tuple(sorted(_BACKENDS))
+
+
+async def create_keychain_signer(backend: str, config: Any) -> SolanaSigner:
+    """Create a ready-to-use signer for ``backend`` from its config object.
+
+    ``config`` must be the backend's own config dataclass (e.g. ``VaultSignerConfig``
+    for ``"vault"``). Backends with optional-extra dependencies raise an
+    ``ImportError`` naming the extra to install when it is missing.
+    """
+    entry = _BACKENDS.get(backend)
+    if entry is None:
+        raise SignerError(
+            SignerErrorCode.CONFIG_ERROR,
+            f"Unknown backend {backend!r}; supported backends: {', '.join(SUPPORTED_BACKENDS)}",
+        )
+    module_name, config_class_name, factory_name = entry
+    module = importlib.import_module(module_name)
+    config_class = getattr(module, config_class_name)
+    if not isinstance(config, config_class):
+        raise SignerError(
+            SignerErrorCode.CONFIG_ERROR,
+            f"Backend {backend!r} requires {config_class_name}, got {type(config).__name__}",
+        )
+    factory = getattr(module, factory_name)
+    signer: SolanaSigner = await factory(config)
+    return signer

--- a/python/src/solana_keychain/memory/__init__.py
+++ b/python/src/solana_keychain/memory/__init__.py
@@ -1,3 +1,7 @@
-from solana_keychain.memory.signer import MemorySigner, MemorySignerConfig
+from solana_keychain.memory.signer import (
+    MemorySigner,
+    MemorySignerConfig,
+    create_memory_signer,
+)
 
-__all__ = ["MemorySigner", "MemorySignerConfig"]
+__all__ = ["MemorySigner", "MemorySignerConfig", "create_memory_signer"]

--- a/python/src/solana_keychain/memory/signer.py
+++ b/python/src/solana_keychain/memory/signer.py
@@ -70,3 +70,8 @@ class MemorySigner(SolanaSigner):
 
     async def is_available(self) -> bool:
         return True
+
+
+async def create_memory_signer(config: MemorySignerConfig) -> MemorySigner:
+    """Create a ready-to-use memory signer."""
+    return MemorySigner.from_config(config)

--- a/python/src/solana_keychain/utila/signer.py
+++ b/python/src/solana_keychain/utila/signer.py
@@ -28,6 +28,7 @@ from solana_keychain.core.transaction_util import (
     add_signature_to_transaction,
     classify_signed_transaction,
     serialize_transaction,
+    signed_message_bytes,
 )
 
 DEFAULT_API_BASE_URL = "https://api.utila.io"
@@ -311,7 +312,7 @@ class UtilaSigner(SolanaSigner):
             ) from None
 
         message = transaction.message
-        if bytes(message) != expected_message:
+        if signed_message_bytes(message) != expected_message:
             raise SignerError(
                 SignerErrorCode.SIGNING_FAILED,
                 "Utila returned a signed transaction with different message bytes",

--- a/python/tests/integration/conftest.py
+++ b/python/tests/integration/conftest.py
@@ -1,0 +1,44 @@
+"""Shared plumbing for the live integration suite.
+
+Every test here talks to a real service. Tests are gated by the ``integration``
+marker (excluded from default runs) and skip themselves when their environment
+variables are absent, so a partially-configured environment runs whatever it can.
+"""
+
+import os
+
+import pytest
+from solders.keypair import Keypair
+from solders.pubkey import Pubkey
+
+from solana_keychain.core.signer import SolanaSigner
+from tests.util import create_test_transaction
+
+
+def require_env(*names: str) -> dict[str, str]:
+    values = {name: os.environ.get(name, "") for name in names}
+    missing = sorted(name for name, value in values.items() if not value)
+    if missing:
+        pytest.skip(f"integration env not set: {', '.join(missing)}")
+    return values
+
+
+def optional_env(name: str, default: str = "") -> str:
+    return os.environ.get(name, default)
+
+
+async def assert_message_roundtrip(signer: SolanaSigner) -> None:
+    message = b"solana-keychain integration test message"
+    signature = await signer.sign_message(message)
+    assert signature.verify(signer.pubkey, message)
+
+
+async def assert_transaction_roundtrip(signer: SolanaSigner) -> None:
+    transaction = create_test_transaction(signer.pubkey, to_pubkey=_burner_recipient())
+    result = await signer.sign_transaction(transaction)
+    assert result.is_complete
+    assert result.signature.verify(signer.pubkey, transaction.message_data())
+
+
+def _burner_recipient() -> Pubkey:
+    return Keypair().pubkey()

--- a/python/tests/integration/conftest.py
+++ b/python/tests/integration/conftest.py
@@ -9,14 +9,13 @@ do) to fail the session when every selected test skipped — an all-skipped run
 means the environment is misconfigured, not that the signer works.
 """
 
+import base64
 import os
 
 import httpx
 import pytest
 from solders.hash import Hash
-from solders.keypair import Keypair
 from solders.message import Message
-from solders.pubkey import Pubkey
 from solders.transaction import Transaction
 
 from solana_keychain.core.signer import SolanaSigner
@@ -78,15 +77,23 @@ async def fetch_latest_blockhash() -> Hash:
     return Hash.from_string(response.json()["result"]["value"]["blockhash"])
 
 
-async def assert_transaction_roundtrip(signer: SolanaSigner) -> None:
-    # An instruction-free transaction keeps this focused on remote signing rather
-    # than balances or program execution.
+async def assert_transaction_roundtrip(
+    signer: SolanaSigner, *, signs_caller_bytes: bool = True
+) -> None:
+    """An instruction-free transaction keeps this focused on remote signing rather
+    than balances or program execution.
+
+    ``signs_caller_bytes=False`` for broadcast-managed services that rewrite the
+    transaction before signing: their signature covers their own bytes, so only
+    its shape and the encoded result can be checked. Each signer verifies the
+    signature against the bytes it actually covers internally.
+    """
     message = Message.new_with_blockhash([], signer.pubkey, await fetch_latest_blockhash())
     transaction = Transaction.new_unsigned(message)
     result = await signer.sign_transaction(transaction)
+
     assert result.is_complete
-    assert result.signature.verify(signer.pubkey, transaction.message_data())
-
-
-def _burner_recipient() -> Pubkey:
-    return Keypair().pubkey()
+    assert len(bytes(result.signature)) == 64
+    assert Transaction.from_bytes(base64.b64decode(result.encoded_transaction))
+    if signs_caller_bytes:
+        assert result.signature.verify(signer.pubkey, transaction.message_data())

--- a/python/tests/integration/conftest.py
+++ b/python/tests/integration/conftest.py
@@ -5,8 +5,9 @@ marker (excluded from default runs) and skip themselves when their environment
 variables are absent, so a partially-configured environment runs whatever it can.
 
 Set ``KEYCHAIN_INTEGRATION_REQUIRE_RUN=1`` (as CI and ``just py-test-integration``
-do) to fail the session when every selected test skipped — an all-skipped run
-means the environment is misconfigured, not that the signer works.
+do) to fail when the flow the run asked for never executed: the backend named by
+``KEYCHAIN_INTEGRATION_BACKEND``, or the local Vault flow for a full-directory
+run. Skipping is only acceptable for backends the run did not ask for.
 """
 
 import base64
@@ -21,24 +22,46 @@ from solders.transaction import Transaction
 from solana_keychain.core.signer import SolanaSigner
 
 REQUIRE_RUN_ENV = "KEYCHAIN_INTEGRATION_REQUIRE_RUN"
+BACKEND_ENV = "KEYCHAIN_INTEGRATION_BACKEND"
+VAULT_TEST_MODULE = "test_vault_integration.py"
 DEFAULT_RPC_URL = "https://api.devnet.solana.com"
 
 
 def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
-    if os.environ.get(REQUIRE_RUN_ENV) != "1":
+    """Fail runs that skipped the flow they were asked to exercise.
+
+    A session-wide pass count is not enough: one configured backend passing would
+    mask the requested one being skipped entirely. So the check is scoped — a
+    single-backend run must have passed a test for that backend, and a full run
+    (the ``just`` recipe, which stands up Vault itself) must have passed a Vault
+    test. Other backends stay free to skip when unconfigured.
+    """
+    if os.environ.get(REQUIRE_RUN_ENV) != "1" or exitstatus != 0:
         return
-    if exitstatus != 0 or session.testscollected == 0:
+    if session.testscollected == 0:
         return
+
     reporter = session.config.pluginmanager.get_plugin("terminalreporter")
-    passed = len(reporter.stats.get("passed", [])) if reporter else 0
-    if passed == 0:
-        session.exitstatus = pytest.ExitCode.TESTS_FAILED
-        if reporter:
-            reporter.write_line(
-                f"{REQUIRE_RUN_ENV}=1 but every selected integration test was "
-                "skipped — environment is not configured for the requested backend",
-                red=True,
-            )
+    passed_node_ids = (
+        [report.nodeid for report in reporter.stats.get("passed", [])] if reporter else []
+    )
+
+    backend = os.environ.get(BACKEND_ENV, "")
+    if backend:
+        required, scope = f"[{backend}]", f"backend {backend}"
+    else:
+        required, scope = f"{VAULT_TEST_MODULE}::", "the local Vault flow"
+
+    if any(required in node_id for node_id in passed_node_ids):
+        return
+
+    session.exitstatus = pytest.ExitCode.TESTS_FAILED
+    if reporter:
+        reporter.write_line(
+            f"{REQUIRE_RUN_ENV}=1 but no test exercised {scope} — its environment "
+            "is not configured (other backends skipping is expected)",
+            red=True,
+        )
 
 
 def require_env(*names: str) -> dict[str, str]:

--- a/python/tests/integration/conftest.py
+++ b/python/tests/integration/conftest.py
@@ -3,6 +3,10 @@
 Every test here talks to a real service. Tests are gated by the ``integration``
 marker (excluded from default runs) and skip themselves when their environment
 variables are absent, so a partially-configured environment runs whatever it can.
+
+Set ``KEYCHAIN_INTEGRATION_REQUIRE_RUN=1`` (as CI and ``just py-test-integration``
+do) to fail the session when every selected test skipped — an all-skipped run
+means the environment is misconfigured, not that the signer works.
 """
 
 import os
@@ -13,6 +17,25 @@ from solders.pubkey import Pubkey
 
 from solana_keychain.core.signer import SolanaSigner
 from tests.util import create_test_transaction
+
+REQUIRE_RUN_ENV = "KEYCHAIN_INTEGRATION_REQUIRE_RUN"
+
+
+def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
+    if os.environ.get(REQUIRE_RUN_ENV) != "1":
+        return
+    if exitstatus != 0 or session.testscollected == 0:
+        return
+    reporter = session.config.pluginmanager.get_plugin("terminalreporter")
+    passed = len(reporter.stats.get("passed", [])) if reporter else 0
+    if passed == 0:
+        session.exitstatus = pytest.ExitCode.TESTS_FAILED
+        if reporter:
+            reporter.write_line(
+                f"{REQUIRE_RUN_ENV}=1 but every selected integration test was "
+                "skipped — environment is not configured for the requested backend",
+                red=True,
+            )
 
 
 def require_env(*names: str) -> dict[str, str]:

--- a/python/tests/integration/conftest.py
+++ b/python/tests/integration/conftest.py
@@ -11,14 +11,18 @@ means the environment is misconfigured, not that the signer works.
 
 import os
 
+import httpx
 import pytest
+from solders.hash import Hash
 from solders.keypair import Keypair
+from solders.message import Message
 from solders.pubkey import Pubkey
+from solders.transaction import Transaction
 
 from solana_keychain.core.signer import SolanaSigner
-from tests.util import create_test_transaction
 
 REQUIRE_RUN_ENV = "KEYCHAIN_INTEGRATION_REQUIRE_RUN"
+DEFAULT_RPC_URL = "https://api.devnet.solana.com"
 
 
 def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
@@ -56,8 +60,29 @@ async def assert_message_roundtrip(signer: SolanaSigner) -> None:
     assert signature.verify(signer.pubkey, message)
 
 
+async def fetch_latest_blockhash() -> Hash:
+    """A live blockhash is required: services reject or silently replace a stale one,
+    and a replaced blockhash changes the message bytes the signature must cover."""
+    rpc_url = os.environ.get("SOLANA_RPC_URL", DEFAULT_RPC_URL)
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        response = await client.post(
+            rpc_url,
+            json={
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "getLatestBlockhash",
+                "params": [{"commitment": "finalized"}],
+            },
+        )
+    response.raise_for_status()
+    return Hash.from_string(response.json()["result"]["value"]["blockhash"])
+
+
 async def assert_transaction_roundtrip(signer: SolanaSigner) -> None:
-    transaction = create_test_transaction(signer.pubkey, to_pubkey=_burner_recipient())
+    # An instruction-free transaction keeps this focused on remote signing rather
+    # than balances or program execution.
+    message = Message.new_with_blockhash([], signer.pubkey, await fetch_latest_blockhash())
+    transaction = Transaction.new_unsigned(message)
     result = await signer.sign_transaction(transaction)
     assert result.is_complete
     assert result.signature.verify(signer.pubkey, transaction.message_data())

--- a/python/tests/integration/test_live_signers.py
+++ b/python/tests/integration/test_live_signers.py
@@ -1,6 +1,13 @@
 """Live integration tests for the remote backends, driven by the same environment
 variables as the repo's other integration suites. Each backend skips itself when
-its variables are absent."""
+its variables are absent.
+
+``KEYCHAIN_INTEGRATION_BACKEND`` restricts the run to a single backend (used by
+the CI matrix). Selection deliberately avoids ``pytest -k``: a ``-k`` expression
+substring-matches marker keywords, and every test here carries ``parametrize``.
+"""
+
+import os
 
 import pytest
 
@@ -235,28 +242,32 @@ _TRANSACTION_ONLY = {
 }
 
 
-def _test_id(backend: str) -> str:
-    # pytest -k cannot express hyphens; ids use underscores so CI can select
-    # one backend per matrix job.
-    return backend.replace("-", "_")
-
-
 _ALL_BACKENDS = _MESSAGE_CAPABLE | _TRANSACTION_ONLY
 
+_SELECTED_BACKEND = os.environ.get("KEYCHAIN_INTEGRATION_BACKEND", "")
 
-@pytest.mark.parametrize("backend", sorted(_MESSAGE_CAPABLE), ids=_test_id)
+
+def _skip_unless_selected(backend: str) -> None:
+    if _SELECTED_BACKEND and backend != _SELECTED_BACKEND:
+        pytest.skip(f"KEYCHAIN_INTEGRATION_BACKEND={_SELECTED_BACKEND} excludes {backend}")
+
+
+@pytest.mark.parametrize("backend", sorted(_MESSAGE_CAPABLE))
 async def test_live_sign_message(backend: str) -> None:
+    _skip_unless_selected(backend)
     signer = await _MESSAGE_CAPABLE[backend]()
     await assert_message_roundtrip(signer)
 
 
-@pytest.mark.parametrize("backend", sorted(_ALL_BACKENDS), ids=_test_id)
+@pytest.mark.parametrize("backend", sorted(_ALL_BACKENDS))
 async def test_live_sign_transaction(backend: str) -> None:
+    _skip_unless_selected(backend)
     signer = await _ALL_BACKENDS[backend]()
     await assert_transaction_roundtrip(signer)
 
 
-@pytest.mark.parametrize("backend", sorted(_ALL_BACKENDS), ids=_test_id)
+@pytest.mark.parametrize("backend", sorted(_ALL_BACKENDS))
 async def test_live_is_available(backend: str) -> None:
+    _skip_unless_selected(backend)
     signer = await _ALL_BACKENDS[backend]()
     assert await signer.is_available()

--- a/python/tests/integration/test_live_signers.py
+++ b/python/tests/integration/test_live_signers.py
@@ -282,11 +282,18 @@ async def test_live_sign_message(backend: str) -> None:
     await assert_message_roundtrip(signer)
 
 
+# Broadcast-managed services rewrite the transaction before signing, so their
+# signature covers their bytes rather than the caller's.
+_REWRITES_TRANSACTION = frozenset({"crossmint"})
+
+
 @pytest.mark.parametrize("backend", sorted(_ALL_BACKENDS))
 async def test_live_sign_transaction(backend: str) -> None:
     _skip_unless_selected(backend)
     signer = await _ALL_BACKENDS[backend]()
-    await assert_transaction_roundtrip(signer)
+    await assert_transaction_roundtrip(
+        signer, signs_caller_bytes=backend not in _REWRITES_TRANSACTION
+    )
 
 
 @pytest.mark.parametrize("backend", sorted(_ALL_BACKENDS))

--- a/python/tests/integration/test_live_signers.py
+++ b/python/tests/integration/test_live_signers.py
@@ -10,6 +10,7 @@ substring-matches marker keywords, and every test here carries ``parametrize``.
 import os
 
 import pytest
+from solders.pubkey import Pubkey
 
 from solana_keychain.core.signer import SolanaSigner
 from tests.integration.conftest import (
@@ -160,12 +161,29 @@ async def make_dfns_signer() -> SolanaSigner:
     )
 
 
+def _crossmint_delegated_signer_pubkey() -> Pubkey | None:
+    """A Crossmint smart wallet's transactions are signed by its delegated signer,
+    never by the wallet address the API reports, so signature checks must run
+    against the delegated key. Prefer the explicit test override, else derive it
+    from the ``server:<pubkey>`` signer locator."""
+    override = optional_env("TEST_CROSSMINT_SIGNER_DERIVED_PUBKEY")
+    if not override:
+        locator = optional_env("CROSSMINT_SIGNER")
+        override = locator.removeprefix("server:").strip() if locator else ""
+    if not override:
+        return None
+    try:
+        return Pubkey.from_string(override)
+    except Exception:
+        return None
+
+
 async def make_crossmint_signer() -> SolanaSigner:
     from solana_keychain.crossmint import CrossmintSignerConfig, create_crossmint_signer
     from solana_keychain.crossmint.signer import DEFAULT_API_BASE_URL
 
     env = require_env("CROSSMINT_API_KEY", "CROSSMINT_WALLET_LOCATOR")
-    return await create_crossmint_signer(
+    signer = await create_crossmint_signer(
         CrossmintSignerConfig(
             api_key=env["CROSSMINT_API_KEY"],
             wallet_locator=env["CROSSMINT_WALLET_LOCATOR"],
@@ -174,6 +192,10 @@ async def make_crossmint_signer() -> SolanaSigner:
             api_base_url=optional_env("CROSSMINT_API_BASE_URL") or DEFAULT_API_BASE_URL,
         )
     )
+    delegated = _crossmint_delegated_signer_pubkey()
+    if delegated is not None:
+        signer._public_key = delegated
+    return signer
 
 
 async def make_openfort_signer() -> SolanaSigner:

--- a/python/tests/integration/test_live_signers.py
+++ b/python/tests/integration/test_live_signers.py
@@ -111,7 +111,7 @@ async def make_para_signer() -> SolanaSigner:
 
 async def make_fireblocks_signer() -> SolanaSigner:
     from solana_keychain.fireblocks import FireblocksSignerConfig, create_fireblocks_signer
-    from solana_keychain.fireblocks.signer import DEFAULT_API_BASE_URL, DEFAULT_ASSET_ID
+    from solana_keychain.fireblocks.signer import DEFAULT_API_BASE_URL
 
     env = require_env(
         "FIREBLOCKS_API_KEY", "FIREBLOCKS_PRIVATE_KEY_PEM", "FIREBLOCKS_VAULT_ACCOUNT_ID"
@@ -121,7 +121,8 @@ async def make_fireblocks_signer() -> SolanaSigner:
             api_key=env["FIREBLOCKS_API_KEY"],
             private_key_pem=env["FIREBLOCKS_PRIVATE_KEY_PEM"],
             vault_account_id=env["FIREBLOCKS_VAULT_ACCOUNT_ID"],
-            asset_id=optional_env("FIREBLOCKS_ASSET_ID") or DEFAULT_ASSET_ID,
+            # Test vaults hold devnet assets; the library default is mainnet SOL.
+            asset_id=optional_env("FIREBLOCKS_ASSET_ID") or "SOL_TEST",
             api_base_url=optional_env("FIREBLOCKS_API_BASE_URL") or DEFAULT_API_BASE_URL,
         )
     )

--- a/python/tests/integration/test_live_signers.py
+++ b/python/tests/integration/test_live_signers.py
@@ -1,0 +1,262 @@
+"""Live integration tests for the remote backends, driven by the same environment
+variables as the repo's other integration suites. Each backend skips itself when
+its variables are absent."""
+
+import pytest
+
+from solana_keychain.core.signer import SolanaSigner
+from tests.integration.conftest import (
+    assert_message_roundtrip,
+    assert_transaction_roundtrip,
+    optional_env,
+    require_env,
+)
+
+pytestmark = pytest.mark.integration
+
+
+async def make_aws_kms_signer() -> SolanaSigner:
+    from solana_keychain.aws_kms import AwsKmsSignerConfig, create_aws_kms_signer
+
+    env = require_env("AWS_KMS_KEY_ID", "AWS_KMS_SIGNER_PUBKEY")
+    return await create_aws_kms_signer(
+        AwsKmsSignerConfig(
+            key_id=env["AWS_KMS_KEY_ID"],
+            public_key=env["AWS_KMS_SIGNER_PUBKEY"],
+            region=optional_env("AWS_KMS_REGION") or None,
+        )
+    )
+
+
+async def make_gcp_kms_signer() -> SolanaSigner:
+    from solana_keychain.gcp_kms import GcpKmsSignerConfig, create_gcp_kms_signer
+
+    env = require_env("GCP_KMS_KEY_NAME", "GCP_KMS_SIGNER_PUBKEY")
+    return await create_gcp_kms_signer(
+        GcpKmsSignerConfig(
+            key_name=env["GCP_KMS_KEY_NAME"], public_key=env["GCP_KMS_SIGNER_PUBKEY"]
+        )
+    )
+
+
+async def make_turnkey_signer() -> SolanaSigner:
+    from solana_keychain.turnkey import TurnkeySignerConfig, create_turnkey_signer
+    from solana_keychain.turnkey.signer import DEFAULT_API_BASE_URL
+
+    env = require_env(
+        "TURNKEY_API_PUBLIC_KEY",
+        "TURNKEY_API_PRIVATE_KEY",
+        "TURNKEY_ORGANIZATION_ID",
+        "TURNKEY_PRIVATE_KEY_ID",
+        "TURNKEY_PUBLIC_KEY",
+    )
+    return await create_turnkey_signer(
+        TurnkeySignerConfig(
+            api_public_key=env["TURNKEY_API_PUBLIC_KEY"],
+            api_private_key=env["TURNKEY_API_PRIVATE_KEY"],
+            organization_id=env["TURNKEY_ORGANIZATION_ID"],
+            private_key_id=env["TURNKEY_PRIVATE_KEY_ID"],
+            public_key=env["TURNKEY_PUBLIC_KEY"],
+            api_base_url=optional_env("TURNKEY_API_BASE_URL") or DEFAULT_API_BASE_URL,
+        )
+    )
+
+
+async def make_privy_signer() -> SolanaSigner:
+    from solana_keychain.privy import (
+        PrivyAuthorizationContext,
+        PrivySignerConfig,
+        create_privy_signer,
+    )
+    from solana_keychain.privy.signer import DEFAULT_API_BASE_URL
+
+    env = require_env("PRIVY_APP_ID", "PRIVY_APP_SECRET", "PRIVY_WALLET_ID")
+    authorization_key = optional_env("PRIVY_AUTHORIZATION_PRIVATE_KEY")
+    authorization_context = (
+        PrivyAuthorizationContext(authorization_private_keys=[authorization_key])
+        if authorization_key
+        else None
+    )
+    return await create_privy_signer(
+        PrivySignerConfig(
+            app_id=env["PRIVY_APP_ID"],
+            app_secret=env["PRIVY_APP_SECRET"],
+            wallet_id=env["PRIVY_WALLET_ID"],
+            api_base_url=optional_env("PRIVY_API_BASE_URL") or DEFAULT_API_BASE_URL,
+            authorization_context=authorization_context,
+        )
+    )
+
+
+async def make_para_signer() -> SolanaSigner:
+    from solana_keychain.para import ParaSignerConfig, create_para_signer
+    from solana_keychain.para.signer import DEFAULT_API_BASE_URL
+
+    env = require_env("PARA_API_KEY", "PARA_WALLET_ID")
+    return await create_para_signer(
+        ParaSignerConfig(
+            api_key=env["PARA_API_KEY"],
+            wallet_id=env["PARA_WALLET_ID"],
+            api_base_url=optional_env("PARA_API_BASE_URL") or DEFAULT_API_BASE_URL,
+        )
+    )
+
+
+async def make_fireblocks_signer() -> SolanaSigner:
+    from solana_keychain.fireblocks import FireblocksSignerConfig, create_fireblocks_signer
+    from solana_keychain.fireblocks.signer import DEFAULT_API_BASE_URL, DEFAULT_ASSET_ID
+
+    env = require_env(
+        "FIREBLOCKS_API_KEY", "FIREBLOCKS_PRIVATE_KEY_PEM", "FIREBLOCKS_VAULT_ACCOUNT_ID"
+    )
+    return await create_fireblocks_signer(
+        FireblocksSignerConfig(
+            api_key=env["FIREBLOCKS_API_KEY"],
+            private_key_pem=env["FIREBLOCKS_PRIVATE_KEY_PEM"],
+            vault_account_id=env["FIREBLOCKS_VAULT_ACCOUNT_ID"],
+            asset_id=optional_env("FIREBLOCKS_ASSET_ID") or DEFAULT_ASSET_ID,
+            api_base_url=optional_env("FIREBLOCKS_API_BASE_URL") or DEFAULT_API_BASE_URL,
+        )
+    )
+
+
+async def make_cdp_signer() -> SolanaSigner:
+    from solana_keychain.cdp import CdpSignerConfig, create_cdp_signer
+
+    env = require_env(
+        "CDP_API_KEY_ID", "CDP_API_KEY_SECRET", "CDP_WALLET_SECRET", "CDP_SOLANA_ADDRESS"
+    )
+    return await create_cdp_signer(
+        CdpSignerConfig(
+            api_key_id=env["CDP_API_KEY_ID"],
+            api_key_secret=env["CDP_API_KEY_SECRET"],
+            wallet_secret=env["CDP_WALLET_SECRET"],
+            address=env["CDP_SOLANA_ADDRESS"],
+        )
+    )
+
+
+async def make_dfns_signer() -> SolanaSigner:
+    from solana_keychain.dfns import DfnsSignerConfig, create_dfns_signer
+    from solana_keychain.dfns.signer import DEFAULT_API_BASE_URL
+
+    env = require_env("DFNS_AUTH_TOKEN", "DFNS_CRED_ID", "DFNS_PRIVATE_KEY_PEM", "DFNS_WALLET_ID")
+    return await create_dfns_signer(
+        DfnsSignerConfig(
+            auth_token=env["DFNS_AUTH_TOKEN"],
+            cred_id=env["DFNS_CRED_ID"],
+            private_key_pem=env["DFNS_PRIVATE_KEY_PEM"],
+            wallet_id=env["DFNS_WALLET_ID"],
+            api_base_url=optional_env("DFNS_API_BASE_URL") or DEFAULT_API_BASE_URL,
+        )
+    )
+
+
+async def make_crossmint_signer() -> SolanaSigner:
+    from solana_keychain.crossmint import CrossmintSignerConfig, create_crossmint_signer
+    from solana_keychain.crossmint.signer import DEFAULT_API_BASE_URL
+
+    env = require_env("CROSSMINT_API_KEY", "CROSSMINT_WALLET_LOCATOR")
+    return await create_crossmint_signer(
+        CrossmintSignerConfig(
+            api_key=env["CROSSMINT_API_KEY"],
+            wallet_locator=env["CROSSMINT_WALLET_LOCATOR"],
+            signer_secret=optional_env("CROSSMINT_SIGNER_SECRET") or None,
+            signer=optional_env("CROSSMINT_SIGNER") or None,
+            api_base_url=optional_env("CROSSMINT_API_BASE_URL") or DEFAULT_API_BASE_URL,
+        )
+    )
+
+
+async def make_openfort_signer() -> SolanaSigner:
+    from solana_keychain.openfort import OpenfortSignerConfig, create_openfort_signer
+    from solana_keychain.openfort.signer import DEFAULT_API_BASE_URL
+
+    env = require_env("OPENFORT_SECRET_KEY", "OPENFORT_ACCOUNT_ID", "OPENFORT_WALLET_SECRET")
+    return await create_openfort_signer(
+        OpenfortSignerConfig(
+            secret_key=env["OPENFORT_SECRET_KEY"],
+            account_id=env["OPENFORT_ACCOUNT_ID"],
+            wallet_secret=env["OPENFORT_WALLET_SECRET"],
+            api_base_url=optional_env("OPENFORT_BASE_URL") or DEFAULT_API_BASE_URL,
+        )
+    )
+
+
+async def make_utila_signer() -> SolanaSigner:
+    from solana_keychain.utila import UtilaSignerConfig, create_utila_signer
+    from solana_keychain.utila.signer import (
+        DEFAULT_API_BASE_URL,
+        DEFAULT_MAX_POLL_ATTEMPTS,
+        DEFAULT_POLL_INTERVAL_MS,
+    )
+
+    env = require_env(
+        "UTILA_SERVICE_ACCOUNT_EMAIL",
+        "UTILA_SERVICE_ACCOUNT_PRIVATE_KEY",
+        "UTILA_VAULT_ID",
+        "UTILA_WALLET_ID",
+        "UTILA_NETWORK",
+    )
+    return await create_utila_signer(
+        UtilaSignerConfig(
+            service_account_email=env["UTILA_SERVICE_ACCOUNT_EMAIL"],
+            service_account_private_key_pem=env["UTILA_SERVICE_ACCOUNT_PRIVATE_KEY"],
+            vault_id=env["UTILA_VAULT_ID"],
+            wallet_id=env["UTILA_WALLET_ID"],
+            network=env["UTILA_NETWORK"],
+            api_base_url=optional_env("UTILA_API_BASE_URL") or DEFAULT_API_BASE_URL,
+            poll_interval_ms=int(
+                optional_env("UTILA_POLL_INTERVAL_MS") or DEFAULT_POLL_INTERVAL_MS
+            ),
+            max_poll_attempts=int(
+                optional_env("UTILA_MAX_POLL_ATTEMPTS") or DEFAULT_MAX_POLL_ATTEMPTS
+            ),
+        )
+    )
+
+
+_MESSAGE_CAPABLE = {
+    "aws-kms": make_aws_kms_signer,
+    "gcp-kms": make_gcp_kms_signer,
+    "turnkey": make_turnkey_signer,
+    "privy": make_privy_signer,
+    "para": make_para_signer,
+    "fireblocks": make_fireblocks_signer,
+    "cdp": make_cdp_signer,
+    "dfns": make_dfns_signer,
+    "openfort": make_openfort_signer,
+}
+
+# Crossmint and Utila sign transactions only.
+_TRANSACTION_ONLY = {
+    "crossmint": make_crossmint_signer,
+    "utila": make_utila_signer,
+}
+
+
+def _test_id(backend: str) -> str:
+    # pytest -k cannot express hyphens; ids use underscores so CI can select
+    # one backend per matrix job.
+    return backend.replace("-", "_")
+
+
+_ALL_BACKENDS = _MESSAGE_CAPABLE | _TRANSACTION_ONLY
+
+
+@pytest.mark.parametrize("backend", sorted(_MESSAGE_CAPABLE), ids=_test_id)
+async def test_live_sign_message(backend: str) -> None:
+    signer = await _MESSAGE_CAPABLE[backend]()
+    await assert_message_roundtrip(signer)
+
+
+@pytest.mark.parametrize("backend", sorted(_ALL_BACKENDS), ids=_test_id)
+async def test_live_sign_transaction(backend: str) -> None:
+    signer = await _ALL_BACKENDS[backend]()
+    await assert_transaction_roundtrip(signer)
+
+
+@pytest.mark.parametrize("backend", sorted(_ALL_BACKENDS), ids=_test_id)
+async def test_live_is_available(backend: str) -> None:
+    signer = await _ALL_BACKENDS[backend]()
+    assert await signer.is_available()

--- a/python/tests/integration/test_vault_integration.py
+++ b/python/tests/integration/test_vault_integration.py
@@ -1,0 +1,37 @@
+"""Vault integration tests against a local ``vault server -dev`` instance with the
+shared transit test key restored (see ``just py-test-integration``)."""
+
+import pytest
+
+from solana_keychain import VaultSigner, VaultSignerConfig, create_vault_signer
+from tests.integration.conftest import (
+    assert_message_roundtrip,
+    assert_transaction_roundtrip,
+    require_env,
+)
+
+pytestmark = pytest.mark.integration
+
+
+async def make_signer() -> VaultSigner:
+    env = require_env("VAULT_ADDR", "VAULT_TOKEN", "VAULT_KEY_NAME", "VAULT_SIGNER_PUBKEY")
+    return await create_vault_signer(
+        VaultSignerConfig(
+            vault_addr=env["VAULT_ADDR"],
+            token=env["VAULT_TOKEN"],
+            key_name=env["VAULT_KEY_NAME"],
+            pubkey=env["VAULT_SIGNER_PUBKEY"],
+        )
+    )
+
+
+async def test_vault_sign_message() -> None:
+    await assert_message_roundtrip(await make_signer())
+
+
+async def test_vault_sign_transaction() -> None:
+    await assert_transaction_roundtrip(await make_signer())
+
+
+async def test_vault_is_available() -> None:
+    assert await (await make_signer()).is_available()

--- a/python/tests/test_crossmint_signer.py
+++ b/python/tests/test_crossmint_signer.py
@@ -347,16 +347,17 @@ async def test_awaiting_approval_with_no_matching_entry_fails() -> None:
 
 
 @respx.mock
-async def test_rewritten_transaction_signature_is_rejected() -> None:
+async def test_rewritten_transaction_signature_is_accepted() -> None:
     keypair = Keypair()
     signer = await initialized_signer(keypair)
     transaction = create_test_transaction(keypair.pubkey())
 
-    # The service returns a validly-signed transaction whose message differs from
-    # the one the caller submitted (same payer, rewritten contents).
+    # Crossmint rewrites the transaction before signing (gas sponsorship, priority
+    # fee, its own blockhash), so the returned signature covers its bytes.
     rewritten = create_test_transaction(keypair.pubkey())
     assert rewritten.message_data() != transaction.message_data()
-    rewritten.signatures = [keypair.sign_message(rewritten.message_data())]
+    expected_signature = keypair.sign_message(rewritten.message_data())
+    rewritten.signatures = [expected_signature]
 
     respx.post(TRANSACTIONS_URL).mock(
         return_value=httpx.Response(
@@ -364,6 +365,29 @@ async def test_rewritten_transaction_signature_is_rejected() -> None:
             json=tx_response(
                 "success",
                 onChain={"transaction": base58.b58encode(bytes(rewritten)).decode()},
+            ),
+        )
+    )
+
+    result = await signer.sign_transaction(transaction)
+    assert result.signature == expected_signature
+
+
+@respx.mock
+async def test_signature_not_covering_returned_transaction_is_rejected() -> None:
+    keypair = Keypair()
+    signer = await initialized_signer(keypair)
+    transaction = create_test_transaction(keypair.pubkey())
+
+    returned = create_test_transaction(keypair.pubkey())
+    returned.signatures = [keypair.sign_message(b"unrelated bytes")]
+
+    respx.post(TRANSACTIONS_URL).mock(
+        return_value=httpx.Response(
+            200,
+            json=tx_response(
+                "success",
+                onChain={"transaction": base58.b58encode(bytes(returned)).decode()},
             ),
         )
     )

--- a/python/tests/test_keychain.py
+++ b/python/tests/test_keychain.py
@@ -1,0 +1,91 @@
+import importlib
+
+import httpx
+import pytest
+import respx
+from solders.keypair import Keypair
+
+from solana_keychain import (
+    SUPPORTED_BACKENDS,
+    MemorySigner,
+    MemorySignerConfig,
+    SignerError,
+    SignerErrorCode,
+    VaultSigner,
+    VaultSignerConfig,
+    create_keychain_signer,
+)
+from solana_keychain.keychain import _BACKENDS
+
+
+def test_supports_all_thirteen_backends() -> None:
+    assert len(SUPPORTED_BACKENDS) == 13
+    assert SUPPORTED_BACKENDS == tuple(sorted(SUPPORTED_BACKENDS))
+
+
+@pytest.mark.parametrize("backend", sorted(_BACKENDS))
+def test_every_backend_entry_resolves(backend: str) -> None:
+    module_name, config_class_name, factory_name = _BACKENDS[backend]
+    module = importlib.import_module(module_name)
+    assert isinstance(getattr(module, config_class_name), type)
+    assert callable(getattr(module, factory_name))
+
+
+async def test_dispatches_memory_backend() -> None:
+    keypair = Keypair()
+    signer = await create_keychain_signer("memory", MemorySignerConfig(keypair=keypair))
+    assert isinstance(signer, MemorySigner)
+    assert signer.pubkey == keypair.pubkey()
+
+
+@respx.mock
+async def test_dispatches_vault_backend() -> None:
+    config = VaultSignerConfig(
+        vault_addr="https://vault.example.com",
+        token="test-token",
+        key_name="test-key",
+        pubkey=str(Keypair().pubkey()),
+    )
+    signer = await create_keychain_signer("vault", config)
+    assert isinstance(signer, VaultSigner)
+
+
+async def test_unknown_backend_is_config_error() -> None:
+    with pytest.raises(SignerError) as excinfo:
+        await create_keychain_signer("ledger", MemorySignerConfig(keypair=Keypair()))
+    error = excinfo.value
+    assert error.code == SignerErrorCode.CONFIG_ERROR
+
+
+async def test_mismatched_config_is_config_error() -> None:
+    with pytest.raises(SignerError) as excinfo:
+        await create_keychain_signer("vault", MemorySignerConfig(keypair=Keypair()))
+    assert excinfo.value.code == SignerErrorCode.CONFIG_ERROR
+
+
+@respx.mock
+async def test_dispatch_awaits_init_backends() -> None:
+    from solana_keychain.para import ParaSignerConfig
+
+    keypair = Keypair()
+    wallet_id = "12345678-1234-1234-1234-123456789abc"
+    respx.get(f"https://para.example.com/v1/wallets/{wallet_id}").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "id": wallet_id,
+                "type": "SOLANA",
+                "status": "ACTIVE",
+                "address": str(keypair.pubkey()),
+            },
+        )
+    )
+    signer = await create_keychain_signer(
+        "para",
+        ParaSignerConfig(
+            api_key="sk_test-key",
+            wallet_id=wallet_id,
+            api_base_url="https://para.example.com",
+        ),
+    )
+    assert signer.pubkey == keypair.pubkey()

--- a/python/tests/test_transaction_util.py
+++ b/python/tests/test_transaction_util.py
@@ -1,6 +1,7 @@
 import base64
 
 import pytest
+from solders.hash import Hash
 from solders.keypair import Keypair
 from solders.pubkey import Pubkey
 from solders.signature import Signature
@@ -81,3 +82,31 @@ def test_serialize_transaction_round_trips_through_bincode() -> None:
 
     assert decoded == transaction
     assert Signature.default() not in decoded.signatures
+
+
+def test_signed_message_bytes_prefixes_versioned_messages() -> None:
+    from solders.instruction import AccountMeta, Instruction
+    from solders.message import MessageV0
+    from solders.transaction import VersionedTransaction
+
+    from solana_keychain.core import signed_message_bytes
+
+    keypair = Keypair()
+    instruction = Instruction(
+        Pubkey.from_bytes(bytes(32)), b"", [AccountMeta(keypair.pubkey(), True, True)]
+    )
+    message = MessageV0.try_compile(keypair.pubkey(), [instruction], [], Hash.default())
+    signature = list(VersionedTransaction(message, [keypair]).signatures)[0]
+
+    # A v0 signature covers 0x80 ‖ serialization, which bytes(message) omits.
+    assert signed_message_bytes(message) == b"\x80" + bytes(message)
+    assert signature.verify(keypair.pubkey(), signed_message_bytes(message))
+    assert not signature.verify(keypair.pubkey(), bytes(message))
+
+
+def test_signed_message_bytes_leaves_legacy_messages_unchanged() -> None:
+    from solana_keychain.core import signed_message_bytes
+
+    keypair = Keypair()
+    transaction = create_test_transaction(keypair.pubkey())
+    assert signed_message_bytes(transaction.message) == transaction.message_data()


### PR DESCRIPTION
## Summary
- **Umbrella factory**: `create_keychain_signer(backend, config)` in `solana_keychain.keychain` dispatches across all thirteen backends by name. Backends are imported lazily so extras-gated dependencies only load when requested (a missing extra surfaces its install-hint `ImportError`); the config object's type must match the backend (`SIGNER_CONFIG_ERROR` otherwise); unknown backends error with the supported list. `SUPPORTED_BACKENDS` exported. Memory gains `create_memory_signer` so every backend shares the async-factory shape.
- **Integration test suite** (`python/tests/integration/`): gated by an `integration` pytest marker and excluded from default runs, so `just py-test` and CI unit jobs are untouched. Driven by the **same environment variable names as the repo's other integration suites** (verified against them), so existing Doppler configs work unchanged. Each backend skips itself when its variables are absent; Crossmint and Utila run transaction-only per their contracts.
- **`just py-test-integration`**: local Vault dev-server flow (shared transit test key, `.env` sourcing) matching the other languages' recipes; wired into the root `test-integration` aggregate.
- **CI**: `python-ci.yml` gains a `resolve-signers` job (`CI_SIGNER_*` repository-variable gating) and a `python-integration-test` matrix job with Doppler OIDC and AWS/GCP credential setup for the KMS backends; fork PRs excluded. Utila and Vault run locally rather than in the live matrix, as in the other language CIs.

## Test Plan
- 421 unit tests pass (19 new: every umbrella registry entry resolves, memory/vault/para dispatch incl. an init-awaiting backend, unknown-backend and mismatched-config errors, thirteen-backend count)
- 34 integration tests collect and skip cleanly with no environment configured; `ruff` + `mypy --strict` + sdist/wheel build clean
- Live runs: `just py-test-integration` (local Vault) and the CI matrix once `CI_SIGNER_*`/Doppler are exercised