### PR TITLE
chore(python): add publish workflow, dependency audit, changelog and docs

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,0 +1,165 @@
+name: Publish Python Package (Manual)
+
+on:
+  workflow_dispatch:
+    inputs:
+      publish-to-pypi:
+        description: 'Publish to PyPI'
+        required: true
+        default: true
+        type: boolean
+      create-github-release:
+        description: 'Create GitHub release'
+        required: true
+        default: true
+        type: boolean
+
+permissions:
+  contents: write
+  id-token: write
+
+concurrency:
+  group: release-python
+  cancel-in-progress: false
+
+jobs:
+  guard-allowed-branch:
+    name: Guard allowed source branch for release publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: Guard allowed source branch for release publish
+        run: |
+          case "${{ github.ref }}" in
+            refs/heads/main|refs/heads/hotfix/*) ;;
+            *)
+              echo "::error::Publish Python Package must be run from main or hotfix/*. Current ref: ${{ github.ref }}"
+              exit 1
+              ;;
+          esac
+
+  publish:
+    name: Publish solana-keychain to PyPI
+    runs-on: ubuntu-latest
+    needs: guard-allowed-branch
+    environment: pypi
+    defaults:
+      run:
+        working-directory: python
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
+          cache: pip
+          cache-dependency-path: python/pyproject.toml
+
+      - name: Install build tooling
+        run: pip install build
+
+      - name: Get version
+        id: version
+        run: |
+          VERSION=$(python -c "import tomllib,pathlib;print(tomllib.loads(pathlib.Path('pyproject.toml').read_text())['project']['version'])")
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "solana-keychain v$VERSION"
+
+      - name: Check version is not already on PyPI
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          if pip index versions solana-keychain 2>/dev/null | grep -q "$VERSION"; then
+            echo "::error::solana-keychain $VERSION is already published to PyPI"
+            exit 1
+          fi
+          echo "✓ $VERSION is not yet on PyPI"
+
+      - name: Check if prerelease
+        id: prerelease
+        run: |
+          # PEP 440 pre-release segments: a1, b2, rc3, .dev4
+          if [[ "${{ steps.version.outputs.version }}" =~ (a|b|rc|\.dev)[0-9]+$ ]]; then
+            echo "is_prerelease=true" >> $GITHUB_OUTPUT
+            echo "Pre-release version detected"
+          else
+            echo "is_prerelease=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Build sdist and wheel
+        run: python -m build
+
+      - name: Verify built artifacts
+        run: |
+          pip install twine
+          twine check dist/*
+          ls -la dist/
+
+      - name: Create and push git tag
+        working-directory: .
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          TAG="python-v${{ steps.version.outputs.version }}"
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "· tag $TAG already exists, skipping"
+          else
+            git tag "$TAG"
+            echo "✓ created tag $TAG"
+          fi
+          git push origin "$TAG" 2>/dev/null || echo "· tag already pushed"
+
+      - name: Publish to PyPI
+        if: ${{ github.event.inputs.publish-to-pypi == 'true' }}
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: python/dist
+
+      - name: Create GitHub Release
+        if: ${{ github.event.inputs.create-github-release == 'true' }}
+        uses: actions/github-script@v9
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const version = '${{ steps.version.outputs.version }}';
+            const tagName = `python-v${version}`;
+
+            try {
+              await github.rest.repos.getReleaseByTag({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                tag: tagName,
+              });
+              console.log(`· release ${tagName} already exists, skipping`);
+              return;
+            } catch (e) {
+              if (e.status !== 404) throw e;
+            }
+
+            await github.rest.repos.createRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              tag_name: tagName,
+              name: `solana-keychain (Python) v${version}`,
+              body: `Release of solana-keychain v${version} (Python)\n\n**PyPI:** https://pypi.org/project/solana-keychain/${version}/`,
+              draft: false,
+              prerelease: '${{ steps.prerelease.outputs.is_prerelease }}' === 'true',
+            });
+
+            console.log(`✓ created release ${tagName}`);
+
+      - name: Publish summary
+        if: always()
+        run: |
+          echo "## solana-keychain (Python) Published" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Version**: \`${{ steps.version.outputs.version }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "**Tag**: \`python-v${{ steps.version.outputs.version }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          if [ "${{ github.event.inputs.publish-to-pypi }}" == "true" ]; then
+            echo "Published to PyPI: https://pypi.org/project/solana-keychain/${{ steps.version.outputs.version }}/" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "Skipped PyPI publish" >> $GITHUB_STEP_SUMMARY
+          fi

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -111,8 +111,13 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
           TAG="python-v${{ steps.version.outputs.version }}"
-          if git rev-parse "$TAG" >/dev/null 2>&1; then
-            echo "· tag $TAG already exists locally"
+          if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
+            TAGGED=$(git rev-parse "$TAG^{commit}")
+            if [ "$TAGGED" != "$GITHUB_SHA" ]; then
+              echo "::error::$TAG already points at $TAGGED but this run builds $GITHUB_SHA — bump the version instead of retagging"
+              exit 1
+            fi
+            echo "· tag $TAG already points at this commit"
           else
             git tag "$TAG"
             echo "✓ created tag $TAG"

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -70,11 +70,19 @@ jobs:
       - name: Check version is not already on PyPI
         run: |
           VERSION="${{ steps.version.outputs.version }}"
-          if pip index versions solana-keychain 2>/dev/null | grep -q "$VERSION"; then
-            echo "::error::solana-keychain $VERSION is already published to PyPI"
-            exit 1
-          fi
-          echo "✓ $VERSION is not yet on PyPI"
+          STATUS=$(curl -sS -o /dev/null -w '%{http_code}' \
+            "https://pypi.org/pypi/solana-keychain/${VERSION}/json")
+          case "$STATUS" in
+            404) echo "✓ $VERSION is not yet on PyPI" ;;
+            200)
+              echo "::error::solana-keychain $VERSION is already published to PyPI"
+              exit 1
+              ;;
+            *)
+              echo "::error::PyPI returned HTTP $STATUS querying solana-keychain $VERSION"
+              exit 1
+              ;;
+          esac
 
       - name: Check if prerelease
         id: prerelease
@@ -104,12 +112,12 @@ jobs:
 
           TAG="python-v${{ steps.version.outputs.version }}"
           if git rev-parse "$TAG" >/dev/null 2>&1; then
-            echo "· tag $TAG already exists, skipping"
+            echo "· tag $TAG already exists locally"
           else
             git tag "$TAG"
             echo "✓ created tag $TAG"
           fi
-          git push origin "$TAG" 2>/dev/null || echo "· tag already pushed"
+          git push origin "$TAG"
 
       - name: Publish to PyPI
         if: ${{ github.event.inputs.publish-to-pypi == 'true' }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -44,6 +44,19 @@ jobs:
           version: 11.13.0
       - run: pnpm audit --ignore-unfixable
 
+  pip-audit:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: python
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
+      - run: pip install -e '.[dev]' pip-audit
+      - run: pip-audit --skip-editable
+
   miri:
     runs-on: ubuntu-latest
     defaults:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,5 +7,5 @@ repos:
         description: Format and lint code
         entry: just fmt
         language: system
-        types_or: [rust, ts]
+        types_or: [rust, ts, python]
         pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## Implementations
 
-This repository contains two implementations:
+This repository contains three implementations:
 
 ### [Rust](rust/)
 
@@ -23,6 +23,14 @@ Solana Kit compatible signer implementation for Node.js and browser environments
 - **Backends**: Memory, Vault, Privy, Turnkey, AWS KMS, Fireblocks, GCP KMS, Dfns, Para, CDP, Crossmint, Openfort, Utila
 - **Features**: Solana Kit compatible, tree-shakeable modules, full type safety
 - [View TypeScript Documentation →](typescript/README.md)
+
+### [Python](python/)
+
+Async signer library built on [`solders`](https://pypi.org/project/solders/) for canonical transaction serialization.
+
+- **Backends**: Memory, Vault, Privy, Turnkey, AWS KMS, Fireblocks, GCP KMS, Dfns, Para, CDP, Crossmint, Openfort, Utila
+- **Features**: Async/await, optional extras so heavy provider SDKs stay out of the base install, strict typing
+- [View Python Documentation →](python/README.md)
 
 ## Security Audit
 

--- a/audits/AUDIT_STATUS.md
+++ b/audits/AUDIT_STATUS.md
@@ -11,6 +11,12 @@ Last updated: 2026-04-03
 
 Audit scope is commit-based. Commits after the audited-through SHA are considered unaudited until a new audit or mitigation review updates this file.
 
+### Language scope
+
+The audit covered the Rust and TypeScript implementations. The Python
+implementation (`python/`) landed after the audited-through commit and is
+**entirely unaudited**, including its port of previously audited signer logic.
+
 ## Branch and Release Model
 
 - `main` is the integration branch and may contain audited and unaudited commits.

--- a/docs/ADDING_SIGNERS.md
+++ b/docs/ADDING_SIGNERS.md
@@ -4,7 +4,7 @@
 
 This guide is for wallet service providers and developers who want to integrate new key management solutions into the `solana-keychain` library. By adding your signer implementation, you'll enable developers to use your service for secure Solana transaction signing through a unified interface.
 
-We strongly prefer PRs that include both [Rust](#rust) and [TypeScript](#typescript) implementations — every signer contributed so far has shipped both. If you can only contribute one, that's fine, but expect the other to be required before the signer ships in a release.
+We strongly prefer PRs that include the [Rust](#rust), [TypeScript](#typescript), and [Python](#python) implementations — the library maintains parity across all three. If you can only contribute one, that's fine, but expect the others to be required before the signer ships in a release.
 
 > **Using Claude Code?** This repo includes an `add-signer` skill (`.claude/skills/add-signer/`) that orchestrates the full workflow below — including gotchas and file ordering that this guide doesn't cover.
 
@@ -945,6 +945,97 @@ Your PR must include:
 - **`typescript-ci.yml`**: add package to unit + integration test matrices, add env vars to integration test step
 - **`typescript-publish.yml`**: add package to `PUBLISH_PACKAGES`, GitHub Release `packages` array, and summary table
 
+## Python
+
+### Quick Checklist
+
+- [ ] Create module `python/src/solana_keychain/<name>/`
+- [ ] Subclass `SolanaSigner` from `solana_keychain.core`
+- [ ] Export `async create_x_signer()` factory (awaits `init()` when the backend needs it)
+- [ ] Export a config dataclass (`XSignerConfig`) with secrets marked `field(repr=False)`
+- [ ] Enforce HTTPS on base-URL fields with `assert_https_url()`
+- [ ] Route every request through `fetch_signer_json()` so the error pipeline and sanitization apply
+- [ ] Add the backend to `_BACKENDS` in `python/src/solana_keychain/keychain.py`
+- [ ] Guard provider-SDK imports and declare an optional extra in `pyproject.toml`
+- [ ] Unit tests with pytest — `respx` for HTTP backends, stub clients for SDK backends
+- [ ] Integration test factory in `python/tests/integration/test_live_signers.py`
+- [ ] README backends table + install-extras line
+- [ ] `.env.example` with required env vars
+- [ ] CI updates (`python-ci.yml` signer gating and integration matrix)
+
+### Module Structure
+
+```
+python/src/solana_keychain/<name>/
+├── __init__.py          # Public exports
+├── signer.py            # Signer class + config dataclass + factory
+└── jwt.py / auth.py     # Auth helpers, when the provider needs them
+```
+
+Tests live at `python/tests/test_<name>_signer.py`. See
+[`python/src/solana_keychain/para/`](../python/src/solana_keychain/para/) for a
+pure-HTTP reference and
+[`python/src/solana_keychain/aws_kms/`](../python/src/solana_keychain/aws_kms/)
+for an extras-gated SDK reference.
+
+### Signer Implementation
+
+Subclass `SolanaSigner` and implement the four contract members:
+
+- `pubkey` property returning `solders.pubkey.Pubkey`
+- `async sign_transaction(transaction) -> SignedTransaction`
+- `async sign_message(message: bytes) -> Signature`
+- `async is_available() -> bool`
+
+Backends that must resolve an address remotely add `async init()` and raise
+`SIGNER_NOT_INITIALIZED` from a private `_initialized_pubkey()` helper when used
+before initialization; the factory awaits `init()` so callers never see an
+uninitialized signer.
+
+Always verify the signature the provider returns against the resolved public key
+before handing it back. For providers that rewrite the transaction before signing,
+verify against the bytes they signed — and use
+`solana_keychain.core.signed_message_bytes()`, which adds the `0x80` prefix that
+versioned-message signatures cover.
+
+### Optional Extras
+
+Backends needing a provider SDK must not break the base install. Guard the import
+and name the extra in the error:
+
+```python
+try:
+    import provider_sdk
+except ImportError as error:  # pragma: no cover
+    raise ImportError(
+        "solana_keychain.<name> requires the <name> extra: "
+        "pip install 'solana-keychain[<name>]'"
+    ) from error
+```
+
+Declare it under `[project.optional-dependencies]` in `python/pyproject.toml`,
+add the same packages to the `dev` extra so CI exercises them, and leave the
+backend out of the package root's eager exports.
+
+### Testing
+
+Unit tests must not touch the network: mock HTTP with `respx`, and inject stub
+clients for SDK-based backends (`botocore.stub.Stubber` for AWS, a hand-written
+async stub for GCP). Cover at minimum the success path with request assertions,
+each provider-specific error path, signature-verification failure, and that no
+secret appears in `str()`/`repr()`/`args` of raised errors.
+
+Integration tests are env-gated: add a `make_<name>_signer()` factory to
+`python/tests/integration/test_live_signers.py` using the same environment
+variable names as the Rust and TypeScript suites, and register it in
+`_MESSAGE_CAPABLE` (or `_TRANSACTION_ONLY` for backends without `sign_message`).
+
+### CI Updates
+
+- **`python-ci.yml`**: add the backend to the `CI_SIGNER_*` gating in
+  `resolve-signers` and to the integration matrix
+- **`python-publish.yml`**: no change needed — the package publishes as a whole
+
 ---
 
 ## Submission Checklist
@@ -959,13 +1050,15 @@ Before submitting your PR:
 - [ ] No `.expect()` or `.unwrap()` on untrusted API responses
 - [ ] HTTPS enforced on HTTP clients (Rust: `https_only(true)`, TS: URL protocol check)
 - [ ] HTTP timeouts configured via `HttpClientConfig`
-- [ ] Follows naming conventions (snake_case for Rust, camelCase for TypeScript)
+- [ ] Follows naming conventions (snake_case for Rust and Python, camelCase for TypeScript)
 - [ ] `error.rs` reqwest cfg gate updated (if using reqwest)
 - [ ] Integration test file added with standard test scenarios
 - [ ] `.env.example` updated (root + TS package)
 - [ ] Added to README.md supported backends table
 - [ ] CI changes included
 - [ ] TypeScript package with unit + integration tests
+- [ ] Python module with unit + integration tests, registered in the umbrella `_BACKENDS`
+- [ ] Python optional extra declared (if the backend needs a provider SDK)
 - [ ] Umbrella package updated (7 files — see [Umbrella Package](#umbrella-package))
 - [ ] Coordinated with maintainers on Phase 1 CI preparation
 

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -1,0 +1,13 @@
+## Unreleased
+
+### Features
+
+- initial Python implementation: `SolanaSigner` contract, redacting `SignerError`, transaction utilities, and golden wire-format vectors (#205)
+- remote signer core — `fetch_signer_json` error pipeline, HTTPS enforcement, response sanitization — plus the Vault backend (#208)
+- thirteen-backend parity: Memory, Vault, Privy, Turnkey, AWS KMS, Fireblocks, GCP KMS, Dfns, Para, CDP, Crossmint, Openfort, Utila (#210, #211, #213–#221)
+- `create_keychain_signer()` umbrella factory with lazy per-backend imports, plus the env-gated live integration suite (#222)
+
+### Bug Fixes
+
+- verify versioned-message signatures against `0x80`-prefixed bytes, which `solders` omits from `bytes(message)` (#222)
+- scope the integration require-run guard to the requested flow so a configured backend cannot mask a skipped one (#222)

--- a/python/src/solana_keychain/aws_kms/signer.py
+++ b/python/src/solana_keychain/aws_kms/signer.py
@@ -19,6 +19,7 @@ from solders.transaction import Transaction
 from solana_keychain.core.errors import SignerError, SignerErrorCode
 from solana_keychain.core.signer import SignedTransaction, SolanaSigner
 from solana_keychain.core.transaction_util import (
+    ED25519_SIGNATURE_LENGTH,
     add_signature_to_transaction,
     classify_signed_transaction,
     serialize_transaction,
@@ -27,8 +28,6 @@ from solana_keychain.core.transaction_util import (
 AWS_KMS_SIGNING_ALGORITHM = "ED25519_SHA_512"
 AWS_KMS_KEY_SPEC = "ECC_NIST_EDWARDS25519"
 AWS_KMS_KEY_USAGE = "SIGN_VERIFY"
-
-ED25519_SIGNATURE_LENGTH = 64
 
 
 @dataclass

--- a/python/src/solana_keychain/cdp/signer.py
+++ b/python/src/solana_keychain/cdp/signer.py
@@ -21,6 +21,7 @@ from solana_keychain.core.errors import SignerError, SignerErrorCode
 from solana_keychain.core.http import assert_https_url, fetch_signer_json, normalize_base_url
 from solana_keychain.core.signer import SignedTransaction, SolanaSigner
 from solana_keychain.core.transaction_util import (
+    ED25519_SIGNATURE_LENGTH,
     add_signature_to_transaction,
     classify_signed_transaction,
     get_signing_keypair_position,
@@ -29,8 +30,6 @@ from solana_keychain.core.transaction_util import (
 
 DEFAULT_API_BASE_URL = "https://api.cdp.coinbase.com"
 BASE_PATH = "/platform/v2/solana/accounts"
-
-ED25519_SIGNATURE_LENGTH = 64
 
 
 @dataclass

--- a/python/src/solana_keychain/core/__init__.py
+++ b/python/src/solana_keychain/core/__init__.py
@@ -8,6 +8,7 @@ from solana_keychain.core.http import (
 )
 from solana_keychain.core.signer import SignedTransaction, SolanaSigner
 from solana_keychain.core.transaction_util import (
+    ED25519_SIGNATURE_LENGTH,
     add_signature_to_transaction,
     classify_signed_transaction,
     get_signing_keypair_position,
@@ -18,6 +19,7 @@ from solana_keychain.core.transaction_util import (
 
 __all__ = [
     "DEFAULT_REQUEST_TIMEOUT_SECONDS",
+    "ED25519_SIGNATURE_LENGTH",
     "SignedTransaction",
     "SignerError",
     "SignerErrorCode",

--- a/python/src/solana_keychain/core/transaction_util.py
+++ b/python/src/solana_keychain/core/transaction_util.py
@@ -11,6 +11,7 @@ from solana_keychain.core.errors import SignerError, SignerErrorCode
 from solana_keychain.core.signer import SignedTransaction
 
 MESSAGE_VERSION_PREFIX = b"\x80"
+ED25519_SIGNATURE_LENGTH = 64
 
 
 def serialize_transaction(transaction: Transaction) -> str:

--- a/python/src/solana_keychain/crossmint/signer.py
+++ b/python/src/solana_keychain/crossmint/signer.py
@@ -17,6 +17,7 @@ from solana_keychain.core.errors import SignerError, SignerErrorCode
 from solana_keychain.core.http import assert_https_url, fetch_signer_json, normalize_base_url
 from solana_keychain.core.signer import SignedTransaction, SolanaSigner
 from solana_keychain.core.transaction_util import (
+    ED25519_SIGNATURE_LENGTH,
     add_signature_to_transaction,
     classify_signed_transaction,
     serialize_transaction,
@@ -30,7 +31,6 @@ DEFAULT_POLL_INTERVAL_MS = 1000
 DEFAULT_MAX_POLL_ATTEMPTS = 60
 AVAILABILITY_TIMEOUT_SECONDS = 5.0
 
-ED25519_SIGNATURE_LENGTH = 64
 
 _AWAITING_APPROVAL_ERROR = (
     "Crossmint transaction is awaiting approval; additional signer approvals are required"

--- a/python/src/solana_keychain/dfns/signer.py
+++ b/python/src/solana_keychain/dfns/signer.py
@@ -13,6 +13,7 @@ from solana_keychain.core.errors import SignerError, SignerErrorCode
 from solana_keychain.core.http import assert_https_url, fetch_signer_json, normalize_base_url
 from solana_keychain.core.signer import SignedTransaction, SolanaSigner
 from solana_keychain.core.transaction_util import (
+    ED25519_SIGNATURE_LENGTH,
     add_signature_to_transaction,
     classify_signed_transaction,
     serialize_transaction,
@@ -20,8 +21,6 @@ from solana_keychain.core.transaction_util import (
 from solana_keychain.dfns.auth import sign_user_action
 
 DEFAULT_API_BASE_URL = "https://api.dfns.io"
-
-ED25519_SIGNATURE_LENGTH = 64
 
 
 @dataclass

--- a/python/src/solana_keychain/fireblocks/signer.py
+++ b/python/src/solana_keychain/fireblocks/signer.py
@@ -15,6 +15,7 @@ from solana_keychain.core.errors import SignerError, SignerErrorCode
 from solana_keychain.core.http import assert_https_url, fetch_signer_json, normalize_base_url
 from solana_keychain.core.signer import SignedTransaction, SolanaSigner
 from solana_keychain.core.transaction_util import (
+    ED25519_SIGNATURE_LENGTH,
     add_signature_to_transaction,
     classify_signed_transaction,
     serialize_transaction,
@@ -26,7 +27,6 @@ DEFAULT_ASSET_ID = "SOL"
 DEFAULT_POLL_INTERVAL_MS = 1000
 DEFAULT_MAX_POLL_ATTEMPTS = 300
 
-ED25519_SIGNATURE_LENGTH = 64
 
 _TERMINAL_FAILURE_STATUSES = frozenset({"FAILED", "CANCELLED", "REJECTED", "BLOCKED"})
 

--- a/python/src/solana_keychain/gcp_kms/signer.py
+++ b/python/src/solana_keychain/gcp_kms/signer.py
@@ -19,14 +19,13 @@ from solders.transaction import Transaction
 from solana_keychain.core.errors import SignerError, SignerErrorCode
 from solana_keychain.core.signer import SignedTransaction, SolanaSigner
 from solana_keychain.core.transaction_util import (
+    ED25519_SIGNATURE_LENGTH,
     add_signature_to_transaction,
     classify_signed_transaction,
     serialize_transaction,
 )
 
 EC_SIGN_ED25519 = kms_v1.CryptoKeyVersion.CryptoKeyVersionAlgorithm.EC_SIGN_ED25519
-
-ED25519_SIGNATURE_LENGTH = 64
 
 
 @dataclass

--- a/python/src/solana_keychain/openfort/signer.py
+++ b/python/src/solana_keychain/openfort/signer.py
@@ -14,6 +14,7 @@ from solana_keychain.core.errors import SignerError, SignerErrorCode
 from solana_keychain.core.http import assert_https_url, fetch_signer_json, normalize_base_url
 from solana_keychain.core.signer import SignedTransaction, SolanaSigner
 from solana_keychain.core.transaction_util import (
+    ED25519_SIGNATURE_LENGTH,
     add_signature_to_transaction,
     classify_signed_transaction,
     serialize_transaction,
@@ -23,8 +24,6 @@ from solana_keychain.openfort.jwt import create_wallet_jwt, extract_host
 DEFAULT_API_BASE_URL = "https://api.openfort.io"
 ACCOUNTS_PATH = "/v2/accounts"
 BACKEND_PATH = "/v2/accounts/backend"
-
-ED25519_SIGNATURE_LENGTH = 64
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- Add `.github/workflows/python-publish.yml` — the Python side of release publishing, mirroring the Rust and TypeScript workflows: branch guard (`main` / `hotfix/*`), version read from `pyproject.toml`, refusal to republish a version already on PyPI, `twine check`, `python-v*` tag, PyPI trusted publishing, and a GitHub release.
- Add a `pip-audit` job to `security.yml` alongside `cargo-audit` and `pnpm-audit`. It installs the `dev` extra so every backend's dependencies are audited, not only the base install.
- Docs: seed `python/CHANGELOG.md` from the shipped PRs, list Python as a third implementation in the root README, add a Python section to `docs/ADDING_SIGNERS.md` matching the TypeScript one, and record in `audits/AUDIT_STATUS.md` that the Python implementation is entirely unaudited.
- Move `ED25519_SIGNATURE_LENGTH` into `core` instead of redefining it in seven backends, and make the pre-commit hook run on Python files (`types_or` previously listed only `rust` and `ts`, so Python edits skipped `just fmt`).

## Test Plan
- `just py-test` — 401 passed, 34 integration deselected
- `python/.venv/bin/mypy` — no issues in 63 source files
- `ruff check` + `ruff format --check` — clean
- `python -m build` — sdist and wheel build
- `pip-audit --skip-editable` run locally against the `dev` environment — no known vulnerabilities
- Both changed workflow files parse as YAML

## Notes
- `python-publish.yml` needs a `pypi` GitHub environment and a PyPI trusted publisher configured for `solana-keychain` before the first dispatch.
- `CLAUDE.md` links to a `RELEASING.md` at the repo root that does not exist, so there was no release runbook to add Python steps to. Flagging rather than fixing here.