### PR TITLE
ci: wire python and go into fork external live tests

### DIFF
--- a/.github/workflows/fork-external-live-manual.yml
+++ b/.github/workflows/fork-external-live-manual.yml
@@ -17,6 +17,10 @@ jobs:
       rust_ci_features: ${{ steps.resolve.outputs.rust_ci_features }}
       ts_live_packages_space: ${{ steps.resolve.outputs.ts_live_packages_space }}
       ts_live_package_count: ${{ steps.resolve.outputs.ts_live_package_count }}
+      python_live_backends_space: ${{ steps.resolve.outputs.python_live_backends_space }}
+      python_live_backend_count: ${{ steps.resolve.outputs.python_live_backend_count }}
+      go_live_modules_space: ${{ steps.resolve.outputs.go_live_modules_space }}
+      go_live_module_count: ${{ steps.resolve.outputs.go_live_module_count }}
       aws_kms_enabled: ${{ steps.resolve.outputs.aws_kms_enabled }}
     steps:
       - name: Resolve enabled signers from repository variables
@@ -113,6 +117,34 @@ jobs:
               ['fordefi', 'fordefi'],
             ];
 
+            const pythonLiveBackendMap = [
+              // gcp-kms omitted: Workload Identity OIDC is not available in the fork external-live environment.
+              ['privy', 'privy'],
+              ['turnkey', 'turnkey'],
+              ['fireblocks', 'fireblocks'],
+              ['fordefi', 'fordefi'],
+              ['aws_kms', 'aws-kms'],
+              ['para', 'para'],
+              ['cdp', 'cdp'],
+              ['dfns', 'dfns'],
+              ['crossmint', 'crossmint'],
+              ['openfort', 'openfort'],
+            ];
+
+            const goLiveModuleMap = [
+              // gcpkms omitted: Workload Identity OIDC is not available in the fork external-live environment.
+              // fordefi omitted: no Go backend.
+              ['privy', 'signers/privy'],
+              ['turnkey', 'signers/turnkey'],
+              ['fireblocks', 'signers/fireblocks'],
+              ['aws_kms', 'signers/awskms'],
+              ['para', 'signers/para'],
+              ['cdp', 'signers/cdp'],
+              ['dfns', 'signers/dfns'],
+              ['crossmint', 'signers/crossmint'],
+              ['openfort', 'signers/openfort'],
+            ];
+
             const rustFeatures = rustFeatureOrder.filter((backend) => enabled[backend]);
             const rustTests = rustLiveTestMap
               .filter(([signer]) => enabled[signer])
@@ -120,12 +152,22 @@ jobs:
             const tsPackages = tsLivePackageMap
               .filter(([signer]) => enabled[signer])
               .map(([, packageName]) => packageName);
+            const pythonBackends = pythonLiveBackendMap
+              .filter(([signer]) => enabled[signer])
+              .map(([, backendName]) => backendName);
+            const goModules = goLiveModuleMap
+              .filter(([signer]) => enabled[signer])
+              .map(([, moduleName]) => moduleName);
 
             core.setOutput('rust_live_tests_space', rustTests.join(' '));
             core.setOutput('rust_live_test_count', String(rustTests.length));
             core.setOutput('rust_ci_features', rustFeatures.join(','));
             core.setOutput('ts_live_packages_space', tsPackages.join(' '));
             core.setOutput('ts_live_package_count', String(tsPackages.length));
+            core.setOutput('python_live_backends_space', pythonBackends.join(' '));
+            core.setOutput('python_live_backend_count', String(pythonBackends.length));
+            core.setOutput('go_live_modules_space', goModules.join(' '));
+            core.setOutput('go_live_module_count', String(goModules.length));
             core.setOutput('aws_kms_enabled', String(enabled.aws_kms));
 
   fork-external-live-manual:
@@ -173,7 +215,7 @@ jobs:
             core.info(`Running external live tests for fork PR #${pr.number} at ${pr.head.sha}.`);
 
       - name: Checkout PR head SHA
-        if: ${{ needs.resolve-signers.outputs.rust_live_test_count != '0' || needs.resolve-signers.outputs.ts_live_package_count != '0' }}
+        if: ${{ needs.resolve-signers.outputs.rust_live_test_count != '0' || needs.resolve-signers.outputs.ts_live_package_count != '0' || needs.resolve-signers.outputs.python_live_backend_count != '0' || needs.resolve-signers.outputs.go_live_module_count != '0' }}
         uses: actions/checkout@v7
         with:
           ref: ${{ steps.pr.outputs.head_sha }}
@@ -190,6 +232,19 @@ jobs:
         uses: pnpm/action-setup@v6.0.9
         with:
           version: 11.13.0
+
+      - if: ${{ needs.resolve-signers.outputs.python_live_backend_count != '0' }}
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
+          cache: pip
+          cache-dependency-path: python/pyproject.toml
+
+      - if: ${{ needs.resolve-signers.outputs.go_live_module_count != '0' }}
+        uses: actions/setup-go@v7
+        with:
+          go-version-file: go/signers/gcpkms/go.mod
+          cache-dependency-path: go/**/go.sum
 
       - uses: dopplerhq/secrets-fetch-action@v2.0.0
         id: doppler
@@ -272,6 +327,50 @@ jobs:
           for package_name in ${TS_LIVE_PACKAGES}; do
             echo "Running @solana/keychain-${package_name} integration tests"
             pnpm -F "@solana/keychain-${package_name}" run test:integration
+          done
+
+      - name: Install Python dependencies
+        if: ${{ needs.resolve-signers.outputs.python_live_backend_count != '0' }}
+        working-directory: python
+        run: pip install -e '.[dev]'
+
+      - name: Run Python external live integration tests
+        if: ${{ needs.resolve-signers.outputs.python_live_backend_count != '0' }}
+        working-directory: python
+        env:
+          PYTHON_LIVE_BACKENDS: ${{ needs.resolve-signers.outputs.python_live_backends_space }}
+          SOLANA_RPC_URL: https://api.devnet.solana.com
+          KEYCHAIN_INTEGRATION_REQUIRE_RUN: '1'
+        run: |
+          set -euo pipefail
+
+          if [ -z "${PYTHON_LIVE_BACKENDS}" ]; then
+            echo "No enabled Python external live integration backends; skipping."
+            exit 0
+          fi
+
+          for backend_name in ${PYTHON_LIVE_BACKENDS}; do
+            echo "Running ${backend_name} integration tests"
+            KEYCHAIN_INTEGRATION_BACKEND="${backend_name}" pytest -m integration tests/integration/test_live_signers.py
+          done
+
+      - name: Run Go external live integration tests
+        if: ${{ needs.resolve-signers.outputs.go_live_module_count != '0' }}
+        working-directory: go
+        env:
+          GO_LIVE_MODULES: ${{ needs.resolve-signers.outputs.go_live_modules_space }}
+          SOLANA_RPC_URL: https://api.devnet.solana.com
+        run: |
+          set -euo pipefail
+
+          if [ -z "${GO_LIVE_MODULES}" ]; then
+            echo "No enabled Go external live integration modules; skipping."
+            exit 0
+          fi
+
+          for module_name in ${GO_LIVE_MODULES}; do
+            echo "Running ${module_name} integration tests"
+            (cd "${module_name}" && go test -tags=integration -race -count=1 ./...)
           done
 
       - name: Verify PR head SHA is unchanged


### PR DESCRIPTION
## Summary
- Extends `fork-external-live-manual.yml` to cover Python and Go: the resolve job now emits `python_live_backends` / `go_live_modules` from the same `CI_SIGNER_*_ENABLED` repository variables, and the run job executes `pytest -m integration` per backend (`KEYCHAIN_INTEGRATION_REQUIRE_RUN=1`, `KEYCHAIN_INTEGRATION_BACKEND=<name>`) and `go test -tags=integration -race` per module, mirroring the `python-ci` / `go-ci` integration jobs.
- Closes a gate loophole: `fork-live-gate` demands the `fork-external-live-pass:<sha>` marker for every fork PR, but the manual workflow only ran Rust + TS live tests — a fork PR touching only `python/` or `go/` could earn the marker without its code ever hitting a live backend.
- Backend sets mirror the per-language CIs: `gcp-kms` stays omitted for both (no Workload Identity OIDC in the fork external-live environment, same as Rust/TS); `fordefi` included for Python only (no Go backend); `vault`/`utila` remain local-only via the `just *-test-integration` recipes.

## Test Plan
- `yamllint` and `actionlint` pass (only pre-existing info-level shellcheck notes on the untouched Rust step).
- After merge: dispatch **Fork External Live Tests** against any open fork PR and confirm the new Python/Go steps run (or cleanly no-op when the counts resolve to zero).