### PR TITLE
fix(fordefi): bind native-mode responses to the submitted transaction

### DIFF
--- a/go/signers/fordefi/signer.go
+++ b/go/signers/fordefi/signer.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/gagliardetto/solana-go"
+	computebudget "github.com/gagliardetto/solana-go/programs/compute-budget"
 
 	"github.com/solana-foundation/solana-keychain/go/core"
 )
@@ -281,15 +282,6 @@ func (s *Signer) signSolanaMessage(ctx context.Context, message []byte) (solana.
 	return extractSignature(result)
 }
 
-// computeBudgetProgramID is the only program Fordefi may add instructions for:
-// it sets the priority fee when the submitted message carries none.
-var computeBudgetProgramID = solana.MustPublicKeyFromBase58("ComputeBudget111111111111111111111111111111")
-
-const (
-	setComputeUnitLimitOpcode = 2
-	setComputeUnitPriceOpcode = 3
-)
-
 // resolvedInstruction is an instruction with its account indices resolved to
 // pubkeys and their signer and writable flags, so two messages stay comparable
 // even when they order or extend AccountKeys differently.
@@ -302,8 +294,9 @@ type resolvedInstruction struct {
 }
 
 func (r resolvedInstruction) isFeeSetting() bool {
-	return r.programID.Equals(computeBudgetProgramID) && r.hasOpcode &&
-		(r.opcode == setComputeUnitLimitOpcode || r.opcode == setComputeUnitPriceOpcode)
+	return r.programID.Equals(computebudget.ProgramID) && r.hasOpcode &&
+		(r.opcode == computebudget.Instruction_SetComputeUnitLimit ||
+			r.opcode == computebudget.Instruction_SetComputeUnitPrice)
 }
 
 func resolveInstructions(message *solana.Message) ([]resolvedInstruction, error) {
@@ -372,7 +365,7 @@ func assertOnlyBlockhashAndFeeRewrites(requested, returned *solana.Message) erro
 	}
 
 	fordefiMayAddFees := !slices.ContainsFunc(submitted, func(instruction resolvedInstruction) bool {
-		return instruction.programID.Equals(computeBudgetProgramID)
+		return instruction.programID.Equals(computebudget.ProgramID)
 	})
 	matched := 0
 	for _, instruction := range returnedInstructions {

--- a/go/signers/fordefi/signer.go
+++ b/go/signers/fordefi/signer.go
@@ -285,6 +285,11 @@ func (s *Signer) signSolanaMessage(ctx context.Context, message []byte) (solana.
 // it sets the priority fee when the submitted message carries none.
 var computeBudgetProgramID = solana.MustPublicKeyFromBase58("ComputeBudget111111111111111111111111111111")
 
+const (
+	setComputeUnitLimitOpcode = 2
+	setComputeUnitPriceOpcode = 3
+)
+
 // resolvedInstruction is an instruction with its account indices resolved to
 // pubkeys and their signer and writable flags, so two messages stay comparable
 // even when they order or extend AccountKeys differently.
@@ -292,6 +297,13 @@ type resolvedInstruction struct {
 	programID solana.PublicKey
 	accounts  string
 	data      string
+	opcode    byte
+	hasOpcode bool
+}
+
+func (r resolvedInstruction) isFeeSetting() bool {
+	return r.programID.Equals(computeBudgetProgramID) && r.hasOpcode &&
+		(r.opcode == setComputeUnitLimitOpcode || r.opcode == setComputeUnitPriceOpcode)
 }
 
 func resolveInstructions(message *solana.Message) ([]resolvedInstruction, error) {
@@ -318,11 +330,16 @@ func resolveInstructions(message *solana.Message) ([]resolvedInstruction, error)
 				(int(index) >= signers && int(index) < writableUnsignedEnd)
 			fmt.Fprintf(&accounts, "%s:%t:%t,", keys[index], int(index) < signers, writable)
 		}
-		resolved = append(resolved, resolvedInstruction{
+		entry := resolvedInstruction{
 			programID: keys[instruction.ProgramIDIndex],
 			accounts:  accounts.String(),
 			data:      base64.StdEncoding.EncodeToString(instruction.Data),
-		})
+		}
+		if len(instruction.Data) > 0 {
+			entry.opcode = instruction.Data[0]
+			entry.hasOpcode = true
+		}
+		resolved = append(resolved, entry)
 	}
 	return resolved, nil
 }
@@ -330,11 +347,12 @@ func resolveInstructions(message *solana.Message) ([]resolvedInstruction, error)
 // assertOnlyBlockhashAndFeeRewrites rejects a Fordefi-returned message that
 // changes more than Fordefi may change.
 //
-// Fordefi overwrites the recent blockhash immediately before signing, and adds
-// ComputeBudget instructions to set the priority fee when the submitted message
-// carries none. Everything else — the signer set, the fee payer, and every
-// submitted instruction — must survive verbatim, so a substituted transaction
-// cannot be reported as a successful signing result.
+// Fordefi overwrites the recent blockhash immediately before signing, and sets
+// the priority fee (SetComputeUnitLimit / SetComputeUnitPrice) only when the
+// submitted message carries no ComputeBudget instructions of its own.
+// Everything else — the signer set, the fee payer, and every submitted
+// instruction — must survive verbatim, so a substituted transaction cannot be
+// reported as a successful signing result.
 func assertOnlyBlockhashAndFeeRewrites(requested, returned *solana.Message) error {
 	requestedSigners := int(requested.Header.NumRequiredSignatures)
 	returnedSigners := int(returned.Header.NumRequiredSignatures)
@@ -353,12 +371,15 @@ func assertOnlyBlockhashAndFeeRewrites(requested, returned *solana.Message) erro
 		return err
 	}
 
+	fordefiMayAddFees := !slices.ContainsFunc(submitted, func(instruction resolvedInstruction) bool {
+		return instruction.programID.Equals(computeBudgetProgramID)
+	})
 	matched := 0
 	for _, instruction := range returnedInstructions {
 		switch {
 		case matched < len(submitted) && instruction == submitted[matched]:
 			matched++
-		case !instruction.programID.Equals(computeBudgetProgramID):
+		case !fordefiMayAddFees || !instruction.isFeeSetting():
 			return core.NewSignerError(core.CodeSigningFailed,
 				"Fordefi returned a transaction with instructions that do not match the submitted message")
 		}
@@ -386,8 +407,8 @@ func (s *Signer) requireSoleRequiredSigner(tx *solana.Transaction) error {
 // Fordefi may modify the transaction (at minimum the blockhash), so the
 // signature is verified against the returned message bytes and tx is replaced
 // with the returned transaction. The returned transaction must otherwise match
-// the submitted one: only a fresh blockhash and added ComputeBudget
-// instructions are accepted.
+// the submitted one: only a fresh blockhash is accepted, plus added fee-setting
+// ComputeBudget instructions when the submitted message carried none.
 func (s *Signer) signTransactionNative(ctx context.Context, tx *solana.Transaction) (core.SignedTransaction, error) {
 	if err := s.requireSoleRequiredSigner(tx); err != nil {
 		return core.SignedTransaction{}, err

--- a/go/signers/fordefi/signer.go
+++ b/go/signers/fordefi/signer.go
@@ -3,7 +3,9 @@ package fordefi
 import (
 	"context"
 	"encoding/base64"
+	"fmt"
 	"net/http"
+	"slices"
 	"strings"
 	"time"
 
@@ -279,6 +281,95 @@ func (s *Signer) signSolanaMessage(ctx context.Context, message []byte) (solana.
 	return extractSignature(result)
 }
 
+// computeBudgetProgramID is the only program Fordefi may add instructions for:
+// it sets the priority fee when the submitted message carries none.
+var computeBudgetProgramID = solana.MustPublicKeyFromBase58("ComputeBudget111111111111111111111111111111")
+
+// resolvedInstruction is an instruction with its account indices resolved to
+// pubkeys and their signer and writable flags, so two messages stay comparable
+// even when they order or extend AccountKeys differently.
+type resolvedInstruction struct {
+	programID solana.PublicKey
+	accounts  string
+	data      string
+}
+
+func resolveInstructions(message *solana.Message) ([]resolvedInstruction, error) {
+	keys := message.AccountKeys
+	header := message.Header
+	signers := int(header.NumRequiredSignatures)
+	writableSigners := signers - int(header.NumReadonlySignedAccounts)
+	writableUnsignedEnd := len(keys) - int(header.NumReadonlyUnsignedAccounts)
+
+	indexOutOfRange := core.NewSignerError(core.CodeSerializationError,
+		"transaction references an account index outside its account keys")
+
+	resolved := make([]resolvedInstruction, 0, len(message.Instructions))
+	for _, instruction := range message.Instructions {
+		if int(instruction.ProgramIDIndex) >= len(keys) {
+			return nil, indexOutOfRange
+		}
+		var accounts strings.Builder
+		for _, index := range instruction.Accounts {
+			if int(index) >= len(keys) {
+				return nil, indexOutOfRange
+			}
+			writable := int(index) < writableSigners ||
+				(int(index) >= signers && int(index) < writableUnsignedEnd)
+			fmt.Fprintf(&accounts, "%s:%t:%t,", keys[index], int(index) < signers, writable)
+		}
+		resolved = append(resolved, resolvedInstruction{
+			programID: keys[instruction.ProgramIDIndex],
+			accounts:  accounts.String(),
+			data:      base64.StdEncoding.EncodeToString(instruction.Data),
+		})
+	}
+	return resolved, nil
+}
+
+// assertOnlyBlockhashAndFeeRewrites rejects a Fordefi-returned message that
+// changes more than Fordefi may change.
+//
+// Fordefi overwrites the recent blockhash immediately before signing, and adds
+// ComputeBudget instructions to set the priority fee when the submitted message
+// carries none. Everything else — the signer set, the fee payer, and every
+// submitted instruction — must survive verbatim, so a substituted transaction
+// cannot be reported as a successful signing result.
+func assertOnlyBlockhashAndFeeRewrites(requested, returned *solana.Message) error {
+	requestedSigners := int(requested.Header.NumRequiredSignatures)
+	returnedSigners := int(returned.Header.NumRequiredSignatures)
+	if requestedSigners > len(requested.AccountKeys) || returnedSigners > len(returned.AccountKeys) ||
+		!slices.Equal(requested.AccountKeys[:requestedSigners], returned.AccountKeys[:returnedSigners]) {
+		return core.NewSignerError(core.CodeSigningFailed,
+			"Fordefi returned a transaction with a different signer set")
+	}
+
+	submitted, err := resolveInstructions(requested)
+	if err != nil {
+		return err
+	}
+	returnedInstructions, err := resolveInstructions(returned)
+	if err != nil {
+		return err
+	}
+
+	matched := 0
+	for _, instruction := range returnedInstructions {
+		switch {
+		case matched < len(submitted) && instruction == submitted[matched]:
+			matched++
+		case !instruction.programID.Equals(computeBudgetProgramID):
+			return core.NewSignerError(core.CodeSigningFailed,
+				"Fordefi returned a transaction with instructions that do not match the submitted message")
+		}
+	}
+	if matched != len(submitted) {
+		return core.NewSignerError(core.CodeSigningFailed,
+			"Fordefi returned a transaction missing submitted instructions")
+	}
+	return nil
+}
+
 // requireSoleRequiredSigner rejects native-mode transactions with additional
 // required signers: native auto-broadcast submits message bytes only, so other
 // signers' partial signatures would be dropped.
@@ -294,7 +385,9 @@ func (s *Signer) requireSoleRequiredSigner(tx *solana.Transaction) error {
 // signTransactionNative signs tx via the native solana_transaction path.
 // Fordefi may modify the transaction (at minimum the blockhash), so the
 // signature is verified against the returned message bytes and tx is replaced
-// with the returned transaction.
+// with the returned transaction. The returned transaction must otherwise match
+// the submitted one: only a fresh blockhash and added ComputeBudget
+// instructions are accepted.
 func (s *Signer) signTransactionNative(ctx context.Context, tx *solana.Transaction) (core.SignedTransaction, error) {
 	if err := s.requireSoleRequiredSigner(tx); err != nil {
 		return core.SignedTransaction{}, err
@@ -357,6 +450,10 @@ func (s *Signer) signTransactionNative(ctx context.Context, tx *solana.Transacti
 	if !core.VerifyEd25519(s.pubkey, returnedMessage, signature) {
 		return core.SignedTransaction{}, core.NewSignerError(core.CodeSigningFailed,
 			"signature verification failed against Fordefi-returned message")
+	}
+
+	if err := assertOnlyBlockhashAndFeeRewrites(&tx.Message, &returned.Message); err != nil {
+		return core.SignedTransaction{}, err
 	}
 
 	*tx = *returned

--- a/go/signers/fordefi/signer_test.go
+++ b/go/signers/fordefi/signer_test.go
@@ -9,6 +9,7 @@ import (
 	"crypto/sha256"
 	"crypto/x509"
 	"encoding/base64"
+	"encoding/binary"
 	"encoding/json"
 	"encoding/pem"
 	"errors"
@@ -23,6 +24,7 @@ import (
 	"time"
 
 	"github.com/gagliardetto/solana-go"
+	"github.com/gagliardetto/solana-go/programs/system"
 
 	"github.com/solana-foundation/solana-keychain/go/core"
 	"github.com/solana-foundation/solana-keychain/go/testutils"
@@ -621,6 +623,172 @@ func TestSignTransactionNativeSuccess(t *testing.T) {
 	}
 	if len(tx.Signatures) == 0 || tx.Signatures[0] != signature {
 		t.Error("caller's transaction must be replaced with the Fordefi-signed one")
+	}
+}
+
+// setComputeUnitPrice is the kind of priority-fee instruction Fordefi adds when
+// the submitted message carries no ComputeBudget instructions.
+func setComputeUnitPrice(microLamports uint64) solana.Instruction {
+	data := []byte{3}
+	return solana.NewInstruction(computeBudgetProgramID, nil,
+		binary.LittleEndian.AppendUint64(data, microLamports))
+}
+
+// testRecipient is the transfer destination testutils.CreateTestTransaction uses.
+func testRecipient(t *testing.T, payer solana.PublicKey) solana.PublicKey {
+	t.Helper()
+	tx, err := testutils.CreateTestTransaction(payer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return tx.Message.AccountKeys[1]
+}
+
+func buildTransaction(t *testing.T, payer solana.PublicKey, instructions ...solana.Instruction) *solana.Transaction {
+	t.Helper()
+	var blockhash solana.Hash
+	blockhash[0] = 0x77
+	tx, err := solana.NewTransaction(instructions, blockhash, solana.TransactionPayer(payer))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return tx
+}
+
+func TestNativeRewriteAcceptsFreshBlockhash(t *testing.T) {
+	pub := testutils.TestPublicKey()
+	tx, err := testutils.CreateTestTransaction(pub)
+	if err != nil {
+		t.Fatal(err)
+	}
+	returned := *tx
+	returned.Message.RecentBlockhash = solana.Hash{0x55}
+
+	if err := assertOnlyBlockhashAndFeeRewrites(&tx.Message, &returned.Message); err != nil {
+		t.Errorf("a re-stamped blockhash is Fordefi's documented rewrite, got %v", err)
+	}
+}
+
+// Fordefi sets the priority fee itself when the submitted message carries no
+// ComputeBudget instructions, so those additions must not be rejected.
+func TestNativeRewriteAcceptsAddedComputeBudgetInstructions(t *testing.T) {
+	pub := testutils.TestPublicKey()
+	tx, err := testutils.CreateTestTransaction(pub)
+	if err != nil {
+		t.Fatal(err)
+	}
+	transfer := system.NewTransferInstruction(testutils.TestTransferLamports, pub, testRecipient(t, pub)).Build()
+	returned := buildTransaction(t, pub, setComputeUnitPrice(5_000), transfer)
+
+	if err := assertOnlyBlockhashAndFeeRewrites(&tx.Message, &returned.Message); err != nil {
+		t.Errorf("Fordefi-added priority fee instructions must be accepted, got %v", err)
+	}
+}
+
+func TestNativeRewriteRejectsSubstitutedRecipient(t *testing.T) {
+	pub := testutils.TestPublicKey()
+	tx, err := testutils.CreateTestTransaction(pub)
+	if err != nil {
+		t.Fatal(err)
+	}
+	attacker := solana.MustPublicKeyFromBase58("11111111111111111111111111111112")
+	substituted := buildTransaction(t, pub,
+		system.NewTransferInstruction(testutils.TestTransferLamports, pub, attacker).Build())
+
+	err = assertOnlyBlockhashAndFeeRewrites(&tx.Message, &substituted.Message)
+	if code, _ := core.CodeOf(err); code != core.CodeSigningFailed {
+		t.Errorf("got %s, want SIGNING_FAILED", code)
+	}
+}
+
+func TestNativeRewriteRejectsChangedLamportAmount(t *testing.T) {
+	pub := testutils.TestPublicKey()
+	tx, err := testutils.CreateTestTransaction(pub)
+	if err != nil {
+		t.Fatal(err)
+	}
+	inflated := buildTransaction(t, pub,
+		system.NewTransferInstruction(500_000_000, pub, testRecipient(t, pub)).Build())
+
+	err = assertOnlyBlockhashAndFeeRewrites(&tx.Message, &inflated.Message)
+	if code, _ := core.CodeOf(err); code != core.CodeSigningFailed {
+		t.Errorf("got %s, want SIGNING_FAILED", code)
+	}
+}
+
+func TestNativeRewriteRejectsDroppedInstruction(t *testing.T) {
+	pub := testutils.TestPublicKey()
+	tx, err := testutils.CreateTestTransaction(pub)
+	if err != nil {
+		t.Fatal(err)
+	}
+	feeOnly := buildTransaction(t, pub, setComputeUnitPrice(1))
+
+	err = assertOnlyBlockhashAndFeeRewrites(&tx.Message, &feeOnly.Message)
+	if code, _ := core.CodeOf(err); code != core.CodeSigningFailed {
+		t.Errorf("got %s, want SIGNING_FAILED", code)
+	}
+}
+
+func TestNativeRewriteRejectsExtraSigner(t *testing.T) {
+	pub := testutils.TestPublicKey()
+	tx, err := testutils.CreateTestTransaction(pub)
+	if err != nil {
+		t.Fatal(err)
+	}
+	returned := *tx
+	returned.Message.AccountKeys = append([]solana.PublicKey{pub,
+		solana.MustPublicKeyFromBase58("11111111111111111111111111111112")},
+		tx.Message.AccountKeys[1:]...)
+	returned.Message.Header.NumRequiredSignatures = 2
+
+	err = assertOnlyBlockhashAndFeeRewrites(&tx.Message, &returned.Message)
+	if code, _ := core.CodeOf(err); code != core.CodeSigningFailed {
+		t.Errorf("got %s, want SIGNING_FAILED", code)
+	}
+}
+
+// A different transaction validly signed by the same vault must not come back
+// through SignTransaction as a successful signing of the submitted one.
+func TestSignTransactionNativeRejectsSubstitutedTransaction(t *testing.T) {
+	priv := testutils.TestPrivateKey()
+	pub := testutils.TestPublicKey()
+
+	attacker := solana.MustPublicKeyFromBase58("11111111111111111111111111111112")
+	substituted := buildTransaction(t, pub,
+		system.NewTransferInstruction(testutils.TestTransferLamports, pub, attacker).Build())
+	substitutedMsg, err := substituted.Message.MarshalBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+	substituted.Signatures = []solana.Signature{solana.SignatureFromBytes(ed25519.Sign(priv, substitutedMsg))}
+	wireBytes, err := substituted.MarshalBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s := newTestSigner(t, nativeConfig(t), pub.String(), func(mux *http.ServeMux) {
+		mux.HandleFunc(transactionsPath, func(w http.ResponseWriter, _ *http.Request) {
+			writeJSON(w, map[string]any{"id": "tx-123"})
+		})
+		mux.HandleFunc(transactionsPath+"/tx-123", func(w http.ResponseWriter, _ *http.Request) {
+			writeJSON(w, map[string]any{
+				"state":           "completed",
+				"raw_transaction": base64.StdEncoding.EncodeToString(wireBytes),
+			})
+		})
+	})
+
+	tx, err := testutils.CreateTestTransaction(pub)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = s.SignTransaction(context.Background(), tx)
+	if err == nil {
+		t.Fatal("expected a substituted transaction to be rejected")
+	}
+	if code, _ := core.CodeOf(err); code != core.CodeSigningFailed {
+		t.Errorf("got %s, want SIGNING_FAILED", code)
 	}
 }
 

--- a/go/signers/fordefi/signer_test.go
+++ b/go/signers/fordefi/signer_test.go
@@ -9,7 +9,6 @@ import (
 	"crypto/sha256"
 	"crypto/x509"
 	"encoding/base64"
-	"encoding/binary"
 	"encoding/json"
 	"encoding/pem"
 	"errors"
@@ -24,6 +23,7 @@ import (
 	"time"
 
 	"github.com/gagliardetto/solana-go"
+	computebudget "github.com/gagliardetto/solana-go/programs/compute-budget"
 	"github.com/gagliardetto/solana-go/programs/system"
 
 	"github.com/solana-foundation/solana-keychain/go/core"
@@ -629,16 +629,12 @@ func TestSignTransactionNativeSuccess(t *testing.T) {
 // setComputeUnitPrice is the kind of priority-fee instruction Fordefi adds when
 // the submitted message carries no ComputeBudget instructions.
 func setComputeUnitPrice(microLamports uint64) solana.Instruction {
-	data := []byte{setComputeUnitPriceOpcode}
-	return solana.NewInstruction(computeBudgetProgramID, nil,
-		binary.LittleEndian.AppendUint64(data, microLamports))
+	return computebudget.NewSetComputeUnitPriceInstruction(microLamports).Build()
 }
 
 // requestHeapFrame is a non-fee ComputeBudget instruction Fordefi never adds.
 func requestHeapFrame() solana.Instruction {
-	data := []byte{1}
-	return solana.NewInstruction(computeBudgetProgramID, nil,
-		binary.LittleEndian.AppendUint32(data, 256*1024))
+	return computebudget.NewRequestHeapFrameInstruction(256 * 1024).Build()
 }
 
 // testRecipient is the transfer destination testutils.CreateTestTransaction uses.

--- a/go/signers/fordefi/signer_test.go
+++ b/go/signers/fordefi/signer_test.go
@@ -629,9 +629,16 @@ func TestSignTransactionNativeSuccess(t *testing.T) {
 // setComputeUnitPrice is the kind of priority-fee instruction Fordefi adds when
 // the submitted message carries no ComputeBudget instructions.
 func setComputeUnitPrice(microLamports uint64) solana.Instruction {
-	data := []byte{3}
+	data := []byte{setComputeUnitPriceOpcode}
 	return solana.NewInstruction(computeBudgetProgramID, nil,
 		binary.LittleEndian.AppendUint64(data, microLamports))
+}
+
+// requestHeapFrame is a non-fee ComputeBudget instruction Fordefi never adds.
+func requestHeapFrame() solana.Instruction {
+	data := []byte{1}
+	return solana.NewInstruction(computeBudgetProgramID, nil,
+		binary.LittleEndian.AppendUint32(data, 256*1024))
 }
 
 // testRecipient is the transfer destination testutils.CreateTestTransaction uses.
@@ -682,6 +689,38 @@ func TestNativeRewriteAcceptsAddedComputeBudgetInstructions(t *testing.T) {
 
 	if err := assertOnlyBlockhashAndFeeRewrites(&tx.Message, &returned.Message); err != nil {
 		t.Errorf("Fordefi-added priority fee instructions must be accepted, got %v", err)
+	}
+}
+
+// Fordefi only sets fees for requests carrying no ComputeBudget instructions,
+// so an addition alongside caller-supplied compute controls is a substitution.
+func TestNativeRewriteRejectsAddedFeesWhenRequestHadComputeBudget(t *testing.T) {
+	pub := testutils.TestPublicKey()
+	transfer := system.NewTransferInstruction(testutils.TestTransferLamports, pub, testRecipient(t, pub)).Build()
+	tx := buildTransaction(t, pub, setComputeUnitPrice(10), transfer)
+	returned := buildTransaction(t, pub,
+		setComputeUnitPrice(10), setComputeUnitPrice(10_000_000), transfer)
+
+	err := assertOnlyBlockhashAndFeeRewrites(&tx.Message, &returned.Message)
+	if code, _ := core.CodeOf(err); code != core.CodeSigningFailed {
+		t.Errorf("got %s, want SIGNING_FAILED", code)
+	}
+}
+
+// Only SetComputeUnitLimit and SetComputeUnitPrice are fee-setting; a
+// RequestHeapFrame addition is not something Fordefi does.
+func TestNativeRewriteRejectsNonFeeComputeBudgetAddition(t *testing.T) {
+	pub := testutils.TestPublicKey()
+	tx, err := testutils.CreateTestTransaction(pub)
+	if err != nil {
+		t.Fatal(err)
+	}
+	transfer := system.NewTransferInstruction(testutils.TestTransferLamports, pub, testRecipient(t, pub)).Build()
+	returned := buildTransaction(t, pub, requestHeapFrame(), transfer)
+
+	err = assertOnlyBlockhashAndFeeRewrites(&tx.Message, &returned.Message)
+	if code, _ := core.CodeOf(err); code != core.CodeSigningFailed {
+		t.Errorf("got %s, want SIGNING_FAILED", code)
 	}
 }
 

--- a/python/src/solana_keychain/fordefi/signer.py
+++ b/python/src/solana_keychain/fordefi/signer.py
@@ -14,6 +14,7 @@ from typing import Any
 from urllib.parse import quote
 
 import httpx
+from solders.message import Message
 from solders.pubkey import Pubkey
 from solders.signature import Signature
 from solders.transaction import Transaction
@@ -40,6 +41,8 @@ DEFAULT_POLL_INTERVAL_MS = 2000
 DEFAULT_MAX_POLL_ATTEMPTS = 50
 SUPPORTED_CHAINS = ("solana_devnet", "solana_mainnet")
 
+COMPUTE_BUDGET_PROGRAM_ID = Pubkey.from_string("ComputeBudget111111111111111111111111111111")
+
 _AVAILABILITY_TIMEOUT_SECONDS = 5.0
 _VAULT_VERIFICATION_TIMEOUT_SECONDS = 10.0
 
@@ -61,6 +64,77 @@ _TERMINAL_FAILURE_STATES = frozenset(
 
 def _timestamp_ms() -> int:
     return int(time.time() * 1000)
+
+
+_AccountMeta = tuple[Pubkey, bool, bool]
+_ResolvedInstruction = tuple[Pubkey, tuple[_AccountMeta, ...], bytes]
+
+
+def _resolved_instructions(message: Message) -> list[_ResolvedInstruction]:
+    """Instructions with account indices resolved to pubkeys and their flags.
+
+    Resolving away the indices makes two messages comparable even when they
+    order or extend ``account_keys`` differently.
+    """
+    keys = message.account_keys
+    header = message.header
+    signers = header.num_required_signatures
+    writable_signers = signers - header.num_readonly_signed_accounts
+    writable_unsigned_end = len(keys) - header.num_readonly_unsigned_accounts
+
+    def account_meta(index: int) -> _AccountMeta:
+        writable = index < writable_signers or signers <= index < writable_unsigned_end
+        return keys[index], index < signers, writable
+
+    try:
+        return [
+            (
+                keys[instruction.program_id_index],
+                tuple(account_meta(index) for index in instruction.accounts),
+                bytes(instruction.data),
+            )
+            for instruction in message.instructions
+        ]
+    except IndexError:
+        raise SignerError(
+            SignerErrorCode.SERIALIZATION_ERROR,
+            "Transaction references an account index outside its account keys",
+        ) from None
+
+
+def _assert_only_blockhash_and_fee_rewrites(requested: Message, returned: Message) -> None:
+    """Reject a Fordefi-returned message that changes more than Fordefi may change.
+
+    Fordefi overwrites the recent blockhash immediately before signing, and adds
+    ComputeBudget instructions to set the priority fee when the submitted
+    message contains none. Everything else — the signer set, the fee payer, and
+    every submitted instruction — must survive verbatim, so a substituted
+    transaction cannot be reported as a successful signing result.
+    """
+    requested_signers = requested.account_keys[: requested.header.num_required_signatures]
+    returned_signers = returned.account_keys[: returned.header.num_required_signatures]
+    if list(returned_signers) != list(requested_signers):
+        raise SignerError(
+            SignerErrorCode.SIGNING_FAILED,
+            "Fordefi returned a transaction with a different signer set",
+        )
+
+    submitted = _resolved_instructions(requested)
+    matched = 0
+    for instruction in _resolved_instructions(returned):
+        if matched < len(submitted) and instruction == submitted[matched]:
+            matched += 1
+        elif instruction[0] != COMPUTE_BUDGET_PROGRAM_ID:
+            raise SignerError(
+                SignerErrorCode.SIGNING_FAILED,
+                "Fordefi returned a transaction with instructions that do not match "
+                "the submitted message",
+            )
+    if matched != len(submitted):
+        raise SignerError(
+            SignerErrorCode.SIGNING_FAILED,
+            "Fordefi returned a transaction missing submitted instructions",
+        )
 
 
 @dataclass
@@ -103,6 +177,8 @@ class FordefiSigner(SolanaSigner):
     Black-box mode (default) signs the caller's exact message bytes and the
     caller broadcasts. Native mode (``chain`` set) lets Fordefi replace the
     blockhash and fees, sign, and auto-broadcast; see ``sign_transaction``.
+    Rewrites beyond the blockhash and added ComputeBudget instructions are
+    rejected rather than reported as a successful signing result.
     """
 
     def __init__(self, config: FordefiSignerConfig) -> None:
@@ -336,6 +412,10 @@ class FordefiSigner(SolanaSigner):
         unmodified — the returned signature identifies the on-chain
         transaction. Only legacy transactions whose sole required signer is
         the configured vault are supported.
+
+        The transaction Fordefi returns is checked against the submitted one:
+        a fresh blockhash and added ComputeBudget instructions are accepted,
+        any other difference raises ``SIGNING_FAILED``.
         """
         if self._chain is not None:
             return await self._sign_transaction_native(transaction)
@@ -393,6 +473,7 @@ class FordefiSigner(SolanaSigner):
             )
         signature = signatures[position]
         self._verify_signature(signature, returned.message_data())
+        _assert_only_blockhash_and_fee_rewrites(transaction.message, returned.message)
         return classify_signed_transaction(returned, "", signature)
 
     async def sign_message(self, message: bytes) -> Signature:

--- a/python/src/solana_keychain/fordefi/signer.py
+++ b/python/src/solana_keychain/fordefi/signer.py
@@ -42,6 +42,7 @@ DEFAULT_MAX_POLL_ATTEMPTS = 50
 SUPPORTED_CHAINS = ("solana_devnet", "solana_mainnet")
 
 COMPUTE_BUDGET_PROGRAM_ID = Pubkey.from_string("ComputeBudget111111111111111111111111111111")
+_FEE_SETTING_COMPUTE_BUDGET_OPCODES = (2, 3)
 
 _AVAILABILITY_TIMEOUT_SECONDS = 5.0
 _VAULT_VERIFICATION_TIMEOUT_SECONDS = 10.0
@@ -102,14 +103,24 @@ def _resolved_instructions(message: Message) -> list[_ResolvedInstruction]:
         ) from None
 
 
+def _is_fee_setting_instruction(instruction: _ResolvedInstruction) -> bool:
+    program_id, _, data = instruction
+    return (
+        program_id == COMPUTE_BUDGET_PROGRAM_ID
+        and len(data) >= 1
+        and data[0] in _FEE_SETTING_COMPUTE_BUDGET_OPCODES
+    )
+
+
 def _assert_only_blockhash_and_fee_rewrites(requested: Message, returned: Message) -> None:
     """Reject a Fordefi-returned message that changes more than Fordefi may change.
 
-    Fordefi overwrites the recent blockhash immediately before signing, and adds
-    ComputeBudget instructions to set the priority fee when the submitted
-    message contains none. Everything else — the signer set, the fee payer, and
-    every submitted instruction — must survive verbatim, so a substituted
-    transaction cannot be reported as a successful signing result.
+    Fordefi overwrites the recent blockhash immediately before signing, and sets
+    the priority fee — SetComputeUnitLimit / SetComputeUnitPrice — only when the
+    submitted message contains no ComputeBudget instructions of its own.
+    Everything else — the signer set, the fee payer, and every submitted
+    instruction — must survive verbatim, so a substituted transaction cannot be
+    reported as a successful signing result.
     """
     requested_signers = requested.account_keys[: requested.header.num_required_signatures]
     returned_signers = returned.account_keys[: returned.header.num_required_signatures]
@@ -120,11 +131,14 @@ def _assert_only_blockhash_and_fee_rewrites(requested: Message, returned: Messag
         )
 
     submitted = _resolved_instructions(requested)
+    fordefi_may_add_fees = all(
+        instruction[0] != COMPUTE_BUDGET_PROGRAM_ID for instruction in submitted
+    )
     matched = 0
     for instruction in _resolved_instructions(returned):
         if matched < len(submitted) and instruction == submitted[matched]:
             matched += 1
-        elif instruction[0] != COMPUTE_BUDGET_PROGRAM_ID:
+        elif not (fordefi_may_add_fees and _is_fee_setting_instruction(instruction)):
             raise SignerError(
                 SignerErrorCode.SIGNING_FAILED,
                 "Fordefi returned a transaction with instructions that do not match "
@@ -414,8 +428,9 @@ class FordefiSigner(SolanaSigner):
         the configured vault are supported.
 
         The transaction Fordefi returns is checked against the submitted one:
-        a fresh blockhash and added ComputeBudget instructions are accepted,
-        any other difference raises ``SIGNING_FAILED``.
+        a fresh blockhash is accepted, as are added fee-setting ComputeBudget
+        instructions when the submitted message carried none. Any other
+        difference raises ``SIGNING_FAILED``.
         """
         if self._chain is not None:
             return await self._sign_transaction_native(transaction)

--- a/python/src/solana_keychain/fordefi/signer.py
+++ b/python/src/solana_keychain/fordefi/signer.py
@@ -14,6 +14,8 @@ from typing import Any
 from urllib.parse import quote
 
 import httpx
+from solders.compute_budget import ID as COMPUTE_BUDGET_PROGRAM_ID
+from solders.compute_budget import set_compute_unit_limit, set_compute_unit_price
 from solders.message import Message
 from solders.pubkey import Pubkey
 from solders.signature import Signature
@@ -41,8 +43,10 @@ DEFAULT_POLL_INTERVAL_MS = 2000
 DEFAULT_MAX_POLL_ATTEMPTS = 50
 SUPPORTED_CHAINS = ("solana_devnet", "solana_mainnet")
 
-COMPUTE_BUDGET_PROGRAM_ID = Pubkey.from_string("ComputeBudget111111111111111111111111111111")
-_FEE_SETTING_COMPUTE_BUDGET_OPCODES = (2, 3)
+_FEE_SETTING_COMPUTE_BUDGET_OPCODES = (
+    bytes(set_compute_unit_limit(0).data)[0],
+    bytes(set_compute_unit_price(0).data)[0],
+)
 
 _AVAILABILITY_TIMEOUT_SECONDS = 5.0
 _VAULT_VERIFICATION_TIMEOUT_SECONDS = 10.0

--- a/python/tests/test_fordefi_signer.py
+++ b/python/tests/test_fordefi_signer.py
@@ -12,7 +12,14 @@ from cryptography.hazmat.primitives.serialization import (
     NoEncryption,
     PrivateFormat,
 )
+from solders.hash import Hash
+from solders.instruction import AccountMeta, Instruction
 from solders.keypair import Keypair
+from solders.message import Message
+from solders.pubkey import Pubkey
+from solders.signature import Signature
+from solders.system_program import TransferParams, transfer
+from solders.transaction import Transaction
 
 from solana_keychain import SignerError, SignerErrorCode
 from solana_keychain.fordefi import (
@@ -22,6 +29,7 @@ from solana_keychain.fordefi import (
     PemRequestSigner,
     create_fordefi_signer,
 )
+from solana_keychain.fordefi.signer import COMPUTE_BUDGET_PROGRAM_ID
 from tests.util import create_test_transaction, create_two_signer_transaction
 
 API_BASE_URL = "https://fordefi.example.com"
@@ -373,11 +381,53 @@ async def test_sign_message_native_mode_uses_solana_message() -> None:
     }
 
 
-def make_signed_wire_transaction(keypair: Keypair) -> tuple[str, Any]:
-    transaction = create_test_transaction(keypair.pubkey())
+def rebuild_with_fresh_blockhash(
+    transaction: Transaction, extra_instructions: list[Instruction] | None = None
+) -> Transaction:
+    """The transaction as Fordefi returns it: fresh blockhash, optional added fees."""
+    instructions = (extra_instructions or []) + decompile_instructions(transaction)
+    message = Message.new_with_blockhash(
+        instructions, transaction.message.account_keys[0], Hash.new_unique()
+    )
+    return Transaction.new_unsigned(message)
+
+
+def decompile_instructions(transaction: Transaction) -> list[Instruction]:
+    message = transaction.message
+    keys = message.account_keys
+    header = message.header
+    signers = header.num_required_signatures
+    writable_signers = signers - header.num_readonly_signed_accounts
+    writable_unsigned_end = len(keys) - header.num_readonly_unsigned_accounts
+    return [
+        Instruction(
+            keys[compiled.program_id_index],
+            bytes(compiled.data),
+            [
+                AccountMeta(
+                    keys[index],
+                    is_signer=index < signers,
+                    is_writable=index < writable_signers
+                    or signers <= index < writable_unsigned_end,
+                )
+                for index in compiled.accounts
+            ],
+        )
+        for compiled in message.instructions
+    ]
+
+
+def sign_wire_transaction(keypair: Keypair, transaction: Transaction) -> tuple[str, Any]:
     signature = keypair.sign_message(transaction.message_data())
-    transaction.signatures = [signature]
+    required = transaction.message.header.num_required_signatures
+    transaction.signatures = [signature] + [Signature.default()] * (required - 1)
     return base64.b64encode(bytes(transaction)).decode("ascii"), signature
+
+
+def mock_native_response(keypair: Keypair, returned: Transaction) -> Any:
+    raw_transaction, signature = sign_wire_transaction(keypair, returned)
+    mock_sign_flow(status_response("completed", raw_transaction=raw_transaction))
+    return signature
 
 
 @respx.mock
@@ -386,12 +436,8 @@ async def test_sign_transaction_native_success() -> None:
     signer = make_signer(
         keypair, chain="solana_mainnet", fee={"type": "priority", "priority_level": "high"}
     )
-    raw_transaction, signature = make_signed_wire_transaction(keypair)
-    mock_sign_flow(
-        status_response("signed"),
-        status_response("completed", raw_transaction=raw_transaction),
-    )
     transaction = create_test_transaction(keypair.pubkey())
+    signature = mock_native_response(keypair, rebuild_with_fresh_blockhash(transaction))
 
     result = await signer.sign_transaction(transaction)
 
@@ -405,6 +451,25 @@ async def test_sign_transaction_native_success() -> None:
     assert body["details"]["push_mode"] == "auto"
     assert body["details"]["fee"] == {"type": "priority", "priority_level": "high"}
     assert body["details"]["data"] == base64.b64encode(transaction.message_data()).decode("ascii")
+
+
+@respx.mock
+async def test_sign_transaction_native_accepts_added_compute_budget_instructions() -> None:
+    """Fordefi sets the priority fee itself when the submitted message has no
+    ComputeBudget instructions, so those additions must not be rejected."""
+    keypair = Keypair()
+    signer = make_signer(keypair, chain="solana_devnet")
+    transaction = create_test_transaction(keypair.pubkey())
+    set_compute_unit_price = Instruction(
+        COMPUTE_BUDGET_PROGRAM_ID, bytes([3]) + (5_000).to_bytes(8, "little"), []
+    )
+    signature = mock_native_response(
+        keypair, rebuild_with_fresh_blockhash(transaction, [set_compute_unit_price])
+    )
+
+    result = await signer.sign_transaction(transaction)
+
+    assert result.signature == signature
 
 
 @respx.mock
@@ -422,10 +487,73 @@ async def test_sign_transaction_native_verifies_against_returned_message() -> No
     keypair = Keypair()
     signer = make_signer(keypair, chain="solana_devnet")
     transaction = create_test_transaction(keypair.pubkey())
-    returned = create_test_transaction(keypair.pubkey())
+    returned = rebuild_with_fresh_blockhash(transaction)
     returned.signatures = [keypair.sign_message(transaction.message_data())]
     raw_transaction = base64.b64encode(bytes(returned)).decode("ascii")
     mock_sign_flow(status_response("completed", raw_transaction=raw_transaction))
+    with pytest.raises(SignerError) as excinfo:
+        await signer.sign_transaction(transaction)
+    assert excinfo.value.code == SignerErrorCode.SIGNING_FAILED
+
+
+@respx.mock
+async def test_sign_transaction_native_rejects_substituted_recipient() -> None:
+    """A different transaction signed by the same vault must not be reported as
+    a successful signing of the submitted one."""
+    keypair = Keypair()
+    signer = make_signer(keypair, chain="solana_devnet")
+    transaction = create_test_transaction(keypair.pubkey())
+    substituted = create_test_transaction(keypair.pubkey(), Pubkey.new_unique())
+    mock_native_response(keypair, substituted)
+
+    with pytest.raises(SignerError) as excinfo:
+        await signer.sign_transaction(transaction)
+    assert excinfo.value.code == SignerErrorCode.SIGNING_FAILED
+
+
+@respx.mock
+async def test_sign_transaction_native_rejects_changed_lamport_amount() -> None:
+    keypair = Keypair()
+    signer = make_signer(keypair, chain="solana_devnet")
+    recipient = Pubkey.new_unique()
+    transaction = create_test_transaction(keypair.pubkey(), recipient)
+    inflated = transfer(
+        TransferParams(from_pubkey=keypair.pubkey(), to_pubkey=recipient, lamports=500_000_000)
+    )
+    returned = Transaction.new_unsigned(
+        Message.new_with_blockhash([inflated], keypair.pubkey(), Hash.new_unique())
+    )
+    mock_native_response(keypair, returned)
+
+    with pytest.raises(SignerError) as excinfo:
+        await signer.sign_transaction(transaction)
+    assert excinfo.value.code == SignerErrorCode.SIGNING_FAILED
+
+
+@respx.mock
+async def test_sign_transaction_native_rejects_dropped_instruction() -> None:
+    keypair = Keypair()
+    signer = make_signer(keypair, chain="solana_devnet")
+    transaction = create_test_transaction(keypair.pubkey())
+    fee_only = Instruction(COMPUTE_BUDGET_PROGRAM_ID, bytes([3]) + (1).to_bytes(8, "little"), [])
+    returned = Transaction.new_unsigned(
+        Message.new_with_blockhash([fee_only], keypair.pubkey(), Hash.new_unique())
+    )
+    mock_native_response(keypair, returned)
+
+    with pytest.raises(SignerError) as excinfo:
+        await signer.sign_transaction(transaction)
+    assert excinfo.value.code == SignerErrorCode.SIGNING_FAILED
+
+
+@respx.mock
+async def test_sign_transaction_native_rejects_extra_signer_in_returned_transaction() -> None:
+    keypair = Keypair()
+    signer = make_signer(keypair, chain="solana_devnet")
+    transaction = create_test_transaction(keypair.pubkey())
+    returned = create_two_signer_transaction(keypair.pubkey(), Keypair().pubkey())
+    mock_native_response(keypair, returned)
+
     with pytest.raises(SignerError) as excinfo:
         await signer.sign_transaction(transaction)
     assert excinfo.value.code == SignerErrorCode.SIGNING_FAILED

--- a/python/tests/test_fordefi_signer.py
+++ b/python/tests/test_fordefi_signer.py
@@ -453,23 +453,84 @@ async def test_sign_transaction_native_success() -> None:
     assert body["details"]["data"] == base64.b64encode(transaction.message_data()).decode("ascii")
 
 
+def set_compute_unit_price_instruction(micro_lamports: int = 5_000) -> Instruction:
+    return Instruction(
+        COMPUTE_BUDGET_PROGRAM_ID, bytes([3]) + micro_lamports.to_bytes(8, "little"), []
+    )
+
+
+def set_compute_unit_limit_instruction(units: int = 200_000) -> Instruction:
+    return Instruction(COMPUTE_BUDGET_PROGRAM_ID, bytes([2]) + units.to_bytes(4, "little"), [])
+
+
 @respx.mock
-async def test_sign_transaction_native_accepts_added_compute_budget_instructions() -> None:
+async def test_sign_transaction_native_accepts_added_fee_instructions() -> None:
     """Fordefi sets the priority fee itself when the submitted message has no
     ComputeBudget instructions, so those additions must not be rejected."""
     keypair = Keypair()
     signer = make_signer(keypair, chain="solana_devnet")
     transaction = create_test_transaction(keypair.pubkey())
-    set_compute_unit_price = Instruction(
-        COMPUTE_BUDGET_PROGRAM_ID, bytes([3]) + (5_000).to_bytes(8, "little"), []
-    )
     signature = mock_native_response(
-        keypair, rebuild_with_fresh_blockhash(transaction, [set_compute_unit_price])
+        keypair,
+        rebuild_with_fresh_blockhash(
+            transaction,
+            [set_compute_unit_limit_instruction(), set_compute_unit_price_instruction()],
+        ),
     )
 
     result = await signer.sign_transaction(transaction)
 
     assert result.signature == signature
+
+
+@respx.mock
+async def test_sign_transaction_native_rejects_added_fees_when_request_had_compute_budget() -> None:
+    """Fordefi only sets fees for requests carrying no ComputeBudget instructions,
+    so an addition alongside caller-supplied compute controls is a substitution."""
+    keypair = Keypair()
+    signer = make_signer(keypair, chain="solana_devnet")
+    recipient = Pubkey.new_unique()
+    transfer_ix = transfer(
+        TransferParams(from_pubkey=keypair.pubkey(), to_pubkey=recipient, lamports=1_000_000)
+    )
+    transaction = Transaction.new_unsigned(
+        Message.new_with_blockhash(
+            [set_compute_unit_price_instruction(10), transfer_ix], keypair.pubkey(), Hash.default()
+        )
+    )
+    returned = Transaction.new_unsigned(
+        Message.new_with_blockhash(
+            [
+                set_compute_unit_price_instruction(10),
+                set_compute_unit_price_instruction(10_000_000),
+                transfer_ix,
+            ],
+            keypair.pubkey(),
+            Hash.new_unique(),
+        )
+    )
+    mock_native_response(keypair, returned)
+
+    with pytest.raises(SignerError) as excinfo:
+        await signer.sign_transaction(transaction)
+    assert excinfo.value.code == SignerErrorCode.SIGNING_FAILED
+
+
+@respx.mock
+async def test_sign_transaction_native_rejects_non_fee_compute_budget_addition() -> None:
+    """Only SetComputeUnitLimit and SetComputeUnitPrice are fee-setting; a
+    RequestHeapFrame addition is not something Fordefi does."""
+    keypair = Keypair()
+    signer = make_signer(keypair, chain="solana_devnet")
+    transaction = create_test_transaction(keypair.pubkey())
+    request_heap_frame = Instruction(
+        COMPUTE_BUDGET_PROGRAM_ID, bytes([1]) + (256 * 1024).to_bytes(4, "little"), []
+    )
+    mock_native_response(keypair, rebuild_with_fresh_blockhash(transaction, [request_heap_frame]))
+
+    with pytest.raises(SignerError) as excinfo:
+        await signer.sign_transaction(transaction)
+    assert excinfo.value.code == SignerErrorCode.SIGNING_FAILED
 
 
 @respx.mock

--- a/python/tests/test_fordefi_signer.py
+++ b/python/tests/test_fordefi_signer.py
@@ -12,6 +12,11 @@ from cryptography.hazmat.primitives.serialization import (
     NoEncryption,
     PrivateFormat,
 )
+from solders.compute_budget import (
+    request_heap_frame,
+    set_compute_unit_limit,
+    set_compute_unit_price,
+)
 from solders.hash import Hash
 from solders.instruction import AccountMeta, Instruction
 from solders.keypair import Keypair
@@ -29,7 +34,6 @@ from solana_keychain.fordefi import (
     PemRequestSigner,
     create_fordefi_signer,
 )
-from solana_keychain.fordefi.signer import COMPUTE_BUDGET_PROGRAM_ID
 from tests.util import create_test_transaction, create_two_signer_transaction
 
 API_BASE_URL = "https://fordefi.example.com"
@@ -453,16 +457,6 @@ async def test_sign_transaction_native_success() -> None:
     assert body["details"]["data"] == base64.b64encode(transaction.message_data()).decode("ascii")
 
 
-def set_compute_unit_price_instruction(micro_lamports: int = 5_000) -> Instruction:
-    return Instruction(
-        COMPUTE_BUDGET_PROGRAM_ID, bytes([3]) + micro_lamports.to_bytes(8, "little"), []
-    )
-
-
-def set_compute_unit_limit_instruction(units: int = 200_000) -> Instruction:
-    return Instruction(COMPUTE_BUDGET_PROGRAM_ID, bytes([2]) + units.to_bytes(4, "little"), [])
-
-
 @respx.mock
 async def test_sign_transaction_native_accepts_added_fee_instructions() -> None:
     """Fordefi sets the priority fee itself when the submitted message has no
@@ -474,7 +468,7 @@ async def test_sign_transaction_native_accepts_added_fee_instructions() -> None:
         keypair,
         rebuild_with_fresh_blockhash(
             transaction,
-            [set_compute_unit_limit_instruction(), set_compute_unit_price_instruction()],
+            [set_compute_unit_limit(200_000), set_compute_unit_price(5_000)],
         ),
     )
 
@@ -495,14 +489,14 @@ async def test_sign_transaction_native_rejects_added_fees_when_request_had_compu
     )
     transaction = Transaction.new_unsigned(
         Message.new_with_blockhash(
-            [set_compute_unit_price_instruction(10), transfer_ix], keypair.pubkey(), Hash.default()
+            [set_compute_unit_price(10), transfer_ix], keypair.pubkey(), Hash.default()
         )
     )
     returned = Transaction.new_unsigned(
         Message.new_with_blockhash(
             [
-                set_compute_unit_price_instruction(10),
-                set_compute_unit_price_instruction(10_000_000),
+                set_compute_unit_price(10),
+                set_compute_unit_price(10_000_000),
                 transfer_ix,
             ],
             keypair.pubkey(),
@@ -523,10 +517,9 @@ async def test_sign_transaction_native_rejects_non_fee_compute_budget_addition()
     keypair = Keypair()
     signer = make_signer(keypair, chain="solana_devnet")
     transaction = create_test_transaction(keypair.pubkey())
-    request_heap_frame = Instruction(
-        COMPUTE_BUDGET_PROGRAM_ID, bytes([1]) + (256 * 1024).to_bytes(4, "little"), []
+    mock_native_response(
+        keypair, rebuild_with_fresh_blockhash(transaction, [request_heap_frame(256 * 1024)])
     )
-    mock_native_response(keypair, rebuild_with_fresh_blockhash(transaction, [request_heap_frame]))
 
     with pytest.raises(SignerError) as excinfo:
         await signer.sign_transaction(transaction)
@@ -596,7 +589,7 @@ async def test_sign_transaction_native_rejects_dropped_instruction() -> None:
     keypair = Keypair()
     signer = make_signer(keypair, chain="solana_devnet")
     transaction = create_test_transaction(keypair.pubkey())
-    fee_only = Instruction(COMPUTE_BUDGET_PROGRAM_ID, bytes([3]) + (1).to_bytes(8, "little"), [])
+    fee_only = set_compute_unit_price(1)
     returned = Transaction.new_unsigned(
         Message.new_with_blockhash([fee_only], keypair.pubkey(), Hash.new_unique())
     )

--- a/rust/src/fordefi/mod.rs
+++ b/rust/src/fordefi/mod.rs
@@ -14,7 +14,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::error::SignerError;
 use crate::http_client_config::HttpClientConfig;
-use crate::sdk_adapter::{Pubkey, Signature, Transaction};
+use crate::sdk_adapter::{Message, Pubkey, Signature, Transaction};
 use crate::traits::{SignTransactionResult, SignedTransaction, SolanaSigner};
 use crate::transaction_util::TransactionUtil;
 pub use request_signer::{FordefiRequestSigner, PemRequestSigner};
@@ -30,6 +30,97 @@ const DEFAULT_POLL_INTERVAL_MS: u64 = 2000;
 const DEFAULT_MAX_POLL_ATTEMPTS: u32 = 50;
 const AVAILABILITY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 const VAULT_VERIFICATION_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+const COMPUTE_BUDGET_PROGRAM_ID: &str = "ComputeBudget111111111111111111111111111111";
+
+/// An instruction with its account indices resolved to pubkeys and their signer
+/// and writable flags, so two messages stay comparable even when they order or
+/// extend `account_keys` differently.
+type ResolvedInstruction = (Pubkey, Vec<(Pubkey, bool, bool)>, Vec<u8>);
+
+fn resolved_instructions(message: &Message) -> Result<Vec<ResolvedInstruction>, SignerError> {
+    let keys = &message.account_keys;
+    let header = &message.header;
+    let signers = header.num_required_signatures as usize;
+    let writable_signers = signers.saturating_sub(header.num_readonly_signed_accounts as usize);
+    let writable_unsigned_end = keys
+        .len()
+        .saturating_sub(header.num_readonly_unsigned_accounts as usize);
+
+    let key_at = |index: usize| -> Result<Pubkey, SignerError> {
+        keys.get(index).copied().ok_or_else(|| {
+            SignerError::SerializationError(
+                "Transaction references an account index outside its account keys".to_string(),
+            )
+        })
+    };
+
+    message
+        .instructions
+        .iter()
+        .map(|instruction| {
+            let accounts = instruction
+                .accounts
+                .iter()
+                .map(|&index| {
+                    let index = index as usize;
+                    Ok((
+                        key_at(index)?,
+                        index < signers,
+                        index < writable_signers
+                            || (index >= signers && index < writable_unsigned_end),
+                    ))
+                })
+                .collect::<Result<Vec<_>, SignerError>>()?;
+            Ok((
+                key_at(instruction.program_id_index as usize)?,
+                accounts,
+                instruction.data.clone(),
+            ))
+        })
+        .collect()
+}
+
+/// Reject a Fordefi-returned message that changes more than Fordefi may change.
+///
+/// Fordefi overwrites the recent blockhash immediately before signing, and adds
+/// ComputeBudget instructions to set the priority fee when the submitted message
+/// carries none. Everything else — the signer set, the fee payer, and every
+/// submitted instruction — must survive verbatim, so a substituted transaction
+/// cannot be reported as a successful signing result.
+fn assert_only_blockhash_and_fee_rewrites(
+    requested: &Message,
+    returned: &Message,
+) -> Result<(), SignerError> {
+    let requested_signers = requested.header.num_required_signatures as usize;
+    let returned_signers = returned.header.num_required_signatures as usize;
+    if requested.account_keys.get(..requested_signers)
+        != returned.account_keys.get(..returned_signers)
+    {
+        return Err(SignerError::SigningFailed(
+            "Fordefi returned a transaction with a different signer set".to_string(),
+        ));
+    }
+
+    let submitted = resolved_instructions(requested)?;
+    let mut matched = 0;
+    for instruction in resolved_instructions(returned)? {
+        if matched < submitted.len() && instruction == submitted[matched] {
+            matched += 1;
+        } else if instruction.0.to_string() != COMPUTE_BUDGET_PROGRAM_ID {
+            return Err(SignerError::SigningFailed(
+                "Fordefi returned a transaction with instructions that do not match the \
+                 submitted message"
+                    .to_string(),
+            ));
+        }
+    }
+    if matched != submitted.len() {
+        return Err(SignerError::SigningFailed(
+            "Fordefi returned a transaction missing submitted instructions".to_string(),
+        ));
+    }
+    Ok(())
+}
 
 /// Configuration for creating a FordefiSigner.
 #[derive(Clone)]
@@ -486,6 +577,10 @@ impl FordefiSigner {
     /// returned message bytes, not the original. The caller's `transaction` is
     /// replaced with the Fordefi-returned transaction.
     ///
+    /// The returned transaction is checked against the submitted one first: a
+    /// fresh blockhash and added ComputeBudget instructions are accepted, any
+    /// other difference is a [`SignerError::SigningFailed`].
+    ///
     /// Because native mode uses `push_mode: "auto"`, Fordefi has already broadcast
     /// the transaction on-chain by the time this returns. Re-sending it would be
     /// superfluous, so the returned serialized-transaction string is intentionally
@@ -538,6 +633,8 @@ impl FordefiSigner {
                 "Signature verification failed against Fordefi-returned message".to_string(),
             ));
         }
+
+        assert_only_blockhash_and_fee_rewrites(&transaction.message, &returned_tx.message)?;
 
         // Replace the caller's transaction with the Fordefi-signed one
         *transaction = returned_tx;
@@ -750,8 +847,11 @@ impl SolanaSigner for FordefiSigner {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::sdk_adapter::{keypair_pubkey, Keypair, Signer as SdkSigner};
-    use crate::test_util::create_test_transaction;
+    use crate::sdk_adapter::{keypair_pubkey, Hash, Instruction, Keypair, Signer as SdkSigner};
+    use crate::test_util::{
+        create_test_transaction, create_test_transaction_with_recipient,
+        create_transfer_instruction,
+    };
     use p256::ecdsa::SigningKey;
     use wiremock::{
         matchers::{header, method, path, path_regex},
@@ -1676,6 +1776,147 @@ mod tests {
             "native mode should return an empty serialized transaction"
         );
         assert!(sig.verify(&pubkey.to_bytes(), &message_data));
+    }
+
+    /// Fordefi's own rewrite: same instructions, freshly stamped blockhash.
+    fn with_fresh_blockhash(tx: &Transaction) -> Transaction {
+        let mut rewritten = tx.clone();
+        rewritten.message.recent_blockhash = Hash::new_unique();
+        rewritten
+    }
+
+    fn compute_budget_instruction() -> Instruction {
+        Instruction {
+            program_id: Pubkey::from_str(COMPUTE_BUDGET_PROGRAM_ID).unwrap(),
+            accounts: vec![],
+            data: {
+                let mut data = vec![3];
+                data.extend_from_slice(&5_000u64.to_le_bytes());
+                data
+            },
+        }
+    }
+
+    #[test]
+    fn test_fordefi_native_accepts_fresh_blockhash() {
+        let pubkey = Pubkey::new_unique();
+        let tx = create_test_transaction(&pubkey);
+        let returned = with_fresh_blockhash(&tx);
+
+        assert!(
+            assert_only_blockhash_and_fee_rewrites(&tx.message, &returned.message).is_ok(),
+            "a re-stamped blockhash is Fordefi's documented rewrite"
+        );
+    }
+
+    /// Fordefi sets the priority fee itself when the submitted message carries no
+    /// ComputeBudget instructions, so those additions must not be rejected.
+    #[test]
+    fn test_fordefi_native_accepts_added_compute_budget_instructions() {
+        let pubkey = Pubkey::new_unique();
+        let recipient = Pubkey::new_unique();
+        let tx = create_test_transaction_with_recipient(&pubkey, &recipient);
+
+        let instructions = vec![
+            compute_budget_instruction(),
+            create_transfer_instruction(&pubkey, &recipient, 1_000_000),
+        ];
+        let mut returned = Transaction::new_unsigned(Message::new(&instructions, Some(&pubkey)));
+        returned.message.recent_blockhash = Hash::new_unique();
+
+        assert!(
+            assert_only_blockhash_and_fee_rewrites(&tx.message, &returned.message).is_ok(),
+            "Fordefi-added priority fee instructions must be accepted"
+        );
+    }
+
+    #[test]
+    fn test_fordefi_native_rejects_substituted_recipient() {
+        let pubkey = Pubkey::new_unique();
+        let tx = create_test_transaction(&pubkey);
+        let substituted = create_test_transaction(&pubkey);
+
+        let result = assert_only_blockhash_and_fee_rewrites(&tx.message, &substituted.message);
+        assert!(matches!(result.unwrap_err(), SignerError::SigningFailed(_)));
+    }
+
+    #[test]
+    fn test_fordefi_native_rejects_changed_lamport_amount() {
+        let pubkey = Pubkey::new_unique();
+        let recipient = Pubkey::new_unique();
+        let tx = create_test_transaction_with_recipient(&pubkey, &recipient);
+
+        let mut returned = tx.clone();
+        let data = &mut returned.message.instructions[0].data;
+        let inflated = 500_000_000u64.to_le_bytes();
+        data[4..12].copy_from_slice(&inflated);
+
+        let result = assert_only_blockhash_and_fee_rewrites(&tx.message, &returned.message);
+        assert!(matches!(result.unwrap_err(), SignerError::SigningFailed(_)));
+    }
+
+    #[test]
+    fn test_fordefi_native_rejects_dropped_instruction() {
+        let pubkey = Pubkey::new_unique();
+        let tx = create_test_transaction(&pubkey);
+        let returned =
+            Transaction::new_unsigned(Message::new(&[compute_budget_instruction()], Some(&pubkey)));
+
+        let result = assert_only_blockhash_and_fee_rewrites(&tx.message, &returned.message);
+        assert!(matches!(result.unwrap_err(), SignerError::SigningFailed(_)));
+    }
+
+    #[test]
+    fn test_fordefi_native_rejects_extra_signer() {
+        let pubkey = Pubkey::new_unique();
+        let tx = create_test_transaction(&pubkey);
+
+        let mut returned = tx.clone();
+        returned
+            .message
+            .account_keys
+            .insert(1, Pubkey::new_unique());
+        returned.message.header.num_required_signatures = 2;
+
+        let result = assert_only_blockhash_and_fee_rewrites(&tx.message, &returned.message);
+        assert!(matches!(result.unwrap_err(), SignerError::SigningFailed(_)));
+    }
+
+    /// A different transaction validly signed by the same vault must not come back
+    /// through `sign_transaction` as a successful signing of the submitted one.
+    #[tokio::test]
+    async fn test_fordefi_native_sign_transaction_rejects_substituted_transaction() {
+        let mock_server = MockServer::start().await;
+        let keypair = create_test_keypair();
+        let pubkey = keypair_pubkey(&keypair);
+        let signer = create_native_test_signer(&mock_server.uri(), pubkey);
+
+        let substituted = create_test_transaction(&pubkey);
+        let wire_b64 = STANDARD.encode(build_mock_wire_transaction(
+            &keypair,
+            &substituted.message_data(),
+        ));
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/transactions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "native-tx-1"
+            })))
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/api/v1/transactions/native-tx-1"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "state": "completed",
+                "raw_transaction": wire_b64
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let mut tx = create_test_transaction(&pubkey);
+        let result = signer.sign_transaction(&mut tx).await;
+        assert!(matches!(result.unwrap_err(), SignerError::SigningFailed(_)));
     }
 
     #[tokio::test]

--- a/rust/src/fordefi/mod.rs
+++ b/rust/src/fordefi/mod.rs
@@ -31,6 +31,7 @@ const DEFAULT_MAX_POLL_ATTEMPTS: u32 = 50;
 const AVAILABILITY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 const VAULT_VERIFICATION_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
 const COMPUTE_BUDGET_PROGRAM_ID: &str = "ComputeBudget111111111111111111111111111111";
+const FEE_SETTING_COMPUTE_BUDGET_OPCODES: [u8; 2] = [2, 3];
 
 /// An instruction with its account indices resolved to pubkeys and their signer
 /// and writable flags, so two messages stay comparable even when they order or
@@ -80,13 +81,26 @@ fn resolved_instructions(message: &Message) -> Result<Vec<ResolvedInstruction>, 
         .collect()
 }
 
+fn is_compute_budget(instruction: &ResolvedInstruction) -> bool {
+    instruction.0.to_string() == COMPUTE_BUDGET_PROGRAM_ID
+}
+
+fn is_fee_setting_instruction(instruction: &ResolvedInstruction) -> bool {
+    is_compute_budget(instruction)
+        && instruction
+            .2
+            .first()
+            .is_some_and(|opcode| FEE_SETTING_COMPUTE_BUDGET_OPCODES.contains(opcode))
+}
+
 /// Reject a Fordefi-returned message that changes more than Fordefi may change.
 ///
-/// Fordefi overwrites the recent blockhash immediately before signing, and adds
-/// ComputeBudget instructions to set the priority fee when the submitted message
-/// carries none. Everything else — the signer set, the fee payer, and every
-/// submitted instruction — must survive verbatim, so a substituted transaction
-/// cannot be reported as a successful signing result.
+/// Fordefi overwrites the recent blockhash immediately before signing, and sets
+/// the priority fee — SetComputeUnitLimit / SetComputeUnitPrice — only when the
+/// submitted message carries no ComputeBudget instructions of its own.
+/// Everything else — the signer set, the fee payer, and every submitted
+/// instruction — must survive verbatim, so a substituted transaction cannot be
+/// reported as a successful signing result.
 fn assert_only_blockhash_and_fee_rewrites(
     requested: &Message,
     returned: &Message,
@@ -102,11 +116,12 @@ fn assert_only_blockhash_and_fee_rewrites(
     }
 
     let submitted = resolved_instructions(requested)?;
+    let fordefi_may_add_fees = !submitted.iter().any(is_compute_budget);
     let mut matched = 0;
     for instruction in resolved_instructions(returned)? {
         if matched < submitted.len() && instruction == submitted[matched] {
             matched += 1;
-        } else if instruction.0.to_string() != COMPUTE_BUDGET_PROGRAM_ID {
+        } else if !(fordefi_may_add_fees && is_fee_setting_instruction(&instruction)) {
             return Err(SignerError::SigningFailed(
                 "Fordefi returned a transaction with instructions that do not match the \
                  submitted message"
@@ -578,8 +593,9 @@ impl FordefiSigner {
     /// replaced with the Fordefi-returned transaction.
     ///
     /// The returned transaction is checked against the submitted one first: a
-    /// fresh blockhash and added ComputeBudget instructions are accepted, any
-    /// other difference is a [`SignerError::SigningFailed`].
+    /// fresh blockhash is accepted, as are added fee-setting ComputeBudget
+    /// instructions when the submitted message carried none. Any other
+    /// difference is a [`SignerError::SigningFailed`].
     ///
     /// Because native mode uses `push_mode: "auto"`, Fordefi has already broadcast
     /// the transaction on-chain by the time this returns. Re-sending it would be
@@ -1785,16 +1801,21 @@ mod tests {
         rewritten
     }
 
-    fn compute_budget_instruction() -> Instruction {
+    fn compute_budget_instruction_with_opcode(opcode: u8) -> Instruction {
         Instruction {
             program_id: Pubkey::from_str(COMPUTE_BUDGET_PROGRAM_ID).unwrap(),
             accounts: vec![],
             data: {
-                let mut data = vec![3];
+                let mut data = vec![opcode];
                 data.extend_from_slice(&5_000u64.to_le_bytes());
                 data
             },
         }
+    }
+
+    /// SetComputeUnitPrice, the fee rewrite Fordefi performs.
+    fn compute_budget_instruction() -> Instruction {
+        compute_budget_instruction_with_opcode(3)
     }
 
     #[test]
@@ -1828,6 +1849,52 @@ mod tests {
             assert_only_blockhash_and_fee_rewrites(&tx.message, &returned.message).is_ok(),
             "Fordefi-added priority fee instructions must be accepted"
         );
+    }
+
+    /// Fordefi only sets fees for requests carrying no ComputeBudget
+    /// instructions, so an addition alongside caller-supplied compute controls
+    /// is a substitution.
+    #[test]
+    fn test_fordefi_native_rejects_added_fees_when_request_had_compute_budget() {
+        let pubkey = Pubkey::new_unique();
+        let recipient = Pubkey::new_unique();
+        let transfer = create_transfer_instruction(&pubkey, &recipient, 1_000_000);
+
+        let tx = Transaction::new_unsigned(Message::new(
+            &[compute_budget_instruction(), transfer.clone()],
+            Some(&pubkey),
+        ));
+        let returned = Transaction::new_unsigned(Message::new(
+            &[
+                compute_budget_instruction(),
+                compute_budget_instruction_with_opcode(3),
+                transfer,
+            ],
+            Some(&pubkey),
+        ));
+
+        let result = assert_only_blockhash_and_fee_rewrites(&tx.message, &returned.message);
+        assert!(matches!(result.unwrap_err(), SignerError::SigningFailed(_)));
+    }
+
+    /// Only SetComputeUnitLimit and SetComputeUnitPrice are fee-setting; a
+    /// RequestHeapFrame addition is not something Fordefi does.
+    #[test]
+    fn test_fordefi_native_rejects_non_fee_compute_budget_addition() {
+        let pubkey = Pubkey::new_unique();
+        let recipient = Pubkey::new_unique();
+        let tx = create_test_transaction_with_recipient(&pubkey, &recipient);
+
+        let returned = Transaction::new_unsigned(Message::new(
+            &[
+                compute_budget_instruction_with_opcode(1),
+                create_transfer_instruction(&pubkey, &recipient, 1_000_000),
+            ],
+            Some(&pubkey),
+        ));
+
+        let result = assert_only_blockhash_and_fee_rewrites(&tx.message, &returned.message);
+        assert!(matches!(result.unwrap_err(), SignerError::SigningFailed(_)));
     }
 
     #[test]

--- a/rust/src/test_util.rs
+++ b/rust/src/test_util.rs
@@ -2,7 +2,7 @@ use std::str::FromStr;
 
 use crate::sdk_adapter::{AccountMeta, Hash, Instruction, Message, Pubkey, Transaction};
 
-fn create_transfer_instruction(from: &Pubkey, to: &Pubkey, lamports: u64) -> Instruction {
+pub fn create_transfer_instruction(from: &Pubkey, to: &Pubkey, lamports: u64) -> Instruction {
     Instruction {
         program_id: Pubkey::from_str("11111111111111111111111111111111").unwrap(),
         accounts: vec![AccountMeta::new(*from, true), AccountMeta::new(*to, false)],

--- a/typescript/packages/fordefi/package.json
+++ b/typescript/packages/fordefi/package.json
@@ -48,6 +48,7 @@
         "@solana/codecs-strings": ">=6.0.1",
         "@solana/keys": ">=6.0.1",
         "@solana/signers": ">=6.0.1",
+        "@solana/transaction-messages": ">=6.0.1",
         "@solana/transactions": ">=6.0.1"
     },
     "publishConfig": {
@@ -56,9 +57,11 @@
     "devDependencies": {
         "@solana/addresses": "^7.0.0",
         "@solana/codecs-strings": "^7.0.0",
+        "@solana/instructions": "^7.0.0",
         "@solana/keychain-test-utils": "workspace:*",
         "@solana/keys": "^7.0.0",
         "@solana/signers": "^7.0.0",
+        "@solana/transaction-messages": "^7.0.0",
         "@solana/transactions": "^7.0.0",
         "dotenv": "^17.4.2"
     }

--- a/typescript/packages/fordefi/src/__tests__/fordefi-signer.test.ts
+++ b/typescript/packages/fordefi/src/__tests__/fordefi-signer.test.ts
@@ -2,8 +2,18 @@ import { generateKeyPairSync } from 'node:crypto';
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { type Address } from '@solana/addresses';
+import { AccountRole, type Instruction } from '@solana/instructions';
 import { assertIsSolanaSigner, assertSignatureValid, extractSignatureFromWireTransaction } from '@solana/keychain-core';
 import { isTransactionSendingSigner } from '@solana/signers';
+import {
+    appendTransactionMessageInstruction,
+    compileTransactionMessage,
+    createTransactionMessage,
+    getCompiledTransactionMessageEncoder,
+    setTransactionMessageFeePayer,
+    setTransactionMessageLifetimeUsingBlockhash,
+} from '@solana/transaction-messages';
 
 vi.mock('@solana/keychain-core', async importOriginal => {
     const mod = await importOriginal<typeof import('@solana/keychain-core')>();
@@ -67,6 +77,59 @@ function mockPollResponse(state: string, sigBase64?: string, rawTransaction?: st
         body.raw_transaction = rawTransaction;
     }
     return new Response(JSON.stringify(body), { status: 200 });
+}
+
+const COMPUTE_BUDGET_PROGRAM_ADDRESS = 'ComputeBudget111111111111111111111111111111' as Address;
+const RECIPIENT_ADDRESS = 'SysvarC1ock11111111111111111111111111111111' as Address;
+const OTHER_RECIPIENT_ADDRESS = 'SysvarRent111111111111111111111111111111111' as Address;
+type TestBlockhash = Parameters<typeof setTransactionMessageLifetimeUsingBlockhash>[0]['blockhash'];
+const MOCK_BLOCKHASH = '11111111111111111111111111111111' as TestBlockhash;
+const FRESH_BLOCKHASH = 'GHtXQBsoZHVnNFa9YevAzFr17DJjgHXk3ycTKD5xD3Zi' as TestBlockhash;
+
+/** A System-transfer-shaped instruction: one writable-signer payer, one writable recipient. */
+function transferInstruction(recipient: Address, lamports: number): Instruction {
+    return {
+        accounts: [
+            { address: MOCK_ADDRESS as Address, role: AccountRole.WRITABLE_SIGNER },
+            { address: recipient, role: AccountRole.WRITABLE },
+        ],
+        data: new Uint8Array([2, 0, 0, 0, lamports, 0, 0, 0, 0, 0, 0, 0]),
+        programAddress: '11111111111111111111111111111112' as Address,
+    };
+}
+
+function setComputeUnitPriceInstruction(): Instruction {
+    return {
+        data: new Uint8Array([3, 136, 19, 0, 0, 0, 0, 0, 0]),
+        programAddress: COMPUTE_BUDGET_PROGRAM_ADDRESS,
+    };
+}
+
+/** Compile a real legacy transaction message and return its wire message bytes. */
+function compiledMessageBytes(
+    instructions: readonly Instruction[],
+    blockhash: TestBlockhash = MOCK_BLOCKHASH,
+    feePayer: Address = MOCK_ADDRESS as Address,
+): Uint8Array<ArrayBuffer> {
+    const message = instructions.reduce(
+        (acc, instruction) => appendTransactionMessageInstruction(instruction, acc),
+        setTransactionMessageLifetimeUsingBlockhash(
+            { blockhash, lastValidBlockHeight: 100n },
+            setTransactionMessageFeePayer(feePayer, createTransactionMessage({ version: 'legacy' })),
+        ) as Parameters<typeof appendTransactionMessageInstruction>[1],
+    );
+    const encoded = getCompiledTransactionMessageEncoder().encode(compileTransactionMessage(message as never));
+    const bytes = new Uint8Array(encoded.length);
+    bytes.set(encoded);
+    return bytes;
+}
+
+/** A submitted transaction carrying a single transfer, as the caller would build it. */
+function mockNativeTransaction(recipient: Address = RECIPIENT_ADDRESS, lamports = 1_000_000): never {
+    return {
+        messageBytes: compiledMessageBytes([transferInstruction(recipient, lamports)]),
+        signatures: { [MOCK_ADDRESS]: null },
+    } as never;
 }
 
 /** Build a fake base64 wire transaction (1-byte sig count + 64-byte sig + message). */
@@ -459,7 +522,11 @@ describe('FordefiSigner', () => {
 
     describe('signAndSendTransactions (native solana mode)', () => {
         it('should expose a TransactionSendingSigner and return the broadcast transaction signature', async () => {
-            const returnedMessage = new Uint8Array(32).fill(0xcd);
+            // Fordefi's own rewrite: same instruction, freshly stamped blockhash.
+            const returnedMessage = compiledMessageBytes(
+                [transferInstruction(RECIPIENT_ADDRESS, 1_000_000)],
+                FRESH_BLOCKHASH,
+            );
             const wireTx = mockWireTransaction(returnedMessage);
             vi.mocked(fetch)
                 .mockResolvedValueOnce(mockVaultResponse())
@@ -473,10 +540,7 @@ describe('FordefiSigner', () => {
                 ),
             ).toBe(true);
 
-            const mockTx = {
-                messageBytes: new Uint8Array(32),
-                signatures: { [MOCK_ADDRESS]: null },
-            } as never;
+            const mockTx = mockNativeTransaction();
             const results = await signer.signAndSendTransactions([mockTx]);
             expect(results).toHaveLength(1);
             expect(results[0]).toEqual(MOCK_SIGNATURE_BYTES);
@@ -541,7 +605,9 @@ describe('FordefiSigner', () => {
         });
 
         it('should poll through intermediate pushable states', async () => {
-            const wireTx = mockWireTransaction();
+            const wireTx = mockWireTransaction(
+                compiledMessageBytes([transferInstruction(RECIPIENT_ADDRESS, 1_000_000)], FRESH_BLOCKHASH),
+            );
             vi.mocked(fetch)
                 .mockResolvedValueOnce(mockVaultResponse())
                 .mockResolvedValueOnce(mockCreateTxResponse('tx-push'))
@@ -550,13 +616,98 @@ describe('FordefiSigner', () => {
                 .mockResolvedValueOnce(mockPollResponse('completed', MOCK_SIGNATURE_BASE64, wireTx));
 
             const signer = await FordefiSigner.create({ ...nativeConfig, pollIntervalMs: 1 });
-            const mockTx = {
-                messageBytes: new Uint8Array(32),
-                signatures: { [MOCK_ADDRESS]: null },
-            } as never;
-            const results = await signer.signAndSendTransactions([mockTx]);
+            const results = await signer.signAndSendTransactions([mockNativeTransaction()]);
             expect(results).toHaveLength(1);
             expect(fetch).toHaveBeenCalledTimes(5);
+        });
+
+        /**
+         * Fordefi sets the priority fee itself when the submitted message carries no
+         * ComputeBudget instructions, so those additions must not be rejected.
+         */
+        it('should accept a returned transaction with added ComputeBudget instructions', async () => {
+            const wireTx = mockWireTransaction(
+                compiledMessageBytes(
+                    [setComputeUnitPriceInstruction(), transferInstruction(RECIPIENT_ADDRESS, 1_000_000)],
+                    FRESH_BLOCKHASH,
+                ),
+            );
+            vi.mocked(fetch)
+                .mockResolvedValueOnce(mockVaultResponse())
+                .mockResolvedValueOnce(mockCreateTxResponse('tx-fee'))
+                .mockResolvedValueOnce(mockPollResponse('completed', MOCK_SIGNATURE_BASE64, wireTx));
+
+            const signer = await FordefiSigner.create(nativeConfig);
+            const results = await signer.signAndSendTransactions([mockNativeTransaction()]);
+            expect(results).toHaveLength(1);
+        });
+
+        /**
+         * A different transaction signed by the same vault must not be reported as a
+         * successful signing of the submitted one.
+         */
+        it('should reject a returned transaction with a substituted recipient', async () => {
+            const wireTx = mockWireTransaction(
+                compiledMessageBytes([transferInstruction(OTHER_RECIPIENT_ADDRESS, 1_000_000)], FRESH_BLOCKHASH),
+            );
+            vi.mocked(fetch)
+                .mockResolvedValueOnce(mockVaultResponse())
+                .mockResolvedValueOnce(mockCreateTxResponse('tx-swap'))
+                .mockResolvedValueOnce(mockPollResponse('completed', MOCK_SIGNATURE_BASE64, wireTx));
+
+            const signer = await FordefiSigner.create(nativeConfig);
+            await expect(signer.signAndSendTransactions([mockNativeTransaction()])).rejects.toMatchObject({
+                code: 'SIGNER_SIGNING_FAILED',
+            });
+        });
+
+        it('should reject a returned transaction with a changed lamport amount', async () => {
+            const wireTx = mockWireTransaction(
+                compiledMessageBytes([transferInstruction(RECIPIENT_ADDRESS, 250)], FRESH_BLOCKHASH),
+            );
+            vi.mocked(fetch)
+                .mockResolvedValueOnce(mockVaultResponse())
+                .mockResolvedValueOnce(mockCreateTxResponse('tx-amount'))
+                .mockResolvedValueOnce(mockPollResponse('completed', MOCK_SIGNATURE_BASE64, wireTx));
+
+            const signer = await FordefiSigner.create(nativeConfig);
+            await expect(signer.signAndSendTransactions([mockNativeTransaction()])).rejects.toMatchObject({
+                code: 'SIGNER_SIGNING_FAILED',
+            });
+        });
+
+        it('should reject a returned transaction that dropped the submitted instruction', async () => {
+            const wireTx = mockWireTransaction(
+                compiledMessageBytes([setComputeUnitPriceInstruction()], FRESH_BLOCKHASH),
+            );
+            vi.mocked(fetch)
+                .mockResolvedValueOnce(mockVaultResponse())
+                .mockResolvedValueOnce(mockCreateTxResponse('tx-dropped'))
+                .mockResolvedValueOnce(mockPollResponse('completed', MOCK_SIGNATURE_BASE64, wireTx));
+
+            const signer = await FordefiSigner.create(nativeConfig);
+            await expect(signer.signAndSendTransactions([mockNativeTransaction()])).rejects.toMatchObject({
+                code: 'SIGNER_SIGNING_FAILED',
+            });
+        });
+
+        it('should reject a returned transaction with a different fee payer', async () => {
+            const wireTx = mockWireTransaction(
+                compiledMessageBytes(
+                    [transferInstruction(RECIPIENT_ADDRESS, 1_000_000)],
+                    FRESH_BLOCKHASH,
+                    OTHER_RECIPIENT_ADDRESS,
+                ),
+            );
+            vi.mocked(fetch)
+                .mockResolvedValueOnce(mockVaultResponse())
+                .mockResolvedValueOnce(mockCreateTxResponse('tx-payer'))
+                .mockResolvedValueOnce(mockPollResponse('completed', MOCK_SIGNATURE_BASE64, wireTx));
+
+            const signer = await FordefiSigner.create(nativeConfig);
+            await expect(signer.signAndSendTransactions([mockNativeTransaction()])).rejects.toMatchObject({
+                code: 'SIGNER_SIGNING_FAILED',
+            });
         });
 
         it('should throw when raw_transaction is missing from response', async () => {

--- a/typescript/packages/fordefi/src/__tests__/fordefi-signer.test.ts
+++ b/typescript/packages/fordefi/src/__tests__/fordefi-signer.test.ts
@@ -82,6 +82,7 @@ function mockPollResponse(state: string, sigBase64?: string, rawTransaction?: st
 const COMPUTE_BUDGET_PROGRAM_ADDRESS = 'ComputeBudget111111111111111111111111111111' as Address;
 const RECIPIENT_ADDRESS = 'SysvarC1ock11111111111111111111111111111111' as Address;
 const OTHER_RECIPIENT_ADDRESS = 'SysvarRent111111111111111111111111111111111' as Address;
+const LOOKUP_TABLE_ADDRESS = 'SysvarS1otHashes111111111111111111111111111' as Address;
 type TestBlockhash = Parameters<typeof setTransactionMessageLifetimeUsingBlockhash>[0]['blockhash'];
 const MOCK_BLOCKHASH = '11111111111111111111111111111111' as TestBlockhash;
 const FRESH_BLOCKHASH = 'GHtXQBsoZHVnNFa9YevAzFr17DJjgHXk3ycTKD5xD3Zi' as TestBlockhash;
@@ -126,6 +127,41 @@ function compiledMessageBytes(
         ) as Parameters<typeof appendTransactionMessageInstruction>[1],
     );
     const encoded = getCompiledTransactionMessageEncoder().encode(compileTransactionMessage(message as never));
+    const bytes = new Uint8Array(encoded.length);
+    bytes.set(encoded);
+    return bytes;
+}
+
+/**
+ * A v0 message that sources an account from an address lookup table, which is the
+ * one shape the static-account comparison cannot resolve.
+ */
+function compiledV0MessageBytesWithLookupTable(): Uint8Array<ArrayBuffer> {
+    const compiled = {
+        addressTableLookups: [
+            {
+                lookupTableAddress: LOOKUP_TABLE_ADDRESS,
+                readonlyIndexes: [],
+                writableIndexes: [1],
+            },
+        ],
+        header: {
+            numReadonlyNonSignerAccounts: 1,
+            numReadonlySignerAccounts: 0,
+            numSignerAccounts: 1,
+        },
+        instructions: [
+            {
+                accountIndices: [0, 2],
+                data: new Uint8Array([2, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0]),
+                programAddressIndex: 1,
+            },
+        ],
+        lifetimeToken: FRESH_BLOCKHASH,
+        staticAccounts: [MOCK_ADDRESS as Address, '11111111111111111111111111111112' as Address],
+        version: 0,
+    };
+    const encoded = getCompiledTransactionMessageEncoder().encode(compiled as never);
     const bytes = new Uint8Array(encoded.length);
     bytes.set(encoded);
     return bytes;
@@ -708,6 +744,29 @@ describe('FordefiSigner', () => {
          * A different transaction signed by the same vault must not be reported as a
          * successful signing of the submitted one.
          */
+        /**
+         * The intent comparison resolves account indices against `staticAccounts`, so
+         * an address sourced from a lookup table is not resolvable. It must say so
+         * clearly rather than failing as a malformed-transaction error.
+         */
+        it('should reject an address-lookup-table transaction with a clear error', async () => {
+            const submitted = {
+                messageBytes: compiledV0MessageBytesWithLookupTable(),
+                signatures: { [MOCK_ADDRESS]: null },
+            } as never;
+            const wireTx = mockWireTransaction(compiledV0MessageBytesWithLookupTable());
+            vi.mocked(fetch)
+                .mockResolvedValueOnce(mockVaultResponse())
+                .mockResolvedValueOnce(mockCreateTxResponse('tx-alt'))
+                .mockResolvedValueOnce(mockPollResponse('completed', MOCK_SIGNATURE_BASE64, wireTx));
+
+            const signer = await FordefiSigner.create(nativeConfig);
+            await expect(signer.signAndSendTransactions([submitted])).rejects.toMatchObject({
+                code: 'SIGNER_SIGNING_FAILED',
+                message: expect.stringContaining('address lookup table'),
+            });
+        });
+
         it('should reject a returned transaction with a substituted recipient', async () => {
             const wireTx = mockWireTransaction(
                 compiledMessageBytes([transferInstruction(OTHER_RECIPIENT_ADDRESS, 1_000_000)], FRESH_BLOCKHASH),

--- a/typescript/packages/fordefi/src/__tests__/fordefi-signer.test.ts
+++ b/typescript/packages/fordefi/src/__tests__/fordefi-signer.test.ts
@@ -98,11 +98,18 @@ function transferInstruction(recipient: Address, lamports: number): Instruction 
     };
 }
 
-function setComputeUnitPriceInstruction(): Instruction {
-    return {
-        data: new Uint8Array([3, 136, 19, 0, 0, 0, 0, 0, 0]),
-        programAddress: COMPUTE_BUDGET_PROGRAM_ADDRESS,
-    };
+function setComputeUnitPriceInstruction(microLamports = 5000): Instruction {
+    const data = new Uint8Array(9);
+    data[0] = 3;
+    new DataView(data.buffer).setBigUint64(1, BigInt(microLamports), true);
+    return { data, programAddress: COMPUTE_BUDGET_PROGRAM_ADDRESS };
+}
+
+function requestHeapFrameInstruction(): Instruction {
+    const data = new Uint8Array(5);
+    data[0] = 1;
+    new DataView(data.buffer).setUint32(1, 256 * 1024, true);
+    return { data, programAddress: COMPUTE_BUDGET_PROGRAM_ADDRESS };
 }
 
 /** Compile a real legacy transaction message and return its wire message bytes. */
@@ -640,6 +647,61 @@ describe('FordefiSigner', () => {
             const signer = await FordefiSigner.create(nativeConfig);
             const results = await signer.signAndSendTransactions([mockNativeTransaction()]);
             expect(results).toHaveLength(1);
+        });
+
+        /**
+         * Fordefi only sets fees for requests carrying no ComputeBudget instructions,
+         * so an addition alongside caller-supplied compute controls is a substitution.
+         */
+        it('should reject added fee instructions when the request already had ComputeBudget', async () => {
+            const submitted = {
+                messageBytes: compiledMessageBytes([
+                    setComputeUnitPriceInstruction(10),
+                    transferInstruction(RECIPIENT_ADDRESS, 1_000_000),
+                ]),
+                signatures: { [MOCK_ADDRESS]: null },
+            } as never;
+            const wireTx = mockWireTransaction(
+                compiledMessageBytes(
+                    [
+                        setComputeUnitPriceInstruction(10),
+                        setComputeUnitPriceInstruction(10_000_000),
+                        transferInstruction(RECIPIENT_ADDRESS, 1_000_000),
+                    ],
+                    FRESH_BLOCKHASH,
+                ),
+            );
+            vi.mocked(fetch)
+                .mockResolvedValueOnce(mockVaultResponse())
+                .mockResolvedValueOnce(mockCreateTxResponse('tx-double-fee'))
+                .mockResolvedValueOnce(mockPollResponse('completed', MOCK_SIGNATURE_BASE64, wireTx));
+
+            const signer = await FordefiSigner.create(nativeConfig);
+            await expect(signer.signAndSendTransactions([submitted])).rejects.toMatchObject({
+                code: 'SIGNER_SIGNING_FAILED',
+            });
+        });
+
+        /**
+         * Only SetComputeUnitLimit and SetComputeUnitPrice are fee-setting; a
+         * RequestHeapFrame addition is not something Fordefi does.
+         */
+        it('should reject a non-fee ComputeBudget addition', async () => {
+            const wireTx = mockWireTransaction(
+                compiledMessageBytes(
+                    [requestHeapFrameInstruction(), transferInstruction(RECIPIENT_ADDRESS, 1_000_000)],
+                    FRESH_BLOCKHASH,
+                ),
+            );
+            vi.mocked(fetch)
+                .mockResolvedValueOnce(mockVaultResponse())
+                .mockResolvedValueOnce(mockCreateTxResponse('tx-heap'))
+                .mockResolvedValueOnce(mockPollResponse('completed', MOCK_SIGNATURE_BASE64, wireTx));
+
+            const signer = await FordefiSigner.create(nativeConfig);
+            await expect(signer.signAndSendTransactions([mockNativeTransaction()])).rejects.toMatchObject({
+                code: 'SIGNER_SIGNING_FAILED',
+            });
         });
 
         /**

--- a/typescript/packages/fordefi/src/fordefi-signer.ts
+++ b/typescript/packages/fordefi/src/fordefi-signer.ts
@@ -65,6 +65,8 @@ const FAILURE_STATES = new Set([
 
 /** The only program Fordefi may add instructions for: it sets the priority fee. */
 const COMPUTE_BUDGET_PROGRAM_ADDRESS = 'ComputeBudget111111111111111111111111111111' as Address;
+/** SetComputeUnitLimit and SetComputeUnitPrice, the fee rewrites Fordefi performs. */
+const FEE_SETTING_COMPUTE_BUDGET_OPCODES = new Set([2, 3]);
 
 /** Legacy and v0 compiled messages; v1 stores instructions in a different shape. */
 type CompiledMessageWithInstructions = Extract<CompiledTransactionMessage, { instructions: readonly unknown[] }>;
@@ -83,7 +85,17 @@ function assertHasInstructions(message: CompiledTransactionMessage): CompiledMes
  * so two compiled messages stay comparable even when they order or extend
  * `staticAccounts` differently.
  */
-function resolveInstructions(message: CompiledMessageWithInstructions): { key: string; programAddress: Address }[] {
+type ResolvedInstruction = { key: string; opcode: number | undefined; programAddress: Address };
+
+function isFeeSettingInstruction(instruction: ResolvedInstruction): boolean {
+    return (
+        instruction.programAddress === COMPUTE_BUDGET_PROGRAM_ADDRESS &&
+        instruction.opcode !== undefined &&
+        FEE_SETTING_COMPUTE_BUDGET_OPCODES.has(instruction.opcode)
+    );
+}
+
+function resolveInstructions(message: CompiledMessageWithInstructions): ResolvedInstruction[] {
     const accounts = message.staticAccounts;
     const { numReadonlyNonSignerAccounts, numReadonlySignerAccounts, numSignerAccounts } = message.header;
     const writableSignerEnd = numSignerAccounts - numReadonlySignerAccounts;
@@ -106,17 +118,22 @@ function resolveInstructions(message: CompiledMessageWithInstructions): { key: s
             return `${addressAt(index)}:${index < numSignerAccounts}:${isWritable}`;
         });
         const programAddress = addressAt(instruction.programAddressIndex);
-        const data = Array.from(instruction.data ?? []).join(',');
-        return { key: `${programAddress}|${metas.join(',')}|${data}`, programAddress };
+        const dataBytes = Array.from(instruction.data ?? []);
+        return {
+            key: `${programAddress}|${metas.join(',')}|${dataBytes.join(',')}`,
+            opcode: dataBytes[0],
+            programAddress,
+        };
     });
 }
 
 /**
  * Rejects a Fordefi-returned message that changes more than Fordefi may change.
  *
- * Fordefi overwrites the recent blockhash immediately before signing, and adds
- * ComputeBudget instructions to set the priority fee when the submitted message
- * carries none. Everything else — the signer set, the fee payer, and every
+ * Fordefi overwrites the recent blockhash immediately before signing, and sets
+ * the priority fee (SetComputeUnitLimit / SetComputeUnitPrice) only when the
+ * submitted message carries no ComputeBudget instructions of its own.
+ * Everything else — the signer set, the fee payer, and every
  * submitted instruction — must survive verbatim, so a substituted transaction
  * cannot be reported as a successful signing result.
  */
@@ -138,11 +155,14 @@ function assertOnlyBlockhashAndFeeRewrites(requestedBytes: TransactionMessageByt
     }
 
     const submitted = resolveInstructions(requested);
+    const fordefiMayAddFees = submitted.every(
+        instruction => instruction.programAddress !== COMPUTE_BUDGET_PROGRAM_ADDRESS,
+    );
     let matched = 0;
     for (const instruction of resolveInstructions(returned)) {
         if (matched < submitted.length && instruction.key === submitted[matched]!.key) {
             matched++;
-        } else if (instruction.programAddress !== COMPUTE_BUDGET_PROGRAM_ADDRESS) {
+        } else if (!(fordefiMayAddFees && isFeeSettingInstruction(instruction))) {
             throwSignerError(SignerErrorCode.SIGNING_FAILED, {
                 message: 'Fordefi returned a transaction with instructions that do not match the submitted message',
             });
@@ -565,7 +585,8 @@ export class FordefiSigner<TAddress extends string = string> implements SolanaSi
      * dictionary to be applied to the caller's original message.
      *
      * The returned transaction is checked against the submitted one: a fresh
-     * blockhash and added ComputeBudget instructions are accepted, any other
+     * blockhash is accepted, as are added fee-setting ComputeBudget
+     * instructions when the submitted message carried none. Any other
      * difference rejects with `SIGNER_SIGNING_FAILED`.
      */
     private async signAndSendNativeTransactions(

--- a/typescript/packages/fordefi/src/fordefi-signer.ts
+++ b/typescript/packages/fordefi/src/fordefi-signer.ts
@@ -71,10 +71,21 @@ const FEE_SETTING_COMPUTE_BUDGET_OPCODES = new Set([2, 3]);
 /** Legacy and v0 compiled messages; v1 stores instructions in a different shape. */
 type CompiledMessageWithInstructions = Extract<CompiledTransactionMessage, { instructions: readonly unknown[] }>;
 
-function assertHasInstructions(message: CompiledTransactionMessage): CompiledMessageWithInstructions {
+function assertComparableMessage(message: CompiledTransactionMessage): CompiledMessageWithInstructions {
     if (!('instructions' in message)) {
         return throwSignerError(SignerErrorCode.SIGNING_FAILED, {
             message: 'Fordefi native mode supports only legacy and v0 transaction messages',
+        });
+    }
+    // Account indices are resolved against `staticAccounts` to compare intent, and
+    // an address sourced from a lookup table is not in there. Resolving such an
+    // index positionally without also comparing the lookup tables would reopen the
+    // substitution gap this comparison exists to close, so refuse instead. The
+    // other three languages support only legacy transactions in native mode.
+    if ('addressTableLookups' in message && (message.addressTableLookups?.length ?? 0) > 0) {
+        return throwSignerError(SignerErrorCode.SIGNING_FAILED, {
+            message:
+                'Fordefi native mode cannot verify a transaction that sources accounts from an address lookup table; submit a transaction with only static accounts',
         });
     }
     return message;
@@ -139,8 +150,8 @@ function resolveInstructions(message: CompiledMessageWithInstructions): Resolved
  */
 function assertOnlyBlockhashAndFeeRewrites(requestedBytes: TransactionMessageBytes, returnedBytes: Uint8Array): void {
     const decoder = getCompiledTransactionMessageDecoder();
-    const requested = assertHasInstructions(decoder.decode(requestedBytes));
-    const returned = assertHasInstructions(decoder.decode(returnedBytes));
+    const requested = assertComparableMessage(decoder.decode(requestedBytes));
+    const returned = assertComparableMessage(decoder.decode(returnedBytes));
 
     const requestedSigners = requested.staticAccounts.slice(0, requested.header.numSignerAccounts);
     const returnedSigners = returned.staticAccounts.slice(0, returned.header.numSignerAccounts);

--- a/typescript/packages/fordefi/src/fordefi-signer.ts
+++ b/typescript/packages/fordefi/src/fordefi-signer.ts
@@ -22,9 +22,11 @@ import {
     TransactionSendingSigner,
     TransactionSendingSignerConfig,
 } from '@solana/signers';
+import { type CompiledTransactionMessage, getCompiledTransactionMessageDecoder } from '@solana/transaction-messages';
 import {
     Base64EncodedWireTransaction,
     Transaction,
+    type TransactionMessageBytes,
     TransactionWithinSizeLimit,
     TransactionWithLifetime,
 } from '@solana/transactions';
@@ -60,6 +62,98 @@ const FAILURE_STATES = new Set([
     'insufficient_funds',
     'mined_reverted',
 ]);
+
+/** The only program Fordefi may add instructions for: it sets the priority fee. */
+const COMPUTE_BUDGET_PROGRAM_ADDRESS = 'ComputeBudget111111111111111111111111111111' as Address;
+
+/** Legacy and v0 compiled messages; v1 stores instructions in a different shape. */
+type CompiledMessageWithInstructions = Extract<CompiledTransactionMessage, { instructions: readonly unknown[] }>;
+
+function assertHasInstructions(message: CompiledTransactionMessage): CompiledMessageWithInstructions {
+    if (!('instructions' in message)) {
+        return throwSignerError(SignerErrorCode.SIGNING_FAILED, {
+            message: 'Fordefi native mode supports only legacy and v0 transaction messages',
+        });
+    }
+    return message;
+}
+
+/**
+ * An instruction keyed by its resolved program address, account metas, and data,
+ * so two compiled messages stay comparable even when they order or extend
+ * `staticAccounts` differently.
+ */
+function resolveInstructions(message: CompiledMessageWithInstructions): { key: string; programAddress: Address }[] {
+    const accounts = message.staticAccounts;
+    const { numReadonlyNonSignerAccounts, numReadonlySignerAccounts, numSignerAccounts } = message.header;
+    const writableSignerEnd = numSignerAccounts - numReadonlySignerAccounts;
+    const writableNonSignerEnd = accounts.length - numReadonlyNonSignerAccounts;
+
+    const addressAt = (index: number): Address => {
+        const address = accounts[index];
+        if (address === undefined) {
+            return throwSignerError(SignerErrorCode.SERIALIZATION_ERROR, {
+                message: 'Transaction references an account index outside its account list',
+            });
+        }
+        return address;
+    };
+
+    return message.instructions.map(instruction => {
+        const metas = (instruction.accountIndices ?? []).map(index => {
+            const isWritable =
+                index < writableSignerEnd || (index >= numSignerAccounts && index < writableNonSignerEnd);
+            return `${addressAt(index)}:${index < numSignerAccounts}:${isWritable}`;
+        });
+        const programAddress = addressAt(instruction.programAddressIndex);
+        const data = Array.from(instruction.data ?? []).join(',');
+        return { key: `${programAddress}|${metas.join(',')}|${data}`, programAddress };
+    });
+}
+
+/**
+ * Rejects a Fordefi-returned message that changes more than Fordefi may change.
+ *
+ * Fordefi overwrites the recent blockhash immediately before signing, and adds
+ * ComputeBudget instructions to set the priority fee when the submitted message
+ * carries none. Everything else — the signer set, the fee payer, and every
+ * submitted instruction — must survive verbatim, so a substituted transaction
+ * cannot be reported as a successful signing result.
+ */
+function assertOnlyBlockhashAndFeeRewrites(requestedBytes: TransactionMessageBytes, returnedBytes: Uint8Array): void {
+    const decoder = getCompiledTransactionMessageDecoder();
+    const requested = assertHasInstructions(decoder.decode(requestedBytes));
+    const returned = assertHasInstructions(decoder.decode(returnedBytes));
+
+    const requestedSigners = requested.staticAccounts.slice(0, requested.header.numSignerAccounts);
+    const returnedSigners = returned.staticAccounts.slice(0, returned.header.numSignerAccounts);
+    if (
+        requested.version !== returned.version ||
+        requestedSigners.length !== returnedSigners.length ||
+        requestedSigners.some((address, index) => address !== returnedSigners[index])
+    ) {
+        throwSignerError(SignerErrorCode.SIGNING_FAILED, {
+            message: 'Fordefi returned a transaction with a different signer set',
+        });
+    }
+
+    const submitted = resolveInstructions(requested);
+    let matched = 0;
+    for (const instruction of resolveInstructions(returned)) {
+        if (matched < submitted.length && instruction.key === submitted[matched]!.key) {
+            matched++;
+        } else if (instruction.programAddress !== COMPUTE_BUDGET_PROGRAM_ADDRESS) {
+            throwSignerError(SignerErrorCode.SIGNING_FAILED, {
+                message: 'Fordefi returned a transaction with instructions that do not match the submitted message',
+            });
+        }
+    }
+    if (matched !== submitted.length) {
+        throwSignerError(SignerErrorCode.SIGNING_FAILED, {
+            message: 'Fordefi returned a transaction missing submitted instructions',
+        });
+    }
+}
 
 /**
  * Signs Fordefi API-request payloads for the `x-signature` header.
@@ -469,6 +563,10 @@ export class FordefiSigner<TAddress extends string = string> implements SolanaSi
      * returned transaction itself. The result is therefore the on-chain
      * transaction identifier (the first wire signature), not a signature
      * dictionary to be applied to the caller's original message.
+     *
+     * The returned transaction is checked against the submitted one: a fresh
+     * blockhash and added ComputeBudget instructions are accepted, any other
+     * difference rejects with `SIGNER_SIGNING_FAILED`.
      */
     private async signAndSendNativeTransactions(
         transactions: readonly (Transaction | (Transaction & TransactionWithLifetime))[],
@@ -516,6 +614,7 @@ export class FordefiSigner<TAddress extends string = string> implements SolanaSi
                     signature: signerSignature,
                     signerAddress: this.address,
                 });
+                assertOnlyBlockhashAndFeeRewrites(transaction.messageBytes, messageBytes);
                 config?.abortSignal?.throwIfAborted();
                 return transactionSignature;
             },

--- a/typescript/packages/keychain/package.json
+++ b/typescript/packages/keychain/package.json
@@ -70,6 +70,7 @@
         "@solana/codecs-strings": ">=6.0.1",
         "@solana/keys": ">=6.0.1",
         "@solana/signers": ">=6.0.1",
+        "@solana/transaction-messages": ">=6.0.1",
         "@solana/transactions": ">=6.0.1"
     },
     "publishConfig": {

--- a/typescript/pnpm-lock.yaml
+++ b/typescript/pnpm-lock.yaml
@@ -280,6 +280,9 @@ importers:
       '@solana/codecs-strings':
         specifier: ^7.0.0
         version: 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/instructions':
+        specifier: ^7.0.0
+        version: 7.0.0(typescript@5.9.3)
       '@solana/keychain-test-utils':
         specifier: workspace:*
         version: link:../test-utils
@@ -287,6 +290,9 @@ importers:
         specifier: ^7.0.0
         version: 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/signers':
+        specifier: ^7.0.0
+        version: 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/transaction-messages':
         specifier: ^7.0.0
         version: 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/transactions':
@@ -392,6 +398,9 @@ importers:
       '@solana/signers':
         specifier: '>=6.0.1'
         version: 6.0.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/transaction-messages':
+        specifier: '>=6.0.1'
+        version: 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/transactions':
         specifier: '>=6.0.1'
         version: 6.0.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)


### PR DESCRIPTION
## What

Fordefi native mode (`chain` set) submits a serialized message with `push_mode: "auto"`, then accepted whatever transaction the poll response carried, as long as the vault signature verified over the **returned** bytes.

Verifying a signature against the response provides no binding to the request. Any transaction that vault ever signed verified cleanly, so a substituted or replayed transaction was reported as a successful signing of the submitted one, with `is_complete` set. Python and TypeScript return no transaction bytes in native mode, so a caller had nothing to reconcile against.

This is not a custodian-proof fix and is not meant to be: Fordefi holds the key and can sign and broadcast anything from the vault without the SDK's cooperation, and with `push_mode: "auto"` the transaction is already on-chain before the response arrives. What this closes is the fail-silent path: causes that do not involve the key at all now surface as a loud error instead of a false success. A provider-side transaction-lookup or polling ID mixup, an injected HTTP client, a TLS-terminating proxy, or a replay of an older vault-signed transaction all previously passed.

The sibling backends already do this. Utila rejects a mismatched message outright (`utila/signer.py`), and CDP verifies against the caller's message bytes (`cdp/signer.py`). Fordefi native was the outlier.

## How

Compare the returned message with the submitted one, allowing only the rewrites Fordefi documents:

- a re-stamped recent blockhash (the server sets it immediately before signing)
- added ComputeBudget instructions (the server sets the priority fee when the request carries none)

The signer set, fee payer, and every submitted instruction must survive verbatim. Instructions are compared by resolved program address, account metas (pubkey + signer + writable, derived from the header), and data, so a message that reorders or extends its account keys still compares equal. Submitted instructions must appear in order; any unmatched returned instruction must target ComputeBudget. Anything else fails with `SIGNING_FAILED`.

Applied to all four implementations for parity:

| Language | File |
| --- | --- |
| Python | `python/src/solana_keychain/fordefi/signer.py` |
| Rust | `rust/src/fordefi/mod.rs` |
| TypeScript | `typescript/packages/fordefi/src/fordefi-signer.ts` |
| Go | `go/signers/fordefi/signer.go` |

## Notable

- **TypeScript gains a dependency.** `@solana/transaction-messages` is needed to decode the two compiled messages; added as a peer + dev dep of `@solana/keychain-fordefi` and to the umbrella's peers. Already present transitively, so the lockfile change is small. v1 compiled messages store instructions in a different shape and are rejected explicitly rather than skipped.
- **`rust/src/test_util.rs`**: `create_transfer_instruction` is now `pub` so the Fordefi tests can build comparison transactions instead of duplicating the helper.
- **A pre-existing test was asserting the vulnerable behavior.** Python's `test_sign_transaction_native_success` built its mocked response from a second `create_test_transaction()` call, which picks a random recipient, and passed. It now derives the response from the request. Rust, Go, and TS built theirs from the submitted message already.

## Testing

Each language gets the same matrix: accepted (fresh blockhash, added ComputeBudget instructions) and rejected (substituted recipient, changed lamport amount, dropped instruction, extra signer / different fee payer). Every rejection test was confirmed to fail with the new check removed.

- `just py-test` — 453 passed; ruff + mypy strict clean
- `just rust-test` — 316 passed on each of `sdk-v2`, `sdk-v3`, `sdk-v4`; clippy `-D warnings` clean on all three
- `just ts-test` — all packages pass; `pnpm typecheck`, eslint, prettier clean; `just ts-treeshake` OK (15/15 factories)
- `go test -race ./...` — clean across every module