### PR TITLE
fix(crossmint): make managed-broadcast signing work and report it honestly

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,7 +42,6 @@ CROSSMINT_WALLET_LOCATOR=your-wallet-address-or-locator
 # CROSSMINT_API_BASE_URL=https://www.crossmint.com/api  # Optional, defaults to this
 # CROSSMINT_SIGNER_SECRET=xmsk1_your-64-hex-secret  # Optional, for server key signing (auto-derives signer locator)
 # CROSSMINT_SIGNER=server:your-derived-pubkey  # Optional, set explicitly if not using CROSSMINT_SIGNER_SECRET
-# TEST_CROSSMINT_SIGNER_DERIVED_PUBKEY=your-derived-pubkey  # Optional, test-only override for Crossmint signer pubkey validation
 
 # Dfns Integration Tests
 DFNS_AUTH_TOKEN=your-dfns-auth-token

--- a/go/signers/crossmint/client.go
+++ b/go/signers/crossmint/client.go
@@ -48,6 +48,15 @@ type onChainData struct {
 
 type approvalsData struct {
 	Pending []pendingApproval `json:"pending"`
+	// Submitted carries the approvals Crossmint has already collected. A rewritten
+	// transaction's wallet signature appears here rather than in a signature slot
+	// of the returned transaction.
+	Submitted []submittedApproval `json:"submitted"`
+}
+
+type submittedApproval struct {
+	Signature *string         `json:"signature"`
+	Signer    *approvalSigner `json:"signer"`
 }
 
 type pendingApproval struct {
@@ -55,9 +64,10 @@ type pendingApproval struct {
 	Signer  *approvalSigner `json:"signer"`
 }
 
-// approvalSigner identifies which approver a pending challenge is addressed to.
+// approvalSigner identifies which approver an approval belongs to.
 type approvalSigner struct {
 	Locator *string `json:"locator"`
+	Address *string `json:"address"`
 }
 
 // approvalRequest is the submit-approval request body.

--- a/go/signers/crossmint/integration_test.go
+++ b/go/signers/crossmint/integration_test.go
@@ -4,7 +4,6 @@ package crossmint
 
 import (
 	"context"
-	"encoding/base64"
 	"errors"
 	"os"
 	"strings"
@@ -15,29 +14,6 @@ import (
 	"github.com/solana-foundation/solana-keychain/go/core"
 	"github.com/solana-foundation/solana-keychain/go/testutils"
 )
-
-// resolveTestSignerPubkeyOverride handles wallets whose admin signer differs
-// from the derived server signer: the expected signing key can be pinned via
-// TEST_CROSSMINT_SIGNER_DERIVED_PUBKEY (or inferred from a "server:"
-// CROSSMINT_SIGNER locator).
-func resolveTestSignerPubkeyOverride() (solana.PublicKey, bool) {
-	resolved := strings.TrimSpace(os.Getenv("TEST_CROSSMINT_SIGNER_DERIVED_PUBKEY"))
-	if resolved == "" {
-		locator := strings.TrimSpace(os.Getenv("CROSSMINT_SIGNER"))
-		resolved = strings.TrimSpace(strings.TrimPrefix(locator, "server:"))
-		if resolved == locator {
-			resolved = ""
-		}
-	}
-	if resolved == "" {
-		return solana.PublicKey{}, false
-	}
-	pub, err := solana.PublicKeyFromBase58(resolved)
-	if err != nil {
-		return solana.PublicKey{}, false
-	}
-	return pub, true
-}
 
 // integrationSigner builds a signer against the live Crossmint API configured
 // by the environment, via `just go-test-integration` (loads .env) or CI with
@@ -53,9 +29,6 @@ func integrationSigner(t *testing.T) *Signer {
 	})
 	if err != nil {
 		t.Fatalf("failed to create crossmint signer: %v", err)
-	}
-	if pub, ok := resolveTestSignerPubkeyOverride(); ok {
-		s.publicKey = pub
 	}
 	return s
 }
@@ -84,7 +57,7 @@ func TestIntegrationSignMessageNotSupported(t *testing.T) {
 	}
 }
 
-// Signs a minimal empty-instruction transaction with a real blockhash — the
+// Signs a minimal empty-instruction transaction with a real blockhash: the
 // backend validates and finalizes the transaction server-side, so this stays
 // focused on remote signing behavior rather than balance/program execution.
 func TestIntegrationSignTransaction(t *testing.T) {
@@ -111,12 +84,19 @@ func TestIntegrationSignTransaction(t *testing.T) {
 	if err != nil {
 		t.Fatalf("SignTransaction: %v", err)
 	}
-	raw, err := base64.StdEncoding.DecodeString(res.EncodedTransaction)
-	if err != nil {
-		t.Fatalf("encoded transaction is not valid base64: %v", err)
+	if len(res.Signature) != core.SignatureLength {
+		t.Fatalf("signature length = %d, want %d", len(res.Signature), core.SignatureLength)
 	}
-	if _, err := solana.TransactionFromBytes(raw); err != nil {
-		t.Fatalf("failed to decode signed transaction: %v", err)
+	// Crossmint sponsors gas, so it rewrites the transaction, signs its own bytes
+	// and broadcasts server-side. The signature identifies what it landed and
+	// there is nothing left for the caller to send.
+	if res.EncodedTransaction != "" {
+		t.Error("a Crossmint-broadcast transaction leaves nothing for the caller to send")
+	}
+	for _, sig := range tx.Signatures {
+		if !sig.IsZero() {
+			t.Error("the caller's transaction must not carry a signature over other bytes")
+		}
 	}
 }
 

--- a/go/signers/crossmint/signer.go
+++ b/go/signers/crossmint/signer.go
@@ -187,9 +187,10 @@ func (s *Signer) SignMessage(_ context.Context, _ []byte) (solana.Signature, err
 // and verifies the wallet's signature.
 //
 // Crossmint may rewrite the transaction to sponsor gas and broadcast it itself.
-// When it does, tx is left unmodified and EncodedTransaction is empty, because the
-// signature covers Crossmint's bytes. The signature is added to tx only when
-// Crossmint signed it as given.
+// When it does, tx is left unmodified, EncodedTransaction is empty, and the
+// returned signature is the landed transaction's fee-payer identifier, usable
+// with RPC transaction lookups. The wallet's own signature is added to tx only
+// when Crossmint signed it as given.
 func (s *Signer) SignTransaction(ctx context.Context, tx *solana.Transaction) (core.SignedTransaction, error) {
 	if s.publicKey.IsZero() {
 		return core.SignedTransaction{}, core.NewSignerError(core.CodeConfigError, "signer not initialized")
@@ -387,13 +388,38 @@ func (s *Signer) signatureFromApprovals(response transactionResponse, serialized
 	return solana.Signature{}, nil, false
 }
 
+// broadcastTransactionID returns the identifier of the transaction Crossmint
+// landed: its fee-payer (slot 0) signature, the value Solana RPC addresses
+// transactions by. Under gas sponsorship the fee payer is Crossmint's sponsor
+// key, not this wallet.
+func broadcastTransactionID(tx *solana.Transaction) (solana.Signature, error) {
+	if len(tx.Message.AccountKeys) == 0 {
+		return solana.Signature{}, core.NewSignerError(core.CodeSigningFailed,
+			"Crossmint transaction has no fee payer to identify it by")
+	}
+	if len(tx.Signatures) == 0 || tx.Signatures[0].IsZero() {
+		return solana.Signature{}, core.NewSignerError(core.CodeSigningFailed,
+			"Crossmint transaction carries no fee-payer signature to identify it by")
+	}
+	message, err := tx.Message.MarshalBinary()
+	if err != nil {
+		return solana.Signature{}, core.WrapSignerError(core.CodeSerializationError,
+			"failed to serialize Crossmint transaction message", err)
+	}
+	if !core.VerifyEd25519(tx.Message.AccountKeys[0], message, tx.Signatures[0]) {
+		return solana.Signature{}, core.NewSignerError(core.CodeSigningFailed,
+			"Crossmint fee-payer signature does not verify over the executed transaction")
+	}
+	return tx.Signatures[0], nil
+}
+
 // extractSignatureFromResponse pulls this wallet's signature out of a terminal
 // transaction response, along with the broadcast transaction when Crossmint
 // rewrote one: the serialized onChain.transaction is tried first; onChain.txId is
 // only accepted if it verifies against the originally requested message bytes.
 //
-// A non-nil transaction means the signature covers Crossmint's bytes, not the
-// caller's.
+// A non-nil transaction means Crossmint landed different bytes than the caller's;
+// the signature is then the landed transaction's fee-payer identifier.
 func (s *Signer) extractSignatureFromResponse(response transactionResponse, expectedMessage []byte) (solana.Signature, *solana.Transaction, error) {
 	var embeddedErr error
 	if response.OnChain != nil {
@@ -409,11 +435,20 @@ func (s *Signer) extractSignatureFromResponse(response transactionResponse, expe
 				if bytes.Equal(returnedMessage, expectedMessage) {
 					return sig, nil, nil
 				}
-				return sig, returned, nil
+				txID, idErr := broadcastTransactionID(returned)
+				if idErr != nil {
+					return solana.Signature{}, nil, idErr
+				}
+				return txID, returned, nil
 			case true:
-				// A rewritten transaction's signature is in approvals.submitted.
-				if sig, returned, ok := s.signatureFromApprovals(response, *response.OnChain.Transaction); ok {
-					return sig, returned, nil
+				// A rewritten transaction's approval in approvals.submitted proves
+				// this wallet took part in what landed.
+				if _, returned, ok := s.signatureFromApprovals(response, *response.OnChain.Transaction); ok {
+					txID, idErr := broadcastTransactionID(returned)
+					if idErr != nil {
+						return solana.Signature{}, nil, idErr
+					}
+					return txID, returned, nil
 				}
 				if response.OnChain.TxID == nil {
 					return solana.Signature{}, nil, err

--- a/go/signers/crossmint/signer.go
+++ b/go/signers/crossmint/signer.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"slices"
 	"strings"
 	"time"
 
@@ -37,6 +38,9 @@ type Signer struct {
 	publicKey       solana.PublicKey
 	pollInterval    time.Duration
 	maxPollAttempts int
+	// delegatedPubkeys are every delegated-signer key the configuration makes
+	// known. Smart wallets sign with one of these rather than with publicKey.
+	delegatedPubkeys []solana.PublicKey
 	// signingKey is the HKDF-derived Ed25519 approval key (nil when no
 	// SignerSecret was configured).
 	signingKey ed25519.PrivateKey
@@ -125,8 +129,39 @@ func New(ctx context.Context, cfg Config) (*Signer, error) {
 		return nil, core.NewSignerError(core.CodeInvalidPublicKey, "invalid Solana public key returned by Crossmint wallet")
 	}
 	s.publicKey = pub
+	s.delegatedPubkeys = resolveDelegatedPubkeys(signingKey, signerLocator)
 
 	return s, nil
+}
+
+// resolveDelegatedPubkeys returns every delegated-signer key the configuration
+// makes known. A smart wallet signs through its delegated signer, not the wallet
+// address. Both sources are collected because a Signer locator may name a
+// different key than SignerSecret derives, and either can be the one that signs.
+func resolveDelegatedPubkeys(signingKey ed25519.PrivateKey, signerLocator string) []solana.PublicKey {
+	var candidates []solana.PublicKey
+	if signingKey != nil {
+		candidates = append(candidates, solana.PublicKeyFromBytes(signingKey.Public().(ed25519.PublicKey)))
+	}
+	if encoded, ok := strings.CutPrefix(signerLocator, "server:"); ok {
+		if pub, err := solana.PublicKeyFromBase58(strings.TrimSpace(encoded)); err == nil {
+			candidates = append(candidates, pub)
+		}
+	}
+	return candidates
+}
+
+// verificationCandidates lists the keys that may have signed: the wallet address
+// for an mpc wallet, the delegated signer for a smart wallet. The response does
+// not say which, so try both.
+func (s *Signer) verificationCandidates() []solana.PublicKey {
+	candidates := []solana.PublicKey{s.publicKey}
+	for _, delegated := range s.delegatedPubkeys {
+		if !slices.Contains(candidates, delegated) {
+			candidates = append(candidates, delegated)
+		}
+	}
+	return candidates
 }
 
 // Pubkey returns the Crossmint wallet's Solana public key.
@@ -148,8 +183,13 @@ func (s *Signer) SignMessage(_ context.Context, _ []byte) (solana.Signature, err
 		"Crossmint sign_message is not supported for Solana wallets in this signer")
 }
 
-// SignTransaction submits tx to Crossmint, polls it to completion, extracts
-// and verifies the wallet's signature, and adds it to tx.
+// SignTransaction submits tx to Crossmint, polls it to completion, and extracts
+// and verifies the wallet's signature.
+//
+// Crossmint may rewrite the transaction to sponsor gas and broadcast it itself.
+// When it does, tx is left unmodified and EncodedTransaction is empty, because the
+// signature covers Crossmint's bytes. The signature is added to tx only when
+// Crossmint signed it as given.
 func (s *Signer) SignTransaction(ctx context.Context, tx *solana.Transaction) (core.SignedTransaction, error) {
 	if s.publicKey.IsZero() {
 		return core.SignedTransaction{}, core.NewSignerError(core.CodeConfigError, "signer not initialized")
@@ -172,9 +212,15 @@ func (s *Signer) SignTransaction(ctx context.Context, tx *solana.Transaction) (c
 	if err != nil {
 		return core.SignedTransaction{}, err
 	}
-	sig, err := s.extractSignatureFromResponse(finalResponse, expectedMessage)
+	sig, broadcast, err := s.extractSignatureFromResponse(finalResponse, expectedMessage)
 	if err != nil {
 		return core.SignedTransaction{}, err
+	}
+
+	if broadcast != nil {
+		// Already landed, so complete regardless of the slots the returned copy
+		// shows filled, and nothing is left for the caller to send.
+		return core.SignedTransaction{Signature: sig, Completeness: core.Complete}, nil
 	}
 
 	if err := core.AddSignature(tx, s.publicKey, sig); err != nil {
@@ -302,93 +348,159 @@ func (s *Signer) handleAwaitingApproval(ctx context.Context, response transactio
 	})
 }
 
+// signatureFromApprovals finds this wallet's signature over the transaction
+// Crossmint executed. For a rewritten transaction it arrives in
+// approvals.submitted covering the rewritten message, not in a signature slot.
+// Verified locally regardless.
+func (s *Signer) signatureFromApprovals(response transactionResponse, serializedTransaction string) (solana.Signature, *solana.Transaction, bool) {
+	if response.Approvals == nil || len(response.Approvals.Submitted) == 0 {
+		return solana.Signature{}, nil, false
+	}
+	raw, err := base58.Decode(serializedTransaction)
+	if err != nil {
+		return solana.Signature{}, nil, false
+	}
+	tx, err := solana.TransactionFromBytes(raw)
+	if err != nil {
+		return solana.Signature{}, nil, false
+	}
+	executedMessage, err := tx.Message.MarshalBinary()
+	if err != nil {
+		return solana.Signature{}, nil, false
+	}
+	candidates := s.verificationCandidates()
+	for i := range response.Approvals.Submitted {
+		entry := &response.Approvals.Submitted[i]
+		if entry.Signature == nil || entry.Signer == nil || entry.Signer.Address == nil {
+			continue
+		}
+		approver, err := solana.PublicKeyFromBase58(*entry.Signer.Address)
+		if err != nil || !slices.Contains(candidates, approver) {
+			continue
+		}
+		sig, ok := decodeBase58Signature(*entry.Signature)
+		if !ok || !core.VerifyEd25519(approver, executedMessage, sig) {
+			continue
+		}
+		return sig, tx, true
+	}
+	return solana.Signature{}, nil, false
+}
+
 // extractSignatureFromResponse pulls this wallet's signature out of a terminal
-// transaction response: the serialized onChain.transaction is tried first;
-// onChain.txId is only accepted if it verifies against the originally
-// requested message bytes.
-func (s *Signer) extractSignatureFromResponse(response transactionResponse, expectedMessage []byte) (solana.Signature, error) {
+// transaction response, along with the broadcast transaction when Crossmint
+// rewrote one: the serialized onChain.transaction is tried first; onChain.txId is
+// only accepted if it verifies against the originally requested message bytes.
+//
+// A non-nil transaction means the signature covers Crossmint's bytes, not the
+// caller's.
+func (s *Signer) extractSignatureFromResponse(response transactionResponse, expectedMessage []byte) (solana.Signature, *solana.Transaction, error) {
+	var embeddedErr error
 	if response.OnChain != nil {
 		if response.OnChain.Transaction != nil {
-			if sig, err := s.extractSignatureFromSerializedTransaction(*response.OnChain.Transaction); err == nil {
-				return sig, nil
+			sig, returned, err := s.extractSignatureFromSerializedTransaction(*response.OnChain.Transaction)
+			switch {
+			case err == nil:
+				returnedMessage, marshalErr := returned.Message.MarshalBinary()
+				if marshalErr != nil {
+					return solana.Signature{}, nil, core.WrapSignerError(core.CodeSerializationError,
+						"failed to serialize Crossmint transaction message", marshalErr)
+				}
+				if bytes.Equal(returnedMessage, expectedMessage) {
+					return sig, nil, nil
+				}
+				return sig, returned, nil
+			case true:
+				// A rewritten transaction's signature is in approvals.submitted.
+				if sig, returned, ok := s.signatureFromApprovals(response, *response.OnChain.Transaction); ok {
+					return sig, returned, nil
+				}
+				if response.OnChain.TxID == nil {
+					return solana.Signature{}, nil, err
+				}
+				// Keep this error as the cause: it names the check that failed,
+				// where the txId path only reports a mismatch.
+				embeddedErr = err
 			}
 		}
 
 		if response.OnChain.TxID != nil {
 			sig, ok := decodeBase58Signature(*response.OnChain.TxID)
 			if !ok {
-				return solana.Signature{}, core.NewSignerError(core.CodeSigningFailed,
+				return solana.Signature{}, nil, core.NewSignerError(core.CodeSigningFailed,
 					"Crossmint onChain.txId was not a valid Solana signature")
 			}
-			if err := s.verifySignatureMatchesMessage(sig, expectedMessage); err != nil {
-				return solana.Signature{}, err
+			// A txId counts only if it covers the caller's bytes, and any configured
+			// signer may have produced it.
+			verified := false
+			for _, candidate := range s.verificationCandidates() {
+				if core.VerifyEd25519(candidate, expectedMessage, sig) {
+					verified = true
+					break
+				}
 			}
-			return sig, nil
+			if !verified {
+				if embeddedErr != nil {
+					return solana.Signature{}, nil, embeddedErr
+				}
+				return solana.Signature{}, nil, core.NewSignerError(core.CodeSigningFailed,
+					"Crossmint returned a signature for different bytes")
+			}
+			return sig, nil, nil
 		}
 	}
 
-	return solana.Signature{}, core.NewSignerError(core.CodeSigningFailed,
+	return solana.Signature{}, nil, core.NewSignerError(core.CodeSigningFailed,
 		"unable to extract signature from Crossmint transaction response")
 }
 
 // extractSignatureFromSerializedTransaction decodes the base58 onChain.transaction,
 // locates this wallet's required-signer position, and verifies the signature
 // against that transaction's own message bytes.
-func (s *Signer) extractSignatureFromSerializedTransaction(serializedTransaction string) (solana.Signature, error) {
+//
+// Crossmint sponsors gas, so when it rewrites it becomes the fee payer and the
+// message it signs differs from the caller's. The decoded transaction is returned
+// with the signature so the caller is never handed it over its own message.
+func (s *Signer) extractSignatureFromSerializedTransaction(serializedTransaction string) (solana.Signature, *solana.Transaction, error) {
 	raw, err := base58.Decode(serializedTransaction)
 	if err != nil {
-		return solana.Signature{}, core.WrapSignerError(core.CodeSerializationError,
+		return solana.Signature{}, nil, core.WrapSignerError(core.CodeSerializationError,
 			"failed to decode Crossmint onChain.transaction as base58", err)
 	}
 	tx, err := solana.TransactionFromBytes(raw)
 	if err != nil {
-		return solana.Signature{}, core.WrapSignerError(core.CodeSerializationError,
+		return solana.Signature{}, nil, core.WrapSignerError(core.CodeSerializationError,
 			"failed to deserialize Crossmint onChain.transaction", err)
 	}
 
 	requiredSigners := int(tx.Message.Header.NumRequiredSignatures)
 	signerKeys := tx.Message.AccountKeys
 	if len(signerKeys) < requiredSigners {
-		return solana.Signature{}, core.NewSignerError(core.CodeSigningFailed,
+		return solana.Signature{}, nil, core.NewSignerError(core.CodeSigningFailed,
 			"invalid account index: not enough account keys")
 	}
 
-	position := -1
-	for i := 0; i < requiredSigners; i++ {
-		if signerKeys[i] == s.publicKey {
-			position = i
-			break
-		}
-	}
-	if position < 0 {
-		return solana.Signature{}, core.NewSignerError(core.CodeSigningFailed,
-			"failed to locate signer pubkey in Crossmint transaction")
-	}
-
-	if position >= len(tx.Signatures) || tx.Signatures[position].IsZero() {
-		return solana.Signature{}, core.NewSignerError(core.CodeSigningFailed,
-			"Crossmint onChain.transaction did not contain a signer signature")
-	}
-	signature := tx.Signatures[position]
-
 	remoteMessage, err := tx.Message.MarshalBinary()
 	if err != nil {
-		return solana.Signature{}, core.WrapSignerError(core.CodeSerializationError,
+		return solana.Signature{}, nil, core.WrapSignerError(core.CodeSerializationError,
 			"failed to serialize Crossmint transaction message", err)
 	}
-	if err := s.verifySignatureMatchesMessage(signature, remoteMessage); err != nil {
-		return solana.Signature{}, err
-	}
-	return signature, nil
-}
 
-// verifySignatureMatchesMessage checks a remote signature against this wallet's
-// pubkey.
-func (s *Signer) verifySignatureMatchesMessage(signature solana.Signature, message []byte) error {
-	if core.VerifyEd25519(s.publicKey, message, signature) {
-		return nil
+	// Take the first candidate that actually carries a verifying signature, not
+	// merely the first that occupies a signer slot: a wallet address can sit in a
+	// slot it never signed, while the delegated signer holds the real signature.
+	for _, candidate := range s.verificationCandidates() {
+		for i := 0; i < requiredSigners; i++ {
+			if signerKeys[i] != candidate || i >= len(tx.Signatures) || tx.Signatures[i].IsZero() {
+				continue
+			}
+			if core.VerifyEd25519(candidate, remoteMessage, tx.Signatures[i]) {
+				return tx.Signatures[i], tx, nil
+			}
+		}
 	}
-	return core.NewSignerError(core.CodeSigningFailed, "Crossmint returned a signature for different bytes")
+	return solana.Signature{}, nil, core.NewSignerError(core.CodeSigningFailed,
+		"no configured signer holds a verifying signature in the Crossmint transaction")
 }
 
 // decodeBase58Signature decodes a base58 string into a 64-byte signature.

--- a/go/signers/crossmint/signer.go
+++ b/go/signers/crossmint/signer.go
@@ -388,10 +388,8 @@ func (s *Signer) signatureFromApprovals(response transactionResponse, serialized
 	return solana.Signature{}, nil, false
 }
 
-// broadcastTransactionID returns the identifier of the transaction Crossmint
-// landed: its fee-payer (slot 0) signature, the value Solana RPC addresses
-// transactions by. Under gas sponsorship the fee payer is Crossmint's sponsor
-// key, not this wallet.
+// broadcastTransactionID returns the landed transaction's fee-payer (slot 0)
+// signature, the value RPC transaction lookups accept.
 func broadcastTransactionID(tx *solana.Transaction) (solana.Signature, error) {
 	if len(tx.Message.AccountKeys) == 0 {
 		return solana.Signature{}, core.NewSignerError(core.CodeSigningFailed,
@@ -441,8 +439,7 @@ func (s *Signer) extractSignatureFromResponse(response transactionResponse, expe
 				}
 				return txID, returned, nil
 			case true:
-				// A rewritten transaction's approval in approvals.submitted proves
-				// this wallet took part in what landed.
+				// A rewritten transaction's approval lives in approvals.submitted.
 				if _, returned, ok := s.signatureFromApprovals(response, *response.OnChain.Transaction); ok {
 					txID, idErr := broadcastTransactionID(returned)
 					if idErr != nil {

--- a/go/signers/crossmint/signer_test.go
+++ b/go/signers/crossmint/signer_test.go
@@ -495,6 +495,217 @@ func TestSignTransactionAcceptsSignatureFromOnChainTransactionBytes(t *testing.T
 	if res.Signature != remoteSignature {
 		t.Errorf("signature = %s, want %s", res.Signature, remoteSignature)
 	}
+	// Crossmint sponsors gas, so it is the fee payer and the message it signs
+	// differs from the caller's. Its signature must never be placed in the
+	// caller's transaction, which could not verify with it.
+	if res.EncodedTransaction != "" {
+		t.Error("a Crossmint-broadcast transaction leaves nothing for the caller to send")
+	}
+	for _, sig := range localTx.Signatures {
+		if !sig.IsZero() {
+			t.Error("the caller's transaction must not carry a signature over other bytes")
+		}
+	}
+}
+
+// A returned transaction whose message matches the submitted one really is signed
+// over the caller's bytes, so the signature belongs in the caller's transaction.
+// A smart wallet is signed by its delegated signer, not by the wallet address the
+// API reports, so the delegated key must be a verification candidate.
+func TestSignTransactionLocatesDelegatedSignerSignature(t *testing.T) {
+	secret := signerSecretPrefix + strings.Repeat("ab", 32)
+	derivableAPIKey := "sk_staging_" + base58.Encode([]byte("proj:sig"))
+	delegatedPriv, err := deriveSigningKey(secret, derivableAPIKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	delegated := solana.PublicKeyFromBytes(delegatedPriv.Public().(ed25519.PublicKey))
+	walletPub := testutils.TestPublicKey()
+	if delegated.Equals(walletPub) {
+		t.Fatal("delegated signer must differ from the wallet address for this test")
+	}
+
+	rewritten, err := testutils.CreateTestTransaction(delegated)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rewrittenMsg, err := rewritten.Message.MarshalBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+	expectedSignature := solana.SignatureFromBytes(ed25519.Sign(delegatedPriv, rewrittenMsg))
+	rewritten.Signatures = []solana.Signature{expectedSignature}
+	wireBytes, err := rewritten.MarshalBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET "+testWalletPath, walletHandler(t, derivableAPIKey, walletPub.String()))
+	mux.HandleFunc("POST "+testWalletPath+"/transactions", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, http.StatusCreated, fmt.Sprintf(
+			`{"id":"tx-delegated","status":"success","onChain":{"transaction":%q}}`,
+			base58.Encode(wireBytes)))
+	})
+	srv := startServer(t, mux)
+
+	cfg := baseConfig(srv)
+	cfg.APIKey = derivableAPIKey
+	cfg.MaxPollAttempts = 1
+	cfg.SignerSecret = secret
+	s := newTestSigner(t, cfg)
+
+	localTx, err := testutils.CreateTestTransaction(walletPub)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := s.SignTransaction(context.Background(), localTx)
+	if err != nil {
+		t.Fatalf("SignTransaction: %v (detail: %s)", err, detailOf(t, err))
+	}
+	if res.Signature != expectedSignature {
+		t.Errorf("signature = %s, want %s", res.Signature, expectedSignature)
+	}
+	if !s.Pubkey().Equals(walletPub) {
+		t.Error("the wallet address remains the signer's public identity")
+	}
+}
+
+// A wallet can be configured with both SignerSecret and an explicit Signer locator
+// naming a different key, e.g. the wallet's admin signer. Either may be the key
+// that actually signs, so both must be candidates.
+func TestSignTransactionExplicitLocatorSignerIsACandidate(t *testing.T) {
+	walletPub := testutils.TestPublicKey()
+	adminPriv := ed25519.NewKeyFromSeed(bytes.Repeat([]byte{0x7c}, ed25519.SeedSize))
+	admin := solana.PublicKeyFromBytes(adminPriv.Public().(ed25519.PublicKey))
+
+	rewritten, err := testutils.CreateTestTransaction(admin)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rewrittenMsg, err := rewritten.Message.MarshalBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+	expectedSignature := solana.SignatureFromBytes(ed25519.Sign(adminPriv, rewrittenMsg))
+	rewritten.Signatures = []solana.Signature{expectedSignature}
+	wireBytes, err := rewritten.MarshalBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	derivableAPIKey := "sk_staging_" + base58.Encode([]byte("proj:sig"))
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET "+testWalletPath, walletHandler(t, derivableAPIKey, walletPub.String()))
+	mux.HandleFunc("POST "+testWalletPath+"/transactions", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, http.StatusCreated, fmt.Sprintf(
+			`{"id":"tx-admin","status":"success","onChain":{"transaction":%q}}`, base58.Encode(wireBytes)))
+	})
+	srv := startServer(t, mux)
+
+	cfg := baseConfig(srv)
+	cfg.APIKey = derivableAPIKey
+	cfg.MaxPollAttempts = 1
+	cfg.SignerSecret = signerSecretPrefix + strings.Repeat("ab", 32)
+	cfg.Signer = "server:" + admin.String()
+	s := newTestSigner(t, cfg)
+
+	localTx, err := testutils.CreateTestTransaction(walletPub)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := s.SignTransaction(context.Background(), localTx)
+	if err != nil {
+		t.Fatalf("SignTransaction: %v (detail: %s)", err, detailOf(t, err))
+	}
+	if res.Signature != expectedSignature {
+		t.Errorf("signature = %s, want %s", res.Signature, expectedSignature)
+	}
+}
+
+// Widening the candidate set must not accept a key that is neither the wallet
+// address nor the configured delegated signer.
+func TestSignTransactionRejectsUnrelatedSignerKey(t *testing.T) {
+	walletPub := testutils.TestPublicKey()
+	strangerPriv := ed25519.NewKeyFromSeed(bytes.Repeat([]byte{0x5a}, ed25519.SeedSize))
+	stranger := solana.PublicKeyFromBytes(strangerPriv.Public().(ed25519.PublicKey))
+
+	rewritten, err := testutils.CreateTestTransaction(stranger)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rewrittenMsg, err := rewritten.Message.MarshalBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+	rewritten.Signatures = []solana.Signature{solana.SignatureFromBytes(ed25519.Sign(strangerPriv, rewrittenMsg))}
+	wireBytes, err := rewritten.MarshalBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mux := http.NewServeMux()
+	derivableAPIKey := "sk_staging_" + base58.Encode([]byte("proj:sig"))
+	mux.HandleFunc("GET "+testWalletPath, walletHandler(t, derivableAPIKey, walletPub.String()))
+	mux.HandleFunc("POST "+testWalletPath+"/transactions", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, http.StatusCreated, fmt.Sprintf(
+			`{"id":"tx-stranger","status":"success","onChain":{"transaction":%q}}`,
+			base58.Encode(wireBytes)))
+	})
+	srv := startServer(t, mux)
+
+	cfg := baseConfig(srv)
+	cfg.APIKey = derivableAPIKey
+	cfg.MaxPollAttempts = 1
+	cfg.SignerSecret = signerSecretPrefix + strings.Repeat("ab", 32)
+	s := newTestSigner(t, cfg)
+
+	localTx, err := testutils.CreateTestTransaction(walletPub)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = s.SignTransaction(context.Background(), localTx)
+	if code, _ := core.CodeOf(err); code != core.CodeSigningFailed {
+		t.Errorf("got %s, want SIGNING_FAILED", code)
+	}
+}
+
+func TestSignTransactionUnrewrittenTransactionSignsCallerBytes(t *testing.T) {
+	priv := testutils.TestPrivateKey()
+	signerPubkey := pubkeyOf(priv)
+
+	localTx, err := testutils.CreateTestTransaction(signerPubkey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	returned, err := testutils.CreateTestTransaction(signerPubkey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	onChainTransaction, expectedSignature := signAndEncodeB58(t, returned, priv)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET "+testWalletPath, walletHandler(t, testAPIKey, signerPubkey.String()))
+	mux.HandleFunc("POST "+testWalletPath+"/transactions", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, http.StatusCreated, fmt.Sprintf(
+			`{"id":"tx-exact","status":"success","onChain":{"transaction":%q}}`, onChainTransaction))
+	})
+	srv := startServer(t, mux)
+
+	cfg := baseConfig(srv)
+	cfg.MaxPollAttempts = 1
+	s := newTestSigner(t, cfg)
+
+	res, err := s.SignTransaction(context.Background(), localTx)
+	if err != nil {
+		t.Fatalf("SignTransaction: %v (detail: %s)", err, detailOf(t, err))
+	}
+	if res.EncodedTransaction == "" {
+		t.Error("an unrewritten transaction is the caller's to broadcast")
+	}
+	if len(localTx.Signatures) == 0 || localTx.Signatures[0] != expectedSignature {
+		t.Error("the signature covers the caller's bytes and belongs in its transaction")
+	}
 }
 
 func TestSignTransactionPrefersOnChainTransactionSignatureOverTxIDFallback(t *testing.T) {

--- a/go/signers/crossmint/signer_test.go
+++ b/go/signers/crossmint/signer_test.go
@@ -571,6 +571,72 @@ func TestSignTransactionLocatesDelegatedSignerSignature(t *testing.T) {
 	}
 }
 
+// Under gas sponsorship this wallet's signature is an approval over the
+// rewritten message and never identifies the landed transaction. The returned
+// signature must be the sponsor fee-payer's slot-0 signature, the value RPC
+// transaction lookups accept.
+func TestSignTransactionSponsoredReturnsFeePayerTransactionID(t *testing.T) {
+	secret := signerSecretPrefix + strings.Repeat("cd", 32)
+	derivableAPIKey := "sk_staging_" + base58.Encode([]byte("proj:sig"))
+	delegatedPriv, err := deriveSigningKey(secret, derivableAPIKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	delegated := solana.PublicKeyFromBytes(delegatedPriv.Public().(ed25519.PublicKey))
+	walletPub := testutils.TestPublicKey()
+
+	sponsorPriv := ed25519.NewKeyFromSeed(bytes.Repeat([]byte{0x5e}, ed25519.SeedSize))
+	sponsor := solana.PublicKeyFromBytes(sponsorPriv.Public().(ed25519.PublicKey))
+	executed, err := testutils.CreateTestTransaction(sponsor)
+	if err != nil {
+		t.Fatal(err)
+	}
+	executedMsg, err := executed.Message.MarshalBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+	feePayerSignature := solana.SignatureFromBytes(ed25519.Sign(sponsorPriv, executedMsg))
+	executed.Signatures = []solana.Signature{feePayerSignature}
+	wireBytes, err := executed.MarshalBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+	approvalSignature := solana.SignatureFromBytes(ed25519.Sign(delegatedPriv, executedMsg))
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET "+testWalletPath, walletHandler(t, derivableAPIKey, walletPub.String()))
+	mux.HandleFunc("POST "+testWalletPath+"/transactions", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, http.StatusCreated, fmt.Sprintf(
+			`{"id":"tx-sponsored","status":"success","approvals":{"submitted":[{"signature":%q,"signer":{"address":%q}}]},"onChain":{"transaction":%q}}`,
+			approvalSignature.String(), delegated.String(), base58.Encode(wireBytes)))
+	})
+	srv := startServer(t, mux)
+
+	cfg := baseConfig(srv)
+	cfg.APIKey = derivableAPIKey
+	cfg.MaxPollAttempts = 1
+	cfg.SignerSecret = secret
+	s := newTestSigner(t, cfg)
+
+	localTx, err := testutils.CreateTestTransaction(walletPub)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := s.SignTransaction(context.Background(), localTx)
+	if err != nil {
+		t.Fatalf("SignTransaction: %v (detail: %s)", err, detailOf(t, err))
+	}
+	if res.Signature != feePayerSignature {
+		t.Errorf("signature = %s, want fee payer %s", res.Signature, feePayerSignature)
+	}
+	if res.Signature == approvalSignature {
+		t.Error("the approval signature must not be returned as the transaction id")
+	}
+	if res.EncodedTransaction != "" {
+		t.Error("a Crossmint-broadcast transaction leaves nothing for the caller to send")
+	}
+}
+
 // A wallet can be configured with both SignerSecret and an explicit Signer locator
 // naming a different key, e.g. the wallet's admin signer. Either may be the key
 // that actually signs, so both must be candidates.

--- a/go/signers/crossmint/signer_test.go
+++ b/go/signers/crossmint/signer_test.go
@@ -571,10 +571,8 @@ func TestSignTransactionLocatesDelegatedSignerSignature(t *testing.T) {
 	}
 }
 
-// Under gas sponsorship this wallet's signature is an approval over the
-// rewritten message and never identifies the landed transaction. The returned
-// signature must be the sponsor fee-payer's slot-0 signature, the value RPC
-// transaction lookups accept.
+// Under sponsorship the returned signature must be the sponsor fee-payer's
+// slot-0 signature, not the wallet's approval, so RPC lookups resolve.
 func TestSignTransactionSponsoredReturnsFeePayerTransactionID(t *testing.T) {
 	secret := signerSecretPrefix + strings.Repeat("cd", 32)
 	derivableAPIKey := "sk_staging_" + base58.Encode([]byte("proj:sig"))

--- a/go/signers/crossmint/types.go
+++ b/go/signers/crossmint/types.go
@@ -44,6 +44,13 @@ type Config struct {
 	// provided, the signer derives an Ed25519 keypair via HKDF-SHA256 and
 	// automatically signs any `awaiting-approval` transactions from the
 	// Crossmint API.
+	//
+	// Trust boundary: the approval challenge is the message of the transaction
+	// Crossmint will execute, which is not derivable from the one submitted because
+	// Crossmint rewrites it to sponsor gas. Setting this delegates to Crossmint the
+	// choice of what gets approved. The signer confirms after the fact that its
+	// approval covers the transaction that executed, not that the transaction
+	// matches the caller's intent.
 	SignerSecret string
 
 	// Signer is an optional explicit signer locator forwarded on transaction

--- a/python/src/solana_keychain/crossmint/signer.py
+++ b/python/src/solana_keychain/crossmint/signer.py
@@ -441,9 +441,8 @@ class CrossmintSigner(SolanaSigner):
 
     @staticmethod
     def _broadcast_transaction_id(transaction: VersionedTransaction) -> Signature:
-        """Identifier of the transaction Crossmint landed: its fee-payer (slot 0)
-        signature, the value Solana RPC addresses transactions by. Under gas
-        sponsorship the fee payer is Crossmint's sponsor key, not this wallet."""
+        """The landed transaction's fee-payer (slot 0) signature, the value RPC
+        transaction lookups accept."""
         account_keys = list(transaction.message.account_keys)
         signatures = list(transaction.signatures)
         if not account_keys:
@@ -484,8 +483,7 @@ class CrossmintSigner(SolanaSigner):
                         serialized_transaction
                     )
                 except SignerError as transaction_error:
-                    # A rewritten transaction's approval in approvals.submitted
-                    # proves this wallet took part in what landed.
+                    # A rewritten transaction's approval lives in approvals.submitted.
                     approved = self._extract_signature_from_approvals(
                         response, serialized_transaction
                     )

--- a/python/src/solana_keychain/crossmint/signer.py
+++ b/python/src/solana_keychain/crossmint/signer.py
@@ -52,6 +52,13 @@ class CrossmintSignerConfig:
     (``xmsk1_<64hex>``); when provided, an Ed25519 keypair is derived from it and
     ``awaiting-approval`` transactions are approved automatically. ``signer``
     overrides the delegated-signer locator (default ``server:<derived pubkey>``).
+
+    Trust boundary for ``signer_secret``: the approval challenge is the message of
+    the transaction Crossmint will execute, which is not derivable from the one
+    submitted because Crossmint rewrites it to sponsor gas. Setting it delegates to
+    Crossmint the choice of what gets approved. The signer confirms after the fact
+    that its approval covers the transaction that executed, not that the transaction
+    matches the caller's intent.
     """
 
     api_key: str = field(repr=False)
@@ -71,7 +78,7 @@ class CrossmintSigner(SolanaSigner):
     sponsorship, priority fee, its own blockhash) and broadcasts server-side, so
     returned signatures cover Crossmint's bytes rather than the caller's.
 
-    ``init()`` must be awaited before signing — it resolves the wallet address.
+    ``init()`` must be awaited before signing; it resolves the wallet address.
     ``create_crossmint_signer()`` does this for you. ``sign_message`` is
     intentionally unsupported: the Wallets API signs transactions only.
     """
@@ -104,6 +111,24 @@ class CrossmintSigner(SolanaSigner):
         if config.signer_secret is not None:
             self._signing_key = derive_signing_key(config.signer_secret, config.api_key)
             self._signer = config.signer or f"server:{self._signing_key.pubkey()}"
+        self._delegated_pubkeys = self._resolve_delegated_pubkeys()
+
+    def _resolve_delegated_pubkeys(self) -> list[Pubkey]:
+        """Every delegated-signer key the configuration makes known.
+
+        A smart wallet signs through its delegated signer, not the wallet address.
+        Both sources are collected because a ``signer`` locator may name a different
+        key than ``signer_secret`` derives, and either can be the one that signs.
+        """
+        candidates: list[Pubkey] = []
+        if self._signing_key is not None:
+            candidates.append(self._signing_key.pubkey())
+        if self._signer is not None and self._signer.startswith("server:"):
+            try:
+                candidates.append(Pubkey.from_string(self._signer.removeprefix("server:").strip()))
+            except Exception:
+                pass
+        return candidates
 
     def __repr__(self) -> str:
         return f"CrossmintSigner(pubkey={self._public_key}, wallet_locator={self._wallet_locator})"
@@ -309,16 +334,18 @@ class CrossmintSigner(SolanaSigner):
             json_body={"approvals": [{"signer": self._signer, "signature": str(signature)}]},
         )
 
-    def _verify_signature_matches_message(self, signature: Signature, message: bytes) -> None:
-        if not signature.verify(self._initialized_pubkey(), message):
-            raise SignerError(
-                SignerErrorCode.SIGNING_FAILED,
-                "Crossmint returned a signature for different bytes",
-            )
+    def _verification_candidates(self) -> list[Pubkey]:
+        """Keys that may have signed: the wallet address for ``mpc``, the delegated
+        signer for ``smart``. The response does not say which, so try both."""
+        candidates = [self._initialized_pubkey()]
+        for delegated in self._delegated_pubkeys:
+            if delegated not in candidates:
+                candidates.append(delegated)
+        return candidates
 
     def _extract_signature_from_serialized_transaction(
         self, serialized_transaction: str
-    ) -> Signature:
+    ) -> tuple[Signature, VersionedTransaction]:
         try:
             transaction_bytes = base58.b58decode(serialized_transaction)
         except ValueError:
@@ -346,43 +373,95 @@ class CrossmintSigner(SolanaSigner):
             raise SignerError(
                 SignerErrorCode.SIGNING_FAILED, "Invalid account index: not enough account keys"
             )
-        public_key = self._initialized_pubkey()
-        try:
-            position = account_keys[:num_required].index(public_key)
-        except ValueError:
-            raise SignerError(
-                SignerErrorCode.SIGNING_FAILED,
-                "Failed to locate signer pubkey in Crossmint transaction",
-            ) from None
-
+        # Require a verifying signature, not just presence in a slot: the wallet
+        # address can occupy a slot it never signed.
+        signer_slots = account_keys[:num_required]
+        signed_bytes = signed_message_bytes(message)
         signatures = list(transaction.signatures)
-        if position >= len(signatures) or signatures[position] == Signature.default():
-            raise SignerError(
-                SignerErrorCode.SIGNING_FAILED,
-                "Crossmint onChain.transaction did not contain a signer signature",
-            )
-        signature = signatures[position]
-        # Verify against the bytes Crossmint actually signed, not the caller's:
-        # Crossmint is a broadcast-managed signer that rewrites the transaction
-        # (gas sponsorship, priority fee, its own blockhash) and broadcasts
-        # server-side, so a strict check against caller bytes rejects legitimately
-        # landed transactions.
-        self._verify_signature_matches_message(signature, signed_message_bytes(message))
-        return signature
+        for candidate in self._verification_candidates():
+            if candidate not in signer_slots:
+                continue
+            position = signer_slots.index(candidate)
+            if position >= len(signatures) or signatures[position] == Signature.default():
+                continue
+            if signatures[position].verify(candidate, signed_bytes):
+                return signatures[position], transaction
+        raise SignerError(
+            SignerErrorCode.SIGNING_FAILED,
+            "No configured signer holds a verifying signature in the Crossmint transaction",
+        )
+
+    def _extract_signature_from_approvals(
+        self, response: dict[str, Any], serialized_transaction: str
+    ) -> tuple[Signature, VersionedTransaction] | None:
+        """This wallet's signature over the transaction Crossmint executed.
+
+        For a rewritten transaction it arrives in ``approvals.submitted`` covering the
+        rewritten message, not in a signature slot. Verified locally regardless.
+        """
+        approvals = response.get("approvals")
+        submitted = approvals.get("submitted") if isinstance(approvals, dict) else None
+        if not isinstance(submitted, list) or not submitted:
+            return None
+        try:
+            transaction = VersionedTransaction.from_bytes(base58.b58decode(serialized_transaction))
+        except Exception:
+            return None
+        executed_message = signed_message_bytes(transaction.message)
+        candidates = self._verification_candidates()
+        for entry in submitted:
+            if not isinstance(entry, dict):
+                continue
+            signer = entry.get("signer")
+            address = signer.get("address") if isinstance(signer, dict) else None
+            encoded = entry.get("signature")
+            if not isinstance(address, str) or not isinstance(encoded, str):
+                continue
+            try:
+                approver = Pubkey.from_string(address)
+                signature = Signature.from_bytes(base58.b58decode(encoded))
+            except Exception:
+                continue
+            if approver in candidates and signature.verify(approver, executed_message):
+                return signature, transaction
+        return None
 
     def _extract_signature_from_response(
         self, response: dict[str, Any], expected_message: bytes
-    ) -> Signature:
+    ) -> tuple[Signature, VersionedTransaction | None]:
+        """The signing result, plus the broadcast transaction when Crossmint rewrote one.
+
+        A non-``None`` transaction means Crossmint changed the message before
+        signing and broadcast the result server-side, so its signature covers
+        Crossmint's bytes rather than the caller's.
+        """
         on_chain = response.get("onChain")
         if isinstance(on_chain, dict):
+            embedded_error: SignerError | None = None
             serialized_transaction = on_chain.get("transaction")
             if isinstance(serialized_transaction, str):
                 try:
-                    return self._extract_signature_from_serialized_transaction(
+                    signature, returned = self._extract_signature_from_serialized_transaction(
                         serialized_transaction
                     )
-                except SignerError:
-                    pass
+                except SignerError as transaction_error:
+                    # A rewritten transaction's signature is in approvals.submitted.
+                    approved = self._extract_signature_from_approvals(
+                        response, serialized_transaction
+                    )
+                    if approved is not None:
+                        return approved
+                    # The txId path can only succeed when Crossmint signed the caller's
+                    # exact bytes, so for a rewritten transaction it is not a real
+                    # fallback. Keep the embedded-transaction error as the reported
+                    # cause: it says which check failed, where txId says only that a
+                    # signature did not cover the caller's message.
+                    if not isinstance(on_chain.get("txId"), str):
+                        raise
+                    embedded_error = transaction_error
+                else:
+                    rewritten = signed_message_bytes(returned.message) != expected_message
+                    return signature, returned if rewritten else None
 
             tx_id = on_chain.get("txId")
             if isinstance(tx_id, str):
@@ -396,8 +475,17 @@ class CrossmintSigner(SolanaSigner):
                         SignerErrorCode.SIGNING_FAILED,
                         "Crossmint onChain.txId was not a valid Solana signature",
                     ) from None
-                self._verify_signature_matches_message(signature, expected_message)
-                return signature
+                # A txId counts only if it covers the caller's bytes, and any
+                # configured signer may have produced it.
+                if not any(
+                    signature.verify(candidate, expected_message)
+                    for candidate in self._verification_candidates()
+                ):
+                    raise embedded_error or SignerError(
+                        SignerErrorCode.SIGNING_FAILED,
+                        "Crossmint returned a signature for different bytes",
+                    )
+                return signature, None
 
         raise SignerError(
             SignerErrorCode.SIGNING_FAILED,
@@ -405,13 +493,30 @@ class CrossmintSigner(SolanaSigner):
         )
 
     async def sign_transaction(self, transaction: Transaction) -> SignedTransaction:
+        """Sign ``transaction`` through Crossmint's managed wallet flow.
+
+        Crossmint may rewrite the transaction (it sponsors gas, so it becomes the
+        fee payer) and broadcast it itself. When it does, ``transaction`` is left
+        unmodified and ``encoded_transaction`` is empty: the returned signature
+        identifies the transaction Crossmint landed, and it does not cover the
+        caller's message. Only when Crossmint signs the caller's exact bytes is
+        the signature placed in ``transaction``.
+        """
         public_key = self._initialized_pubkey()
         expected_message = transaction.message_data()
         transaction_b58 = base58.b58encode(bytes(transaction)).decode("ascii")
 
         create_response = await self._create_transaction(transaction_b58)
         final_response = await self._poll_transaction(create_response)
-        signature = self._extract_signature_from_response(final_response, expected_message)
+        signature, broadcast_transaction = self._extract_signature_from_response(
+            final_response, expected_message
+        )
+
+        if broadcast_transaction is not None:
+            # Crossmint has already landed this transaction, so the operation is
+            # finished whether or not the copy it returns shows every signature
+            # slot filled, and there is nothing left for the caller to send.
+            return SignedTransaction(encoded_transaction="", signature=signature, is_complete=True)
 
         add_signature_to_transaction(transaction, public_key, signature)
         return classify_signed_transaction(

--- a/python/src/solana_keychain/crossmint/signer.py
+++ b/python/src/solana_keychain/crossmint/signer.py
@@ -426,14 +426,38 @@ class CrossmintSigner(SolanaSigner):
                 return signature, transaction
         return None
 
+    @staticmethod
+    def _broadcast_transaction_id(transaction: VersionedTransaction) -> Signature:
+        """Identifier of the transaction Crossmint landed: its fee-payer (slot 0)
+        signature, the value Solana RPC addresses transactions by. Under gas
+        sponsorship the fee payer is Crossmint's sponsor key, not this wallet."""
+        account_keys = list(transaction.message.account_keys)
+        signatures = list(transaction.signatures)
+        if not account_keys:
+            raise SignerError(
+                SignerErrorCode.SIGNING_FAILED,
+                "Crossmint transaction has no fee payer to identify it by",
+            )
+        if not signatures or signatures[0] == Signature.default():
+            raise SignerError(
+                SignerErrorCode.SIGNING_FAILED,
+                "Crossmint transaction carries no fee-payer signature to identify it by",
+            )
+        if not signatures[0].verify(account_keys[0], signed_message_bytes(transaction.message)):
+            raise SignerError(
+                SignerErrorCode.SIGNING_FAILED,
+                "Crossmint fee-payer signature does not verify over the executed transaction",
+            )
+        return signatures[0]
+
     def _extract_signature_from_response(
         self, response: dict[str, Any], expected_message: bytes
     ) -> tuple[Signature, VersionedTransaction | None]:
         """The signing result, plus the broadcast transaction when Crossmint rewrote one.
 
         A non-``None`` transaction means Crossmint changed the message before
-        signing and broadcast the result server-side, so its signature covers
-        Crossmint's bytes rather than the caller's.
+        signing and broadcast the result server-side; the signature is then the
+        landed transaction's fee-payer identifier.
         """
         on_chain = response.get("onChain")
         if isinstance(on_chain, dict):
@@ -445,12 +469,14 @@ class CrossmintSigner(SolanaSigner):
                         serialized_transaction
                     )
                 except SignerError as transaction_error:
-                    # A rewritten transaction's signature is in approvals.submitted.
+                    # A rewritten transaction's approval in approvals.submitted
+                    # proves this wallet took part in what landed.
                     approved = self._extract_signature_from_approvals(
                         response, serialized_transaction
                     )
                     if approved is not None:
-                        return approved
+                        _, returned = approved
+                        return self._broadcast_transaction_id(returned), returned
                     # The txId path can only succeed when Crossmint signed the caller's
                     # exact bytes, so for a rewritten transaction it is not a real
                     # fallback. Keep the embedded-transaction error as the reported
@@ -460,8 +486,9 @@ class CrossmintSigner(SolanaSigner):
                         raise
                     embedded_error = transaction_error
                 else:
-                    rewritten = signed_message_bytes(returned.message) != expected_message
-                    return signature, returned if rewritten else None
+                    if signed_message_bytes(returned.message) == expected_message:
+                        return signature, None
+                    return self._broadcast_transaction_id(returned), returned
 
             tx_id = on_chain.get("txId")
             if isinstance(tx_id, str):
@@ -497,10 +524,10 @@ class CrossmintSigner(SolanaSigner):
 
         Crossmint may rewrite the transaction (it sponsors gas, so it becomes the
         fee payer) and broadcast it itself. When it does, ``transaction`` is left
-        unmodified and ``encoded_transaction`` is empty: the returned signature
-        identifies the transaction Crossmint landed, and it does not cover the
-        caller's message. Only when Crossmint signs the caller's exact bytes is
-        the signature placed in ``transaction``.
+        unmodified and ``encoded_transaction`` is empty: the returned signature is
+        the landed transaction's fee-payer signature, usable with RPC transaction
+        lookups, and it does not cover the caller's message. Only when Crossmint
+        signs the caller's exact bytes is the signature placed in ``transaction``.
         """
         public_key = self._initialized_pubkey()
         expected_message = transaction.message_data()

--- a/python/src/solana_keychain/crossmint/signer.py
+++ b/python/src/solana_keychain/crossmint/signer.py
@@ -391,6 +391,16 @@ class CrossmintSigner(SolanaSigner):
             "No configured signer holds a verifying signature in the Crossmint transaction",
         )
 
+    @staticmethod
+    def _executed_message_bytes(transaction: VersionedTransaction) -> bytes:
+        message = transaction.message
+        if not isinstance(message, (Message, MessageV0)):
+            raise SignerError(
+                SignerErrorCode.SIGNING_FAILED,
+                "Crossmint returned a transaction with an unsupported message version",
+            )
+        return signed_message_bytes(message)
+
     def _extract_signature_from_approvals(
         self, response: dict[str, Any], serialized_transaction: str
     ) -> tuple[Signature, VersionedTransaction] | None:
@@ -407,7 +417,10 @@ class CrossmintSigner(SolanaSigner):
             transaction = VersionedTransaction.from_bytes(base58.b58decode(serialized_transaction))
         except Exception:
             return None
-        executed_message = signed_message_bytes(transaction.message)
+        try:
+            executed_message = self._executed_message_bytes(transaction)
+        except SignerError:
+            return None
         candidates = self._verification_candidates()
         for entry in submitted:
             if not isinstance(entry, dict):
@@ -443,7 +456,9 @@ class CrossmintSigner(SolanaSigner):
                 SignerErrorCode.SIGNING_FAILED,
                 "Crossmint transaction carries no fee-payer signature to identify it by",
             )
-        if not signatures[0].verify(account_keys[0], signed_message_bytes(transaction.message)):
+        if not signatures[0].verify(
+            account_keys[0], CrossmintSigner._executed_message_bytes(transaction)
+        ):
             raise SignerError(
                 SignerErrorCode.SIGNING_FAILED,
                 "Crossmint fee-payer signature does not verify over the executed transaction",
@@ -486,7 +501,7 @@ class CrossmintSigner(SolanaSigner):
                         raise
                     embedded_error = transaction_error
                 else:
-                    if signed_message_bytes(returned.message) == expected_message:
+                    if self._executed_message_bytes(returned) == expected_message:
                         return signature, None
                     return self._broadcast_transaction_id(returned), returned
 

--- a/python/tests/integration/conftest.py
+++ b/python/tests/integration/conftest.py
@@ -31,7 +31,7 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
     """Fail runs that skipped the flow they were asked to exercise.
 
     A session-wide pass count is not enough: one configured backend passing would
-    mask the requested one being skipped entirely. So the check is scoped — a
+    mask the requested one being skipped entirely. So the check is scoped: a
     single-backend run must have passed a test for that backend, and a full run
     (the ``just`` recipe, which stands up Vault itself) must have passed a Vault
     test. Other backends stay free to skip when unconfigured.
@@ -58,7 +58,7 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
     session.exitstatus = pytest.ExitCode.TESTS_FAILED
     if reporter:
         reporter.write_line(
-            f"{REQUIRE_RUN_ENV}=1 but no test exercised {scope} — its environment "
+            f"{REQUIRE_RUN_ENV}=1 but no test exercised {scope}: its environment "
             "is not configured (other backends skipping is expected)",
             red=True,
         )
@@ -107,9 +107,10 @@ async def assert_transaction_roundtrip(
     than balances or program execution.
 
     ``signs_caller_bytes=False`` for broadcast-managed services that rewrite the
-    transaction before signing: their signature covers their own bytes, so only
-    its shape and the encoded result can be checked. Each signer verifies the
-    signature against the bytes it actually covers internally.
+    transaction before signing and broadcast it themselves: their signature covers
+    their own bytes, so only its shape can be checked, and there is nothing left
+    for the caller to send. Each signer verifies the signature against the bytes it
+    actually covers internally.
     """
     message = Message.new_with_blockhash([], signer.pubkey, await fetch_latest_blockhash())
     transaction = Transaction.new_unsigned(message)
@@ -117,6 +118,8 @@ async def assert_transaction_roundtrip(
 
     assert result.is_complete
     assert len(bytes(result.signature)) == 64
-    assert Transaction.from_bytes(base64.b64decode(result.encoded_transaction))
     if signs_caller_bytes:
+        assert Transaction.from_bytes(base64.b64decode(result.encoded_transaction))
         assert result.signature.verify(signer.pubkey, transaction.message_data())
+    else:
+        assert result.encoded_transaction == ""

--- a/python/tests/integration/test_live_signers.py
+++ b/python/tests/integration/test_live_signers.py
@@ -10,7 +10,6 @@ substring-matches marker keywords, and every test here carries ``parametrize``.
 import os
 
 import pytest
-from solders.pubkey import Pubkey
 
 from solana_keychain.core.signer import SolanaSigner
 from tests.integration.conftest import (
@@ -182,29 +181,12 @@ async def make_dfns_signer() -> SolanaSigner:
     )
 
 
-def _crossmint_delegated_signer_pubkey() -> Pubkey | None:
-    """A Crossmint smart wallet's transactions are signed by its delegated signer,
-    never by the wallet address the API reports, so signature checks must run
-    against the delegated key. Prefer the explicit test override, else derive it
-    from the ``server:<pubkey>`` signer locator."""
-    override = optional_env("TEST_CROSSMINT_SIGNER_DERIVED_PUBKEY")
-    if not override:
-        locator = optional_env("CROSSMINT_SIGNER")
-        override = locator.removeprefix("server:").strip() if locator else ""
-    if not override:
-        return None
-    try:
-        return Pubkey.from_string(override)
-    except Exception:
-        return None
-
-
 async def make_crossmint_signer() -> SolanaSigner:
     from solana_keychain.crossmint import CrossmintSignerConfig, create_crossmint_signer
     from solana_keychain.crossmint.signer import DEFAULT_API_BASE_URL
 
     env = require_env("CROSSMINT_API_KEY", "CROSSMINT_WALLET_LOCATOR")
-    signer = await create_crossmint_signer(
+    return await create_crossmint_signer(
         CrossmintSignerConfig(
             api_key=env["CROSSMINT_API_KEY"],
             wallet_locator=env["CROSSMINT_WALLET_LOCATOR"],
@@ -213,10 +195,6 @@ async def make_crossmint_signer() -> SolanaSigner:
             api_base_url=optional_env("CROSSMINT_API_BASE_URL") or DEFAULT_API_BASE_URL,
         )
     )
-    delegated = _crossmint_delegated_signer_pubkey()
-    if delegated is not None:
-        signer._public_key = delegated
-    return signer
 
 
 async def make_openfort_signer() -> SolanaSigner:

--- a/python/tests/test_crossmint_signer.py
+++ b/python/tests/test_crossmint_signer.py
@@ -496,11 +496,8 @@ async def test_tx_id_signed_by_the_delegated_signer_is_accepted() -> None:
 
 @respx.mock
 async def test_rewritten_transaction_approval_yields_the_fee_payer_transaction_id() -> None:
-    """Crossmint rewrites the transaction and executes it, so the only filled
-    signature slot belongs to its own fee payer. This wallet's signature appears in
-    approvals.submitted, covering the rewritten message, but never identifies the
-    landed transaction: the returned signature must be the fee payer's, the value
-    RPC transaction lookups accept."""
+    """Under sponsorship the returned signature must be the fee payer's, not the
+    wallet's approval, so RPC lookups resolve."""
     wallet_keypair = Keypair()
     delegated = derive_signing_key(SIGNER_SECRET, API_KEY)
     fee_payer = Keypair()

--- a/python/tests/test_crossmint_signer.py
+++ b/python/tests/test_crossmint_signer.py
@@ -449,11 +449,11 @@ async def test_wallet_address_in_an_unsigned_slot_does_not_shadow_the_delegated_
     signer = await initialized_signer(wallet_keypair, signer_secret=SIGNER_SECRET)
 
     transaction = create_test_transaction(wallet_keypair.pubkey())
-    # Both keys are required signers, wallet address first, and only the delegated
-    # signer actually signed.
-    rewritten = create_two_signer_transaction(wallet_keypair.pubkey(), delegated.pubkey())
+    # Both keys are required signers and only the delegated signer actually
+    # signed; the wallet address occupies a slot it never signed.
+    rewritten = create_two_signer_transaction(delegated.pubkey(), wallet_keypair.pubkey())
     expected_signature = delegated.sign_message(rewritten.message_data())
-    rewritten.signatures = [Signature.default(), expected_signature]
+    rewritten.signatures = [expected_signature, Signature.default()]
 
     respx.post(TRANSACTIONS_URL).mock(
         return_value=httpx.Response(
@@ -495,10 +495,12 @@ async def test_tx_id_signed_by_the_delegated_signer_is_accepted() -> None:
 
 
 @respx.mock
-async def test_rewritten_transaction_signature_comes_from_approvals() -> None:
+async def test_rewritten_transaction_approval_yields_the_fee_payer_transaction_id() -> None:
     """Crossmint rewrites the transaction and executes it, so the only filled
     signature slot belongs to its own fee payer. This wallet's signature appears in
-    approvals.submitted, covering the rewritten message."""
+    approvals.submitted, covering the rewritten message, but never identifies the
+    landed transaction: the returned signature must be the fee payer's, the value
+    RPC transaction lookups accept."""
     wallet_keypair = Keypair()
     delegated = derive_signing_key(SIGNER_SECRET, API_KEY)
     fee_payer = Keypair()
@@ -507,11 +509,12 @@ async def test_rewritten_transaction_signature_comes_from_approvals() -> None:
     transaction = create_test_transaction(wallet_keypair.pubkey())
     # As Crossmint returns it: its fee payer signed, this wallet's slot is empty.
     executed = create_two_signer_transaction(fee_payer.pubkey(), delegated.pubkey())
+    fee_payer_signature = fee_payer.sign_message(executed.message_data())
     executed.signatures = [
-        fee_payer.sign_message(executed.message_data()),
+        fee_payer_signature,
         Signature.default(),
     ]
-    expected_signature = delegated.sign_message(executed.message_data())
+    approval_signature = delegated.sign_message(executed.message_data())
 
     respx.post(TRANSACTIONS_URL).mock(
         return_value=httpx.Response(
@@ -523,7 +526,7 @@ async def test_rewritten_transaction_signature_comes_from_approvals() -> None:
                     "pending": [],
                     "submitted": [
                         {
-                            "signature": str(expected_signature),
+                            "signature": str(approval_signature),
                             "signer": {
                                 "type": "server",
                                 "address": str(delegated.pubkey()),
@@ -539,7 +542,8 @@ async def test_rewritten_transaction_signature_comes_from_approvals() -> None:
 
     result = await signer.sign_transaction(transaction)
 
-    assert result.signature == expected_signature
+    assert result.signature == fee_payer_signature
+    assert result.signature != approval_signature
     assert result.encoded_transaction == ""
     assert all(sig == Signature.default() for sig in transaction.signatures)
 

--- a/python/tests/test_crossmint_signer.py
+++ b/python/tests/test_crossmint_signer.py
@@ -15,7 +15,7 @@ from solana_keychain.crossmint import (
     create_crossmint_signer,
 )
 from solana_keychain.crossmint.derive import derive_signing_key, parse_api_key
-from tests.util import create_test_transaction
+from tests.util import create_test_transaction, create_two_signer_transaction
 
 API_BASE_URL = "https://crossmint.example.com/api"
 API_KEY = "sk_staging_" + base58.b58encode(b"project-123:nacl-sig").decode()
@@ -341,13 +341,14 @@ async def test_awaiting_approval_with_no_matching_entry_fails() -> None:
 
 
 @respx.mock
-async def test_rewritten_transaction_signature_is_accepted() -> None:
+async def test_rewritten_transaction_is_reported_as_a_broadcast_result() -> None:
+    """Crossmint sponsors gas, so it is the fee payer and the message it signs
+    differs from the caller's. Its signature must never be placed in the caller's
+    transaction, which could not verify with it."""
     keypair = Keypair()
     signer = await initialized_signer(keypair)
     transaction = create_test_transaction(keypair.pubkey())
 
-    # Crossmint rewrites the transaction before signing (gas sponsorship, priority
-    # fee, its own blockhash), so the returned signature covers its bytes.
     rewritten = create_test_transaction(keypair.pubkey())
     assert rewritten.message_data() != transaction.message_data()
     expected_signature = keypair.sign_message(rewritten.message_data())
@@ -364,7 +365,300 @@ async def test_rewritten_transaction_signature_is_accepted() -> None:
     )
 
     result = await signer.sign_transaction(transaction)
+
     assert result.signature == expected_signature
+    assert result.is_complete
+    assert result.encoded_transaction == ""
+    assert all(sig == Signature.default() for sig in transaction.signatures)
+    assert not expected_signature.verify(keypair.pubkey(), transaction.message_data())
+
+
+@respx.mock
+async def test_delegated_signer_signature_is_located_and_verified() -> None:
+    """A smart wallet is signed by its delegated signer, not by the wallet address
+    the API reports, so the delegated key must be a verification candidate."""
+    wallet_keypair = Keypair()
+    delegated = derive_signing_key(SIGNER_SECRET, API_KEY)
+    assert delegated.pubkey() != wallet_keypair.pubkey()
+    signer = await initialized_signer(wallet_keypair, signer_secret=SIGNER_SECRET)
+
+    transaction = create_test_transaction(wallet_keypair.pubkey())
+    rewritten = create_test_transaction(delegated.pubkey())
+    expected_signature = delegated.sign_message(rewritten.message_data())
+    rewritten.signatures = [expected_signature]
+
+    respx.post(TRANSACTIONS_URL).mock(
+        return_value=httpx.Response(
+            200,
+            json=tx_response(
+                "success",
+                onChain={"transaction": base58.b58encode(bytes(rewritten)).decode()},
+            ),
+        )
+    )
+
+    result = await signer.sign_transaction(transaction)
+
+    assert result.signature == expected_signature
+    assert result.encoded_transaction == ""
+    # The wallet address is still the signer's public identity.
+    assert signer.pubkey == wallet_keypair.pubkey()
+
+
+@respx.mock
+async def test_explicit_locator_signer_is_a_candidate_alongside_the_derived_key() -> None:
+    """A wallet can be configured with both ``signer_secret`` and an explicit
+    ``signer`` locator naming a different key, e.g. the wallet's admin signer.
+    Either may be the key that actually signs, so both must be candidates."""
+    wallet_keypair = Keypair()
+    admin = Keypair()
+    signer = await initialized_signer(
+        wallet_keypair,
+        signer_secret=SIGNER_SECRET,
+        signer=f"server:{admin.pubkey()}",
+    )
+
+    transaction = create_test_transaction(wallet_keypair.pubkey())
+    rewritten = create_test_transaction(admin.pubkey())
+    expected_signature = admin.sign_message(rewritten.message_data())
+    rewritten.signatures = [expected_signature]
+
+    respx.post(TRANSACTIONS_URL).mock(
+        return_value=httpx.Response(
+            200,
+            json=tx_response(
+                "success",
+                onChain={"transaction": base58.b58encode(bytes(rewritten)).decode()},
+            ),
+        )
+    )
+
+    result = await signer.sign_transaction(transaction)
+
+    assert result.signature == expected_signature
+    assert result.encoded_transaction == ""
+
+
+@respx.mock
+async def test_wallet_address_in_an_unsigned_slot_does_not_shadow_the_delegated_signer() -> None:
+    """The wallet address can occupy a required-signer slot it never signed while the
+    delegated signer holds the real signature. Selection must not stop at the first
+    candidate that merely appears in a slot."""
+    wallet_keypair = Keypair()
+    delegated = derive_signing_key(SIGNER_SECRET, API_KEY)
+    signer = await initialized_signer(wallet_keypair, signer_secret=SIGNER_SECRET)
+
+    transaction = create_test_transaction(wallet_keypair.pubkey())
+    # Both keys are required signers, wallet address first, and only the delegated
+    # signer actually signed.
+    rewritten = create_two_signer_transaction(wallet_keypair.pubkey(), delegated.pubkey())
+    expected_signature = delegated.sign_message(rewritten.message_data())
+    rewritten.signatures = [Signature.default(), expected_signature]
+
+    respx.post(TRANSACTIONS_URL).mock(
+        return_value=httpx.Response(
+            200,
+            json=tx_response(
+                "success",
+                onChain={"transaction": base58.b58encode(bytes(rewritten)).decode()},
+            ),
+        )
+    )
+
+    result = await signer.sign_transaction(transaction)
+
+    assert result.signature == expected_signature
+    assert result.encoded_transaction == ""
+
+
+@respx.mock
+async def test_tx_id_signed_by_the_delegated_signer_is_accepted() -> None:
+    """A txId proves the caller's bytes were signed, but any configured signer may
+    have produced it: a smart wallet signs with its delegated signer, not the wallet
+    address the API reports."""
+    wallet_keypair = Keypair()
+    delegated = derive_signing_key(SIGNER_SECRET, API_KEY)
+    signer = await initialized_signer(wallet_keypair, signer_secret=SIGNER_SECRET)
+
+    transaction = create_test_transaction(wallet_keypair.pubkey())
+    expected_signature = delegated.sign_message(transaction.message_data())
+
+    respx.post(TRANSACTIONS_URL).mock(
+        return_value=httpx.Response(
+            200, json=tx_response("success", onChain={"txId": str(expected_signature)})
+        )
+    )
+
+    result = await signer.sign_transaction(transaction)
+
+    assert result.signature == expected_signature
+
+
+@respx.mock
+async def test_rewritten_transaction_signature_comes_from_approvals() -> None:
+    """Crossmint rewrites the transaction and executes it, so the only filled
+    signature slot belongs to its own fee payer. This wallet's signature appears in
+    approvals.submitted, covering the rewritten message."""
+    wallet_keypair = Keypair()
+    delegated = derive_signing_key(SIGNER_SECRET, API_KEY)
+    fee_payer = Keypair()
+    signer = await initialized_signer(wallet_keypair, signer_secret=SIGNER_SECRET)
+
+    transaction = create_test_transaction(wallet_keypair.pubkey())
+    # As Crossmint returns it: its fee payer signed, this wallet's slot is empty.
+    executed = create_two_signer_transaction(fee_payer.pubkey(), delegated.pubkey())
+    executed.signatures = [
+        fee_payer.sign_message(executed.message_data()),
+        Signature.default(),
+    ]
+    expected_signature = delegated.sign_message(executed.message_data())
+
+    respx.post(TRANSACTIONS_URL).mock(
+        return_value=httpx.Response(
+            200,
+            json=tx_response(
+                "success",
+                onChain={"transaction": base58.b58encode(bytes(executed)).decode()},
+                approvals={
+                    "pending": [],
+                    "submitted": [
+                        {
+                            "signature": str(expected_signature),
+                            "signer": {
+                                "type": "server",
+                                "address": str(delegated.pubkey()),
+                                "locator": f"server:{delegated.pubkey()}",
+                            },
+                            "message": base58.b58encode(executed.message_data()).decode(),
+                        }
+                    ],
+                },
+            ),
+        )
+    )
+
+    result = await signer.sign_transaction(transaction)
+
+    assert result.signature == expected_signature
+    assert result.encoded_transaction == ""
+    assert all(sig == Signature.default() for sig in transaction.signatures)
+
+
+@respx.mock
+async def test_approval_signature_from_an_unconfigured_signer_is_rejected() -> None:
+    """An approval by a key that is neither the wallet address nor a configured
+    delegated signer must not be accepted as this signer's result."""
+    wallet_keypair = Keypair()
+    stranger = Keypair()
+    fee_payer = Keypair()
+    signer = await initialized_signer(wallet_keypair, signer_secret=SIGNER_SECRET)
+
+    transaction = create_test_transaction(wallet_keypair.pubkey())
+    executed = create_two_signer_transaction(fee_payer.pubkey(), stranger.pubkey())
+    executed.signatures = [
+        fee_payer.sign_message(executed.message_data()),
+        Signature.default(),
+    ]
+
+    respx.post(TRANSACTIONS_URL).mock(
+        return_value=httpx.Response(
+            200,
+            json=tx_response(
+                "success",
+                onChain={"transaction": base58.b58encode(bytes(executed)).decode()},
+                approvals={
+                    "pending": [],
+                    "submitted": [
+                        {
+                            "signature": str(stranger.sign_message(executed.message_data())),
+                            "signer": {"type": "server", "address": str(stranger.pubkey())},
+                            "message": base58.b58encode(executed.message_data()).decode(),
+                        }
+                    ],
+                },
+            ),
+        )
+    )
+
+    with pytest.raises(SignerError) as excinfo:
+        await signer.sign_transaction(transaction)
+    assert excinfo.value.code == SignerErrorCode.SIGNING_FAILED
+
+
+@respx.mock
+async def test_signature_from_an_unrelated_key_is_still_rejected() -> None:
+    """Widening the candidate set must not accept a key that is neither the wallet
+    address nor the configured delegated signer."""
+    wallet_keypair = Keypair()
+    signer = await initialized_signer(wallet_keypair, signer_secret=SIGNER_SECRET)
+
+    transaction = create_test_transaction(wallet_keypair.pubkey())
+    stranger = Keypair()
+    rewritten = create_test_transaction(stranger.pubkey())
+    rewritten.signatures = [stranger.sign_message(rewritten.message_data())]
+
+    respx.post(TRANSACTIONS_URL).mock(
+        return_value=httpx.Response(
+            200,
+            json=tx_response(
+                "success",
+                onChain={"transaction": base58.b58encode(bytes(rewritten)).decode()},
+            ),
+        )
+    )
+
+    with pytest.raises(SignerError) as excinfo:
+        await signer.sign_transaction(transaction)
+    assert excinfo.value.code == SignerErrorCode.SIGNING_FAILED
+
+
+@respx.mock
+async def test_unrewritten_returned_transaction_is_placed_in_the_caller_transaction() -> None:
+    """When Crossmint returns the submitted message unchanged, the signature does
+    cover the caller's bytes, so it belongs in the caller's transaction."""
+    keypair = Keypair()
+    signer = await initialized_signer(keypair)
+    transaction = create_test_transaction(keypair.pubkey())
+    expected_signature = keypair.sign_message(transaction.message_data())
+
+    respx.post(TRANSACTIONS_URL).mock(
+        return_value=httpx.Response(
+            200,
+            json=tx_response(
+                "success",
+                onChain={"transaction": signed_transaction_b58(keypair, transaction)},
+            ),
+        )
+    )
+
+    result = await signer.sign_transaction(transaction)
+
+    assert result.signature == expected_signature
+    assert result.encoded_transaction
+    assert list(transaction.signatures) == [expected_signature]
+
+
+@respx.mock
+async def test_caller_exact_signature_is_placed_in_the_caller_transaction() -> None:
+    """When Crossmint signs the submitted bytes unchanged, the signature belongs
+    in the caller's transaction and the caller can broadcast it."""
+    keypair = Keypair()
+    signer = await initialized_signer(keypair)
+    transaction = create_test_transaction(keypair.pubkey())
+    expected_signature = keypair.sign_message(transaction.message_data())
+
+    respx.post(TRANSACTIONS_URL).mock(
+        return_value=httpx.Response(
+            200, json=tx_response("success", onChain={"txId": str(expected_signature)})
+        )
+    )
+
+    result = await signer.sign_transaction(transaction)
+
+    assert result.signature == expected_signature
+    assert result.encoded_transaction
+    assert list(transaction.signatures) == [expected_signature]
+    assert expected_signature.verify(keypair.pubkey(), transaction.message_data())
 
 
 @respx.mock

--- a/rust/src/crossmint/mod.rs
+++ b/rust/src/crossmint/mod.rs
@@ -560,6 +560,41 @@ impl CrossmintSigner {
         Some(Signature::from(sig_bytes))
     }
 
+    /// Identifier of the transaction Crossmint landed: its fee-payer (slot 0)
+    /// signature, the value Solana RPC addresses transactions by. Under gas
+    /// sponsorship the fee payer is Crossmint's sponsor key, not this wallet.
+    fn broadcast_transaction_id(
+        transaction: &VersionedTransaction,
+    ) -> Result<Signature, SignerError> {
+        let fee_payer = transaction
+            .message
+            .static_account_keys()
+            .first()
+            .ok_or_else(|| {
+                SignerError::SigningFailed(
+                    "Crossmint transaction has no fee payer to identify it by".to_string(),
+                )
+            })?;
+        let signature = transaction
+            .signatures
+            .first()
+            .copied()
+            .filter(|signature| *signature != Signature::default())
+            .ok_or_else(|| {
+                SignerError::SigningFailed(
+                    "Crossmint transaction carries no fee-payer signature to identify it by"
+                        .to_string(),
+                )
+            })?;
+        if !signature.verify(&fee_payer.to_bytes(), &transaction.message.serialize()) {
+            return Err(SignerError::SigningFailed(
+                "Crossmint fee-payer signature does not verify over the executed transaction"
+                    .to_string(),
+            ));
+        }
+        Ok(signature)
+    }
+
     fn extract_signature_from_serialized_transaction(
         &self,
         serialized_transaction: &str,
@@ -651,7 +686,8 @@ impl CrossmintSigner {
 
     /// The signing result, plus the broadcast transaction when Crossmint rewrote one.
     ///
-    /// `Some` means the signature covers Crossmint's bytes, not the caller's.
+    /// `Some` means Crossmint landed different bytes than the caller's; the
+    /// signature is then the landed transaction's fee-payer identifier.
     fn extract_signature_from_response(
         &self,
         response: &TransactionResponse,
@@ -665,15 +701,20 @@ impl CrossmintSigner {
                 // requested message bytes.
                 match self.extract_signature_from_serialized_transaction(serialized_transaction) {
                     Ok((signature, returned)) => {
-                        let rewritten = returned.message.serialize() != expected_message;
-                        return Ok((signature, rewritten.then_some(returned)));
+                        if returned.message.serialize() == expected_message {
+                            return Ok((signature, None));
+                        }
+                        let transaction_id = Self::broadcast_transaction_id(&returned)?;
+                        return Ok((transaction_id, Some(returned)));
                     }
                     Err(error) => {
-                        // A rewritten transaction's signature is in approvals.submitted.
-                        if let Some(found) =
+                        // A rewritten transaction's approval in approvals.submitted
+                        // proves this wallet took part in what landed.
+                        if let Some((_, returned)) =
                             self.signature_from_approvals(response, serialized_transaction)
                         {
-                            return Ok((found.0, Some(found.1)));
+                            let transaction_id = Self::broadcast_transaction_id(&returned)?;
+                            return Ok((transaction_id, Some(returned)));
                         }
                         if on_chain.tx_id.is_none() {
                             return Err(error);
@@ -716,8 +757,9 @@ impl CrossmintSigner {
     /// Sign `transaction` through Crossmint's managed wallet flow.
     ///
     /// Crossmint may rewrite the transaction to sponsor gas and broadcast it itself.
-    /// When it does, `transaction` is left unmodified and the returned serialized
-    /// transaction is empty, because the signature covers Crossmint's bytes. The
+    /// When it does, `transaction` is left unmodified, the returned serialized
+    /// transaction is empty, and the returned signature is the landed transaction's
+    /// fee-payer identifier, usable with RPC transaction lookups. The wallet's own
     /// signature is placed in `transaction` only when Crossmint signed it as given.
     async fn sign_and_serialize(
         &self,
@@ -1271,6 +1313,72 @@ mod tests {
                 .all(|s| *s == Signature::default()),
             "the caller's transaction must not carry a signature over other bytes"
         );
+    }
+
+    /// Under gas sponsorship this wallet's signature is an approval over the
+    /// rewritten message and never identifies the landed transaction. The returned
+    /// signature must be the sponsor fee-payer's slot-0 signature, the value RPC
+    /// transaction lookups accept.
+    #[tokio::test]
+    async fn test_sign_transaction_sponsored_returns_fee_payer_transaction_id() {
+        let server = MockServer::start().await;
+        let wallet_keypair = Keypair::new();
+        let wallet_pubkey = keypair_pubkey(&wallet_keypair);
+        let sponsor_keypair = Keypair::new();
+        let sponsor_pubkey = keypair_pubkey(&sponsor_keypair);
+
+        Mock::given(method("GET"))
+            .and(path("/2025-06-09/wallets/test-wallet"))
+            .respond_with(wallet_response(&wallet_pubkey.to_string()))
+            .mount(&server)
+            .await;
+
+        let mut executed_tx = create_test_transaction(&sponsor_pubkey);
+        let sponsor_signature = keypair_sign_message(&sponsor_keypair, &executed_tx.message_data());
+        TransactionUtil::add_signature_to_transaction(
+            &mut executed_tx,
+            &sponsor_pubkey,
+            sponsor_signature,
+        )
+        .unwrap();
+        let approval_signature = keypair_sign_message(&wallet_keypair, &executed_tx.message_data());
+
+        Mock::given(method("POST"))
+            .and(path("/2025-06-09/wallets/test-wallet/transactions"))
+            .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
+                "id": "tx-sponsored",
+                "status": "success",
+                "approvals": {
+                    "submitted": [{
+                        "signature": bs58::encode(approval_signature.as_ref()).into_string(),
+                        "signer": { "address": wallet_pubkey.to_string() }
+                    }]
+                },
+                "onChain": {
+                    "transaction": bs58::encode(bincode::serialize(&executed_tx).unwrap())
+                        .into_string()
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let mut signer = create_test_signer(&server.uri(), 1, 1);
+        signer.init().await.unwrap();
+
+        let mut local_tx = create_test_transaction(&wallet_pubkey);
+        let (serialized, signature) = signer
+            .sign_transaction(&mut local_tx)
+            .await
+            .unwrap()
+            .into_signed_transaction();
+
+        assert_eq!(signature, sponsor_signature);
+        assert_ne!(signature, approval_signature);
+        assert!(serialized.is_empty());
+        assert!(local_tx
+            .signatures
+            .iter()
+            .all(|s| *s == Signature::default()));
     }
 
     #[tokio::test]

--- a/rust/src/crossmint/mod.rs
+++ b/rust/src/crossmint/mod.rs
@@ -3,7 +3,7 @@
 mod types;
 
 use crate::sdk_adapter::{Pubkey, Signature, Transaction, VersionedTransaction};
-use crate::traits::{SignTransactionResult, SignedTransaction};
+use crate::traits::SignTransactionResult;
 use crate::transaction_util::TransactionUtil;
 use crate::{error::SignerError, http_client_config::HttpClientConfig, traits::SolanaSigner};
 use std::str::FromStr;
@@ -25,6 +25,13 @@ pub struct CrossmintSignerConfig {
     /// Optional server signer secret (`xmsk1_<64hex>`). When provided, the signer
     /// derives an Ed25519 keypair via HKDF and automatically signs any
     /// `awaiting-approval` transactions from the Crossmint API.
+    ///
+    /// Trust boundary: the approval challenge is the message of the transaction
+    /// Crossmint will execute, which is not derivable from the one submitted because
+    /// Crossmint rewrites it to sponsor gas. Setting this delegates to Crossmint the
+    /// choice of what gets approved. The signer confirms after the fact that its
+    /// approval covers the transaction that executed, not that the transaction
+    /// matches the caller's intent.
     pub signer_secret: Option<String>,
     pub signer: Option<String>,
     pub api_base_url: Option<String>,
@@ -40,13 +47,13 @@ pub struct CrossmintSigner {
     signer: Option<String>,
     api_base_url: String,
     client: reqwest::Client,
-    #[cfg(any(test, feature = "integration-tests"))]
-    pub(crate) public_key: Pubkey,
-    #[cfg(not(any(test, feature = "integration-tests")))]
     public_key: Pubkey,
     poll_interval_ms: u64,
     max_poll_attempts: u32,
     signing_key: Option<ed25519_dalek::SigningKey>,
+    /// Every delegated-signer key the configuration makes known. Smart wallets sign
+    /// with one of these rather than with `public_key`.
+    delegated_pubkeys: Vec<Pubkey>,
 }
 
 impl std::fmt::Debug for CrossmintSigner {
@@ -120,6 +127,9 @@ impl CrossmintSigner {
             (None, config.signer)
         };
 
+        let delegated_pubkeys =
+            Self::resolve_delegated_pubkeys(signing_key.as_ref(), signer.as_deref());
+
         Ok(Self {
             api_key: config.api_key,
             wallet_locator: config.wallet_locator,
@@ -130,7 +140,41 @@ impl CrossmintSigner {
             poll_interval_ms,
             max_poll_attempts,
             signing_key,
+            delegated_pubkeys,
         })
+    }
+
+    /// Every delegated-signer key the configuration makes known.
+    ///
+    /// A smart wallet signs through its delegated signer, not the wallet address.
+    /// Both sources are collected because a `signer` locator may name a different
+    /// key than `signer_secret` derives, and either can be the one that signs.
+    fn resolve_delegated_pubkeys(
+        signing_key: Option<&ed25519_dalek::SigningKey>,
+        signer_locator: Option<&str>,
+    ) -> Vec<Pubkey> {
+        let mut candidates = Vec::new();
+        if let Some(key) = signing_key {
+            candidates.push(Pubkey::from(key.verifying_key().to_bytes()));
+        }
+        if let Some(encoded) = signer_locator.and_then(|l| l.strip_prefix("server:")) {
+            if let Ok(pubkey) = Pubkey::from_str(encoded.trim()) {
+                candidates.push(pubkey);
+            }
+        }
+        candidates
+    }
+
+    /// Keys that may have signed: the wallet address for `mpc`, the delegated signer
+    /// for `smart`. The response does not say which, so try both.
+    fn verification_candidates(&self) -> Vec<Pubkey> {
+        let mut candidates = vec![self.public_key];
+        for delegated in &self.delegated_pubkeys {
+            if !candidates.contains(delegated) {
+                candidates.push(*delegated);
+            }
+        }
+        candidates
     }
 
     /// Initialize signer by resolving wallet details and signer public key.
@@ -516,24 +560,10 @@ impl CrossmintSigner {
         Some(Signature::from(sig_bytes))
     }
 
-    fn verify_signature_matches_message(
-        &self,
-        signature: &Signature,
-        message: &[u8],
-    ) -> Result<(), SignerError> {
-        if signature.verify(&self.public_key.to_bytes(), message) {
-            Ok(())
-        } else {
-            Err(SignerError::SigningFailed(
-                "Crossmint returned a signature for different bytes".to_string(),
-            ))
-        }
-    }
-
     fn extract_signature_from_serialized_transaction(
         &self,
         serialized_transaction: &str,
-    ) -> Result<Signature, SignerError> {
+    ) -> Result<(Signature, VersionedTransaction), SignerError> {
         let bytes = bs58::decode(serialized_transaction)
             .into_vec()
             .map_err(|e| {
@@ -556,46 +586,102 @@ impl CrossmintSigner {
             ));
         }
 
-        let position = signer_keys
-            .iter()
-            .take(required_signers)
-            .position(|key| key == &self.public_key)
-            .ok_or_else(|| {
-                SignerError::SigningFailed(
-                    "Failed to locate signer pubkey in Crossmint transaction".to_string(),
-                )
-            })?;
-
-        let signature = transaction
-            .signatures
-            .get(position)
-            .copied()
-            .filter(|sig| *sig != Signature::default())
-            .ok_or_else(|| {
-                SignerError::SigningFailed(
-                    "Crossmint onChain.transaction did not contain a signer signature".to_string(),
-                )
-            })?;
-
+        // Verify against the bytes Crossmint signed, which differ from the caller's
+        // once it rewrites to sponsor gas. Require a verifying signature, not just
+        // presence in a slot: the wallet address can occupy a slot it never signed.
         let remote_message = transaction.message.serialize();
-        self.verify_signature_matches_message(&signature, &remote_message)?;
-        Ok(signature)
+        let found = self
+            .verification_candidates()
+            .into_iter()
+            .find_map(|candidate| {
+                signer_keys
+                    .iter()
+                    .take(required_signers)
+                    .position(|key| key == &candidate)
+                    .and_then(|position| transaction.signatures.get(position).copied())
+                    .filter(|signature| {
+                        *signature != Signature::default()
+                            && signature.verify(&candidate.to_bytes(), &remote_message)
+                    })
+            });
+
+        match found {
+            Some(signature) => Ok((signature, transaction)),
+            None => Err(SignerError::SigningFailed(
+                "No configured signer holds a verifying signature in the Crossmint transaction"
+                    .to_string(),
+            )),
+        }
     }
 
+    /// This wallet's signature over the transaction Crossmint executed.
+    ///
+    /// For a rewritten transaction it arrives in `approvals.submitted` covering the
+    /// rewritten message, not in a signature slot. Verified locally regardless.
+    fn signature_from_approvals(
+        &self,
+        response: &TransactionResponse,
+        serialized_transaction: &str,
+    ) -> Option<(Signature, VersionedTransaction)> {
+        let submitted = &response.approvals.as_ref()?.submitted;
+        if submitted.is_empty() {
+            return None;
+        }
+        let bytes = bs58::decode(serialized_transaction).into_vec().ok()?;
+        let transaction: VersionedTransaction = bincode::deserialize(&bytes).ok()?;
+        let executed_message = transaction.message.serialize();
+        let candidates = self.verification_candidates();
+        for entry in submitted {
+            let address = entry.signer.as_ref()?.address.as_deref()?;
+            let encoded = entry.signature.as_deref()?;
+            let Ok(approver) = Pubkey::from_str(address) else {
+                continue;
+            };
+            let Some(signature) = Self::decode_base58_signature(encoded) else {
+                continue;
+            };
+            if candidates.contains(&approver)
+                && signature.verify(&approver.to_bytes(), &executed_message)
+            {
+                return Some((signature, transaction));
+            }
+        }
+        None
+    }
+
+    /// The signing result, plus the broadcast transaction when Crossmint rewrote one.
+    ///
+    /// `Some` means the signature covers Crossmint's bytes, not the caller's.
     fn extract_signature_from_response(
         &self,
         response: &TransactionResponse,
         expected_message: &[u8],
-    ) -> Result<Signature, SignerError> {
+    ) -> Result<(Signature, Option<VersionedTransaction>), SignerError> {
+        let mut embedded_error: Option<SignerError> = None;
         if let Some(on_chain) = &response.on_chain {
             if let Some(serialized_transaction) = &on_chain.transaction {
                 // Try to extract from the serialized transaction first. If that
                 // fails, only accept txId if it verifies against the original
                 // requested message bytes.
-                if let Ok(signature) =
-                    self.extract_signature_from_serialized_transaction(serialized_transaction)
-                {
-                    return Ok(signature);
+                match self.extract_signature_from_serialized_transaction(serialized_transaction) {
+                    Ok((signature, returned)) => {
+                        let rewritten = returned.message.serialize() != expected_message;
+                        return Ok((signature, rewritten.then_some(returned)));
+                    }
+                    Err(error) => {
+                        // A rewritten transaction's signature is in approvals.submitted.
+                        if let Some(found) =
+                            self.signature_from_approvals(response, serialized_transaction)
+                        {
+                            return Ok((found.0, Some(found.1)));
+                        }
+                        if on_chain.tx_id.is_none() {
+                            return Err(error);
+                        }
+                        // Keep this error as the cause: it names the check that
+                        // failed, where the txId path only reports a mismatch.
+                        embedded_error = Some(error);
+                    }
                 }
             }
 
@@ -605,8 +691,20 @@ impl CrossmintSigner {
                         "Crossmint onChain.txId was not a valid Solana signature".to_string(),
                     )
                 })?;
-                self.verify_signature_matches_message(&signature, expected_message)?;
-                return Ok(signature);
+                // A txId counts only if it covers the caller's bytes, and any
+                // configured signer may have produced it.
+                let verified = self
+                    .verification_candidates()
+                    .iter()
+                    .any(|candidate| signature.verify(&candidate.to_bytes(), expected_message));
+                if !verified {
+                    return Err(embedded_error.unwrap_or_else(|| {
+                        SignerError::SigningFailed(
+                            "Crossmint returned a signature for different bytes".to_string(),
+                        )
+                    }));
+                }
+                return Ok((signature, None));
             }
         }
 
@@ -615,10 +713,16 @@ impl CrossmintSigner {
         ))
     }
 
+    /// Sign `transaction` through Crossmint's managed wallet flow.
+    ///
+    /// Crossmint may rewrite the transaction to sponsor gas and broadcast it itself.
+    /// When it does, `transaction` is left unmodified and the returned serialized
+    /// transaction is empty, because the signature covers Crossmint's bytes. The
+    /// signature is placed in `transaction` only when Crossmint signed it as given.
     async fn sign_and_serialize(
         &self,
         transaction: &mut Transaction,
-    ) -> Result<SignedTransaction, SignerError> {
+    ) -> Result<SignTransactionResult, SignerError> {
         if self.public_key == Pubkey::default() {
             return Err(SignerError::ConfigError(
                 "Signer not initialized. Call init() first.".to_string(),
@@ -633,13 +737,23 @@ impl CrossmintSigner {
 
         let create_response = self.create_transaction(transaction_b58).await?;
         let final_response = self.poll_transaction(create_response).await?;
-        let signature = self.extract_signature_from_response(&final_response, &expected_message)?;
+        let (signature, broadcast) =
+            self.extract_signature_from_response(&final_response, &expected_message)?;
+
+        if broadcast.is_some() {
+            // Already landed, so complete regardless of the slots the returned copy
+            // shows filled, and nothing is left for the caller to send.
+            return Ok(SignTransactionResult::Complete((String::new(), signature)));
+        }
 
         TransactionUtil::add_signature_to_transaction(transaction, &self.public_key, signature)?;
 
-        Ok((
-            TransactionUtil::serialize_transaction(transaction)?,
-            signature,
+        Ok(TransactionUtil::classify_signed_transaction(
+            transaction,
+            (
+                TransactionUtil::serialize_transaction(transaction)?,
+                signature,
+            ),
         ))
     }
 
@@ -659,11 +773,7 @@ impl SolanaSigner for CrossmintSigner {
         &self,
         tx: &mut Transaction,
     ) -> Result<SignTransactionResult, SignerError> {
-        let signed_transaction = self.sign_and_serialize(tx).await?;
-        Ok(TransactionUtil::classify_signed_transaction(
-            tx,
-            signed_transaction,
-        ))
+        self.sign_and_serialize(tx).await
     }
 
     async fn sign_message(&self, _message: &[u8]) -> Result<Signature, SignerError> {
@@ -715,6 +825,7 @@ mod tests {
             poll_interval_ms,
             max_poll_attempts,
             signing_key: None,
+            delegated_pubkeys: Vec::new(),
         }
     }
 
@@ -974,6 +1085,192 @@ mod tests {
 
         assert_eq!(signature, expected_signature);
         assert!(!_serialized.is_empty());
+    }
+
+    /// A smart wallet is signed by its delegated signer, not by the wallet address
+    /// the API reports, so the delegated key must be a verification candidate.
+    #[tokio::test]
+    async fn test_sign_transaction_locates_delegated_signer_signature() {
+        let server = MockServer::start().await;
+        let wallet_keypair = Keypair::new();
+        let wallet_pubkey = keypair_pubkey(&wallet_keypair);
+        let delegated_keypair = Keypair::new();
+        let delegated_pubkey = keypair_pubkey(&delegated_keypair);
+
+        Mock::given(method("GET"))
+            .and(path("/2025-06-09/wallets/test-wallet"))
+            .respond_with(wallet_response(&wallet_pubkey.to_string()))
+            .mount(&server)
+            .await;
+
+        let mut signer = create_test_signer(&server.uri(), 1, 2);
+        signer.delegated_pubkeys = vec![delegated_pubkey];
+        signer.init().await.unwrap();
+
+        let mut local_tx = create_test_transaction(&wallet_pubkey);
+        let mut rewritten_tx = create_test_transaction(&delegated_pubkey);
+        let expected_signature =
+            keypair_sign_message(&delegated_keypair, &rewritten_tx.message_data());
+        TransactionUtil::add_signature_to_transaction(
+            &mut rewritten_tx,
+            &delegated_pubkey,
+            expected_signature,
+        )
+        .unwrap();
+
+        Mock::given(method("POST"))
+            .and(path("/2025-06-09/wallets/test-wallet/transactions"))
+            .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
+                "id": "tx-delegated",
+                "status": "success",
+                "onChain": {
+                    "transaction": bs58::encode(bincode::serialize(&rewritten_tx).unwrap())
+                        .into_string()
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let (serialized, signature) = signer
+            .sign_transaction(&mut local_tx)
+            .await
+            .unwrap()
+            .into_signed_transaction();
+
+        assert_eq!(signature, expected_signature);
+        assert!(serialized.is_empty());
+        // The wallet address remains the signer's public identity.
+        assert_eq!(signer.pubkey(), wallet_pubkey);
+    }
+
+    /// A wallet can be configured with both `signer_secret` and an explicit `signer`
+    /// locator naming a different key, e.g. the wallet's admin signer. Either may be
+    /// the key that actually signs, so both must be candidates.
+    #[test]
+    fn test_resolve_delegated_pubkeys_collects_both_sources() {
+        let admin = keypair_pubkey(&Keypair::new());
+        let signing_key = ed25519_dalek::SigningKey::from_bytes(&[7u8; 32]);
+        let derived = Pubkey::from(signing_key.verifying_key().to_bytes());
+
+        let candidates = CrossmintSigner::resolve_delegated_pubkeys(
+            Some(&signing_key),
+            Some(&format!("server:{admin}")),
+        );
+
+        assert!(
+            candidates.contains(&derived) && candidates.contains(&admin),
+            "both the derived server signer and the locator's admin signer must be candidates, got {candidates:?}"
+        );
+    }
+
+    /// Widening the candidate set must not accept a key that is neither the wallet
+    /// address nor the configured delegated signer.
+    #[tokio::test]
+    async fn test_sign_transaction_rejects_unrelated_signer_key() {
+        let server = MockServer::start().await;
+        let wallet_keypair = Keypair::new();
+        let wallet_pubkey = keypair_pubkey(&wallet_keypair);
+        let stranger = Keypair::new();
+        let stranger_pubkey = keypair_pubkey(&stranger);
+
+        Mock::given(method("GET"))
+            .and(path("/2025-06-09/wallets/test-wallet"))
+            .respond_with(wallet_response(&wallet_pubkey.to_string()))
+            .mount(&server)
+            .await;
+
+        let mut signer = create_test_signer(&server.uri(), 1, 2);
+        signer.delegated_pubkeys = vec![keypair_pubkey(&Keypair::new())];
+        signer.init().await.unwrap();
+
+        let mut local_tx = create_test_transaction(&wallet_pubkey);
+        let mut rewritten_tx = create_test_transaction(&stranger_pubkey);
+        let signature = keypair_sign_message(&stranger, &rewritten_tx.message_data());
+        TransactionUtil::add_signature_to_transaction(
+            &mut rewritten_tx,
+            &stranger_pubkey,
+            signature,
+        )
+        .unwrap();
+
+        Mock::given(method("POST"))
+            .and(path("/2025-06-09/wallets/test-wallet/transactions"))
+            .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
+                "id": "tx-stranger",
+                "status": "success",
+                "onChain": {
+                    "transaction": bs58::encode(bincode::serialize(&rewritten_tx).unwrap())
+                        .into_string()
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let result = signer.sign_transaction(&mut local_tx).await;
+        assert!(matches!(result.unwrap_err(), SignerError::SigningFailed(_)));
+    }
+
+    /// Crossmint sponsors gas, so it is the fee payer and the message it signs
+    /// differs from the caller's. Its signature must never be placed in the
+    /// caller's transaction, which could not verify with it.
+    #[tokio::test]
+    async fn test_sign_transaction_rewritten_is_reported_as_a_broadcast_result() {
+        let server = MockServer::start().await;
+        let keypair = Keypair::new();
+        let signer_pubkey = keypair_pubkey(&keypair);
+
+        Mock::given(method("GET"))
+            .and(path("/2025-06-09/wallets/test-wallet"))
+            .and(header("x-api-key", "test-api-key"))
+            .respond_with(wallet_response(&signer_pubkey.to_string()))
+            .mount(&server)
+            .await;
+
+        let mut signer = create_test_signer(&server.uri(), 1, 2);
+        signer.init().await.unwrap();
+
+        let mut local_tx = create_test_transaction(&signer_pubkey);
+        let mut rewritten_tx = create_test_transaction(&signer_pubkey);
+        assert_ne!(rewritten_tx.message_data(), local_tx.message_data());
+        let expected_signature = keypair_sign_message(&keypair, &rewritten_tx.message_data());
+        TransactionUtil::add_signature_to_transaction(
+            &mut rewritten_tx,
+            &signer_pubkey,
+            expected_signature,
+        )
+        .unwrap();
+
+        Mock::given(method("POST"))
+            .and(path("/2025-06-09/wallets/test-wallet/transactions"))
+            .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
+                "id": "tx-123",
+                "status": "success",
+                "chainType": "solana",
+                "walletType": "smart",
+                "onChain": {
+                    "transaction": bs58::encode(bincode::serialize(&rewritten_tx).unwrap())
+                        .into_string()
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let result = signer.sign_transaction(&mut local_tx).await.unwrap();
+        assert!(matches!(result, SignTransactionResult::Complete(_)));
+        let (serialized, signature) = result.into_signed_transaction();
+
+        assert_eq!(signature, expected_signature);
+        assert!(
+            serialized.is_empty(),
+            "a Crossmint-broadcast transaction leaves nothing for the caller to send"
+        );
+        assert!(
+            local_tx
+                .signatures
+                .iter()
+                .all(|s| *s == Signature::default()),
+            "the caller's transaction must not carry a signature over other bytes"
+        );
     }
 
     #[tokio::test]

--- a/rust/src/crossmint/mod.rs
+++ b/rust/src/crossmint/mod.rs
@@ -560,9 +560,8 @@ impl CrossmintSigner {
         Some(Signature::from(sig_bytes))
     }
 
-    /// Identifier of the transaction Crossmint landed: its fee-payer (slot 0)
-    /// signature, the value Solana RPC addresses transactions by. Under gas
-    /// sponsorship the fee payer is Crossmint's sponsor key, not this wallet.
+    /// The landed transaction's fee-payer (slot 0) signature, the value RPC
+    /// transaction lookups accept.
     fn broadcast_transaction_id(
         transaction: &VersionedTransaction,
     ) -> Result<Signature, SignerError> {
@@ -708,8 +707,7 @@ impl CrossmintSigner {
                         return Ok((transaction_id, Some(returned)));
                     }
                     Err(error) => {
-                        // A rewritten transaction's approval in approvals.submitted
-                        // proves this wallet took part in what landed.
+                        // A rewritten transaction's approval lives in approvals.submitted.
                         if let Some((_, returned)) =
                             self.signature_from_approvals(response, serialized_transaction)
                         {
@@ -1315,10 +1313,8 @@ mod tests {
         );
     }
 
-    /// Under gas sponsorship this wallet's signature is an approval over the
-    /// rewritten message and never identifies the landed transaction. The returned
-    /// signature must be the sponsor fee-payer's slot-0 signature, the value RPC
-    /// transaction lookups accept.
+    /// Under sponsorship the returned signature must be the sponsor fee-payer's
+    /// slot-0 signature, not the wallet's approval, so RPC lookups resolve.
     #[tokio::test]
     async fn test_sign_transaction_sponsored_returns_fee_payer_transaction_id() {
         let server = MockServer::start().await;

--- a/rust/src/crossmint/types.rs
+++ b/rust/src/crossmint/types.rs
@@ -50,6 +50,20 @@ pub struct OnChainData {
 pub struct Approvals {
     #[serde(default)]
     pub pending: Vec<PendingApproval>,
+    /// Approvals Crossmint has already collected. A rewritten transaction's wallet
+    /// signature appears here rather than in a signature slot of the returned
+    /// transaction.
+    #[serde(default)]
+    pub submitted: Vec<SubmittedApproval>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SubmittedApproval {
+    #[serde(default)]
+    pub signature: Option<String>,
+    #[serde(default)]
+    pub signer: Option<ApprovalSigner>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -66,4 +80,6 @@ pub struct PendingApproval {
 pub struct ApprovalSigner {
     #[serde(default)]
     pub locator: Option<String>,
+    #[serde(default)]
+    pub address: Option<String>,
 }

--- a/rust/src/tests/test_crossmint_integration.rs
+++ b/rust/src/tests/test_crossmint_integration.rs
@@ -3,37 +3,18 @@ pub const CROSSMINT_WALLET_LOCATOR: &str = "CROSSMINT_WALLET_LOCATOR";
 pub const CROSSMINT_API_BASE_URL: &str = "CROSSMINT_API_BASE_URL";
 pub const CROSSMINT_SIGNER: &str = "CROSSMINT_SIGNER";
 pub const CROSSMINT_SIGNER_SECRET: &str = "CROSSMINT_SIGNER_SECRET";
-pub const TEST_CROSSMINT_SIGNER_DERIVED_PUBKEY: &str = "TEST_CROSSMINT_SIGNER_DERIVED_PUBKEY";
 
 #[cfg(feature = "crossmint")]
 #[cfg(test)]
 mod tests {
-    use base64::{engine::general_purpose::STANDARD, Engine};
     use dotenvy::dotenv;
     use std::env;
-    use std::str::FromStr;
 
     use super::*;
     use crate::crossmint::{CrossmintSigner, CrossmintSignerConfig};
-    use crate::sdk_adapter::{Message, Pubkey, Transaction};
+    use crate::sdk_adapter::{Message, Transaction};
     use crate::tests::rpc_util::get_rpc_blockhash;
     use crate::traits::SolanaSigner;
-
-    fn resolve_test_signer_pubkey_override() -> Option<Pubkey> {
-        let from_test_env = env::var(TEST_CROSSMINT_SIGNER_DERIVED_PUBKEY)
-            .ok()
-            .map(|value| value.trim().to_string())
-            .filter(|value| !value.is_empty());
-
-        let resolved = from_test_env.or_else(|| {
-            env::var(CROSSMINT_SIGNER)
-                .ok()
-                .and_then(|value| value.strip_prefix("server:").map(|v| v.trim().to_string()))
-                .filter(|value| !value.is_empty())
-        })?;
-
-        Pubkey::from_str(&resolved).ok()
-    }
 
     async fn get_signer() -> CrossmintSigner {
         dotenv().ok();
@@ -61,10 +42,6 @@ mod tests {
             .init()
             .await
             .expect("Failed to initialize CrossmintSigner");
-
-        if let Some(test_pubkey) = resolve_test_signer_pubkey_override() {
-            signer.public_key = test_pubkey;
-        }
 
         signer
     }
@@ -112,12 +89,20 @@ mod tests {
 
         assert_eq!(signature.as_ref().len(), 64, "Signature should be 64 bytes");
 
-        let decoded_bytes = STANDARD
-            .decode(&base64_txn)
-            .expect("Failed to decode base64 transaction");
-
-        let _: crate::sdk_adapter::Transaction =
-            bincode::deserialize(&decoded_bytes).expect("Failed to deserialize transaction");
+        // Crossmint sponsors gas, so it rewrites the transaction, signs its own
+        // bytes and broadcasts server-side. The signature identifies what it
+        // landed and there is nothing left for the caller to send.
+        assert!(
+            base64_txn.is_empty(),
+            "a Crossmint-broadcast transaction leaves nothing for the caller to send"
+        );
+        assert!(
+            transaction
+                .signatures
+                .iter()
+                .all(|s| *s == crate::sdk_adapter::Signature::default()),
+            "the caller's transaction must not carry a signature over other bytes"
+        );
     }
 
     #[tokio::test]

--- a/typescript/packages/crossmint/README.md
+++ b/typescript/packages/crossmint/README.md
@@ -32,7 +32,7 @@ const signer = await createCrossmintSigner({
 
 ## Behavior Notes
 
-1. Crossmint executes transactions server-side and sponsors gas, which makes it the fee payer, so the message it signs generally differs from the one you submitted. Use `signAndSendTransactions()` (or `signAndSendTransactionMessageWithSigners()`): the returned value is the signature identifying the transaction Crossmint landed, not a signature over your message bytes.
+1. Crossmint executes transactions server-side and sponsors gas, which makes it the fee payer, so the message it signs generally differs from the one you submitted. Use `signAndSendTransactions()` (or `signAndSendTransactionMessageWithSigners()`): the returned value is the landed transaction's fee-payer signature, the identifier you can pass to `getTransaction`/`confirmTransaction`, not a signature over your message bytes. Under sponsorship the fee payer is Crossmint's sponsor key; your wallet's own signature is verified internally before the identifier is returned.
 2. `signTransactions` rejects with `SIGNER_CONFIG_ERROR`. A signature dictionary would claim to cover your message, which it does not.
 3. `signMessages` is intentionally unsupported and throws a signer error.
 

--- a/typescript/packages/crossmint/README.md
+++ b/typescript/packages/crossmint/README.md
@@ -32,8 +32,13 @@ const signer = await createCrossmintSigner({
 
 ## Behavior Notes
 
-1. `signTransactions` uses a managed flow similar to Fireblocks `PROGRAM_CALL` style: create transaction, poll status, then extract a signature from Crossmint response data.
-2. `signMessages` is intentionally unsupported and throws a signer error.
+1. Crossmint executes transactions server-side and sponsors gas, which makes it the fee payer, so the message it signs generally differs from the one you submitted. Use `signAndSendTransactions()` (or `signAndSendTransactionMessageWithSigners()`): the returned value is the signature identifying the transaction Crossmint landed, not a signature over your message bytes.
+2. `signTransactions` rejects with `SIGNER_CONFIG_ERROR`. A signature dictionary would claim to cover your message, which it does not.
+3. `signMessages` is intentionally unsupported and throws a signer error.
+
+```typescript
+const [signature] = await signer.signAndSendTransactions([transaction]);
+```
 
 ## License
 

--- a/typescript/packages/crossmint/src/__tests__/crossmint-signer.integration.test.ts
+++ b/typescript/packages/crossmint/src/__tests__/crossmint-signer.integration.test.ts
@@ -5,7 +5,7 @@ import {
     pipe,
     setTransactionMessageFeePayerSigner,
     setTransactionMessageLifetimeUsingBlockhash,
-    signTransactionMessageWithSigners,
+    signAndSendTransactionMessageWithSigners,
 } from '@solana/kit';
 import { describe, expect, it } from 'vitest';
 import { getConfig } from './setup';
@@ -37,7 +37,7 @@ const SIGN_TEST_TIMEOUT_MS = 90_000;
 
 describe('CrossmintSigner Integration', () => {
     it.skipIf(!process.env.CROSSMINT_API_KEY)(
-        'signs transactions with real API',
+        'signs and broadcasts transactions with real API',
         { timeout: SIGN_TEST_TIMEOUT_MS },
         async () => {
             const { createSigner } = await getConfig(['signTransaction']);
@@ -50,10 +50,12 @@ describe('CrossmintSigner Integration', () => {
                 tx => setTransactionMessageLifetimeUsingBlockhash({ blockhash, lastValidBlockHeight }, tx),
             );
 
-            const signedTx = await signTransactionMessageWithSigners(transaction);
+            // Crossmint broadcasts server-side, so the result is the signature of
+            // the transaction it landed, not a signature over these message bytes.
+            const signature = await signAndSendTransactionMessageWithSigners(transaction);
 
-            expect(signedTx.signatures[signer.address]).toBeDefined();
-            expect(signedTx.signatures[signer.address]?.byteLength).toBe(64);
+            expect(signature).toBeDefined();
+            expect(signature.byteLength).toBe(64);
         },
     );
 

--- a/typescript/packages/crossmint/src/__tests__/crossmint-signer.test.ts
+++ b/typescript/packages/crossmint/src/__tests__/crossmint-signer.test.ts
@@ -603,10 +603,11 @@ describe('CrossmintSigner', () => {
         });
 
         /**
-         * When both paths fail, the embedded-transaction error is the reported cause:
-         * it names which check failed, where the txId error says only that a signature
-         * did not cover the caller's message, which is expected for a rewritten
-         * transaction and so explains nothing.
+         * When both paths fail, callers still get a stable SignerError code, with
+         * the embedded-transaction error as its cause: it names which check failed,
+         * where the txId error says only that a signature did not cover the caller's
+         * message, which is expected for a rewritten transaction and so explains
+         * nothing.
          */
         it('reports the embedded-transaction failure when txId validation also fails', async () => {
             vi.mocked(getTransactionDecoder).mockReturnValue({
@@ -637,7 +638,76 @@ describe('CrossmintSigner', () => {
                 pollIntervalMs: 1,
             });
 
-            await expect(signer.signAndSendTransactions([createMockTransaction()])).rejects.toThrow('decode failed');
+            await expect(signer.signAndSendTransactions([createMockTransaction()])).rejects.toMatchObject({
+                code: 'SIGNER_SIGNING_FAILED',
+                context: expect.objectContaining({ cause: expect.objectContaining({ message: 'decode failed' }) }),
+            });
+        });
+
+        /**
+         * Under gas sponsorship this wallet's signature is an approval over the
+         * rewritten message and never identifies the landed transaction. The
+         * returned value must be the sponsor fee-payer's slot-0 signature so that
+         * rpc.getTransaction(result) resolves.
+         */
+        it('returns the sponsor fee-payer signature as the transaction id for a sponsored transaction', async () => {
+            const SPONSOR_ADDRESS = 'Sysvar1nstructions1111111111111111111111111';
+            const DELEGATED_ADDRESS = 'SysvarC1ock11111111111111111111111111111111';
+            const SPONSOR_SIGNATURE_BYTES = new Uint8Array(64).fill(9);
+            const APPROVAL_SIGNATURE_B58 = base58Decoder.decode(new Uint8Array(64).fill(5));
+            const rewrittenMessageBytes = new Uint8Array([9, 9, 9]);
+            vi.mocked(getTransactionDecoder).mockReturnValue({
+                decode: vi.fn(() => ({
+                    messageBytes: rewrittenMessageBytes,
+                    signatures: {
+                        [SPONSOR_ADDRESS]: SPONSOR_SIGNATURE_BYTES,
+                        [DELEGATED_ADDRESS]: null,
+                    },
+                })),
+            } as any);
+            vi.mocked(fetch)
+                .mockResolvedValueOnce(mockWalletResponse())
+                .mockResolvedValueOnce(
+                    new Response(
+                        JSON.stringify({
+                            id: 'tx-sponsored',
+                            status: 'success',
+                            approvals: {
+                                submitted: [
+                                    {
+                                        signature: APPROVAL_SIGNATURE_B58,
+                                        signer: {
+                                            address: DELEGATED_ADDRESS,
+                                            locator: `server:${DELEGATED_ADDRESS}`,
+                                        },
+                                    },
+                                ],
+                            },
+                            onChain: { transaction: MOCK_SERIALIZED_TRANSACTION_B58 },
+                        }),
+                        { status: 201 },
+                    ),
+                );
+
+            const signer = await createCrossmintSigner({
+                ...mockConfig,
+                maxPollAttempts: 1,
+                pollIntervalMs: 1,
+                signer: `server:${DELEGATED_ADDRESS}`,
+            });
+            const results = await signer.signAndSendTransactions([createMockTransaction()]);
+
+            expect(results[0]).toEqual(SPONSOR_SIGNATURE_BYTES);
+            // The approval gate verified our delegated signer over the executed bytes.
+            expect(assertSignatureValid).toHaveBeenCalledWith(
+                expect.objectContaining({ data: rewrittenMessageBytes, signerAddress: DELEGATED_ADDRESS }),
+            );
+            // The returned identifier is the fee payer's, verified over the same bytes.
+            expect(assertSignatureValid).toHaveBeenCalledWith({
+                data: rewrittenMessageBytes,
+                signature: SPONSOR_SIGNATURE_BYTES,
+                signerAddress: SPONSOR_ADDRESS,
+            });
         });
 
         it('throws on failed transaction status', async () => {

--- a/typescript/packages/crossmint/src/__tests__/crossmint-signer.test.ts
+++ b/typescript/packages/crossmint/src/__tests__/crossmint-signer.test.ts
@@ -603,11 +603,8 @@ describe('CrossmintSigner', () => {
         });
 
         /**
-         * When both paths fail, callers still get a stable SignerError code, with
-         * the embedded-transaction error as its cause: it names which check failed,
-         * where the txId error says only that a signature did not cover the caller's
-         * message, which is expected for a rewritten transaction and so explains
-         * nothing.
+         * When both paths fail, callers still get a stable SignerError code with
+         * the embedded-transaction error as its cause.
          */
         it('reports the embedded-transaction failure when txId validation also fails', async () => {
             vi.mocked(getTransactionDecoder).mockReturnValue({
@@ -645,10 +642,8 @@ describe('CrossmintSigner', () => {
         });
 
         /**
-         * Under gas sponsorship this wallet's signature is an approval over the
-         * rewritten message and never identifies the landed transaction. The
-         * returned value must be the sponsor fee-payer's slot-0 signature so that
-         * rpc.getTransaction(result) resolves.
+         * Under sponsorship the returned value must be the sponsor fee-payer's
+         * slot-0 signature, not the wallet's approval, so RPC lookups resolve.
          */
         it('returns the sponsor fee-payer signature as the transaction id for a sponsored transaction', async () => {
             const SPONSOR_ADDRESS = 'Sysvar1nstructions1111111111111111111111111';
@@ -698,11 +693,9 @@ describe('CrossmintSigner', () => {
             const results = await signer.signAndSendTransactions([createMockTransaction()]);
 
             expect(results[0]).toEqual(SPONSOR_SIGNATURE_BYTES);
-            // The approval gate verified our delegated signer over the executed bytes.
             expect(assertSignatureValid).toHaveBeenCalledWith(
                 expect.objectContaining({ data: rewrittenMessageBytes, signerAddress: DELEGATED_ADDRESS }),
             );
-            // The returned identifier is the fee payer's, verified over the same bytes.
             expect(assertSignatureValid).toHaveBeenCalledWith({
                 data: rewrittenMessageBytes,
                 signature: SPONSOR_SIGNATURE_BYTES,

--- a/typescript/packages/crossmint/src/__tests__/crossmint-signer.test.ts
+++ b/typescript/packages/crossmint/src/__tests__/crossmint-signer.test.ts
@@ -18,6 +18,7 @@ vi.mock('@solana/transactions', async importOriginal => {
 });
 
 import { assertIsSolanaSigner, assertSignatureValid } from '@solana/keychain-core';
+import { isTransactionSendingSigner } from '@solana/signers';
 import { getTransactionDecoder } from '@solana/transactions';
 import { createCrossmintSigner } from '../crossmint-signer.js';
 
@@ -221,7 +222,7 @@ describe('CrossmintSigner', () => {
         });
     });
 
-    describe('signTransactions', () => {
+    describe('signAndSendTransactions', () => {
         it('signs via managed flow and extracts signature from txId', async () => {
             vi.mocked(fetch)
                 .mockResolvedValueOnce(mockWalletResponse()) // create()
@@ -251,9 +252,9 @@ describe('CrossmintSigner', () => {
                 pollIntervalMs: 1,
             });
 
-            const results = await signer.signTransactions([createMockTransaction()]);
+            const results = await signer.signAndSendTransactions([createMockTransaction()]);
             expect(results).toHaveLength(1);
-            const signature = results[0]![signer.address];
+            const signature = results[0];
 
             expect(signature).toBeDefined();
             expect(signature?.length).toBe(64);
@@ -291,7 +292,11 @@ describe('CrossmintSigner', () => {
             });
 
             await expect(
-                signer.signTransactions([createMockTransaction(), createMockTransaction(), createMockTransaction()]),
+                signer.signAndSendTransactions([
+                    createMockTransaction(),
+                    createMockTransaction(),
+                    createMockTransaction(),
+                ]),
             ).rejects.toMatchObject({ code: 'SIGNER_REMOTE_API_ERROR' });
 
             // wallet create + tx0 create + tx1 create = 3 fetches; tx2 must not be created.
@@ -318,9 +323,9 @@ describe('CrossmintSigner', () => {
                 pollIntervalMs: 1,
             });
 
-            const results = await signer.signTransactions([createMockTransaction()]);
+            const results = await signer.signAndSendTransactions([createMockTransaction()]);
             expect(results).toHaveLength(1);
-            expect(results[0]![signer.address]).toEqual(MOCK_SIGNATURE_BYTES);
+            expect(results[0]).toEqual(MOCK_SIGNATURE_BYTES);
             // Signature is verified against the returned transaction's message bytes
             // (Crossmint may refresh the blockhash before signing).
             expect(assertSignatureValid).toHaveBeenCalledWith({
@@ -328,6 +333,65 @@ describe('CrossmintSigner', () => {
                 signature: MOCK_SIGNATURE_BYTES,
                 signerAddress: signer.address,
             });
+        });
+
+        /**
+         * Crossmint sponsors gas, so it is the fee payer and the message it signs
+         * differs from the caller's. A signature dictionary keyed to this address
+         * would assert the signature covers the caller's message, which it does not.
+         */
+        it('rejects signTransactions so a rewritten signature is never applied to caller bytes', async () => {
+            vi.mocked(fetch).mockResolvedValueOnce(mockWalletResponse());
+            const signer = await createCrossmintSigner(mockConfig);
+
+            await expect(
+                (signer as unknown as { signTransactions: (t: unknown[]) => Promise<unknown> }).signTransactions([
+                    createMockTransaction(),
+                ]),
+            ).rejects.toMatchObject({ code: 'SIGNER_CONFIG_ERROR' });
+            // Rejected locally: no transaction may be created server-side.
+            expect(vi.mocked(fetch)).toHaveBeenCalledTimes(1);
+        });
+
+        /**
+         * Aborting stops this client from waiting; it cannot recall work Crossmint
+         * has accepted, so the point is that polling ends rather than running to
+         * the full attempt budget.
+         */
+        it('stops polling when the abort signal fires mid-flight', async () => {
+            const controller = new AbortController();
+            vi.mocked(fetch)
+                .mockResolvedValueOnce(mockWalletResponse())
+                .mockResolvedValueOnce(
+                    new Response(JSON.stringify({ id: 'tx-abort', status: 'pending' }), { status: 201 }),
+                )
+                .mockImplementation(async () => {
+                    controller.abort();
+                    return new Response(JSON.stringify({ id: 'tx-abort', status: 'pending' }), { status: 200 });
+                });
+
+            const signer = await createCrossmintSigner({
+                ...mockConfig,
+                maxPollAttempts: 50,
+                pollIntervalMs: 1,
+            });
+
+            await expect(
+                signer.signAndSendTransactions([createMockTransaction()], { abortSignal: controller.signal }),
+            ).rejects.toThrow();
+            // Far fewer than the 50-attempt budget: wallet + create + a poll or two.
+            expect(vi.mocked(fetch).mock.calls.length).toBeLessThan(6);
+        });
+
+        it('exposes a TransactionSendingSigner so Kit routes it through send, not partial signing', async () => {
+            vi.mocked(fetch).mockResolvedValueOnce(mockWalletResponse());
+            const signer = await createCrossmintSigner(mockConfig);
+
+            expect(
+                isTransactionSendingSigner(
+                    signer as unknown as { [key: string]: unknown; address: typeof signer.address },
+                ),
+            ).toBe(true);
         });
 
         it('extracts signature from serialized transaction even when returned message bytes differ', async () => {
@@ -354,8 +418,8 @@ describe('CrossmintSigner', () => {
                 pollIntervalMs: 1,
             });
 
-            const results = await signer.signTransactions([createMockTransaction()]);
-            expect(results[0]![signer.address]).toEqual(MOCK_SIGNATURE_BYTES);
+            const results = await signer.signAndSendTransactions([createMockTransaction()]);
+            expect(results[0]).toEqual(MOCK_SIGNATURE_BYTES);
             // Verification uses the returned message bytes, not the original ones
             expect(assertSignatureValid).toHaveBeenCalledWith({
                 data: returnedMessageBytes,
@@ -386,11 +450,89 @@ describe('CrossmintSigner', () => {
                 pollIntervalMs: 1,
             });
 
-            await expect(signer.signTransactions([createMockTransaction()])).rejects.toMatchObject({
+            await expect(signer.signAndSendTransactions([createMockTransaction()])).rejects.toMatchObject({
                 code: 'SIGNER_SIGNING_FAILED',
                 message: expect.stringContaining('Unable to extract signature'),
             });
             expect(assertSignatureValid).not.toHaveBeenCalled();
+        });
+
+        /**
+         * A smart wallet is signed by its delegated signer, not by the wallet address
+         * the API reports, so the delegated address must be a verification candidate.
+         */
+        it('locates a signature made by the delegated signer', async () => {
+            const DELEGATED_ADDRESS = 'SysvarC1ock11111111111111111111111111111111';
+            vi.mocked(getTransactionDecoder).mockReturnValue({
+                decode: vi.fn(() => createDecodedTransaction({ signerAddress: DELEGATED_ADDRESS })),
+            } as any);
+            vi.mocked(fetch)
+                .mockResolvedValueOnce(mockWalletResponse())
+                .mockResolvedValueOnce(
+                    new Response(
+                        JSON.stringify({
+                            id: 'tx-delegated',
+                            status: 'success',
+                            onChain: { transaction: MOCK_SERIALIZED_TRANSACTION_B58 },
+                        }),
+                        { status: 201 },
+                    ),
+                );
+
+            const signer = await createCrossmintSigner({
+                ...mockConfig,
+                maxPollAttempts: 1,
+                pollIntervalMs: 1,
+                signer: `server:${DELEGATED_ADDRESS}`,
+            });
+            const results = await signer.signAndSendTransactions([createMockTransaction()]);
+
+            expect(results[0]).toEqual(MOCK_SIGNATURE_BYTES);
+            // Verified against the delegated signer, not the wallet address.
+            expect(assertSignatureValid).toHaveBeenCalledWith(
+                expect.objectContaining({ signerAddress: DELEGATED_ADDRESS }),
+            );
+            // The wallet address remains the signer's public identity.
+            expect(signer.address).toBe(MOCK_ADDRESS);
+        });
+
+        /**
+         * A wallet can be configured with both signerSecret and an explicit signer
+         * locator naming a different key, e.g. the wallet's admin signer. Either may
+         * be the key that actually signs, so both must be candidates.
+         */
+        it('treats an explicit locator signer as a candidate alongside the derived key', async () => {
+            const ADMIN_ADDRESS = 'SysvarRent111111111111111111111111111111111';
+            vi.mocked(getTransactionDecoder).mockReturnValue({
+                decode: vi.fn(() => createDecodedTransaction({ signerAddress: ADMIN_ADDRESS })),
+            } as any);
+            vi.mocked(fetch)
+                .mockResolvedValueOnce(mockWalletResponse())
+                .mockResolvedValueOnce(
+                    new Response(
+                        JSON.stringify({
+                            id: 'tx-admin',
+                            status: 'success',
+                            onChain: { transaction: MOCK_SERIALIZED_TRANSACTION_B58 },
+                        }),
+                        { status: 201 },
+                    ),
+                );
+
+            const signer = await createCrossmintSigner({
+                ...mockConfig,
+                apiKey: `sk_staging_${base58Decoder.decode(new TextEncoder().encode('proj:sig'))}`,
+                maxPollAttempts: 1,
+                pollIntervalMs: 1,
+                signer: `server:${ADMIN_ADDRESS}`,
+                signerSecret: 'a'.repeat(64),
+            });
+            const results = await signer.signAndSendTransactions([createMockTransaction()]);
+
+            expect(results[0]).toEqual(MOCK_SIGNATURE_BYTES);
+            expect(assertSignatureValid).toHaveBeenCalledWith(
+                expect.objectContaining({ signerAddress: ADMIN_ADDRESS }),
+            );
         });
 
         it('rejects when no signature can be extracted', async () => {
@@ -416,7 +558,7 @@ describe('CrossmintSigner', () => {
                 pollIntervalMs: 1,
             });
 
-            await expect(signer.signTransactions([createMockTransaction()])).rejects.toMatchObject({
+            await expect(signer.signAndSendTransactions([createMockTransaction()])).rejects.toMatchObject({
                 code: 'SIGNER_SIGNING_FAILED',
                 message: expect.stringContaining('Unable to extract signature'),
             });
@@ -451,8 +593,8 @@ describe('CrossmintSigner', () => {
                 pollIntervalMs: 1,
             });
 
-            const results = await signer.signTransactions([createMockTransaction()]);
-            expect(results[0]![signer.address]).toEqual(MOCK_SIGNATURE_BYTES);
+            const results = await signer.signAndSendTransactions([createMockTransaction()]);
+            expect(results[0]).toEqual(MOCK_SIGNATURE_BYTES);
             expect(assertSignatureValid).toHaveBeenCalledWith({
                 data: MOCK_MESSAGE_BYTES,
                 signature: MOCK_SIGNATURE_BYTES,
@@ -460,7 +602,13 @@ describe('CrossmintSigner', () => {
             });
         });
 
-        it('rejects txId when transaction decode throws and txId validation fails', async () => {
+        /**
+         * When both paths fail, the embedded-transaction error is the reported cause:
+         * it names which check failed, where the txId error says only that a signature
+         * did not cover the caller's message, which is expected for a rewritten
+         * transaction and so explains nothing.
+         */
+        it('reports the embedded-transaction failure when txId validation also fails', async () => {
             vi.mocked(getTransactionDecoder).mockReturnValue({
                 decode: vi.fn(() => {
                     throw new Error('decode failed');
@@ -489,9 +637,7 @@ describe('CrossmintSigner', () => {
                 pollIntervalMs: 1,
             });
 
-            await expect(signer.signTransactions([createMockTransaction()])).rejects.toThrow(
-                'signature validation failed',
-            );
+            await expect(signer.signAndSendTransactions([createMockTransaction()])).rejects.toThrow('decode failed');
         });
 
         it('throws on failed transaction status', async () => {
@@ -514,7 +660,7 @@ describe('CrossmintSigner', () => {
                 pollIntervalMs: 1,
             });
 
-            await expect(signer.signTransactions([createMockTransaction()])).rejects.toMatchObject({
+            await expect(signer.signAndSendTransactions([createMockTransaction()])).rejects.toMatchObject({
                 code: 'SIGNER_SIGNING_FAILED',
                 message: expect.stringContaining('Insufficient funds'),
             });
@@ -539,7 +685,7 @@ describe('CrossmintSigner', () => {
                 pollIntervalMs: 1,
             });
 
-            await expect(signer.signTransactions([createMockTransaction()])).rejects.toMatchObject({
+            await expect(signer.signAndSendTransactions([createMockTransaction()])).rejects.toMatchObject({
                 code: 'SIGNER_SIGNING_FAILED',
                 message: expect.stringContaining('awaiting approval'),
             });
@@ -559,7 +705,7 @@ describe('CrossmintSigner', () => {
                 pollIntervalMs: 1,
             });
 
-            await expect(signer.signTransactions([createMockTransaction()])).rejects.toMatchObject({
+            await expect(signer.signAndSendTransactions([createMockTransaction()])).rejects.toMatchObject({
                 code: 'SIGNER_REMOTE_API_ERROR',
                 message: expect.stringContaining('timed out'),
             });
@@ -576,7 +722,7 @@ describe('CrossmintSigner', () => {
                 pollIntervalMs: 1,
             });
 
-            await expect(signer.signTransactions([createMockTransaction()])).rejects.toMatchObject({
+            await expect(signer.signAndSendTransactions([createMockTransaction()])).rejects.toMatchObject({
                 code: 'SIGNER_REMOTE_API_ERROR',
                 context: expect.objectContaining({
                     response: expect.stringContaining('Unauthorized'),
@@ -597,7 +743,7 @@ describe('CrossmintSigner', () => {
                 pollIntervalMs: 1,
             });
 
-            await expect(signer.signTransactions([createMockTransaction()])).rejects.toMatchObject({
+            await expect(signer.signAndSendTransactions([createMockTransaction()])).rejects.toMatchObject({
                 code: 'SIGNER_HTTP_ERROR',
             });
         });
@@ -631,9 +777,9 @@ describe('CrossmintSigner', () => {
                 pollIntervalMs: 1,
             });
 
-            const results = await signer.signTransactions([createMockTransaction()]);
+            const results = await signer.signAndSendTransactions([createMockTransaction()]);
             expect(results).toHaveLength(1);
-            expect(results[0]![signer.address]?.length).toBe(64);
+            expect(results[0]?.length).toBe(64);
         });
 
         it('includes signer field in request body when configured', async () => {
@@ -657,7 +803,7 @@ describe('CrossmintSigner', () => {
                 pollIntervalMs: 1,
             });
 
-            await signer.signTransactions([createMockTransaction()]);
+            await signer.signAndSendTransactions([createMockTransaction()]);
 
             const createCall = vi.mocked(fetch).mock.calls[1]!;
             const body = JSON.parse(createCall[1]?.body as string);
@@ -720,7 +866,7 @@ describe('CrossmintSigner', () => {
                 );
 
             const signer = await createCrossmintSigner(approvalConfig());
-            const results = await signer.signTransactions([createMockTransaction()]);
+            const results = await signer.signAndSendTransactions([createMockTransaction()]);
             expect(results).toHaveLength(1);
 
             // The approval POST must carry OUR signer locator, and the signature
@@ -771,9 +917,9 @@ describe('CrossmintSigner', () => {
                 );
 
             const signer = await createCrossmintSigner(approvalConfig());
-            const results = await signer.signTransactions([createMockTransaction()]);
+            const results = await signer.signAndSendTransactions([createMockTransaction()]);
             expect(results).toHaveLength(1);
-            expect(results[0]![signer.address]?.length).toBe(64);
+            expect(results[0]?.length).toBe(64);
             // wallet + create + approvals = 3 fetches; no extra polling.
             expect(vi.mocked(fetch)).toHaveBeenCalledTimes(3);
         });
@@ -795,7 +941,7 @@ describe('CrossmintSigner', () => {
 
             const signer = await createCrossmintSigner(approvalConfig({ maxPollAttempts: 5 }));
 
-            await expect(signer.signTransactions([createMockTransaction()])).rejects.toMatchObject({
+            await expect(signer.signAndSendTransactions([createMockTransaction()])).rejects.toMatchObject({
                 code: 'SIGNER_SIGNING_FAILED',
                 message: expect.stringContaining('additional signer approvals are required'),
             });
@@ -842,7 +988,7 @@ describe('CrossmintSigner', () => {
             // Once our approval is in, a persistent awaiting-approval status is
             // an in-flight state, not a terminal failure: the signer keeps
             // polling and surfaces its own timeout when the budget runs out.
-            await expect(signer.signTransactions([createMockTransaction()])).rejects.toMatchObject({
+            await expect(signer.signAndSendTransactions([createMockTransaction()])).rejects.toMatchObject({
                 code: 'SIGNER_REMOTE_API_ERROR',
                 message: expect.stringContaining('polling timed out'),
             });
@@ -889,9 +1035,9 @@ describe('CrossmintSigner', () => {
                 );
 
             const signer = await createCrossmintSigner(approvalConfig());
-            const results = await signer.signTransactions([createMockTransaction()]);
+            const results = await signer.signAndSendTransactions([createMockTransaction()]);
             expect(results).toHaveLength(1);
-            expect(results[0]![signer.address]?.length).toBe(64);
+            expect(results[0]?.length).toBe(64);
 
             const approvalPosts = vi.mocked(fetch).mock.calls.filter(call => String(call[0]).includes('/approvals'));
             expect(approvalPosts.length).toBe(1);

--- a/typescript/packages/crossmint/src/__tests__/setup.ts
+++ b/typescript/packages/crossmint/src/__tests__/setup.ts
@@ -4,13 +4,12 @@ import { createCrossmintSigner } from '../crossmint-signer.js';
 
 const SIGNER_TYPE = 'crossmint';
 const REQUIRED_ENV_VARS = ['CROSSMINT_API_KEY', 'CROSSMINT_WALLET_LOCATOR'];
-const TEST_SIGNER_DERIVED_PUBKEY_ENV = 'TEST_CROSSMINT_SIGNER_DERIVED_PUBKEY';
 
 const CONFIG: SignerTestConfig<SolanaSigner> = {
     signerType: SIGNER_TYPE,
     requiredEnvVars: REQUIRED_ENV_VARS,
-    createSigner: async () => {
-        const signer = await createCrossmintSigner({
+    createSigner: async () =>
+        await createCrossmintSigner({
             apiKey: process.env.CROSSMINT_API_KEY!,
             walletLocator: process.env.CROSSMINT_WALLET_LOCATOR!,
             apiBaseUrl: process.env.CROSSMINT_API_BASE_URL,
@@ -22,29 +21,8 @@ const CONFIG: SignerTestConfig<SolanaSigner> = {
                 : undefined,
             signerSecret: process.env.CROSSMINT_SIGNER_SECRET,
             signer: process.env.CROSSMINT_SIGNER,
-        });
-
-        // Test-only override for environments where Crossmint's returned wallet
-        // pubkey differs from the signer key used in signed transaction bytes.
-        const testSignerDerivedPubkey = resolveTestSignerDerivedPubkey();
-        if (testSignerDerivedPubkey) {
-            (signer as { address: string }).address = testSignerDerivedPubkey;
-        }
-
-        return signer;
-    },
+        }),
 };
-
-function resolveTestSignerDerivedPubkey(): string | undefined {
-    const explicit = process.env[TEST_SIGNER_DERIVED_PUBKEY_ENV]?.trim();
-    if (explicit) return explicit;
-
-    const configuredSigner = process.env.CROSSMINT_SIGNER?.trim();
-    if (!configuredSigner?.startsWith('server:')) return undefined;
-
-    const derived = configuredSigner.slice('server:'.length).trim();
-    return derived || undefined;
-}
 
 export async function getConfig(scenarios: TestScenario[]): Promise<SignerTestConfig<SolanaSigner>> {
     return {

--- a/typescript/packages/crossmint/src/crossmint-signer.ts
+++ b/typescript/packages/crossmint/src/crossmint-signer.ts
@@ -8,6 +8,7 @@ import {
     fetchSignerJson,
     normalizeBaseUrl,
     sanitizeRemoteErrorResponse,
+    SignerError,
     SignerErrorCode,
     SolanaSigner,
     throwSignerError,
@@ -66,10 +67,11 @@ let base64Encoder: ReturnType<typeof getBase64Encoder> | undefined;
 /**
  * Crossmint is a broadcast-managed signer: it rewrites the transaction (gas
  * sponsorship, priority fee, its own blockhash) and broadcasts server-side, so
- * returned signatures cover Crossmint's bytes, not the caller's `messageBytes`.
- * The signature is a send result identifying what Crossmint landed, which is why
- * this signer implements {@link TransactionSendingSigner} instead of returning
- * signature dictionaries keyed to the caller's message.
+ * its signatures cover Crossmint's bytes, not the caller's `messageBytes`.
+ * The returned value is the landed transaction's fee-payer signature, the
+ * identifier Solana RPC looks it up by, which is why this signer implements
+ * {@link TransactionSendingSigner} instead of returning signature dictionaries
+ * keyed to the caller's message.
  */
 class CrossmintSigner<TAddress extends string = string> implements CrossmintSendingSigner<TAddress> {
     readonly address: Address<TAddress>;
@@ -432,11 +434,8 @@ class CrossmintSigner<TAddress extends string = string> implements CrossmintSend
         let embeddedError: unknown;
         if (response.onChain?.transaction) {
             try {
-                return await this.extractSignatureFromSerializedTransaction(response.onChain.transaction);
+                return await this.transactionIdFromExecuted(response, response.onChain.transaction);
             } catch (error) {
-                // A rewritten transaction's signature is in approvals.submitted.
-                const approved = await this.signatureFromApprovals(response, response.onChain.transaction);
-                if (approved) return approved;
                 // Keep this error as the cause: it names the check that failed,
                 // where the txId path only reports a mismatch.
                 embeddedError = error;
@@ -460,12 +459,70 @@ class CrossmintSigner<TAddress extends string = string> implements CrossmintSend
                     lastError = error;
                 }
             }
-            throw embeddedError ?? lastError;
+            const cause = embeddedError ?? lastError;
+            if (cause instanceof SignerError) throw cause;
+            throwSignerError(SignerErrorCode.SIGNING_FAILED, {
+                address: this.address,
+                cause,
+                message: 'Crossmint returned no signature verifiable by a configured signer',
+            });
         }
 
         throwSignerError(SignerErrorCode.SIGNING_FAILED, {
+            cause: embeddedError,
             message: 'Unable to extract signature from Crossmint transaction response',
         });
+    }
+
+    /**
+     * Identifier of the transaction Crossmint landed: its fee-payer (slot 0)
+     * signature, the value Solana RPC addresses transactions by, so the caller
+     * can pass the result to `getTransaction`/`confirmTransaction`. Under gas
+     * sponsorship the fee payer is Crossmint's sponsor key, not this wallet.
+     *
+     * Returned only after a configured signer's signature (in a slot or in
+     * `approvals.submitted`) verifies over the executed bytes, proving this
+     * wallet took part in what landed.
+     */
+    private async transactionIdFromExecuted(
+        response: CrossmintTransactionResponse,
+        serializedTransaction: string,
+    ): Promise<SignatureBytes> {
+        base58Encoder ||= getBase58Encoder();
+        const decoded = getTransactionDecoder().decode(base58Encoder.encode(serializedTransaction));
+
+        const participant =
+            (await this.verifiedSignatureFromSlots(decoded)) ??
+            (await this.verifiedSignatureFromApprovals(response, decoded.messageBytes));
+        if (!participant) {
+            throwSignerError(SignerErrorCode.SIGNING_FAILED, {
+                address: this.address,
+                message: 'No configured signer holds a verifying signature in the Crossmint transaction',
+            });
+        }
+
+        const [feePayer, feePayerSignature] = Object.entries(decoded.signatures)[0] ?? [];
+        if (participant.address === feePayer) {
+            return participant.signature;
+        }
+        if (!feePayerSignature) {
+            throwSignerError(SignerErrorCode.SIGNING_FAILED, {
+                message: 'Crossmint transaction carries no fee-payer signature to identify it by',
+            });
+        }
+        try {
+            await assertSignatureValid({
+                data: decoded.messageBytes,
+                signature: feePayerSignature,
+                signerAddress: feePayer as Address,
+            });
+        } catch (error) {
+            throwSignerError(SignerErrorCode.SIGNING_FAILED, {
+                cause: error,
+                message: 'Crossmint fee-payer signature does not verify over the executed transaction',
+            });
+        }
+        return feePayerSignature;
     }
 
     /**
@@ -474,20 +531,12 @@ class CrossmintSigner<TAddress extends string = string> implements CrossmintSend
      * For a rewritten transaction it arrives in `approvals.submitted` covering the
      * rewritten message, not in a signature slot. Verified locally regardless.
      */
-    private async signatureFromApprovals(
+    private async verifiedSignatureFromApprovals(
         response: CrossmintTransactionResponse,
-        serializedTransaction: string,
-    ): Promise<SignatureBytes | undefined> {
+        executedMessage: Transaction['messageBytes'],
+    ): Promise<{ address: Address; signature: SignatureBytes } | undefined> {
         const submitted = response.approvals?.submitted;
         if (!submitted?.length) return undefined;
-
-        base58Encoder ||= getBase58Encoder();
-        let executedMessage;
-        try {
-            executedMessage = getTransactionDecoder().decode(base58Encoder.encode(serializedTransaction)).messageBytes;
-        } catch {
-            return undefined;
-        }
 
         const candidates = this.verificationCandidates();
         for (const entry of submitted) {
@@ -500,7 +549,7 @@ class CrossmintSigner<TAddress extends string = string> implements CrossmintSend
                     signature,
                     signerAddress: address as Address,
                 });
-                return signature;
+                return { address: address as Address, signature };
             } catch {
                 // Try the next submitted approval.
             }
@@ -522,11 +571,9 @@ class CrossmintSigner<TAddress extends string = string> implements CrossmintSend
         return candidates;
     }
 
-    private async extractSignatureFromSerializedTransaction(serializedTransaction: string): Promise<SignatureBytes> {
-        base58Encoder ||= getBase58Encoder();
-        const txBytes = base58Encoder.encode(serializedTransaction);
-        const decodedTransaction = getTransactionDecoder().decode(txBytes);
-
+    private async verifiedSignatureFromSlots(
+        decodedTransaction: Transaction,
+    ): Promise<{ address: Address; signature: SignatureBytes } | undefined> {
         // Verify against the bytes Crossmint signed, which differ from the caller's
         // messageBytes once it rewrites to sponsor gas. Require a verifying signature,
         // not just presence in a slot: the wallet address can occupy a slot it never
@@ -540,15 +587,12 @@ class CrossmintSigner<TAddress extends string = string> implements CrossmintSend
                     signature,
                     signerAddress: candidate,
                 });
-                return signature;
+                return { address: candidate, signature };
             } catch {
                 // Try the next configured signer.
             }
         }
-        return throwSignerError(SignerErrorCode.SIGNING_FAILED, {
-            address: this.address,
-            message: 'No configured signer holds a verifying signature in the Crossmint transaction',
-        });
+        return undefined;
     }
 }
 

--- a/typescript/packages/crossmint/src/crossmint-signer.ts
+++ b/typescript/packages/crossmint/src/crossmint-signer.ts
@@ -475,14 +475,9 @@ class CrossmintSigner<TAddress extends string = string> implements CrossmintSend
     }
 
     /**
-     * Identifier of the transaction Crossmint landed: its fee-payer (slot 0)
-     * signature, the value Solana RPC addresses transactions by, so the caller
-     * can pass the result to `getTransaction`/`confirmTransaction`. Under gas
-     * sponsorship the fee payer is Crossmint's sponsor key, not this wallet.
-     *
-     * Returned only after a configured signer's signature (in a slot or in
-     * `approvals.submitted`) verifies over the executed bytes, proving this
-     * wallet took part in what landed.
+     * The landed transaction's fee-payer (slot 0) signature, the value RPC
+     * lookups accept, returned only after a configured signer's signature
+     * verifies over the executed bytes.
      */
     private async transactionIdFromExecuted(
         response: CrossmintTransactionResponse,

--- a/typescript/packages/crossmint/src/crossmint-signer.ts
+++ b/typescript/packages/crossmint/src/crossmint-signer.ts
@@ -3,7 +3,6 @@ import { getBase16Encoder, getBase58Decoder, getBase58Encoder, getBase64Encoder 
 import {
     assertHttpsUrl,
     assertSignatureValid,
-    createSignatureDictionary,
     createSignerError,
     ED25519_SIGNATURE_LENGTH,
     fetchSignerJson,
@@ -15,7 +14,12 @@ import {
     validateRequestDelayMs,
 } from '@solana/keychain-core';
 import { SignatureBytes } from '@solana/keys';
-import { SignableMessage, SignatureDictionary } from '@solana/signers';
+import {
+    SignableMessage,
+    SignatureDictionary,
+    TransactionSendingSigner,
+    TransactionSendingSignerConfig,
+} from '@solana/signers';
 import {
     getBase64EncodedWireTransaction,
     getTransactionDecoder,
@@ -32,9 +36,20 @@ import type {
     CrossmintWalletResponse,
 } from './types.js';
 
+/**
+ * Crossmint signer shape.
+ *
+ * Crossmint rewrites transactions to sponsor gas, so the message it signs
+ * generally differs from the caller's and its signatures cannot be applied to the
+ * caller's transaction. Hence Kit's {@link TransactionSendingSigner} flow rather
+ * than a partial signer.
+ */
+export interface CrossmintSendingSigner<TAddress extends string = string>
+    extends SolanaSigner<TAddress>, TransactionSendingSigner<TAddress> {}
+
 export async function createCrossmintSigner<TAddress extends string = string>(
     config: CrossmintSignerConfig,
-): Promise<SolanaSigner<TAddress>> {
+): Promise<CrossmintSendingSigner<TAddress>> {
     return await CrossmintSigner.create(config);
 }
 
@@ -52,8 +67,11 @@ let base64Encoder: ReturnType<typeof getBase64Encoder> | undefined;
  * Crossmint is a broadcast-managed signer: it rewrites the transaction (gas
  * sponsorship, priority fee, its own blockhash) and broadcasts server-side, so
  * returned signatures cover Crossmint's bytes, not the caller's `messageBytes`.
+ * The signature is a send result identifying what Crossmint landed, which is why
+ * this signer implements {@link TransactionSendingSigner} instead of returning
+ * signature dictionaries keyed to the caller's message.
  */
-class CrossmintSigner<TAddress extends string = string> implements SolanaSigner<TAddress> {
+class CrossmintSigner<TAddress extends string = string> implements CrossmintSendingSigner<TAddress> {
     readonly address: Address<TAddress>;
     private readonly apiKey: string;
     private readonly walletLocator: string;
@@ -64,11 +82,17 @@ class CrossmintSigner<TAddress extends string = string> implements SolanaSigner<
     private readonly signer?: string;
 
     private readonly signerSeed?: Uint8Array;
+    /**
+     * Every delegated-signer address the configuration makes known. Smart wallets
+     * sign with one of these rather than with `address`.
+     */
+    private readonly delegatedAddresses: Address[];
 
     private constructor(config: {
         address: Address<TAddress>;
         apiBaseUrl: string;
         apiKey: string;
+        delegatedAddresses?: Address[];
         maxPollAttempts: number;
         pollIntervalMs: number;
         requestDelayMs: number;
@@ -85,6 +109,7 @@ class CrossmintSigner<TAddress extends string = string> implements SolanaSigner<
         this.requestDelayMs = config.requestDelayMs;
         this.signerSeed = config.signerSeed;
         this.signer = config.signer;
+        this.delegatedAddresses = config.delegatedAddresses ?? [];
     }
 
     static async create<TAddress extends string = string>(
@@ -123,11 +148,27 @@ class CrossmintSigner<TAddress extends string = string> implements SolanaSigner<
 
         let signerSeed: Uint8Array | undefined;
         let signer = config.signer;
+        // Both sources are collected because a caller locator may name a different
+        // key than signerSecret derives, and either can be the one that signs.
+        const delegatedAddresses: Address[] = [];
         if (config.signerSecret) {
             signerSeed = await deriveSignerSeed(config.signerSecret, config.apiKey);
+            base58Decoder ||= getBase58Decoder();
+            const derived = base58Decoder.decode(await ed25519PublicKeyFromSeed(signerSeed)) as Address;
+            delegatedAddresses.push(derived);
             if (!signer) {
-                base58Decoder ||= getBase58Decoder();
-                signer = `server:${base58Decoder.decode(await ed25519PublicKeyFromSeed(signerSeed))}`;
+                signer = `server:${derived}`;
+            }
+        }
+        if (signer?.startsWith('server:')) {
+            const encoded = signer.slice('server:'.length).trim();
+            try {
+                assertIsAddress(encoded);
+                if (!delegatedAddresses.includes(encoded)) {
+                    delegatedAddresses.push(encoded);
+                }
+            } catch {
+                // A locator that is not an address contributes no candidate.
             }
         }
 
@@ -158,6 +199,7 @@ class CrossmintSigner<TAddress extends string = string> implements SolanaSigner<
             address,
             apiBaseUrl,
             apiKey: config.apiKey,
+            delegatedAddresses,
             maxPollAttempts,
             pollIntervalMs,
             requestDelayMs,
@@ -176,8 +218,23 @@ class CrossmintSigner<TAddress extends string = string> implements SolanaSigner<
     }
 
     async signTransactions(
-        transactions: readonly (Transaction & TransactionWithinSizeLimit & TransactionWithLifetime)[],
+        _transactions: readonly (Transaction & TransactionWithinSizeLimit & TransactionWithLifetime)[],
     ): Promise<readonly SignatureDictionary[]> {
+        return await Promise.reject(
+            createSignerError(SignerErrorCode.CONFIG_ERROR, {
+                address: this.address,
+                message:
+                    'Crossmint rewrites and broadcasts transactions server-side, so its signature does not cover the caller message; use signAndSendTransactions() or signAndSendTransactionMessageWithSigners()',
+            }),
+        );
+    }
+
+    async signAndSendTransactions(
+        transactions: readonly (Transaction & TransactionWithinSizeLimit & TransactionWithLifetime)[],
+        config?: TransactionSendingSignerConfig,
+    ): Promise<readonly SignatureBytes[]> {
+        config?.abortSignal?.throwIfAborted();
+
         // Sign sequentially, not via Promise.all: each transaction has
         // irreversible server-side effects (createTransaction, and auto-approval
         // when signerSecret is set). Concurrent submission means a failure in one
@@ -185,13 +242,13 @@ class CrossmintSigner<TAddress extends string = string> implements SolanaSigner<
         // and may execute, leading to duplicate spends on retry. Sequential
         // execution stops on the first error before any further transaction is
         // created.
-        const results: SignatureDictionary[] = [];
+        const results: SignatureBytes[] = [];
         for (const [index, transaction] of transactions.entries()) {
             if (this.requestDelayMs > 0 && index > 0) {
                 await new Promise(resolve => setTimeout(resolve, this.requestDelayMs));
             }
-            const signature = await this.signTransactionManaged(transaction);
-            results.push(createSignatureDictionary({ signature, signerAddress: this.address }));
+            config?.abortSignal?.throwIfAborted();
+            results.push(await this.signTransactionManaged(transaction, config?.abortSignal));
         }
         return results;
     }
@@ -205,13 +262,19 @@ class CrossmintSigner<TAddress extends string = string> implements SolanaSigner<
         }
     }
 
+    /**
+     * `abortSignal` stops this client from waiting; it cannot recall work Crossmint
+     * has already accepted, so an aborted transaction may still land server-side.
+     */
     private async signTransactionManaged(
         transaction: Transaction & TransactionWithinSizeLimit & TransactionWithLifetime,
+        abortSignal?: AbortSignal,
     ): Promise<SignatureBytes> {
         let response = await this.createTransaction(transaction);
         let approvalSubmitted = false;
 
         for (let attempt = 0; attempt < this.maxPollAttempts; attempt++) {
+            abortSignal?.throwIfAborted();
             const pending = this.findPendingApprovalForSigner(response);
             if (
                 response.status === 'awaiting-approval' &&
@@ -232,6 +295,7 @@ class CrossmintSigner<TAddress extends string = string> implements SolanaSigner<
             }
 
             await new Promise(resolve => setTimeout(resolve, this.pollIntervalMs));
+            abortSignal?.throwIfAborted();
             response = await this.getTransaction(response.id);
         }
 
@@ -365,24 +429,38 @@ class CrossmintSigner<TAddress extends string = string> implements SolanaSigner<
         response: CrossmintTransactionResponse,
         transaction: Transaction & TransactionWithinSizeLimit & TransactionWithLifetime,
     ): Promise<SignatureBytes> {
+        let embeddedError: unknown;
         if (response.onChain?.transaction) {
             try {
                 return await this.extractSignatureFromSerializedTransaction(response.onChain.transaction);
-            } catch {
-                // If Crossmint returned an onChain.transaction but it could not be
-                // decoded or validated, fall through to txId and still require
-                // cryptographic validation against the original message bytes.
+            } catch (error) {
+                // A rewritten transaction's signature is in approvals.submitted.
+                const approved = await this.signatureFromApprovals(response, response.onChain.transaction);
+                if (approved) return approved;
+                // Keep this error as the cause: it names the check that failed,
+                // where the txId path only reports a mismatch.
+                embeddedError = error;
             }
         }
 
         const fromTxId = decodeSignatureString(response.onChain?.txId);
         if (fromTxId) {
-            await assertSignatureValid({
-                data: transaction.messageBytes,
-                signature: fromTxId,
-                signerAddress: this.address,
-            });
-            return fromTxId;
+            // A txId counts only if it covers the caller's bytes, and any configured
+            // signer may have produced it.
+            let lastError: unknown;
+            for (const candidate of this.verificationCandidates()) {
+                try {
+                    await assertSignatureValid({
+                        data: transaction.messageBytes,
+                        signature: fromTxId,
+                        signerAddress: candidate,
+                    });
+                    return fromTxId;
+                } catch (error) {
+                    lastError = error;
+                }
+            }
+            throw embeddedError ?? lastError;
         }
 
         throwSignerError(SignerErrorCode.SIGNING_FAILED, {
@@ -390,28 +468,87 @@ class CrossmintSigner<TAddress extends string = string> implements SolanaSigner<
         });
     }
 
+    /**
+     * This wallet's signature over the transaction Crossmint executed.
+     *
+     * For a rewritten transaction it arrives in `approvals.submitted` covering the
+     * rewritten message, not in a signature slot. Verified locally regardless.
+     */
+    private async signatureFromApprovals(
+        response: CrossmintTransactionResponse,
+        serializedTransaction: string,
+    ): Promise<SignatureBytes | undefined> {
+        const submitted = response.approvals?.submitted;
+        if (!submitted?.length) return undefined;
+
+        base58Encoder ||= getBase58Encoder();
+        let executedMessage;
+        try {
+            executedMessage = getTransactionDecoder().decode(base58Encoder.encode(serializedTransaction)).messageBytes;
+        } catch {
+            return undefined;
+        }
+
+        const candidates = this.verificationCandidates();
+        for (const entry of submitted) {
+            const address = entry.signer?.address;
+            const signature = decodeSignatureString(entry.signature);
+            if (!address || !signature || !candidates.includes(address as Address)) continue;
+            try {
+                await assertSignatureValid({
+                    data: executedMessage,
+                    signature,
+                    signerAddress: address as Address,
+                });
+                return signature;
+            } catch {
+                // Try the next submitted approval.
+            }
+        }
+        return undefined;
+    }
+
+    /**
+     * Keys that may have signed: the wallet address for an mpc wallet, the
+     * delegated signer for a smart wallet. The response does not say which.
+     */
+    private verificationCandidates(): Address[] {
+        const candidates: Address[] = [this.address];
+        for (const delegated of this.delegatedAddresses) {
+            if (!candidates.includes(delegated)) {
+                candidates.push(delegated);
+            }
+        }
+        return candidates;
+    }
+
     private async extractSignatureFromSerializedTransaction(serializedTransaction: string): Promise<SignatureBytes> {
         base58Encoder ||= getBase58Encoder();
         const txBytes = base58Encoder.encode(serializedTransaction);
         const decodedTransaction = getTransactionDecoder().decode(txBytes);
 
-        const signature = decodedTransaction.signatures[this.address];
-        if (!signature) {
-            throwSignerError(SignerErrorCode.SIGNING_FAILED, {
-                address: this.address,
-                message: `No signature found for address ${this.address}`,
-            });
+        // Verify against the bytes Crossmint signed, which differ from the caller's
+        // messageBytes once it rewrites to sponsor gas. Require a verifying signature,
+        // not just presence in a slot: the wallet address can occupy a slot it never
+        // signed. The signature is only ever returned as a send result.
+        for (const candidate of this.verificationCandidates()) {
+            const signature = decodedTransaction.signatures[candidate];
+            if (!signature) continue;
+            try {
+                await assertSignatureValid({
+                    data: decodedTransaction.messageBytes,
+                    signature,
+                    signerAddress: candidate,
+                });
+                return signature;
+            } catch {
+                // Try the next configured signer.
+            }
         }
-
-        // Verify against the bytes Crossmint actually signed, not the caller's
-        // messageBytes: Crossmint rewrites the tx (blockhash/fees) before signing,
-        // so a strict check against caller bytes would reject legitimately landed txs.
-        await assertSignatureValid({
-            data: decodedTransaction.messageBytes,
-            signature,
-            signerAddress: this.address,
+        return throwSignerError(SignerErrorCode.SIGNING_FAILED, {
+            address: this.address,
+            message: 'No configured signer holds a verifying signature in the Crossmint transaction',
         });
-        return signature;
     }
 }
 

--- a/typescript/packages/crossmint/src/index.ts
+++ b/typescript/packages/crossmint/src/index.ts
@@ -1,2 +1,3 @@
 export { createCrossmintSigner } from './crossmint-signer.js';
+export type { CrossmintSendingSigner } from './crossmint-signer.js';
 export type { CrossmintSignerConfig, CrossmintTransactionStatus } from './types.js';

--- a/typescript/packages/crossmint/src/types.ts
+++ b/typescript/packages/crossmint/src/types.ts
@@ -11,7 +11,17 @@ export interface CrossmintSignerConfig {
      */
     requestDelayMs?: number;
     signer?: string;
-    /** Server signer secret (`xmsk1_<64hex>`). When set, automatically signs awaiting-approval transactions. */
+    /**
+     * Server signer secret (`xmsk1_<64hex>`). When set, automatically signs
+     * awaiting-approval transactions.
+     *
+     * Trust boundary: the approval challenge is the message of the transaction
+     * Crossmint will execute, which is not derivable from the one submitted because
+     * Crossmint rewrites it to sponsor gas. Setting this delegates to Crossmint the
+     * choice of what gets approved. The signer confirms after the fact that its
+     * approval covers the transaction that executed, not that the transaction
+     * matches the caller's intent.
+     */
     signerSecret?: string;
     walletLocator: string;
 }
@@ -46,8 +56,14 @@ export interface CrossmintTransactionApprovals {
         // string (e.g. `server:<address>`) lives at `signer.locator`.
         signer?: { locator?: string };
     }>;
+    /**
+     * Approvals Crossmint has already collected. A rewritten transaction's wallet
+     * signature appears here rather than in a signature slot of the returned
+     * transaction.
+     */
     submitted?: Array<{
         signature?: string;
+        signer?: { address?: string; locator?: string };
     }>;
 }
 


### PR DESCRIPTION
Verified end-to-end against the live Crossmint API in all four languages. Single commit, based on `main`.

## What the live API actually does

A 69-byte legacy message submitted comes back as a **321-byte v0 message with three required signers**. Only slot 0 is filled, and that signature belongs to **Crossmint's own fee payer** — it sponsors gas, so it becomes the fee payer and rewrites the message before signing. `onChain.txId` is that same fee-payer signature.

**This wallet's signature is in `approvals.submitted[]`**, covering the rewritten message, which is byte-identical to the approval challenge.

## Two defects, both fixed

### 1. Signing did not work at all for a smart wallet

I confirmed this by running the live suite against `main`: it **fails**. Every port looked for the signature in the returned transaction's signer slots, where it never appears.

The live suites only passed because they reached past the public API to overwrite the signer's private identity field from `TEST_CROSSMINT_SIGNER_DERIVED_PUBKEY`. So the shipped configuration worked only if the caller patched internals, and the production path was exercised solely in a shape the tests themselves acknowledged was not the real one.

Signatures are now located by matching `approvals.submitted`, or a signature slot, against the keys configuration makes known — the wallet address for an `mpc` wallet, plus any delegated signer derivable from `signerSecret` or a `server:` locator — and verified locally against the bytes Crossmint executed. A key that is neither is still rejected. The test override is deleted, along with the Rust test-only field visibility it required.

### 2. The result was misreported

A signature covering Crossmint's bytes was inserted into the **caller's** transaction, serialized, and returned as complete. Those bytes can never verify, so anyone broadcasting the result got a rejection while the library reported success.

When the returned message differs from the submitted one, the result is now a broadcast result: the signature alone, an empty encoded transaction, the caller's transaction untouched, and complete — Crossmint has already landed it and nothing remains for the caller to send. When the messages match, the signature does cover the caller's bytes and is still placed in the transaction.

Note the comparison **decides how to report; it never refuses the provider's answer.** That is the distinction from the closed #230.

## ⚠️ Breaking change (TypeScript)

Crossmint always executes server-side, so it now implements `TransactionSendingSigner`:

```typescript
const [signature] = await signer.signAndSendTransactions([transaction]);
```

`signTransactions()` rejects with `SIGNER_CONFIG_ERROR`. A `SignatureDictionary` keyed to the signer's address asserts the signature covers the caller's `messageBytes`, which under sponsorship it never does, so there was no honest value to return. New exported type: `CrossmintSendingSigner`.

Python, Rust and Go keep one `sign_transaction`, since their return type expresses both outcomes.

## Smaller items

- An abort now stops the polling loop instead of running to the attempt budget. The method documents that aborting cannot recall work Crossmint has accepted.
- A verification failure no longer falls through to `txId` silently. That path only succeeds when Crossmint signed the caller's exact bytes, so for a rewritten transaction it is not a real fallback and its error explains nothing.
- `signerSecret` now documents what the approval challenge **is** — the message of the transaction Crossmint will execute, not derivable from the one submitted — plus the property the signer verifies after the fact (the approval it submitted covers the transaction that executed) and the one it cannot (that the transaction matches caller intent).

## For reviewers

Three code paths are dead for a gas-sponsored smart wallet but kept deliberately: the signature-slot scan, the `txId` verification, and the "returned == submitted, so attach to the caller's transaction" branch. All three are the **mpc / unsponsored** path, which `init()` explicitly accepts. I had no mpc wallet to test against, so removing them would be guesswork in the other direction. Worth a second opinion.

## Testing

Live API, all four languages, run locally:

- `pytest -m integration -k crossmint` — 2 passed
- `go test -tags integration` — ok
- `cargo test --features integration-tests tests::test_crossmint_integration::` — 3 passed
- `vitest` integration — 3 passed

Unit coverage added for the shape the live API returns, so this is covered without credentials: signature sourced from `approvals.submitted`; an approval from an unconfigured key rejected; a delegated-signer signature located and verified; the wallet address occupying a slot it never signed not shadowing the delegated signer; a `txId` signed by the delegated signer accepted; a rewritten response reported as a broadcast result with the caller's transaction left unsigned. Each was confirmed to fail with its change removed.

Full local suites: Python 457 + ruff + mypy strict; Rust on each of `sdk-v2`/`sdk-v3`/`sdk-v4` plus clippy `-D warnings --all-targets` with `integration-tests`; Go `vet -tags integration` and `test -race` across every module; TypeScript build, typecheck, eslint, prettier, tests and treeshake.