### PR TITLE
ci: skip live signer tests on draft pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    # ready_for_review re-runs the live tests that the draft gate below skips.
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'rust/**'
       - '.github/workflows/ci.yml'
@@ -141,7 +143,10 @@ jobs:
 
   rust-integration-test:
     needs: resolve-signers
-    if: ${{ (github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork) && needs.resolve-signers.outputs.rust_integration_test_count != '0' }}
+    # Live tests call third-party signing providers, so they are skipped on
+    # draft pull requests: open a PR as a draft to iterate without spending
+    # provider rate limits, and mark it ready for review to run them.
+    if: ${{ (github.event_name != 'pull_request' || (!github.event.pull_request.head.repo.fork && !github.event.pull_request.draft)) && needs.resolve-signers.outputs.rust_integration_test_count != '0' }}
     runs-on: ubuntu-latest
     permissions:
       id-token: write

--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    # ready_for_review re-runs the live tests that the draft gate below skips.
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'go/**'
       - '.github/workflows/go-ci.yml'
@@ -156,7 +158,10 @@ jobs:
 
   go-integration-test:
     needs: resolve-signers
-    if: ${{ (github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork) && needs.resolve-signers.outputs.go_integration_module_count != '0' }}
+    # Live tests call third-party signing providers, so they are skipped on
+    # draft pull requests: open a PR as a draft to iterate without spending
+    # provider rate limits, and mark it ready for review to run them.
+    if: ${{ (github.event_name != 'pull_request' || (!github.event.pull_request.head.repo.fork && !github.event.pull_request.draft)) && needs.resolve-signers.outputs.go_integration_module_count != '0' }}
     runs-on: ubuntu-latest
     permissions:
       id-token: write

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    # ready_for_review re-runs the live tests that the draft gate below skips.
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'python/**'
       - '.github/workflows/python-ci.yml'
@@ -123,7 +125,10 @@ jobs:
 
   python-integration-test:
     needs: resolve-signers
-    if: ${{ (github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork) && needs.resolve-signers.outputs.python_integration_backend_count != '0' }}
+    # Live tests call third-party signing providers, so they are skipped on
+    # draft pull requests: open a PR as a draft to iterate without spending
+    # provider rate limits, and mark it ready for review to run them.
+    if: ${{ (github.event_name != 'pull_request' || (!github.event.pull_request.head.repo.fork && !github.event.pull_request.draft)) && needs.resolve-signers.outputs.python_integration_backend_count != '0' }}
     runs-on: ubuntu-latest
     permissions:
       id-token: write

--- a/.github/workflows/typescript-ci.yml
+++ b/.github/workflows/typescript-ci.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    # ready_for_review re-runs the live tests that the draft gate below skips.
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'typescript/**'
       - '.github/workflows/typescript-ci.yml'
@@ -159,7 +161,10 @@ jobs:
 
   typescript-test-integration:
     needs: resolve-signers
-    if: ${{ (github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork) && needs.resolve-signers.outputs.ts_integration_package_count != '0' }}
+    # Live tests call third-party signing providers, so they are skipped on
+    # draft pull requests: open a PR as a draft to iterate without spending
+    # provider rate limits, and mark it ready for review to run them.
+    if: ${{ (github.event_name != 'pull_request' || (!github.event.pull_request.head.repo.fork && !github.event.pull_request.draft)) && needs.resolve-signers.outputs.ts_integration_package_count != '0' }}
     runs-on: ubuntu-latest
     permissions:
       id-token: write


### PR DESCRIPTION
The integration jobs call the third-party signing providers on every
internal pull request and on every push to one. A stack of pull requests
therefore spends provider rate limits once per layer, per push, with no
way to opt out short of not opening the pull request.

Gate those jobs on the pull request not being a draft, so a draft can be
opened and iterated on with unit tests, lint and build for signal while
no provider is contacted, and marking it ready for review runs the live
tests. Draft status does not skip workflows on its own, which is why the
condition is needed. ready_for_review joins the event types so undrafting
re-runs the jobs the gate skipped rather than waiting for a later push.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>