### PR TITLE
fix(utila): keep access token cache writable on frozen signer instances

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,8 @@ jobs:
               ['fordefi', 'test_fordefi_integration'],
               ['aws_kms', 'test_aws_kms_integration'],
               ['gcp_kms', 'test_gcp_kms_integration'],
+              ['para', 'test_para_integration'],
+              ['cdp', 'test_cdp_integration'],
               ['dfns', 'test_dfns_integration'],
               ['crossmint', 'test_crossmint_integration'],
               ['openfort', 'test_openfort_integration'],

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,7 @@ jobs:
               ['dfns', 'test_dfns_integration'],
               ['crossmint', 'test_crossmint_integration'],
               ['openfort', 'test_openfort_integration'],
+              ['utila', 'test_utila_integration'],
             ];
             const rustIntegrationTests = rustIntegrationMap
               .filter(([signer]) => enabled[signer])

--- a/.github/workflows/fork-external-live-manual.yml
+++ b/.github/workflows/fork-external-live-manual.yml
@@ -129,6 +129,7 @@ jobs:
               ['dfns', 'dfns'],
               ['crossmint', 'crossmint'],
               ['openfort', 'openfort'],
+              ['utila', 'utila'],
             ];
 
             const goLiveModuleMap = [
@@ -143,6 +144,7 @@ jobs:
               ['dfns', 'signers/dfns'],
               ['crossmint', 'signers/crossmint'],
               ['openfort', 'signers/openfort'],
+              ['utila', 'signers/utila'],
             ];
 
             const rustFeatures = rustFeatureOrder.filter((backend) => enabled[backend]);

--- a/.github/workflows/fork-external-live-manual.yml
+++ b/.github/workflows/fork-external-live-manual.yml
@@ -134,7 +134,6 @@ jobs:
 
             const goLiveModuleMap = [
               // gcpkms omitted: Workload Identity OIDC is not available in the fork external-live environment.
-              // fordefi omitted: no Go backend.
               ['privy', 'signers/privy'],
               ['turnkey', 'signers/turnkey'],
               ['fireblocks', 'signers/fireblocks'],
@@ -145,6 +144,7 @@ jobs:
               ['crossmint', 'signers/crossmint'],
               ['openfort', 'signers/openfort'],
               ['utila', 'signers/utila'],
+              ['fordefi', 'signers/fordefi'],
             ];
 
             const rustFeatures = rustFeatureOrder.filter((backend) => enabled[backend]);

--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -110,8 +110,8 @@ jobs:
             core.setOutput('go_unit_module_count', String(goUnitModules.length));
             core.setOutput('go_modules_space', goUnitModules.join(' '));
 
-            // Same live-credential set as the TS CI (utila and vault run
-            // locally via `just go-test-integration`, as in Rust/TS).
+            // Same live-credential set as the TS CI (vault runs locally via
+            // `just go-test-integration`, as in Rust/TS).
             const goIntegrationOrder = [
               'privy',
               'turnkey',
@@ -124,6 +124,7 @@ jobs:
               'crossmint',
               'openfort',
               'fordefi',
+              'utila',
             ];
             const goIntegrationModules = goIntegrationOrder
               .filter((signer) => enabled[signer])

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -31,6 +31,7 @@ jobs:
           CI_SIGNER_DFNS_ENABLED: ${{ vars.CI_SIGNER_DFNS_ENABLED || 'true' }}
           CI_SIGNER_CROSSMINT_ENABLED: ${{ vars.CI_SIGNER_CROSSMINT_ENABLED || 'true' }}
           CI_SIGNER_OPENFORT_ENABLED: ${{ vars.CI_SIGNER_OPENFORT_ENABLED || 'true' }}
+          CI_SIGNER_UTILA_ENABLED: ${{ vars.CI_SIGNER_UTILA_ENABLED || 'true' }}
         with:
           script: |
             const parseVar = (name) => {

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -43,8 +43,8 @@ jobs:
               return raw === 'true';
             };
 
-            // Same live-credential set as the other language CIs (utila and
-            // vault run locally via `just py-test-integration`).
+            // Same live-credential set as the other language CIs (vault runs
+            // locally via `just py-test-integration`).
             const integrationOrder = [
               ['privy', 'CI_SIGNER_PRIVY_ENABLED'],
               ['turnkey', 'CI_SIGNER_TURNKEY_ENABLED'],
@@ -57,6 +57,7 @@ jobs:
               ['dfns', 'CI_SIGNER_DFNS_ENABLED'],
               ['crossmint', 'CI_SIGNER_CROSSMINT_ENABLED'],
               ['openfort', 'CI_SIGNER_OPENFORT_ENABLED'],
+              ['utila', 'CI_SIGNER_UTILA_ENABLED'],
             ];
             const backends = integrationOrder
               .filter(([, variable]) => parseVar(variable))

--- a/.github/workflows/typescript-ci.yml
+++ b/.github/workflows/typescript-ci.yml
@@ -113,6 +113,7 @@ jobs:
               'dfns',
               'crossmint',
               'openfort',
+              'utila',
             ];
 
             const unitPackages = unitSignerOrder

--- a/typescript/packages/utila/src/__tests__/utila-signer.test.ts
+++ b/typescript/packages/utila/src/__tests__/utila-signer.test.ts
@@ -250,6 +250,41 @@ describe('UtilaSigner', () => {
             expect(fetchCall(2)[0]).toBe('https://api.test.utila.io/v2/vaults/vault-test/transactions/tx-1?view=FULL');
         });
 
+        it('signs when the signer instance is frozen, as @solana/signers freezes fee-payer signers', async () => {
+            vi.mocked(fetch)
+                .mockResolvedValueOnce(mockWalletResponse())
+                .mockResolvedValueOnce(
+                    jsonResponse({
+                        transaction: {
+                            name: 'vaults/vault-test/transactions/tx-1',
+                            state: 'AWAITING_SIGNATURE',
+                        },
+                    }),
+                )
+                .mockResolvedValueOnce(
+                    jsonResponse({
+                        transaction: {
+                            name: 'vaults/vault-test/transactions/tx-1',
+                            solanaTransaction: {
+                                rawTransaction: MOCK_RAW_TRANSACTION,
+                            },
+                            state: 'SIGNED',
+                        },
+                    }),
+                );
+
+            const signer = await createUtilaSigner({
+                ...mockConfig,
+                maxPollAttempts: 2,
+                pollIntervalMs: 1,
+            });
+            Object.freeze(signer);
+            const results = await signer.signTransactions([createMockTransaction()]);
+
+            expect(results).toHaveLength(1);
+            expect(results[0]![signer.address]).toEqual(MOCK_SIGNATURE_BYTES);
+        });
+
         it('throws on terminal Utila state', async () => {
             vi.mocked(fetch)
                 .mockResolvedValueOnce(mockWalletResponse())

--- a/typescript/packages/utila/src/utila-signer.ts
+++ b/typescript/packages/utila/src/utila-signer.ts
@@ -103,7 +103,9 @@ export class UtilaSigner<TAddress extends string = string> implements SolanaSign
     private readonly serviceAccountPrivateKey: ImportedPrivateKey;
     private readonly vaultId: string;
     private readonly walletId: string;
-    private accessToken: { expiresAtMs: number; tokenPromise: Promise<string> } | null = null;
+    private readonly tokenCache: { entry: { expiresAtMs: number; tokenPromise: Promise<string> } | null } = {
+        entry: null,
+    };
 
     static async create<TAddress extends string = string>(config: UtilaSignerConfig): Promise<UtilaSigner<TAddress>> {
         validateRequired('serviceAccountEmail', config.serviceAccountEmail);
@@ -335,21 +337,27 @@ export class UtilaSigner<TAddress extends string = string> implements SolanaSign
      * {@link TOKEN_REFRESH_MARGIN_MS} of expiry. The pending mint promise is
      * cached (not the resolved token) so concurrent callers share one mint;
      * a failed mint evicts itself so the next call retries.
+     *
+     * The cache lives in a nested `tokenCache` object rather than directly on
+     * the instance because `@solana/signers` freezes fee-payer signers
+     * (`Object.freeze` is shallow, so the nested object stays writable).
      */
     private getAccessToken(): Promise<string> {
-        if (!this.accessToken || Date.now() >= this.accessToken.expiresAtMs - TOKEN_REFRESH_MARGIN_MS) {
-            const entry = {
-                expiresAtMs: Date.now() + TOKEN_TTL_MS,
-                tokenPromise: createUtilaAccessToken(this.serviceAccountEmail, this.serviceAccountPrivateKey),
-            };
-            this.accessToken = entry;
-            entry.tokenPromise.catch(() => {
-                if (this.accessToken === entry) {
-                    this.accessToken = null;
-                }
-            });
+        const cached = this.tokenCache.entry;
+        if (cached && Date.now() < cached.expiresAtMs - TOKEN_REFRESH_MARGIN_MS) {
+            return cached.tokenPromise;
         }
-        return this.accessToken.tokenPromise;
+        const entry = {
+            expiresAtMs: Date.now() + TOKEN_TTL_MS,
+            tokenPromise: createUtilaAccessToken(this.serviceAccountEmail, this.serviceAccountPrivateKey),
+        };
+        this.tokenCache.entry = entry;
+        entry.tokenPromise.catch(() => {
+            if (this.tokenCache.entry === entry) {
+                this.tokenCache.entry = null;
+            }
+        });
+        return entry.tokenPromise;
     }
 
     private async request<T>(path: string, method: 'GET' | 'POST', body?: unknown): Promise<T> {


### PR DESCRIPTION
## Summary
- `@solana/signers` freezes fee-payer signers inside `setTransactionMessageFeePayerSigner` (`Object.freeze(feePayer)`), so the Utila signer's lazy JWT mint (`this.accessToken = entry`) throws `TypeError: Cannot assign to read only property 'accessToken'` whenever a token is minted or refreshed during signing.
- Move the token cache into a nested `tokenCache` object created in the constructor. `Object.freeze` is shallow, so the nested object stays writable and the mint/evict logic is unchanged.
- Add a unit test that freezes the signer instance before signing; it reproduces the exact live-test failure without the fix.
- Close the live integration matrix gaps this exposed:
  - **utila** added to the Rust, TypeScript, Python, and Go CI integration matrices and the fork workflow's Python and Go maps (it only ever ran live via the manual fork workflow, Rust/TS only, which is why this bug survived until a fork PR's live run)
  - **para** and **cdp** added to the Rust integration matrix (tests exist and already run in the fork workflow)
  - **fordefi** added to the fork workflow's Go map (was skipped under a stale "no Go backend" comment predating the Go backend)
  - corrected stale Python/Go CI comments claiming utila runs locally

This is what failed the Utila step of the [Fork External Live Tests run](https://github.com/solana-foundation/solana-keychain/actions/runs/31510169240/job/93841737817): the integration test builds the transaction kit-style, which freezes the signer. Unit tests never hit it because they call `signTransactions()` directly. Utila is the only backend that mutates instance state on the signing path; the others assign only in their constructors (Fireblocks' `privateKeyPromise ??=` is populated during factory `init()`, before any freeze can happen).

The CI jobs are fully generic (Doppler-injected env vars, per-backend matrix), so the list entries are the only wiring needed; env var names already match across all four language suites and exist in the Doppler `stg_github` config. Remaining intentional omissions are documented in-file: gcp-kms in the fork workflow (no Workload Identity OIDC there) and memory/vault everywhere (local-only).

## Test Plan
- `pnpm --filter @solana/keychain-utila run test` (21 passed, includes new frozen-instance regression test)
- Verified the new test fails with the exact CI `TypeError` when the fix is reverted
- `pnpm --filter "@solana/keychain-utila..." run build` + `typecheck` clean, eslint + prettier clean
- `actionlint` on all edited workflows: no new findings (six pre-existing SC2086 infos unchanged)
- After merge: utila/para/cdp live integration run in the main CI matrices; rerun Fork External Live Tests against PR #234 to confirm the original failure is gone