### PR TITLE
ci: run Go Fordefi live tests in the fork external-live workflow

### DIFF
--- a/.github/workflows/fork-external-live-manual.yml
+++ b/.github/workflows/fork-external-live-manual.yml
@@ -133,10 +133,10 @@ jobs:
 
             const goLiveModuleMap = [
               // gcpkms omitted: Workload Identity OIDC is not available in the fork external-live environment.
-              // fordefi omitted: no Go backend.
               ['privy', 'signers/privy'],
               ['turnkey', 'signers/turnkey'],
               ['fireblocks', 'signers/fireblocks'],
+              ['fordefi', 'signers/fordefi'],
               ['aws_kms', 'signers/awskms'],
               ['para', 'signers/para'],
               ['cdp', 'signers/cdp'],


### PR DESCRIPTION
## What

`goLiveModuleMap` in `.github/workflows/fork-external-live-manual.yml` skipped Fordefi with the comment `// fordefi omitted: no Go backend.` That stopped being true when the Go Fordefi signer landed in #229, which shipped with an integration test.

The three sibling maps all list Fordefi (`rustLiveTestMap`, `tsLivePackageMap`, `pythonLiveBackendMap`), and `go-ci.yml` already includes `fordefi` in `goIntegrationOrder`, so the live credentials exist. Only the fork workflow was out of date.

## Why it matters, and why it is not urgent

The risk runs the opposite way from a gate bypass. `fork-live-gate.yml` still hard-fails any fork PR lacking the pass marker, and `go-ci.yml` skips its live job for forks, so **nothing was running ungated**.

The problem is inverted: a maintainer could not run Go Fordefi live tests for a fork PR at all, while the workflow still posted its pass marker (the loop just iterated a shorter list). A reviewer reading that marker on a fork PR touching `go/signers/fordefi` would over-trust it for a custody backend.

## Notes

- This workflow is `workflow_dispatch`-only and appears in no `paths` filter, so **this change triggers no CI**.
- It has to land on `main` before it helps any fork PR, since the workflow runs from `main`'s YAML.
- Verification is a maintainer dispatching "Fork External Live Tests" against a real fork PR and confirming the Go step logs `signers/fordefi` before the marker is posted. Not unit-testable.
- Related drift worth a follow-up, not fixed here: `.claude/commands/add-signer-ci.md` still says "Rust and TS if applicable", which is how this diverged after Python and Go were wired in (#228). A regression guard asserting every signer in `goIntegrationOrder` appears in `goLiveModuleMap` would prevent a recurrence.