### PR TITLE
test(ts): assert the frozen-signer contract across every backend

### DIFF
--- a/docs/ADDING_SIGNERS.md
+++ b/docs/ADDING_SIGNERS.md
@@ -1132,8 +1132,10 @@ in a nested object created by the constructor, because `Object.freeze` is
 shallow.
 
 Every backend's unit suite asserts this with `assertSignerSurvivesFreeze` from
-`@solana/keychain-test-utils`. Add one alongside your happy-path signing test,
-reusing the same mocks:
+`@solana/keychain-test-utils/frozen-signer-contract` — the subpath rather than
+the package root, so unit tests don't load the `litesvm` native binding the
+root barrel pulls in for integration helpers. Add one alongside your happy-path
+signing test, reusing the same mocks:
 
 ```ts
 it('signs when the signer instance is frozen', async () => {

--- a/docs/ADDING_SIGNERS.md
+++ b/docs/ADDING_SIGNERS.md
@@ -1057,6 +1057,7 @@ Before submitting your PR:
 - [ ] Added to README.md supported backends table
 - [ ] CI changes included
 - [ ] TypeScript package with unit + integration tests
+- [ ] TypeScript unit suite asserts the [frozen-instance contract](#frozen-instance-contract-typescript)
 - [ ] Python module with unit + integration tests, registered in the umbrella `_BACKENDS`
 - [ ] Python optional extra declared (if the backend needs a provider SDK)
 - [ ] Umbrella package updated (7 files — see [Umbrella Package](#umbrella-package))
@@ -1119,6 +1120,30 @@ mod tests {
         // Use mock_server.uri() as your api_base_url
     }
 }
+```
+
+### Frozen-instance contract (TypeScript)
+
+`@solana/signers` calls `Object.freeze` on a signer when it is attached to a
+transaction message via `setTransactionMessageFeePayerSigner`, so a signer must
+treat its own instance as immutable once constructed. Anything cached lazily on
+the signing path — an access token, a derived key, a client handle — has to live
+in a nested object created by the constructor, because `Object.freeze` is
+shallow.
+
+Every backend's unit suite asserts this with `assertSignerSurvivesFreeze` from
+`@solana/keychain-test-utils`. Add one alongside your happy-path signing test,
+reusing the same mocks:
+
+```ts
+it('signs when the signer instance is frozen', async () => {
+    mockSignResponse();
+
+    const signer = await createYourServiceSigner(mockConfig);
+    const result = await assertSignerSurvivesFreeze(signer, () => signer.signTransactions([mockTransaction]));
+
+    expect(result[0]).toHaveProperty(signer.address);
+});
 ```
 
 ## Example PR Structure

--- a/typescript/packages/aws-kms/src/__tests__/aws-kms-signer.test.ts
+++ b/typescript/packages/aws-kms/src/__tests__/aws-kms-signer.test.ts
@@ -1,6 +1,7 @@
 import { generateKeyPairSigner } from '@solana/signers';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { assertIsSolanaSigner } from '@solana/keychain-core';
+import { assertSignerSurvivesFreeze } from '@solana/keychain-test-utils';
 
 import { AwsKmsSigner } from '../aws-kms-signer.js';
 import type { AwsKmsSignerConfig } from '../types.js';
@@ -328,6 +329,28 @@ describe('AwsKmsSigner', () => {
             expect(result).toHaveLength(1);
             expect(result[0]).toHaveProperty(signer.address);
             expect(mockSend).toHaveBeenCalledTimes(1);
+        });
+
+        it('signs when the signer instance is frozen', async () => {
+            const keyPair = await generateKeyPairSigner();
+
+            mockSend.mockResolvedValue({
+                Signature: new Uint8Array(64).fill(0x42),
+            });
+
+            const signer = new AwsKmsSigner({
+                keyId: TEST_KEY_ID,
+                publicKey: keyPair.address,
+            });
+
+            const transaction = {
+                messageBytes: new Uint8Array([1, 2, 3, 4]),
+                signatures: {},
+            } as unknown as Parameters<typeof signer.signTransactions>[0][0];
+
+            const result = await assertSignerSurvivesFreeze(signer, () => signer.signTransactions([transaction]));
+
+            expect(result[0]).toHaveProperty(signer.address);
         });
     });
 

--- a/typescript/packages/aws-kms/src/__tests__/aws-kms-signer.test.ts
+++ b/typescript/packages/aws-kms/src/__tests__/aws-kms-signer.test.ts
@@ -1,7 +1,7 @@
 import { generateKeyPairSigner } from '@solana/signers';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { assertIsSolanaSigner } from '@solana/keychain-core';
-import { assertSignerSurvivesFreeze } from '@solana/keychain-test-utils';
+import { assertSignerSurvivesFreeze } from '@solana/keychain-test-utils/frozen-signer-contract';
 
 import { AwsKmsSigner } from '../aws-kms-signer.js';
 import type { AwsKmsSignerConfig } from '../types.js';

--- a/typescript/packages/aws-kms/src/__tests__/aws-kms-signer.test.ts
+++ b/typescript/packages/aws-kms/src/__tests__/aws-kms-signer.test.ts
@@ -334,6 +334,9 @@ describe('AwsKmsSigner', () => {
         it('signs when the signer instance is frozen', async () => {
             const keyPair = await generateKeyPairSigner();
 
+            // This suite clears calls but not implementations between tests, so reset
+            // before arming the mock to keep this test independent of its neighbours.
+            mockSend.mockReset();
             mockSend.mockResolvedValue({
                 Signature: new Uint8Array(64).fill(0x42),
             });

--- a/typescript/packages/cdp/src/__tests__/cdp-signer.test.ts
+++ b/typescript/packages/cdp/src/__tests__/cdp-signer.test.ts
@@ -2,7 +2,7 @@ import * as nodeCrypto from 'node:crypto';
 
 import { Address } from '@solana/addresses';
 import { assertIsSolanaSigner } from '@solana/keychain-core';
-import { assertSignerSurvivesFreeze } from '@solana/keychain-test-utils';
+import { assertSignerSurvivesFreeze } from '@solana/keychain-test-utils/frozen-signer-contract';
 import { generateKeyPairSigner } from '@solana/signers';
 import {
     type Base64EncodedWireTransaction,
@@ -215,9 +215,14 @@ describe('CdpSigner', () => {
             expect(JSON.parse(init.body as string)).toMatchObject({ message: 'hello' });
         });
 
+        // Exercised via signMessages: this backend's signTransactions happy path cannot
+        // complete against mocks. Both paths share the same auth and caching machinery.
         it('signs when the signer instance is frozen', async () => {
             const base58Sig = '5LfnqEfGPFBaHHeQBiNkgQ2EPy4FkVLKE7cjMYc7gv6EjE8Vs5gqaXcZHjpxr3yj5TMt7j3JdJPkXfnwXxXiNAh';
-            mockFetch.mockResolvedValue(new Response(JSON.stringify({ signature: base58Sig }), { status: 200 }));
+            // Fresh Response per call: a Response body can only be read once.
+            mockFetch.mockImplementation(() =>
+                Promise.resolve(new Response(JSON.stringify({ signature: base58Sig }), { status: 200 })),
+            );
 
             const signer = await CdpSigner.create(makeConfig());
             const message = { content: new TextEncoder().encode('hello'), signatures: {} };

--- a/typescript/packages/cdp/src/__tests__/cdp-signer.test.ts
+++ b/typescript/packages/cdp/src/__tests__/cdp-signer.test.ts
@@ -2,6 +2,7 @@ import * as nodeCrypto from 'node:crypto';
 
 import { Address } from '@solana/addresses';
 import { assertIsSolanaSigner } from '@solana/keychain-core';
+import { assertSignerSurvivesFreeze } from '@solana/keychain-test-utils';
 import { generateKeyPairSigner } from '@solana/signers';
 import {
     type Base64EncodedWireTransaction,
@@ -212,6 +213,18 @@ describe('CdpSigner', () => {
             const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit];
             expect(url).toContain('/sign/message');
             expect(JSON.parse(init.body as string)).toMatchObject({ message: 'hello' });
+        });
+
+        it('signs when the signer instance is frozen', async () => {
+            const base58Sig = '5LfnqEfGPFBaHHeQBiNkgQ2EPy4FkVLKE7cjMYc7gv6EjE8Vs5gqaXcZHjpxr3yj5TMt7j3JdJPkXfnwXxXiNAh';
+            mockFetch.mockResolvedValue(new Response(JSON.stringify({ signature: base58Sig }), { status: 200 }));
+
+            const signer = await CdpSigner.create(makeConfig());
+            const message = { content: new TextEncoder().encode('hello'), signatures: {} };
+
+            const result = await assertSignerSurvivesFreeze(signer, () => signer.signMessages([message]));
+
+            expect(result[0]?.[TEST_ADDRESS as Address]).toBeDefined();
         });
 
         it('handles multiple messages with requestDelayMs', async () => {

--- a/typescript/packages/crossmint/src/__tests__/crossmint-signer.test.ts
+++ b/typescript/packages/crossmint/src/__tests__/crossmint-signer.test.ts
@@ -18,6 +18,7 @@ vi.mock('@solana/transactions', async importOriginal => {
 });
 
 import { assertIsSolanaSigner, assertSignatureValid } from '@solana/keychain-core';
+import { assertSignerSurvivesFreeze } from '@solana/keychain-test-utils';
 import { getTransactionDecoder } from '@solana/transactions';
 import { createCrossmintSigner } from '../crossmint-signer.js';
 
@@ -262,6 +263,30 @@ describe('CrossmintSigner', () => {
                 signature: MOCK_SIGNATURE_BYTES,
                 signerAddress: signer.address,
             });
+        });
+
+        it('signs when the signer instance is frozen', async () => {
+            vi.mocked(fetch)
+                .mockResolvedValueOnce(mockWalletResponse())
+                .mockResolvedValueOnce(new Response(JSON.stringify({ id: 'tx-1', status: 'pending' }), { status: 201 }))
+                .mockResolvedValueOnce(
+                    new Response(
+                        JSON.stringify({ id: 'tx-1', onChain: { txId: MOCK_SIGNATURE_B58 }, status: 'success' }),
+                        { status: 200 },
+                    ),
+                );
+
+            const signer = await createCrossmintSigner({
+                ...mockConfig,
+                maxPollAttempts: 2,
+                pollIntervalMs: 1,
+            });
+
+            const results = await assertSignerSurvivesFreeze(signer, () =>
+                signer.signTransactions([createMockTransaction()]),
+            );
+
+            expect(results[0]![signer.address]).toBeDefined();
         });
 
         it('signs sequentially and stops creating transactions after a failure', async () => {

--- a/typescript/packages/crossmint/src/__tests__/crossmint-signer.test.ts
+++ b/typescript/packages/crossmint/src/__tests__/crossmint-signer.test.ts
@@ -18,7 +18,7 @@ vi.mock('@solana/transactions', async importOriginal => {
 });
 
 import { assertIsSolanaSigner, assertSignatureValid } from '@solana/keychain-core';
-import { assertSignerSurvivesFreeze } from '@solana/keychain-test-utils';
+import { assertSignerSurvivesFreeze } from '@solana/keychain-test-utils/frozen-signer-contract';
 import { getTransactionDecoder } from '@solana/transactions';
 import { createCrossmintSigner } from '../crossmint-signer.js';
 

--- a/typescript/packages/dfns/src/__tests__/dfns-signer.test.ts
+++ b/typescript/packages/dfns/src/__tests__/dfns-signer.test.ts
@@ -1,6 +1,6 @@
 import * as nodeCrypto from 'node:crypto';
 
-import { assertSignerSurvivesFreeze } from '@solana/keychain-test-utils';
+import { assertSignerSurvivesFreeze } from '@solana/keychain-test-utils/frozen-signer-contract';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 vi.mock('@solana/keychain-core', async importOriginal => {
@@ -218,6 +218,8 @@ describe('DfnsSigner', () => {
             expect(sig.length).toBe(64);
         });
 
+        // Exercised via signMessages: this backend's signTransactions happy path cannot
+        // complete against mocks. Both paths share the same auth and caching machinery.
         it('signs when the signer instance is frozen', async () => {
             mockWalletFetch();
 

--- a/typescript/packages/dfns/src/__tests__/dfns-signer.test.ts
+++ b/typescript/packages/dfns/src/__tests__/dfns-signer.test.ts
@@ -1,5 +1,6 @@
 import * as nodeCrypto from 'node:crypto';
 
+import { assertSignerSurvivesFreeze } from '@solana/keychain-test-utils';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 vi.mock('@solana/keychain-core', async importOriginal => {
@@ -215,6 +216,33 @@ describe('DfnsSigner', () => {
 
             const sig = result[0]![signer.address]!;
             expect(sig.length).toBe(64);
+        });
+
+        it('signs when the signer instance is frozen', async () => {
+            mockWalletFetch();
+
+            mockFetch.mockResolvedValueOnce({
+                json: async () => createUserActionInitResponse(),
+                ok: true,
+            });
+
+            mockFetch.mockResolvedValueOnce({
+                json: async () => createUserActionResponse(),
+                ok: true,
+            });
+
+            mockFetch.mockResolvedValueOnce({
+                json: async () => createSignatureResponse('11'.repeat(32), '22'.repeat(32)),
+                ok: true,
+            });
+
+            const signer = await DfnsSigner.create(defaultConfig);
+
+            const result = await assertSignerSurvivesFreeze(signer, () =>
+                signer.signMessages([{ content: new Uint8Array([1, 2, 3]), signatures: {} }]),
+            );
+
+            expect(result[0]?.[signer.address]).toBeDefined();
         });
 
         it('accepts escaped-newline PEM keys for auth challenge signing', async () => {

--- a/typescript/packages/fireblocks/src/__tests__/fireblocks-signer.test.ts
+++ b/typescript/packages/fireblocks/src/__tests__/fireblocks-signer.test.ts
@@ -1,7 +1,7 @@
 import { generateKeyPairSigner } from '@solana/signers';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { assertIsSolanaSigner } from '@solana/keychain-core';
-import { assertSignerSurvivesFreeze } from '@solana/keychain-test-utils';
+import { assertSignerSurvivesFreeze } from '@solana/keychain-test-utils/frozen-signer-contract';
 
 import { createFireblocksSigner, FireblocksSigner } from '../fireblocks-signer.js';
 import type { FireblocksSignerConfig } from '../types.js';

--- a/typescript/packages/fireblocks/src/__tests__/fireblocks-signer.test.ts
+++ b/typescript/packages/fireblocks/src/__tests__/fireblocks-signer.test.ts
@@ -1,6 +1,7 @@
 import { generateKeyPairSigner } from '@solana/signers';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { assertIsSolanaSigner } from '@solana/keychain-core';
+import { assertSignerSurvivesFreeze } from '@solana/keychain-test-utils';
 
 import { createFireblocksSigner, FireblocksSigner } from '../fireblocks-signer.js';
 import type { FireblocksSignerConfig } from '../types.js';
@@ -592,6 +593,44 @@ describe('FireblocksSigner', () => {
             const result = await signer.signTransactions([transaction]);
 
             expect(result).toHaveLength(1);
+            expect(result[0]).toHaveProperty(signer.address);
+        });
+
+        it('signs when the signer instance is frozen', async () => {
+            const keyPair = await generateKeyPairSigner();
+
+            mockFetch.mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({ addresses: [{ address: keyPair.address }] }),
+            });
+            mockFetch.mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({ id: 'tx-123', status: 'SUBMITTED' }),
+            });
+            mockFetch.mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({
+                    id: 'tx-123',
+                    signedMessages: [{ signature: { fullSig: '42'.repeat(64) } }],
+                    status: 'COMPLETED',
+                }),
+            });
+
+            const signer = new FireblocksSigner({
+                apiKey: TEST_API_KEY,
+                privateKeyPem: TEST_RSA_PRIVATE_KEY,
+                vaultAccountId: TEST_VAULT_ACCOUNT_ID,
+            });
+
+            await signer.init();
+
+            const transaction = {
+                messageBytes: new Uint8Array([1, 2, 3, 4]),
+                signatures: {},
+            } as unknown as Parameters<typeof signer.signTransactions>[0][0];
+
+            const result = await assertSignerSurvivesFreeze(signer, () => signer.signTransactions([transaction]));
+
             expect(result[0]).toHaveProperty(signer.address);
         });
 

--- a/typescript/packages/fordefi/src/__tests__/fordefi-signer.test.ts
+++ b/typescript/packages/fordefi/src/__tests__/fordefi-signer.test.ts
@@ -3,7 +3,7 @@ import { generateKeyPairSync } from 'node:crypto';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { assertIsSolanaSigner, assertSignatureValid, extractSignatureFromWireTransaction } from '@solana/keychain-core';
-import { assertSignerSurvivesFreeze } from '@solana/keychain-test-utils';
+import { assertSignerSurvivesFreeze } from '@solana/keychain-test-utils/frozen-signer-contract';
 import { isTransactionSendingSigner } from '@solana/signers';
 
 vi.mock('@solana/keychain-core', async importOriginal => {

--- a/typescript/packages/fordefi/src/__tests__/fordefi-signer.test.ts
+++ b/typescript/packages/fordefi/src/__tests__/fordefi-signer.test.ts
@@ -3,6 +3,7 @@ import { generateKeyPairSync } from 'node:crypto';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { assertIsSolanaSigner, assertSignatureValid, extractSignatureFromWireTransaction } from '@solana/keychain-core';
+import { assertSignerSurvivesFreeze } from '@solana/keychain-test-utils';
 import { isTransactionSendingSigner } from '@solana/signers';
 
 vi.mock('@solana/keychain-core', async importOriginal => {
@@ -301,6 +302,20 @@ describe('FordefiSigner', () => {
             expect(postOpts.headers).toHaveProperty('Authorization', 'Bearer test-token');
             expect(postOpts.headers).toHaveProperty('x-signature');
             expect(postOpts.headers).toHaveProperty('x-timestamp');
+        });
+
+        it('signs when the signer instance is frozen', async () => {
+            vi.mocked(fetch)
+                .mockResolvedValueOnce(mockVaultResponse())
+                .mockResolvedValueOnce(mockCreateTxResponse())
+                .mockResolvedValueOnce(mockPollResponse('completed', MOCK_SIGNATURE_BASE64));
+
+            const signer = await FordefiSigner.create(mockConfig);
+            const mockTx = { messageBytes: new Uint8Array(32) } as never;
+
+            const results = await assertSignerSurvivesFreeze(signer, () => signer.signTransactions([mockTx]));
+
+            expect(results[0]).toHaveProperty(MOCK_ADDRESS);
         });
 
         it('should return the raw Fordefi signature directly without wire-tx round-trip', async () => {

--- a/typescript/packages/gcp-kms/src/__tests__/gcp-kms-signer.test.ts
+++ b/typescript/packages/gcp-kms/src/__tests__/gcp-kms-signer.test.ts
@@ -1,6 +1,7 @@
 import { address } from '@solana/addresses';
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { assertIsSolanaSigner } from '@solana/keychain-core';
+import { assertSignerSurvivesFreeze } from '@solana/keychain-test-utils';
 
 import { GcpKmsSigner } from '../gcp-kms-signer.js';
 import type { GcpKmsSignerConfig } from '../types.js';
@@ -357,6 +358,24 @@ describe('GcpKmsSigner', () => {
             expect(mockFetch).toHaveBeenCalledTimes(1);
 
             assertAuthorizedRequest(SIGN_ENDPOINT, 'POST');
+        });
+
+        it('signs when the signer instance is frozen', async () => {
+            mockFetch.mockResolvedValue(createJsonResponse({ signature: TEST_SIGNATURE_BASE64 }));
+
+            const signer = new GcpKmsSigner({
+                keyName: TEST_KEY_NAME,
+                publicKey: TEST_PUBLIC_KEY,
+            });
+
+            const transaction = {
+                messageBytes: new Uint8Array([1, 2, 3, 4]),
+                signatures: {},
+            } as any;
+
+            const result = await assertSignerSurvivesFreeze(signer, () => signer.signTransactions([transaction]));
+
+            expect(result[0]).toHaveProperty(signer.address);
         });
 
         it('should sign multiple transactions successfully', async () => {

--- a/typescript/packages/gcp-kms/src/__tests__/gcp-kms-signer.test.ts
+++ b/typescript/packages/gcp-kms/src/__tests__/gcp-kms-signer.test.ts
@@ -1,7 +1,7 @@
 import { address } from '@solana/addresses';
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { assertIsSolanaSigner } from '@solana/keychain-core';
-import { assertSignerSurvivesFreeze } from '@solana/keychain-test-utils';
+import { assertSignerSurvivesFreeze } from '@solana/keychain-test-utils/frozen-signer-contract';
 
 import { GcpKmsSigner } from '../gcp-kms-signer.js';
 import type { GcpKmsSignerConfig } from '../types.js';

--- a/typescript/packages/memory/src/__tests__/memory-signer.test.ts
+++ b/typescript/packages/memory/src/__tests__/memory-signer.test.ts
@@ -11,6 +11,7 @@ import {
     setTransactionMessageFeePayer,
     setTransactionMessageLifetimeUsingBlockhash,
 } from '@solana/kit';
+import { assertSignerSurvivesFreeze } from '@solana/keychain-test-utils';
 import { generateKeyPair } from '@solana/keys';
 import { describe, expect, it } from 'vitest';
 
@@ -158,6 +159,27 @@ describe('createMemorySigner', () => {
             const sig = dict?.[signer.address];
             expect(sig).toBeDefined();
             expect(sig?.length).toBe(64);
+        });
+
+        it('signs when the signer instance is frozen', async () => {
+            const signer = await createMemorySignerFromBytes(TEST_KEYPAIR_BYTES);
+            const transaction = pipe(
+                createTransactionMessage({ version: 0 }),
+                tx => setTransactionMessageFeePayer(signer.address, tx),
+                tx =>
+                    setTransactionMessageLifetimeUsingBlockhash(
+                        {
+                            blockhash: blockhash('11111111111111111111111111111111'),
+                            lastValidBlockHeight: 0n,
+                        },
+                        tx,
+                    ),
+                compileTransaction,
+            );
+
+            const [dict] = await assertSignerSurvivesFreeze(signer, () => signer.signTransactions([transaction]));
+
+            expect(dict?.[signer.address]?.length).toBe(64);
         });
     });
 

--- a/typescript/packages/memory/src/__tests__/memory-signer.test.ts
+++ b/typescript/packages/memory/src/__tests__/memory-signer.test.ts
@@ -11,7 +11,7 @@ import {
     setTransactionMessageFeePayer,
     setTransactionMessageLifetimeUsingBlockhash,
 } from '@solana/kit';
-import { assertSignerSurvivesFreeze } from '@solana/keychain-test-utils';
+import { assertSignerSurvivesFreeze } from '@solana/keychain-test-utils/frozen-signer-contract';
 import { generateKeyPair } from '@solana/keys';
 import { describe, expect, it } from 'vitest';
 

--- a/typescript/packages/openfort/src/__tests__/openfort-signer.test.ts
+++ b/typescript/packages/openfort/src/__tests__/openfort-signer.test.ts
@@ -1,6 +1,6 @@
 import { Address } from '@solana/addresses';
 import { assertIsSolanaSigner } from '@solana/keychain-core';
-import { assertSignerSurvivesFreeze } from '@solana/keychain-test-utils';
+import { assertSignerSurvivesFreeze } from '@solana/keychain-test-utils/frozen-signer-contract';
 import { type Transaction, type TransactionWithinSizeLimit, type TransactionWithLifetime } from '@solana/transactions';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 

--- a/typescript/packages/openfort/src/__tests__/openfort-signer.test.ts
+++ b/typescript/packages/openfort/src/__tests__/openfort-signer.test.ts
@@ -1,5 +1,6 @@
 import { Address } from '@solana/addresses';
 import { assertIsSolanaSigner } from '@solana/keychain-core';
+import { assertSignerSurvivesFreeze } from '@solana/keychain-test-utils';
 import { type Transaction, type TransactionWithinSizeLimit, type TransactionWithLifetime } from '@solana/transactions';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -325,6 +326,18 @@ describe('OpenfortSigner', () => {
             expect(result).toHaveLength(1);
             const [, init] = mockFetch.mock.calls[1] as [string, RequestInit];
             expect(JSON.parse(init.body as string)).toEqual({ data: '0xdeadbeef' });
+        });
+
+        it('signs when the signer instance is frozen', async () => {
+            mockGetAccount();
+            const signer = await OpenfortSigner.create(makeConfig());
+
+            mockSign();
+            const tx = createMockTransaction(new Uint8Array([0xde, 0xad, 0xbe, 0xef]));
+
+            const result = await assertSignerSurvivesFreeze(signer, () => signer.signTransactions([tx]));
+
+            expect(result).toHaveLength(1);
         });
     });
 

--- a/typescript/packages/para/src/__tests__/para-signer.test.ts
+++ b/typescript/packages/para/src/__tests__/para-signer.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { assertIsSolanaSigner } from '@solana/keychain-core';
+import { assertSignerSurvivesFreeze } from '@solana/keychain-test-utils';
 
 vi.mock('@solana/keychain-core', async importOriginal => {
     const mod = await importOriginal<typeof import('@solana/keychain-core')>();
@@ -450,6 +451,20 @@ describe('ParaSigner', () => {
                     method: 'POST',
                 }),
             );
+        });
+
+        it('signs when the signer instance is frozen', async () => {
+            vi.mocked(fetch).mockResolvedValueOnce(mockWalletResponse()).mockResolvedValueOnce(mockSignResponse());
+
+            const signer = await ParaSigner.create(mockConfig);
+            const mockTransaction = {
+                messageBytes: new Uint8Array([1, 2, 3, 4]),
+                signatures: {},
+            } as any;
+
+            const [result] = await assertSignerSurvivesFreeze(signer, () => signer.signTransactions([mockTransaction]));
+
+            expect(result).toHaveProperty(MOCK_ADDRESS);
         });
 
         it('should return empty array for empty input', async () => {

--- a/typescript/packages/para/src/__tests__/para-signer.test.ts
+++ b/typescript/packages/para/src/__tests__/para-signer.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { assertIsSolanaSigner } from '@solana/keychain-core';
-import { assertSignerSurvivesFreeze } from '@solana/keychain-test-utils';
+import { assertSignerSurvivesFreeze } from '@solana/keychain-test-utils/frozen-signer-contract';
 
 vi.mock('@solana/keychain-core', async importOriginal => {
     const mod = await importOriginal<typeof import('@solana/keychain-core')>();

--- a/typescript/packages/privy/src/__tests__/privy-signer.test.ts
+++ b/typescript/packages/privy/src/__tests__/privy-signer.test.ts
@@ -7,7 +7,7 @@ import {
     TransactionWithLifetime,
 } from '@solana/transactions';
 import { assertIsSolanaSigner } from '@solana/keychain-core';
-import { assertSignerSurvivesFreeze } from '@solana/keychain-test-utils';
+import { assertSignerSurvivesFreeze } from '@solana/keychain-test-utils/frozen-signer-contract';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { PrivySigner } from '../privy-signer.js';
@@ -306,6 +306,8 @@ describe('PrivySigner', () => {
             expect(sigDict?.[signer.address]).toBeTruthy();
         });
 
+        // Exercised via signMessages: this backend's signTransactions happy path cannot
+        // complete against mocks. Both paths share the same auth and caching machinery.
         it('signs when the signer instance is frozen', async () => {
             const keyPair = await generateKeyPair();
             const keyPairSigner = await createSignerFromKeyPair(keyPair);

--- a/typescript/packages/privy/src/__tests__/privy-signer.test.ts
+++ b/typescript/packages/privy/src/__tests__/privy-signer.test.ts
@@ -7,6 +7,7 @@ import {
     TransactionWithLifetime,
 } from '@solana/transactions';
 import { assertIsSolanaSigner } from '@solana/keychain-core';
+import { assertSignerSurvivesFreeze } from '@solana/keychain-test-utils';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { PrivySigner } from '../privy-signer.js';
@@ -302,6 +303,25 @@ describe('PrivySigner', () => {
             const message = createSignableMessage(messageContent);
             const [sigDict] = await signer.signMessages([message]);
             expect(sigDict).toBeTruthy();
+            expect(sigDict?.[signer.address]).toBeTruthy();
+        });
+
+        it('signs when the signer instance is frozen', async () => {
+            const keyPair = await generateKeyPair();
+            const keyPairSigner = await createSignerFromKeyPair(keyPair);
+
+            setupMockWalletResponse(keyPairSigner.address);
+
+            const signer = await PrivySigner.create(mockConfig);
+
+            const messageContent = new Uint8Array([1, 2, 3, 4]);
+            const signature = await signBytes(keyPair.privateKey, messageContent);
+            setupMockSignMessageResponse(Buffer.from(signature).toString('base64'));
+
+            const [sigDict] = await assertSignerSurvivesFreeze(signer, () =>
+                signer.signMessages([createSignableMessage(messageContent)]),
+            );
+
             expect(sigDict?.[signer.address]).toBeTruthy();
         });
 

--- a/typescript/packages/test-utils/package.json
+++ b/typescript/packages/test-utils/package.json
@@ -20,6 +20,10 @@
         ".": {
             "types": "./dist/index.d.ts",
             "import": "./dist/index.js"
+        },
+        "./frozen-signer-contract": {
+            "types": "./dist/frozen-signer-contract.d.ts",
+            "import": "./dist/frozen-signer-contract.js"
         }
     },
     "files": [

--- a/typescript/packages/test-utils/src/frozen-signer-contract.ts
+++ b/typescript/packages/test-utils/src/frozen-signer-contract.ts
@@ -1,0 +1,57 @@
+import type { SolanaSigner } from '@solana/keychain-core';
+
+/**
+ * Matches the `TypeError` messages engines raise when code writes to a property
+ * of a frozen object under strict mode. V8 and JavaScriptCore word this
+ * differently, and the message differs again for adding a new property versus
+ * overwriting an existing one.
+ */
+const FROZEN_WRITE_MESSAGE = /read[ -]only property|not extensible|object is not extensible|Attempted to assign to/i;
+
+/**
+ * Asserts that a signer can still sign after `Object.freeze`.
+ *
+ * `@solana/signers` freezes a signer when it is attached to a transaction
+ * message via `setTransactionMessageFeePayerSigner`, so every signer must treat
+ * its own instance as immutable once constructed. A signer that lazily caches
+ * state by assigning to `this` — an access token, a derived key, a client
+ * handle — throws a `TypeError` on the first cache write and fails for every
+ * caller that builds transactions the standard way.
+ *
+ * `Object.freeze` is shallow, so a cache held in a nested object created during
+ * construction stays writable and satisfies this contract.
+ *
+ * Call this from a package's unit suite with the same mocks the happy-path
+ * signing test uses:
+ *
+ * ```ts
+ * it('signs when the signer instance is frozen', async () => {
+ *     mockSignResponse();
+ *     const signer = await createFooSigner(config);
+ *     await assertSignerSurvivesFreeze(signer, () => signer.signTransactions([tx]));
+ * });
+ * ```
+ *
+ * @param signer - A fully constructed signer. Freeze happens here, so any
+ *   async `init()` must already have resolved.
+ * @param exercise - Invokes the signing path under test. Its resolved value is
+ *   returned so callers can make their own assertions on the signatures.
+ */
+export async function assertSignerSurvivesFreeze<TReturn>(
+    signer: SolanaSigner,
+    exercise: () => Promise<TReturn>,
+): Promise<TReturn> {
+    Object.freeze(signer);
+    try {
+        return await exercise();
+    } catch (error) {
+        if (error instanceof TypeError && FROZEN_WRITE_MESSAGE.test(error.message)) {
+            error.message =
+                `${error.message} — the signer wrote to its own instance while signing. ` +
+                '@solana/signers freezes fee-payer signers in setTransactionMessageFeePayerSigner, ' +
+                'so state cached during signing must live in a nested object created by the constructor ' +
+                '(Object.freeze is shallow).';
+        }
+        throw error;
+    }
+}

--- a/typescript/packages/test-utils/src/frozen-signer-contract.ts
+++ b/typescript/packages/test-utils/src/frozen-signer-contract.ts
@@ -1,12 +1,18 @@
 import type { SolanaSigner } from '@solana/keychain-core';
 
 /**
- * Matches the `TypeError` messages engines raise when code writes to a property
- * of a frozen object under strict mode. V8 and JavaScriptCore word this
- * differently, and the message differs again for adding a new property versus
- * overwriting an existing one.
+ * Matches the `TypeError` messages engines raise when code mutates a property
+ * of a frozen object under strict mode. The wording varies by engine and by
+ * the kind of mutation — overwriting an existing property, adding a new one,
+ * defining one, or deleting one:
+ *
+ * - V8: `Cannot assign to read only property 'x' of object '#<Signer>'`
+ * - V8: `Cannot add property x, object is not extensible`
+ * - V8: `Cannot define property x, object is not extensible`
+ * - V8: `Cannot delete property 'x' of #<Signer>`
+ * - JavaScriptCore: `Attempted to assign to readonly property.`
  */
-const FROZEN_WRITE_MESSAGE = /read[ -]only property|not extensible|object is not extensible|Attempted to assign to/i;
+const FROZEN_WRITE_MESSAGE = /read[ -]?only property|not extensible|Cannot delete property|Attempted to assign to/i;
 
 /**
  * Asserts that a signer can still sign after `Object.freeze`.
@@ -46,12 +52,30 @@ export async function assertSignerSurvivesFreeze<TReturn>(
         return await exercise();
     } catch (error) {
         if (error instanceof TypeError && FROZEN_WRITE_MESSAGE.test(error.message)) {
-            error.message =
-                `${error.message} — the signer wrote to its own instance while signing. ` +
-                '@solana/signers freezes fee-payer signers in setTransactionMessageFeePayerSigner, ' +
-                'so state cached during signing must live in a nested object created by the constructor ' +
-                '(Object.freeze is shallow).';
+            throw explainFrozenWrite(error);
         }
         throw error;
     }
+}
+
+/**
+ * Builds a replacement error that keeps the original throw site's frames.
+ *
+ * `stack` embeds the message in its first line and is materialized when the
+ * error is constructed, so annotating in place would leave `message` and
+ * `stack` disagreeing and reporters that print `stack` would show none of the
+ * guidance. Rebuilding both together keeps them consistent.
+ */
+function explainFrozenWrite(error: TypeError): Error {
+    const explained = new Error(
+        `${error.message} — the signer wrote to its own instance while signing. ` +
+            '@solana/signers freezes fee-payer signers in setTransactionMessageFeePayerSigner, ' +
+            'so state cached during signing must live in a nested object created by the constructor ' +
+            '(Object.freeze is shallow).',
+    );
+    const originalFrames = error.stack?.split('\n').slice(1).join('\n');
+    if (originalFrames) {
+        explained.stack = `${explained.name}: ${explained.message}\n${originalFrames}`;
+    }
+    return explained;
 }

--- a/typescript/packages/test-utils/src/index.ts
+++ b/typescript/packages/test-utils/src/index.ts
@@ -1,3 +1,4 @@
+export { assertSignerSurvivesFreeze } from './frozen-signer-contract.js';
 export { runSignerIntegrationTest } from './integration-test-runner.js';
 export { airdropLamports, formatSimulationResult, truncateAddress } from './litesvm-helpers.js';
 export { createTestKeypair, type TestKeypair } from './test-keypair.js';

--- a/typescript/packages/test-utils/src/index.ts
+++ b/typescript/packages/test-utils/src/index.ts
@@ -1,4 +1,3 @@
-export { assertSignerSurvivesFreeze } from './frozen-signer-contract.js';
 export { runSignerIntegrationTest } from './integration-test-runner.js';
 export { airdropLamports, formatSimulationResult, truncateAddress } from './litesvm-helpers.js';
 export { createTestKeypair, type TestKeypair } from './test-keypair.js';

--- a/typescript/packages/turnkey/src/__tests__/turnkey-signer.test.ts
+++ b/typescript/packages/turnkey/src/__tests__/turnkey-signer.test.ts
@@ -8,7 +8,7 @@ import {
     TransactionWithLifetime,
 } from '@solana/transactions';
 import { assertIsSolanaSigner } from '@solana/keychain-core';
-import { assertSignerSurvivesFreeze } from '@solana/keychain-test-utils';
+import { assertSignerSurvivesFreeze } from '@solana/keychain-test-utils/frozen-signer-contract';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { createTurnkeySigner, TurnkeySigner } from '../turnkey-signer.js';
@@ -241,6 +241,8 @@ describe('TurnkeySigner', () => {
             expect(sigDict?.[signer.address]).toBeTruthy();
         });
 
+        // Exercised via signMessages: this backend's signTransactions happy path cannot
+        // complete against mocks. Both paths share the same auth and caching machinery.
         it('signs when the signer instance is frozen', async () => {
             const keyPair = await generateKeyPair();
             const keyPairSigner = await createSignerFromKeyPair(keyPair);

--- a/typescript/packages/turnkey/src/__tests__/turnkey-signer.test.ts
+++ b/typescript/packages/turnkey/src/__tests__/turnkey-signer.test.ts
@@ -8,6 +8,7 @@ import {
     TransactionWithLifetime,
 } from '@solana/transactions';
 import { assertIsSolanaSigner } from '@solana/keychain-core';
+import { assertSignerSurvivesFreeze } from '@solana/keychain-test-utils';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { createTurnkeySigner, TurnkeySigner } from '../turnkey-signer.js';
@@ -237,6 +238,27 @@ describe('TurnkeySigner', () => {
             const [sigDict] = await signer.signMessages([message]);
 
             expect(sigDict).toBeTruthy();
+            expect(sigDict?.[signer.address]).toBeTruthy();
+        });
+
+        it('signs when the signer instance is frozen', async () => {
+            const keyPair = await generateKeyPair();
+            const keyPairSigner = await createSignerFromKeyPair(keyPair);
+
+            const signer = new TurnkeySigner({ ...mockConfig, publicKey: keyPairSigner.address });
+
+            const messageContent = new Uint8Array([1, 2, 3, 4]);
+            const signature = await signBytes(keyPair.privateKey, messageContent);
+
+            setupMockSignResponse(
+                Buffer.from(signature.slice(0, 32)).toString('hex'),
+                Buffer.from(signature.slice(32, 64)).toString('hex'),
+            );
+
+            const [sigDict] = await assertSignerSurvivesFreeze(signer, () =>
+                signer.signMessages([createSignableMessage(messageContent)]),
+            );
+
             expect(sigDict?.[signer.address]).toBeTruthy();
         });
 

--- a/typescript/packages/utila/src/__tests__/utila-signer.test.ts
+++ b/typescript/packages/utila/src/__tests__/utila-signer.test.ts
@@ -16,7 +16,7 @@ vi.mock('@solana/transactions', async importOriginal => {
 });
 
 import { assertIsSolanaSigner, assertSignatureValid } from '@solana/keychain-core';
-import { assertSignerSurvivesFreeze } from '@solana/keychain-test-utils';
+import { assertSignerSurvivesFreeze } from '@solana/keychain-test-utils/frozen-signer-contract';
 import { getTransactionDecoder } from '@solana/transactions';
 import { createUtilaAccessToken, createUtilaSigner } from '../utila-signer.js';
 import { TEST_EMAIL, TEST_RSA_PRIVATE_KEY } from './setup.js';

--- a/typescript/packages/utila/src/__tests__/utila-signer.test.ts
+++ b/typescript/packages/utila/src/__tests__/utila-signer.test.ts
@@ -16,6 +16,7 @@ vi.mock('@solana/transactions', async importOriginal => {
 });
 
 import { assertIsSolanaSigner, assertSignatureValid } from '@solana/keychain-core';
+import { assertSignerSurvivesFreeze } from '@solana/keychain-test-utils';
 import { getTransactionDecoder } from '@solana/transactions';
 import { createUtilaAccessToken, createUtilaSigner } from '../utila-signer.js';
 import { TEST_EMAIL, TEST_RSA_PRIVATE_KEY } from './setup.js';
@@ -250,7 +251,7 @@ describe('UtilaSigner', () => {
             expect(fetchCall(2)[0]).toBe('https://api.test.utila.io/v2/vaults/vault-test/transactions/tx-1?view=FULL');
         });
 
-        it('signs when the signer instance is frozen, as @solana/signers freezes fee-payer signers', async () => {
+        it('signs when the signer instance is frozen', async () => {
             vi.mocked(fetch)
                 .mockResolvedValueOnce(mockWalletResponse())
                 .mockResolvedValueOnce(
@@ -278,8 +279,9 @@ describe('UtilaSigner', () => {
                 maxPollAttempts: 2,
                 pollIntervalMs: 1,
             });
-            Object.freeze(signer);
-            const results = await signer.signTransactions([createMockTransaction()]);
+            const results = await assertSignerSurvivesFreeze(signer, () =>
+                signer.signTransactions([createMockTransaction()]),
+            );
 
             expect(results).toHaveLength(1);
             expect(results[0]![signer.address]).toEqual(MOCK_SIGNATURE_BYTES);

--- a/typescript/packages/vault/src/__tests__/vault-signer.test.ts
+++ b/typescript/packages/vault/src/__tests__/vault-signer.test.ts
@@ -1,3 +1,4 @@
+import { assertSignerSurvivesFreeze } from '@solana/keychain-test-utils';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { VaultSigner } from '../vault-signer.js';
@@ -469,6 +470,24 @@ describe('VaultSigner', () => {
                     method: 'POST',
                 }),
             );
+        });
+
+        it('signs when the signer instance is frozen', async () => {
+            vi.mocked(fetch).mockResolvedValueOnce(
+                new Response(JSON.stringify({ data: { signature: 'vault:v1:' + 'a'.repeat(86) } }), { status: 200 }),
+            );
+
+            const signer = new VaultSigner(mockConfig);
+            const mockTransaction = {
+                '"__transactionSize:@solana/kit"': 100,
+                lifetimeConstraint: { blockhash: 'test', lastValidBlockHeight: 100n },
+                messageBytes: new Uint8Array([1, 2, 3, 4]),
+                signatures: {},
+            } as any;
+
+            const [result] = await assertSignerSurvivesFreeze(signer, () => signer.signTransactions([mockTransaction]));
+
+            expect(result).toHaveProperty(mockConfig.publicKey);
         });
     });
 });

--- a/typescript/packages/vault/src/__tests__/vault-signer.test.ts
+++ b/typescript/packages/vault/src/__tests__/vault-signer.test.ts
@@ -473,6 +473,9 @@ describe('VaultSigner', () => {
         });
 
         it('signs when the signer instance is frozen', async () => {
+            // This suite clears calls but not implementations between tests, so reset
+            // before arming the mock to keep this test independent of its neighbours.
+            vi.mocked(fetch).mockReset();
             vi.mocked(fetch).mockResolvedValueOnce(
                 new Response(JSON.stringify({ data: { signature: 'vault:v1:' + 'a'.repeat(86) } }), { status: 200 }),
             );

--- a/typescript/packages/vault/src/__tests__/vault-signer.test.ts
+++ b/typescript/packages/vault/src/__tests__/vault-signer.test.ts
@@ -1,4 +1,4 @@
-import { assertSignerSurvivesFreeze } from '@solana/keychain-test-utils';
+import { assertSignerSurvivesFreeze } from '@solana/keychain-test-utils/frozen-signer-contract';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { VaultSigner } from '../vault-signer.js';


### PR DESCRIPTION
## Summary

Follow-up to #235. That bug — Utila's lazy JWT mint writing `this.accessToken` on a signer frozen by `setTransactionMessageFeePayerSigner` — only surfaced in the credential-gated Fork External Live Tests run. Nothing in PR CI covered it, because every backend's unit suite calls `signTransactions()` / `signMessages()` directly on a raw instance and never freezes.

This makes the contract explicit and enforces it everywhere:

- **`assertSignerSurvivesFreeze`** in `@solana/keychain-test-utils` — freezes the signer, runs the caller's signing thunk, and annotates a frozen-write `TypeError` with the root cause and the fix (cache in a nested object; `Object.freeze` is shallow).
- **All fourteen backend unit suites** get a `signs when the signer instance is frozen` case, reusing each package's existing happy-path mocks. Utila's existing regression test is refactored onto the shared helper.
- **[docs/ADDING_SIGNERS.md](../blob/test/frozen-signer-contract-all-backends/docs/ADDING_SIGNERS.md)** documents the contract and adds a checklist item, so new backends inherit it.

Backends whose `signTransactions` happy path can't complete against mocks (CDP, Dfns, Privy, Turnkey) assert via `signMessages` instead — same auth/caching machinery, same contract.

No signer source changed; this is test + docs only.

## Test Plan

- `just ts-test` — all packages pass
- `pnpm typecheck` (workspace) and `just ts-fmt` clean
- `just ts-treeshake` — 15/15 factories still tree-shake cleanly
- **Verified the helper catches the real bug**: reverting `typescript/packages/utila/src/utila-signer.ts` to its pre-#235 state fails the Utila frozen test with

  ```
  TypeError: Cannot assign to read only property 'accessToken' of object '#<UtilaSigner>' — the signer
  wrote to its own instance while signing. @solana/signers freezes fee-payer signers in
  setTransactionMessageFeePayerSigner, so state cached during signing must live in a nested object
  created by the constructor (Object.freeze is shallow).
      ❯ UtilaSigner.getAccessToken src/utila-signer.ts:345:18
  ```