### PR TITLE
fix(turnkey): reject signatures from non-completed activities

### DIFF
--- a/go/signers/turnkey/signer.go
+++ b/go/signers/turnkey/signer.go
@@ -147,6 +147,17 @@ func (s *Signer) signBytes(ctx context.Context, message []byte) (solana.Signatur
 	if err := json.Unmarshal(respBody, &resp); err != nil {
 		return solana.Signature{}, core.WrapSignerError(core.CodeSerializationError, "failed to parse sign response", err)
 	}
+	// Turnkey executes activities optimistically and populates result only once
+	// the activity reaches ACTIVITY_STATUS_COMPLETED; anything else (e.g.
+	// CONSENSUS_NEEDED under a quorum policy) carries no signature.
+	if resp.Activity.Status != "ACTIVITY_STATUS_COMPLETED" {
+		status := resp.Activity.Status
+		if status == "" {
+			status = "<missing>"
+		}
+		return solana.Signature{}, core.NewSignerError(core.CodeSigningFailed,
+			"Turnkey activity is not completed (status: "+status+")")
+	}
 	result := resp.Activity.Result
 	if result == nil || result.SignRawPayloadResult == nil {
 		return solana.Signature{}, core.NewSignerError(core.CodeSigningFailed, "invalid response from Turnkey API")

--- a/go/signers/turnkey/signer_test.go
+++ b/go/signers/turnkey/signer_test.go
@@ -11,9 +11,11 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync/atomic"
 	"testing"
 
@@ -61,7 +63,7 @@ func testConfig(t *testing.T, pubkey string, srv *httptest.Server) Config {
 // signResultBody renders the activity JSON Turnkey returns for a signature,
 // split into hex r and s components.
 func signResultBody(sig []byte) string {
-	return `{"activity":{"result":{"signRawPayloadResult":{"r":"` +
+	return `{"activity":{"status":"ACTIVITY_STATUS_COMPLETED","result":{"signRawPayloadResult":{"r":"` +
 		hex.EncodeToString(sig[:32]) + `","s":"` + hex.EncodeToString(sig[32:]) + `"}}}}`
 }
 
@@ -313,7 +315,7 @@ func TestSignUnauthorized(t *testing.T) {
 
 func TestSignInvalidResponse(t *testing.T) {
 	var calls int32
-	srv := signServer(t, http.StatusOK, `{"activity":{}}`, &calls)
+	srv := signServer(t, http.StatusOK, `{"activity":{"status":"ACTIVITY_STATUS_COMPLETED"}}`, &calls)
 	defer srv.Close()
 
 	s, err := New(testConfig(t, testutils.TestPublicKey().String(), srv))
@@ -331,7 +333,7 @@ func TestSignInvalidResponse(t *testing.T) {
 
 func TestSignInvalidHex(t *testing.T) {
 	var calls int32
-	body := `{"activity":{"result":{"signRawPayloadResult":{"r":"not-valid-hex!!!","s":"also-not-valid-hex!!!"}}}}`
+	body := `{"activity":{"status":"ACTIVITY_STATUS_COMPLETED","result":{"signRawPayloadResult":{"r":"not-valid-hex!!!","s":"also-not-valid-hex!!!"}}}}`
 	srv := signServer(t, http.StatusOK, body, &calls)
 	defer srv.Close()
 
@@ -348,9 +350,49 @@ func TestSignInvalidHex(t *testing.T) {
 	}
 }
 
+func TestSignRejectsNonCompletedActivity(t *testing.T) {
+	var calls int32
+	srv := signServer(t, http.StatusOK, `{"activity":{"status":"ACTIVITY_STATUS_CONSENSUS_NEEDED"}}`, &calls)
+	defer srv.Close()
+
+	s, err := New(testConfig(t, testutils.TestPublicKey().String(), srv))
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = s.SignMessage(context.Background(), []byte("test"))
+	if err == nil {
+		t.Fatal("expected error for non-completed activity")
+	}
+	if code, _ := core.CodeOf(err); code != core.CodeSigningFailed {
+		t.Errorf("got %s, want SIGNING_FAILED", code)
+	}
+	var se *core.SignerError
+	if !errors.As(err, &se) || !strings.Contains(se.Detail(), "ACTIVITY_STATUS_CONSENSUS_NEEDED") {
+		t.Errorf("error must name the received status, got %v", err)
+	}
+}
+
+func TestSignRejectsMissingActivityStatus(t *testing.T) {
+	var calls int32
+	srv := signServer(t, http.StatusOK, `{"activity":{}}`, &calls)
+	defer srv.Close()
+
+	s, err := New(testConfig(t, testutils.TestPublicKey().String(), srv))
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = s.SignMessage(context.Background(), []byte("test"))
+	if err == nil {
+		t.Fatal("expected error for missing activity status")
+	}
+	if code, _ := core.CodeOf(err); code != core.CodeSigningFailed {
+		t.Errorf("got %s, want SIGNING_FAILED", code)
+	}
+}
+
 func TestSignOversizedComponent(t *testing.T) {
 	var calls int32
-	body := `{"activity":{"result":{"signRawPayloadResult":{"r":"` +
+	body := `{"activity":{"status":"ACTIVITY_STATUS_COMPLETED","result":{"signRawPayloadResult":{"r":"` +
 		hex.EncodeToString(bytes.Repeat([]byte{0xFF}, 33)) + `","s":"` +
 		hex.EncodeToString(bytes.Repeat([]byte{0x01}, 32)) + `"}}}}`
 	srv := signServer(t, http.StatusOK, body, &calls)

--- a/go/signers/turnkey/types.go
+++ b/go/signers/turnkey/types.go
@@ -71,8 +71,9 @@ type activityResponse struct {
 	Activity activity `json:"activity"`
 }
 
-// activity carries the (optional) activity result.
+// activity carries the activity status and (optional) result.
 type activity struct {
+	Status string          `json:"status"`
 	Result *activityResult `json:"result"`
 }
 

--- a/python/src/solana_keychain/turnkey/signer.py
+++ b/python/src/solana_keychain/turnkey/signer.py
@@ -175,6 +175,12 @@ class TurnkeySigner(SolanaSigner):
         response = await self._post_stamped("/public/v1/submit/sign_raw_payload", request)
 
         activity = response.get("activity") if isinstance(response, dict) else None
+        status = activity.get("status") if isinstance(activity, dict) else None
+        if status != "ACTIVITY_STATUS_COMPLETED":
+            raise SignerError(
+                SignerErrorCode.SIGNING_FAILED,
+                f"Turnkey activity is not completed (status: {status or '<missing>'})",
+            )
         result = activity.get("result") if isinstance(activity, dict) else None
         sign_result = result.get("signRawPayloadResult") if isinstance(result, dict) else None
         if (

--- a/python/tests/test_turnkey_signer.py
+++ b/python/tests/test_turnkey_signer.py
@@ -52,7 +52,12 @@ def mock_sign_response(r_hex: str, s_hex: str) -> None:
     respx.post(SIGN_URL).mock(
         return_value=httpx.Response(
             200,
-            json={"activity": {"result": {"signRawPayloadResult": {"r": r_hex, "s": s_hex}}}},
+            json={
+                "activity": {
+                    "status": "ACTIVITY_STATUS_COMPLETED",
+                    "result": {"signRawPayloadResult": {"r": r_hex, "s": s_hex}},
+                }
+            },
         )
     )
 
@@ -185,6 +190,33 @@ async def test_sign_message_rejects_undecodable_component() -> None:
 
 @respx.mock
 async def test_sign_message_missing_result() -> None:
+    keypair = Keypair()
+    respx.post(SIGN_URL).mock(
+        return_value=httpx.Response(200, json={"activity": {"status": "ACTIVITY_STATUS_COMPLETED"}})
+    )
+    signer = make_signer(str(keypair.pubkey()))
+    with pytest.raises(SignerError) as excinfo:
+        await signer.sign_message(b"hello")
+    assert excinfo.value.code == SignerErrorCode.SIGNING_FAILED
+
+
+@respx.mock
+async def test_sign_message_rejects_non_completed_activity() -> None:
+    keypair = Keypair()
+    respx.post(SIGN_URL).mock(
+        return_value=httpx.Response(
+            200, json={"activity": {"status": "ACTIVITY_STATUS_CONSENSUS_NEEDED"}}
+        )
+    )
+    signer = make_signer(str(keypair.pubkey()))
+    with pytest.raises(SignerError) as excinfo:
+        await signer.sign_message(b"hello")
+    assert excinfo.value.code == SignerErrorCode.SIGNING_FAILED
+    assert "ACTIVITY_STATUS_CONSENSUS_NEEDED" in excinfo.value._detail
+
+
+@respx.mock
+async def test_sign_message_rejects_missing_activity_status() -> None:
     keypair = Keypair()
     respx.post(SIGN_URL).mock(return_value=httpx.Response(200, json={"activity": {}}))
     signer = make_signer(str(keypair.pubkey()))

--- a/rust/src/turnkey/mod.rs
+++ b/rust/src/turnkey/mod.rs
@@ -149,6 +149,16 @@ impl TurnkeySigner {
         let response_text = response.text().await?;
         let response: ActivityResponse = serde_json::from_str(&response_text)?;
 
+        // Turnkey executes activities optimistically and populates `result` only
+        // once the activity reaches ACTIVITY_STATUS_COMPLETED; anything else
+        // (e.g. CONSENSUS_NEEDED under a quorum policy) carries no signature.
+        let status = response.activity.status.as_deref().unwrap_or("<missing>");
+        if status != "ACTIVITY_STATUS_COMPLETED" {
+            return Err(SignerError::SigningFailed(format!(
+                "Turnkey activity is not completed (status: {status})"
+            )));
+        }
+
         if let Some(result) = response.activity.result {
             if let Some(sign_result) = result.sign_raw_payload_result {
                 // Decode r and s components
@@ -403,6 +413,7 @@ mod tests {
             .and(header("Content-Type", "application/json"))
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
                 "activity": {
+                    "status": "ACTIVITY_STATUS_COMPLETED",
                     "result": {
                         "signRawPayloadResult": {
                             "r": r_hex,
@@ -449,6 +460,7 @@ mod tests {
             .and(header("Content-Type", "application/json"))
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
                 "activity": {
+                    "status": "ACTIVITY_STATUS_COMPLETED",
                     "result": {
                         "signRawPayloadResult": {
                             "r": r_hex,
@@ -498,6 +510,7 @@ mod tests {
             .and(path("/public/v1/submit/sign_raw_payload"))
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
                 "activity": {
+                    "status": "ACTIVITY_STATUS_COMPLETED",
                     "result": {
                         "signRawPayloadResult": {
                             "r": r_hex,
@@ -577,7 +590,7 @@ mod tests {
         Mock::given(method("POST"))
             .and(path("/public/v1/submit/sign_raw_payload"))
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-                "activity": {}
+                "activity": { "status": "ACTIVITY_STATUS_COMPLETED" }
             })))
             .expect(1)
             .mount(&mock_server)
@@ -600,6 +613,74 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_turnkey_sign_rejects_non_completed_activity() {
+        let mock_server = MockServer::start().await;
+        let keypair = create_test_keypair();
+        let (api_public_key, api_private_key) = create_test_api_keys();
+
+        Mock::given(method("POST"))
+            .and(path("/public/v1/submit/sign_raw_payload"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "activity": { "status": "ACTIVITY_STATUS_CONSENSUS_NEEDED" }
+            })))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let mut signer = TurnkeySigner::new(
+            api_public_key,
+            api_private_key,
+            "test-org-id".to_string(),
+            "test-key-id".to_string(),
+            keypair.pubkey().to_string(),
+        )
+        .unwrap();
+        signer.client = reqwest::Client::new();
+        signer.api_base_url = mock_server.uri();
+
+        let result = signer.sign_message(b"test").await;
+        match result.unwrap_err() {
+            SignerError::SigningFailed(message) => {
+                assert!(
+                    message.contains("ACTIVITY_STATUS_CONSENSUS_NEEDED"),
+                    "error must name the received status, got: {message}"
+                );
+            }
+            other => panic!("Expected SigningFailed, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_turnkey_sign_rejects_missing_activity_status() {
+        let mock_server = MockServer::start().await;
+        let keypair = create_test_keypair();
+        let (api_public_key, api_private_key) = create_test_api_keys();
+
+        Mock::given(method("POST"))
+            .and(path("/public/v1/submit/sign_raw_payload"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "activity": {}
+            })))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let mut signer = TurnkeySigner::new(
+            api_public_key,
+            api_private_key,
+            "test-org-id".to_string(),
+            "test-key-id".to_string(),
+            keypair.pubkey().to_string(),
+        )
+        .unwrap();
+        signer.client = reqwest::Client::new();
+        signer.api_base_url = mock_server.uri();
+
+        let result = signer.sign_message(b"test").await;
+        assert!(matches!(result.unwrap_err(), SignerError::SigningFailed(_)));
+    }
+
+    #[tokio::test]
     async fn test_turnkey_sign_invalid_hex() {
         let mock_server = MockServer::start().await;
         let keypair = create_test_keypair();
@@ -610,6 +691,7 @@ mod tests {
             .and(path("/public/v1/submit/sign_raw_payload"))
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
                 "activity": {
+                    "status": "ACTIVITY_STATUS_COMPLETED",
                     "result": {
                         "signRawPayloadResult": {
                             "r": "not-valid-hex!!!",
@@ -747,6 +829,7 @@ mod tests {
             .and(path("/public/v1/submit/sign_raw_payload"))
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
                 "activity": {
+                    "status": "ACTIVITY_STATUS_COMPLETED",
                     "result": {
                         "signRawPayloadResult": {
                             "r": r_hex,

--- a/rust/src/turnkey/types.rs
+++ b/rust/src/turnkey/types.rs
@@ -30,6 +30,7 @@ pub struct ActivityResponse {
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Activity {
+    pub status: Option<String>,
     pub result: Option<ActivityResult>,
 }
 

--- a/typescript/packages/turnkey/src/__tests__/turnkey-signer.test.ts
+++ b/typescript/packages/turnkey/src/__tests__/turnkey-signer.test.ts
@@ -74,7 +74,7 @@ describe('TurnkeySigner', () => {
                                 s,
                             },
                         },
-                        status: 'COMPLETED',
+                        status: 'ACTIVITY_STATUS_COMPLETED',
                     },
                 }),
             ok: true,
@@ -383,7 +383,7 @@ describe('TurnkeySigner', () => {
             });
         });
 
-        it('throws structured SIGNER_REMOTE_API_ERROR for malformed response shape', async () => {
+        it('throws SIGNING_FAILED for malformed response shape', async () => {
             const keyPair = await generateKeyPairSigner();
 
             const config = {
@@ -402,8 +402,37 @@ describe('TurnkeySigner', () => {
             const message = createSignableMessage(new Uint8Array([1, 2, 3, 4]));
 
             await expect(signer.signMessages([message])).rejects.toMatchObject({
-                code: 'SIGNER_REMOTE_API_ERROR',
-                message: expect.stringContaining('Missing signature components'),
+                code: 'SIGNER_SIGNING_FAILED',
+                message: expect.stringContaining('not completed'),
+            });
+        });
+
+        it('throws SIGNING_FAILED when the activity is not completed', async () => {
+            const keyPair = await generateKeyPairSigner();
+
+            const config = {
+                ...mockConfig,
+                publicKey: keyPair.address,
+            };
+
+            const signer = new TurnkeySigner(config);
+
+            (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+                json: () =>
+                    Promise.resolve({
+                        activity: {
+                            status: 'ACTIVITY_STATUS_CONSENSUS_NEEDED',
+                        },
+                    }),
+                ok: true,
+                status: 200,
+            });
+
+            const message = createSignableMessage(new Uint8Array([1, 2, 3, 4]));
+
+            await expect(signer.signMessages([message])).rejects.toMatchObject({
+                code: 'SIGNER_SIGNING_FAILED',
+                message: expect.stringContaining('ACTIVITY_STATUS_CONSENSUS_NEEDED'),
             });
         });
 
@@ -424,7 +453,7 @@ describe('TurnkeySigner', () => {
                             result: {
                                 // Missing signRawPayloadResult
                             },
-                            status: 'COMPLETED',
+                            status: 'ACTIVITY_STATUS_COMPLETED',
                         },
                     }),
                 ok: true,
@@ -488,7 +517,7 @@ describe('TurnkeySigner', () => {
                                     signedTransaction: signedTransactionHex,
                                 },
                             },
-                            status: 'COMPLETED',
+                            status: 'ACTIVITY_STATUS_COMPLETED',
                         },
                     }),
                 ok: true,
@@ -603,7 +632,7 @@ describe('TurnkeySigner', () => {
             });
         });
 
-        it('throws structured SIGNER_REMOTE_API_ERROR for malformed transaction response shape', async () => {
+        it('throws SIGNING_FAILED for malformed transaction response shape', async () => {
             const keyPair = await generateKeyPairSigner();
 
             const config = {
@@ -622,8 +651,8 @@ describe('TurnkeySigner', () => {
             const mockTx = createMockTransaction();
 
             await expect(signer.signTransactions([mockTx])).rejects.toMatchObject({
-                code: 'SIGNER_REMOTE_API_ERROR',
-                message: expect.stringContaining('Missing signedTransaction'),
+                code: 'SIGNER_SIGNING_FAILED',
+                message: expect.stringContaining('not completed'),
             });
         });
 
@@ -642,7 +671,7 @@ describe('TurnkeySigner', () => {
                     Promise.resolve({
                         activity: {
                             result: {},
-                            status: 'COMPLETED',
+                            status: 'ACTIVITY_STATUS_COMPLETED',
                         },
                     }),
                 ok: true,
@@ -654,6 +683,35 @@ describe('TurnkeySigner', () => {
             await expect(signer.signTransactions([mockTx])).rejects.toMatchObject({
                 code: 'SIGNER_REMOTE_API_ERROR',
                 message: expect.stringContaining('Missing signedTransaction'),
+            });
+        });
+
+        it('throws SIGNING_FAILED when the activity is not completed', async () => {
+            const keyPair = await generateKeyPairSigner();
+
+            const config = {
+                ...mockConfig,
+                publicKey: keyPair.address,
+            };
+
+            const signer = new TurnkeySigner(config);
+
+            (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+                json: () =>
+                    Promise.resolve({
+                        activity: {
+                            status: 'ACTIVITY_STATUS_CONSENSUS_NEEDED',
+                        },
+                    }),
+                ok: true,
+                status: 200,
+            });
+
+            const mockTx = createMockTransaction();
+
+            await expect(signer.signTransactions([mockTx])).rejects.toMatchObject({
+                code: 'SIGNER_SIGNING_FAILED',
+                message: expect.stringContaining('ACTIVITY_STATUS_CONSENSUS_NEEDED'),
             });
         });
     });

--- a/typescript/packages/turnkey/src/turnkey-signer.ts
+++ b/typescript/packages/turnkey/src/turnkey-signer.ts
@@ -115,6 +115,22 @@ export class TurnkeySigner<TAddress extends string = string> implements SolanaSi
     }
 
     /**
+     * Reject activity responses that have not completed.
+     *
+     * Turnkey executes activities optimistically and populates `result` only once
+     * the activity reaches `ACTIVITY_STATUS_COMPLETED`; anything else (e.g.
+     * `ACTIVITY_STATUS_CONSENSUS_NEEDED` under a quorum policy) carries no signature.
+     */
+    private assertActivityCompleted(activityResponse: ActivityResponse): void {
+        const status = activityResponse.activity?.status;
+        if (status !== 'ACTIVITY_STATUS_COMPLETED') {
+            throwSignerError(SignerErrorCode.SIGNING_FAILED, {
+                message: `Turnkey activity is not completed (status: ${status || '<missing>'})`,
+            });
+        }
+    }
+
+    /**
      * Pad signature component to exactly 32 bytes
      * Components from Turnkey may be shorter than 32 bytes and need left-padding with zeros
      */
@@ -174,6 +190,8 @@ export class TurnkeySigner<TAddress extends string = string> implements SolanaSi
             providerName: 'Turnkey',
             url: `${this.apiBaseUrl}/public/v1/submit/sign_raw_payload`,
         });
+
+        this.assertActivityCompleted(activityResponse);
 
         const signResult = activityResponse.activity?.result?.signRawPayloadResult;
         if (!signResult || !signResult.r || !signResult.s) {
@@ -253,6 +271,8 @@ export class TurnkeySigner<TAddress extends string = string> implements SolanaSi
             providerName: 'Turnkey',
             url: `${this.apiBaseUrl}/public/v1/submit/sign_transaction`,
         });
+
+        this.assertActivityCompleted(activityResponse);
 
         const signedTransaction = activityResponse.activity?.result?.signTransactionResult?.signedTransaction;
         if (!signedTransaction) {


### PR DESCRIPTION
## Problem

Turnkey executes activities optimistically: the [activities overview](https://docs.turnkey.com/api-reference/activities/overview) documents that `activity.result` is populated only once the activity reaches `ACTIVITY_STATUS_COMPLETED` (the full status enum is `CREATED`, `PENDING`, `COMPLETED`, `FAILED`, `CONSENSUS_NEEDED`, `REJECTED`, `AUTHENTICATORS_NEEDED`).

None of the four implementations read `activity.status` - Rust and Go dropped it at the type level, TypeScript declared it and never read it, Python never looked. An activity parked in `CONSENSUS_NEEDED` (org with a quorum policy), `PENDING`, or `FAILED` therefore surfaced as a generic "missing signature components" / "invalid response" error, hiding the actual state from the caller.

This is a diagnosability fix, not a signature-acceptance hole: a non-completed activity carries no `signRawPayloadResult`, and the mandatory local verification already rejects any bytes that are not a valid signature by the configured key over the caller's exact message.

## Fix

All four languages now deserialize `activity.status` and reject anything but `ACTIVITY_STATUS_COMPLETED` with an error naming the received status (`Turnkey activity is not completed (status: ACTIVITY_STATUS_CONSENSUS_NEEDED)`). A missing status field is also rejected. Signature extraction and local verification are unchanged.

TypeScript gates both request paths (`sign_raw_payload` and `sign_transaction`).

## Behavior change

Responses that previously failed with "missing signature components" now fail earlier with the status-naming error (same error code family). Existing test fixtures used `COMPLETED` or omitted the field entirely; they now use the documented `ACTIVITY_STATUS_COMPLETED` value.

## Testing

- New unit tests per language: non-completed activity rejected with an error naming the status; missing status rejected.
- Rust: turnkey suite on sdk-v2/v3/v4, clippy `-D warnings`, fmt
- Python: 457 unit tests, ruff, mypy strict
- Go: `go test -race`, vet, golangci-lint
- TypeScript: 43 tests, typecheck, eslint, prettier, build