### PR TITLE
feat(errors): report unconfirmed broadcasts with the provider transaction id

### DIFF
--- a/go/core/errors.go
+++ b/go/core/errors.go
@@ -26,6 +26,7 @@ const (
 	CodeSerializationError   Code = "SIGNER_SERIALIZATION_ERROR"
 	CodeNotInitialized       Code = "SIGNER_NOT_INITIALIZED"
 	CodeSigningFailed        Code = "SIGNER_SIGNING_FAILED"
+	CodeBroadcastUnconfirmed Code = "SIGNER_BROADCAST_UNCONFIRMED"
 	CodeOther                Code = "SIGNER_ERROR"
 )
 
@@ -45,6 +46,7 @@ var genericMessages = map[Code]string{
 	CodeSerializationError:   "Serialization error",
 	CodeNotInitialized:       "Signer not initialized",
 	CodeSigningFailed:        "Signing failed",
+	CodeBroadcastUnconfirmed: "Broadcast unconfirmed; the provider may have executed the transaction",
 	CodeOther:                "Signer error",
 }
 
@@ -62,9 +64,15 @@ func (c Code) message() string {
 // Code is surfaced, ensuring key material and raw remote-API responses never leak
 // through formatted output or logs.
 type SignerError struct {
-	Code   Code
-	detail string
-	cause  error
+	Code Code
+	// ProviderTxID is the provider-side transaction id for
+	// CodeBroadcastUnconfirmed errors ("" otherwise). It is deliberately
+	// exported and rendered by Error(): it is the caller's only handle to check
+	// the transaction's outcome before retrying, and contains no secret
+	// material.
+	ProviderTxID string
+	detail       string
+	cause        error
 }
 
 // NewSignerError builds a SignerError with a (private) detail string.
@@ -78,9 +86,12 @@ func WrapSignerError(code Code, detail string, cause error) *SignerError {
 	return &SignerError{Code: code, detail: detail, cause: cause}
 }
 
-// Error returns the fixed, generic message for the error's Code. It never
-// includes the detail or cause.
+// Error returns the fixed, generic message for the error's Code plus the
+// provider transaction id when present. It never includes the detail or cause.
 func (e *SignerError) Error() string {
+	if e.ProviderTxID != "" {
+		return e.Code.message() + " (provider transaction id: " + e.ProviderTxID + ")"
+	}
 	return e.Code.message()
 }
 
@@ -103,6 +114,13 @@ func (e *SignerError) Is(target error) bool {
 // Detail returns the unredacted detail string. It is opt-in: nothing calls this
 // during normal formatting, so detail only surfaces when a caller explicitly asks.
 func (e *SignerError) Detail() string { return e.detail }
+
+// NewBroadcastUnconfirmedError reports a failure after the provider has
+// accepted a transaction it broadcasts itself, carrying the provider-side
+// transaction id the caller must check before retrying.
+func NewBroadcastUnconfirmedError(providerTxID, detail string) *SignerError {
+	return &SignerError{Code: CodeBroadcastUnconfirmed, ProviderTxID: providerTxID, detail: detail}
+}
 
 // CodeOf extracts the Code from an error if it is (or wraps) a *SignerError.
 func CodeOf(err error) (Code, bool) {

--- a/go/core/errors_test.go
+++ b/go/core/errors_test.go
@@ -14,6 +14,7 @@ func TestErrorMessageIsRedacted(t *testing.T) {
 		CodeConfigError, CodeExpectedSolanaSigner, CodeHTTPError, CodeInvalidPrivateKey,
 		CodeInvalidPublicKey, CodeIOError, CodeNotAvailable, CodeParsingError,
 		CodeRemoteAPIError, CodeSerializationError, CodeNotInitialized, CodeSigningFailed, CodeOther,
+		CodeBroadcastUnconfirmed,
 	}
 	for _, code := range codes {
 		err := NewSignerError(code, secret)
@@ -48,6 +49,23 @@ func TestErrorStableMessages(t *testing.T) {
 		if got := NewSignerError(code, "x").Error(); got != want {
 			t.Errorf("code %s: Error() = %q, want %q", code, got, want)
 		}
+	}
+}
+
+func TestBroadcastUnconfirmedSurfacesTxIDButNotDetail(t *testing.T) {
+	const secret = "sensitive-secret-material"
+	err := NewBroadcastUnconfirmedError("provider-tx-123", secret)
+	if err.Code != CodeBroadcastUnconfirmed {
+		t.Errorf("Code = %s, want %s", err.Code, CodeBroadcastUnconfirmed)
+	}
+	if !strings.Contains(err.Error(), "provider-tx-123") {
+		t.Errorf("Error() must surface the provider transaction id, got %q", err.Error())
+	}
+	if strings.Contains(err.Error(), secret) {
+		t.Errorf("Error() leaked detail: %q", err.Error())
+	}
+	if err.Detail() != secret {
+		t.Errorf("Detail() = %q, want the original detail", err.Detail())
 	}
 }
 

--- a/go/signers/fordefi/client.go
+++ b/go/signers/fordefi/client.go
@@ -146,7 +146,7 @@ func (s *Signer) signRequest(ctx context.Context, path string, timestamp int64, 
 
 // submitTransaction POSTs a signing request to /api/v1/transactions with
 // request-level P-256 signing and returns the Fordefi transaction ID.
-func (s *Signer) submitTransaction(ctx context.Context, request transactionRequest) (string, error) {
+func (s *Signer) submitTransaction(ctx context.Context, request transactionRequest, idempotenceID string) (string, error) {
 	body, err := json.Marshal(request)
 	if err != nil {
 		return "", core.WrapSignerError(core.CodeSerializationError, "failed to serialize fordefi request", err)
@@ -165,6 +165,9 @@ func (s *Signer) submitTransaction(ctx context.Context, request transactionReque
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("x-signature", signature)
 	req.Header.Set("x-timestamp", strconv.FormatInt(timestamp, 10))
+	if idempotenceID != "" {
+		req.Header.Set("x-idempotence-id", idempotenceID)
+	}
 
 	status, respBody, err := s.send(req)
 	if err != nil {

--- a/go/signers/fordefi/signer.go
+++ b/go/signers/fordefi/signer.go
@@ -3,6 +3,7 @@ package fordefi
 import (
 	"context"
 	"encoding/base64"
+	"errors"
 	"net/http"
 	"strings"
 	"time"
@@ -195,6 +196,10 @@ func (s *Signer) SignMessage(ctx context.Context, message []byte) (solana.Signat
 // the returned EncodedTransaction is empty — the transaction is already
 // on-chain, so there is nothing for the caller to send. Only transactions
 // whose sole required signer is the configured vault are supported.
+//
+// Native mode is not retry-safe: any failure after Fordefi accepts the
+// submission returns CodeBroadcastUnconfirmed carrying the Fordefi transaction
+// id; check that transaction with Fordefi before retrying.
 func (s *Signer) SignTransaction(ctx context.Context, tx *solana.Transaction) (core.SignedTransaction, error) {
 	if s.chain != "" {
 		return s.signTransactionNative(ctx, tx)
@@ -319,6 +324,26 @@ func (s *Signer) signTransactionNative(ctx context.Context, tx *solana.Transacti
 	if err != nil {
 		return core.SignedTransaction{}, err
 	}
+	// Once the submit is accepted Fordefi is already broadcasting (push_mode
+	// "auto"), so any later failure leaves an on-chain outcome this client
+	// cannot rule out. Report those as CodeBroadcastUnconfirmed carrying the
+	// Fordefi transaction id instead of a generic error a caller might blindly
+	// retry into a duplicate spend.
+	signed, err := s.finishNativeBroadcast(ctx, tx, txID)
+	if err != nil {
+		detail := err.Error()
+		var se *core.SignerError
+		if errors.As(err, &se) {
+			detail = se.Detail()
+		}
+		return core.SignedTransaction{}, core.NewBroadcastUnconfirmedError(txID, detail)
+	}
+	return signed, nil
+}
+
+// finishNativeBroadcast polls a submitted native transaction to completion and
+// extracts and verifies the vault's signature from the returned wire bytes.
+func (s *Signer) finishNativeBroadcast(ctx context.Context, tx *solana.Transaction, txID string) (core.SignedTransaction, error) {
 	result, err := s.pollForResult(ctx, txID, true)
 	if err != nil {
 		return core.SignedTransaction{}, err

--- a/go/signers/fordefi/signer.go
+++ b/go/signers/fordefi/signer.go
@@ -2,8 +2,10 @@ package fordefi
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/base64"
 	"errors"
+	"fmt"
 	"net/http"
 	"strings"
 	"time"
@@ -199,7 +201,10 @@ func (s *Signer) SignMessage(ctx context.Context, message []byte) (solana.Signat
 //
 // Native mode is not retry-safe: any failure after Fordefi accepts the
 // submission returns CodeBroadcastUnconfirmed carrying the Fordefi transaction
-// id; check that transaction with Fordefi before retrying.
+// id; check that transaction with Fordefi before retrying. Each native create
+// carries an x-idempotence-id derived from the message bytes, so retrying the
+// exact same bytes cannot create a second Fordefi transaction; a retry built
+// with a fresh blockhash is a new transaction.
 func (s *Signer) SignTransaction(ctx context.Context, tx *solana.Transaction) (core.SignedTransaction, error) {
 	if s.chain != "" {
 		return s.signTransactionNative(ctx, tx)
@@ -250,7 +255,7 @@ func (s *Signer) signBlackBox(ctx context.Context, data []byte) (solana.Signatur
 			Format:     "hash_binary",
 			HashBinary: base64.StdEncoding.EncodeToString(data),
 		},
-	})
+	}, "")
 	if err != nil {
 		return solana.Signature{}, err
 	}
@@ -273,7 +278,7 @@ func (s *Signer) signSolanaMessage(ctx context.Context, message []byte) (solana.
 			Chain:   s.chain,
 			RawData: base64.StdEncoding.EncodeToString(message),
 		},
-	})
+	}, "")
 	if err != nil {
 		return solana.Signature{}, err
 	}
@@ -294,6 +299,18 @@ func (s *Signer) requireSoleRequiredSigner(tx *solana.Transaction) error {
 			"Fordefi native auto-broadcast currently supports only transactions whose sole required signer is the configured vault")
 	}
 	return nil
+}
+
+// idempotenceIDFromMessage derives the x-idempotence-id for a native create:
+// a UUID built from the first 16 bytes of SHA-256(message bytes), so retrying
+// the same message reuses the same id and Fordefi deduplicates the create
+// instead of broadcasting a second transaction.
+func idempotenceIDFromMessage(messageBytes []byte) string {
+	digest := sha256.Sum256(messageBytes)
+	id := digest[:16]
+	id[6] = (id[6] & 0x0f) | 0x40
+	id[8] = (id[8] & 0x3f) | 0x80
+	return fmt.Sprintf("%x-%x-%x-%x-%x", id[0:4], id[4:6], id[6:8], id[8:10], id[10:16])
 }
 
 // signTransactionNative signs tx via the native solana_transaction path.
@@ -320,7 +337,7 @@ func (s *Signer) signTransactionNative(ctx context.Context, tx *solana.Transacti
 			PushMode: "auto",
 			Fee:      s.fee,
 		},
-	})
+	}, idempotenceIDFromMessage(messageBytes))
 	if err != nil {
 		return core.SignedTransaction{}, err
 	}

--- a/go/signers/fordefi/signer.go
+++ b/go/signers/fordefi/signer.go
@@ -203,8 +203,7 @@ func (s *Signer) SignMessage(ctx context.Context, message []byte) (solana.Signat
 // submission returns CodeBroadcastUnconfirmed carrying the Fordefi transaction
 // id; check that transaction with Fordefi before retrying. Each native create
 // carries an x-idempotence-id derived from the message bytes, so retrying the
-// exact same bytes cannot create a second Fordefi transaction; a retry built
-// with a fresh blockhash is a new transaction.
+// exact same bytes cannot create a second Fordefi transaction.
 func (s *Signer) SignTransaction(ctx context.Context, tx *solana.Transaction) (core.SignedTransaction, error) {
 	if s.chain != "" {
 		return s.signTransactionNative(ctx, tx)
@@ -301,10 +300,8 @@ func (s *Signer) requireSoleRequiredSigner(tx *solana.Transaction) error {
 	return nil
 }
 
-// idempotenceIDFromMessage derives the x-idempotence-id for a native create:
-// a UUID built from the first 16 bytes of SHA-256(message bytes), so retrying
-// the same message reuses the same id and Fordefi deduplicates the create
-// instead of broadcasting a second transaction.
+// idempotenceIDFromMessage derives a UUID from SHA-256(message bytes), so a
+// retry of the same bytes reuses the id and Fordefi deduplicates the create.
 func idempotenceIDFromMessage(messageBytes []byte) string {
 	digest := sha256.Sum256(messageBytes)
 	id := digest[:16]

--- a/go/signers/fordefi/signer_test.go
+++ b/go/signers/fordefi/signer_test.go
@@ -639,8 +639,22 @@ func TestSignTransactionNativeWaitsForCompleted(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected polling timeout when a pushable transaction never completes")
 	}
-	if code, _ := core.CodeOf(err); code != core.CodeRemoteAPIError {
-		t.Errorf("got %s, want REMOTE_API_ERROR", code)
+	assertBroadcastUnconfirmed(t, err, "tx-123")
+}
+
+// assertBroadcastUnconfirmed checks that err is a CodeBroadcastUnconfirmed
+// SignerError carrying the expected provider transaction id.
+func assertBroadcastUnconfirmed(t *testing.T, err error, wantTxID string) {
+	t.Helper()
+	if code, _ := core.CodeOf(err); code != core.CodeBroadcastUnconfirmed {
+		t.Errorf("got %s, want BROADCAST_UNCONFIRMED", code)
+	}
+	var se *core.SignerError
+	if !errors.As(err, &se) || se.ProviderTxID != wantTxID {
+		t.Errorf("error must carry provider transaction id %q, got %v", wantTxID, err)
+	}
+	if !strings.Contains(err.Error(), wantTxID) {
+		t.Errorf("Error() must surface the provider transaction id, got %q", err.Error())
 	}
 }
 
@@ -684,9 +698,7 @@ func TestSignTransactionNativeMissingRawTransaction(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error when raw_transaction is missing")
 	}
-	if code, _ := core.CodeOf(err); code != core.CodeSigningFailed {
-		t.Errorf("got %s, want SIGNING_FAILED", code)
-	}
+	assertBroadcastUnconfirmed(t, err, "tx-123")
 }
 
 func TestSignTransactionNativeUndecodableRawTransaction(t *testing.T) {
@@ -711,9 +723,7 @@ func TestSignTransactionNativeUndecodableRawTransaction(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for an undecodable wire transaction")
 	}
-	if code, _ := core.CodeOf(err); code != core.CodeSerializationError {
-		t.Errorf("got %s, want SERIALIZATION_ERROR", code)
-	}
+	assertBroadcastUnconfirmed(t, err, "tx-123")
 }
 
 func TestSignMessageNativeUsesSolanaMessage(t *testing.T) {

--- a/go/signers/fordefi/signer_test.go
+++ b/go/signers/fordefi/signer_test.go
@@ -383,6 +383,11 @@ func TestSignMessageBlackBoxSuccess(t *testing.T) {
 				details["hash_binary"] != base64.StdEncoding.EncodeToString(message) {
 				t.Errorf("unexpected black box details: %v", details)
 			}
+			// Black box never broadcasts, so a duplicate create is harmless and
+			// carries no idempotence id.
+			if got := r.Header.Get("x-idempotence-id"); got != "" {
+				t.Errorf("x-idempotence-id = %q, want none on the black-box path", got)
+			}
 
 			writeJSON(w, map[string]any{"id": "tx-123"})
 		})
@@ -591,6 +596,22 @@ func TestSignTransactionNativeSuccess(t *testing.T) {
 			fee, _ := details["fee"].(map[string]any)
 			if fee["type"] != FeeTypePriority || fee["priority_level"] != string(PriorityMedium) {
 				t.Errorf("unexpected fee: %v", fee)
+			}
+			// The native create carries a deterministic x-idempotence-id derived
+			// from the submitted message bytes, so a blind retry of the same
+			// bytes reuses the id and Fordefi deduplicates the create.
+			encodedData, _ := details["data"].(string)
+			submittedMessage, decodeErr := base64.StdEncoding.DecodeString(encodedData)
+			if decodeErr != nil {
+				t.Errorf("decode submitted message: %v", decodeErr)
+			}
+			digest := sha256.Sum256(submittedMessage)
+			id := digest[:16]
+			id[6] = (id[6] & 0x0f) | 0x40
+			id[8] = (id[8] & 0x3f) | 0x80
+			want := fmt.Sprintf("%x-%x-%x-%x-%x", id[0:4], id[4:6], id[6:8], id[8:10], id[10:16])
+			if got := r.Header.Get("x-idempotence-id"); got != want {
+				t.Errorf("x-idempotence-id = %q, want %q", got, want)
 			}
 			writeJSON(w, map[string]any{"id": "tx-123"})
 		})

--- a/go/signers/fordefi/signer_test.go
+++ b/go/signers/fordefi/signer_test.go
@@ -383,8 +383,6 @@ func TestSignMessageBlackBoxSuccess(t *testing.T) {
 				details["hash_binary"] != base64.StdEncoding.EncodeToString(message) {
 				t.Errorf("unexpected black box details: %v", details)
 			}
-			// Black box never broadcasts, so a duplicate create is harmless and
-			// carries no idempotence id.
 			if got := r.Header.Get("x-idempotence-id"); got != "" {
 				t.Errorf("x-idempotence-id = %q, want none on the black-box path", got)
 			}
@@ -597,9 +595,6 @@ func TestSignTransactionNativeSuccess(t *testing.T) {
 			if fee["type"] != FeeTypePriority || fee["priority_level"] != string(PriorityMedium) {
 				t.Errorf("unexpected fee: %v", fee)
 			}
-			// The native create carries a deterministic x-idempotence-id derived
-			// from the submitted message bytes, so a blind retry of the same
-			// bytes reuses the id and Fordefi deduplicates the create.
 			encodedData, _ := details["data"].(string)
 			submittedMessage, decodeErr := base64.StdEncoding.DecodeString(encodedData)
 			if decodeErr != nil {

--- a/python/src/solana_keychain/core/errors.py
+++ b/python/src/solana_keychain/core/errors.py
@@ -7,6 +7,7 @@ from enum import Enum, unique
 class SignerErrorCode(str, Enum):
     """Stable, machine-readable error codes for every signer failure mode."""
 
+    BROADCAST_UNCONFIRMED = "SIGNER_BROADCAST_UNCONFIRMED"
     CONFIG_ERROR = "SIGNER_CONFIG_ERROR"
     EXPECTED_SOLANA_SIGNER = "SIGNER_EXPECTED_SOLANA_SIGNER"
     HTTP_ERROR = "SIGNER_HTTP_ERROR"
@@ -23,6 +24,9 @@ class SignerErrorCode(str, Enum):
 
 
 _GENERIC_MESSAGES: dict[SignerErrorCode, str] = {
+    SignerErrorCode.BROADCAST_UNCONFIRMED: (
+        "Broadcast unconfirmed; the provider may have executed the transaction"
+    ),
     SignerErrorCode.CONFIG_ERROR: "Configuration error",
     SignerErrorCode.EXPECTED_SOLANA_SIGNER: "Expected a Solana signer",
     SignerErrorCode.HTTP_ERROR: "HTTP request failed",
@@ -47,10 +51,20 @@ class SignerError(Exception):
     raw remote-API responses cannot leak through formatted output or logs.
     """
 
-    def __init__(self, code: SignerErrorCode, detail: str = "") -> None:
-        super().__init__(_GENERIC_MESSAGES[code])
+    def __init__(
+        self,
+        code: SignerErrorCode,
+        detail: str = "",
+        *,
+        provider_transaction_id: str | None = None,
+    ) -> None:
+        message = _GENERIC_MESSAGES[code]
+        if provider_transaction_id is not None:
+            message += f" (provider transaction id: {provider_transaction_id})"
+        super().__init__(message)
         self.code = code
         self._detail = detail
+        self.provider_transaction_id = provider_transaction_id
 
     def __repr__(self) -> str:
         return f"SignerError({self.code.value})"

--- a/python/src/solana_keychain/fordefi/signer.py
+++ b/python/src/solana_keychain/fordefi/signer.py
@@ -9,6 +9,7 @@ import asyncio
 import base64
 import hashlib
 import json
+import logging
 import time
 import uuid
 from dataclasses import dataclass, field
@@ -36,6 +37,8 @@ from solana_keychain.core.transaction_util import (
     serialize_transaction,
 )
 from solana_keychain.fordefi.request_signer import FordefiRequestSigner, PemRequestSigner
+
+_logger = logging.getLogger("solana_keychain")
 
 DEFAULT_API_BASE_URL = "https://api.fordefi.com"
 DEFAULT_POLL_INTERVAL_MS = 2000
@@ -391,7 +394,12 @@ class FordefiSigner(SolanaSigner):
         try:
             return await self._finish_native_broadcast(transaction_id)
         except asyncio.CancelledError as error:
-            # Must stay a CancelledError for asyncio; carry the id in the message.
+            # Awaiting a cancelled task strips the raised instance, so the id is
+            # also logged; the re-raise must stay a CancelledError for asyncio.
+            _logger.warning(
+                "Fordefi may have executed cancelled transaction %s; check it before retrying",
+                transaction_id,
+            )
             raise asyncio.CancelledError(
                 "Fordefi may have executed the transaction, but the outcome could "
                 f"not be confirmed (provider transaction id: {transaction_id})"

--- a/python/src/solana_keychain/fordefi/signer.py
+++ b/python/src/solana_keychain/fordefi/signer.py
@@ -66,10 +66,8 @@ def _timestamp_ms() -> int:
 
 
 def _idempotence_id_from_message(message_bytes: bytes) -> str:
-    """The x-idempotence-id for a native create: a UUID built from the first 16
-    bytes of SHA-256(message bytes), so retrying the same message reuses the
-    same id and Fordefi deduplicates the create instead of broadcasting a
-    second transaction."""
+    """A UUID derived from SHA-256(message bytes), so a retry of the same bytes
+    reuses the id and Fordefi deduplicates the create."""
     digest = bytearray(hashlib.sha256(message_bytes).digest()[:16])
     digest[6] = (digest[6] & 0x0F) | 0x40
     digest[8] = (digest[8] & 0x3F) | 0x80
@@ -360,8 +358,7 @@ class FordefiSigner(SolanaSigner):
         ``provider_transaction_id``; check that transaction with Fordefi
         before retrying. Each native create carries an ``x-idempotence-id``
         derived from the message bytes, so retrying the exact same bytes
-        cannot create a second Fordefi transaction; a retry built with a
-        fresh blockhash is a new transaction.
+        cannot create a second transaction.
         """
         if self._chain is not None:
             return await self._sign_transaction_native(transaction)
@@ -394,9 +391,7 @@ class FordefiSigner(SolanaSigner):
         try:
             return await self._finish_native_broadcast(transaction_id)
         except asyncio.CancelledError as error:
-            # Cancellation must stay a CancelledError for asyncio's task
-            # machinery, but the caller still needs the provider transaction id
-            # to reconcile before retrying, so re-raise with it in the message.
+            # Must stay a CancelledError for asyncio; carry the id in the message.
             raise asyncio.CancelledError(
                 "Fordefi may have executed the transaction, but the outcome could "
                 f"not be confirmed (provider transaction id: {transaction_id})"

--- a/python/src/solana_keychain/fordefi/signer.py
+++ b/python/src/solana_keychain/fordefi/signer.py
@@ -393,6 +393,14 @@ class FordefiSigner(SolanaSigner):
         )
         try:
             return await self._finish_native_broadcast(transaction_id)
+        except asyncio.CancelledError as error:
+            # Cancellation must stay a CancelledError for asyncio's task
+            # machinery, but the caller still needs the provider transaction id
+            # to reconcile before retrying, so re-raise with it in the message.
+            raise asyncio.CancelledError(
+                "Fordefi may have executed the transaction, but the outcome could "
+                f"not be confirmed (provider transaction id: {transaction_id})"
+            ) from error
         except SignerError as error:
             raise SignerError(
                 SignerErrorCode.BROADCAST_UNCONFIRMED,

--- a/python/src/solana_keychain/fordefi/signer.py
+++ b/python/src/solana_keychain/fordefi/signer.py
@@ -7,8 +7,10 @@ signature in the ``x-signature`` header.
 
 import asyncio
 import base64
+import hashlib
 import json
 import time
+import uuid
 from dataclasses import dataclass, field
 from typing import Any
 from urllib.parse import quote
@@ -61,6 +63,17 @@ _TERMINAL_FAILURE_STATES = frozenset(
 
 def _timestamp_ms() -> int:
     return int(time.time() * 1000)
+
+
+def _idempotence_id_from_message(message_bytes: bytes) -> str:
+    """The x-idempotence-id for a native create: a UUID built from the first 16
+    bytes of SHA-256(message bytes), so retrying the same message reuses the
+    same id and Fordefi deduplicates the create instead of broadcasting a
+    second transaction."""
+    digest = bytearray(hashlib.sha256(message_bytes).digest()[:16])
+    digest[6] = (digest[6] & 0x0F) | 0x40
+    digest[8] = (digest[8] & 0x3F) | 0x80
+    return str(uuid.UUID(bytes=bytes(digest)))
 
 
 @dataclass
@@ -197,21 +210,26 @@ class FordefiSigner(SolanaSigner):
             client=self._http_client,
         )
 
-    async def _post_transaction(self, request: dict[str, Any]) -> str:
+    async def _post_transaction(
+        self, request: dict[str, Any], idempotence_id: str | None = None
+    ) -> str:
         path = "/api/v1/transactions"
         body = json.dumps(request, separators=(",", ":"))
         timestamp = _timestamp_ms()
         signature = await self._sign_request(path, timestamp, body)
+        headers = {
+            "Authorization": f"Bearer {self._access_token}",
+            "Content-Type": "application/json",
+            "x-signature": signature,
+            "x-timestamp": str(timestamp),
+        }
+        if idempotence_id is not None:
+            headers["x-idempotence-id"] = idempotence_id
         response = await fetch_signer_json(
             url=f"{self._api_base_url}{path}",
             provider_name="Fordefi",
             method="POST",
-            headers={
-                "Authorization": f"Bearer {self._access_token}",
-                "Content-Type": "application/json",
-                "x-signature": signature,
-                "x-timestamp": str(timestamp),
-            },
+            headers=headers,
             content=body.encode(),
             client=self._http_client,
         )
@@ -340,7 +358,10 @@ class FordefiSigner(SolanaSigner):
         Native mode is not retry-safe: any failure after Fordefi accepts the
         submission raises ``BROADCAST_UNCONFIRMED`` carrying
         ``provider_transaction_id``; check that transaction with Fordefi
-        before retrying.
+        before retrying. Each native create carries an ``x-idempotence-id``
+        derived from the message bytes, so retrying the exact same bytes
+        cannot create a second Fordefi transaction; a retry built with a
+        fresh blockhash is a new transaction.
         """
         if self._chain is not None:
             return await self._sign_transaction_native(transaction)
@@ -365,8 +386,10 @@ class FordefiSigner(SolanaSigner):
 
     async def _sign_transaction_native(self, transaction: Transaction) -> SignedTransaction:
         self._require_sole_required_signer(transaction)
+        message_data = transaction.message_data()
         transaction_id = await self._post_transaction(
-            self._solana_transaction_request(transaction.message_data())
+            self._solana_transaction_request(message_data),
+            idempotence_id=_idempotence_id_from_message(message_data),
         )
         try:
             return await self._finish_native_broadcast(transaction_id)

--- a/python/src/solana_keychain/fordefi/signer.py
+++ b/python/src/solana_keychain/fordefi/signer.py
@@ -336,6 +336,11 @@ class FordefiSigner(SolanaSigner):
         unmodified — the returned signature identifies the on-chain
         transaction. Only legacy transactions whose sole required signer is
         the configured vault are supported.
+
+        Native mode is not retry-safe: any failure after Fordefi accepts the
+        submission raises ``BROADCAST_UNCONFIRMED`` carrying
+        ``provider_transaction_id``; check that transaction with Fordefi
+        before retrying.
         """
         if self._chain is not None:
             return await self._sign_transaction_native(transaction)
@@ -363,6 +368,16 @@ class FordefiSigner(SolanaSigner):
         transaction_id = await self._post_transaction(
             self._solana_transaction_request(transaction.message_data())
         )
+        try:
+            return await self._finish_native_broadcast(transaction_id)
+        except SignerError as error:
+            raise SignerError(
+                SignerErrorCode.BROADCAST_UNCONFIRMED,
+                error._detail,
+                provider_transaction_id=transaction_id,
+            ) from None
+
+    async def _finish_native_broadcast(self, transaction_id: str) -> SignedTransaction:
         result = await self._poll_for_result(transaction_id, pushable=True)
         raw_transaction = result.get("raw_transaction")
         if not isinstance(raw_transaction, str):

--- a/python/tests/test_errors.py
+++ b/python/tests/test_errors.py
@@ -7,6 +7,9 @@ from solana_keychain import SignerError, SignerErrorCode
 SECRET = "sensitive-secret-material"
 
 EXPECTED_GENERIC_MESSAGES = {
+    SignerErrorCode.BROADCAST_UNCONFIRMED: (
+        "Broadcast unconfirmed; the provider may have executed the transaction"
+    ),
     SignerErrorCode.CONFIG_ERROR: "Configuration error",
     SignerErrorCode.EXPECTED_SOLANA_SIGNER: "Expected a Solana signer",
     SignerErrorCode.HTTP_ERROR: "HTTP request failed",
@@ -50,6 +53,7 @@ def test_pickle_round_trip_preserves_code_and_redacts_detail() -> None:
 
 def test_code_values_are_frozen() -> None:
     assert {code.value for code in SignerErrorCode} == {
+        "SIGNER_BROADCAST_UNCONFIRMED",
         "SIGNER_CONFIG_ERROR",
         "SIGNER_ERROR",
         "SIGNER_EXPECTED_SOLANA_SIGNER",
@@ -64,3 +68,15 @@ def test_code_values_are_frozen() -> None:
         "SIGNER_SERIALIZATION_ERROR",
         "SIGNER_SIGNING_FAILED",
     }
+
+
+def test_broadcast_unconfirmed_surfaces_tx_id_but_not_detail() -> None:
+    error = SignerError(
+        SignerErrorCode.BROADCAST_UNCONFIRMED,
+        SECRET,
+        provider_transaction_id="provider-tx-123",
+    )
+    assert error.provider_transaction_id == "provider-tx-123"
+    assert "provider-tx-123" in str(error)
+    assert SECRET not in str(error)
+    assert SECRET not in repr(error)

--- a/python/tests/test_fordefi_signer.py
+++ b/python/tests/test_fordefi_signer.py
@@ -239,8 +239,6 @@ async def test_sign_message_black_box_success_with_stamped_request() -> None:
     create_request = respx.calls[0].request
     assert create_request.headers["Authorization"] == f"Bearer {ACCESS_TOKEN}"
     assert_valid_request_signature(create_request)
-    # Black box never broadcasts, so a duplicate create is harmless and carries
-    # no idempotence id.
     assert "x-idempotence-id" not in create_request.headers
     body = json.loads(create_request.content)
     assert body == {
@@ -359,9 +357,7 @@ async def test_sign_transaction_native_polling_timeout_is_broadcast_unconfirmed(
 
 @respx.mock
 async def test_sign_transaction_native_cancellation_carries_the_transaction_id() -> None:
-    """Cancellation must stay a CancelledError for asyncio's task machinery, but
-    the caller still needs the provider transaction id to reconcile with Fordefi
-    before retrying, so the re-raised error carries it in its message."""
+    """The re-raised CancelledError must carry the provider transaction id."""
     keypair = Keypair()
     signer = make_signer(keypair, chain="solana_devnet")
     polling = asyncio.Event()
@@ -450,9 +446,6 @@ async def test_sign_transaction_native_success() -> None:
     assert body["details"]["push_mode"] == "auto"
     assert body["details"]["fee"] == {"type": "priority", "priority_level": "high"}
     assert body["details"]["data"] == base64.b64encode(transaction.message_data()).decode("ascii")
-    # The native create carries a deterministic x-idempotence-id derived from
-    # the message bytes, so a blind retry of the same bytes reuses the id and
-    # Fordefi deduplicates the create.
     digest = bytearray(hashlib.sha256(transaction.message_data()).digest()[:16])
     digest[6] = (digest[6] & 0x0F) | 0x40
     digest[8] = (digest[8] & 0x3F) | 0x80

--- a/python/tests/test_fordefi_signer.py
+++ b/python/tests/test_fordefi_signer.py
@@ -357,10 +357,14 @@ async def test_sign_transaction_native_polling_timeout_is_broadcast_unconfirmed(
 
 @respx.mock
 async def test_sign_transaction_native_cancellation_carries_the_transaction_id() -> None:
-    """The re-raised CancelledError must carry the provider transaction id."""
+    """The re-raised CancelledError must carry the provider transaction id.
+
+    Observed inside the cancelled task: awaiting the task itself yields a fresh
+    CancelledError from the task machinery, without the message."""
     keypair = Keypair()
     signer = make_signer(keypair, chain="solana_devnet")
     polling = asyncio.Event()
+    observed: list[str] = []
 
     async def hang(_request: httpx.Request) -> httpx.Response:
         polling.set()
@@ -370,12 +374,19 @@ async def test_sign_transaction_native_cancellation_carries_the_transaction_id()
     respx.post(TRANSACTIONS_URL).mock(return_value=httpx.Response(200, json={"id": "tx-1"}))
     respx.get(f"{TRANSACTIONS_URL}/tx-1").mock(side_effect=hang)
 
-    task = asyncio.create_task(signer.sign_transaction(create_test_transaction(keypair.pubkey())))
+    async def run() -> None:
+        try:
+            await signer.sign_transaction(create_test_transaction(keypair.pubkey()))
+        except asyncio.CancelledError as error:
+            observed.append(str(error))
+            raise
+
+    task = asyncio.create_task(run())
     await polling.wait()
     task.cancel()
-    with pytest.raises(asyncio.CancelledError) as excinfo:
+    with pytest.raises(asyncio.CancelledError):
         await task
-    assert "tx-1" in str(excinfo.value)
+    assert observed and "tx-1" in observed[0]
 
 
 @respx.mock

--- a/python/tests/test_fordefi_signer.py
+++ b/python/tests/test_fordefi_signer.py
@@ -1,5 +1,7 @@
 import base64
+import hashlib
 import json
+import uuid
 from typing import Any
 
 import httpx
@@ -236,6 +238,9 @@ async def test_sign_message_black_box_success_with_stamped_request() -> None:
     create_request = respx.calls[0].request
     assert create_request.headers["Authorization"] == f"Bearer {ACCESS_TOKEN}"
     assert_valid_request_signature(create_request)
+    # Black box never broadcasts, so a duplicate create is harmless and carries
+    # no idempotence id.
+    assert "x-idempotence-id" not in create_request.headers
     body = json.loads(create_request.content)
     assert body == {
         "vault_id": VAULT_ID,
@@ -419,6 +424,13 @@ async def test_sign_transaction_native_success() -> None:
     assert body["details"]["push_mode"] == "auto"
     assert body["details"]["fee"] == {"type": "priority", "priority_level": "high"}
     assert body["details"]["data"] == base64.b64encode(transaction.message_data()).decode("ascii")
+    # The native create carries a deterministic x-idempotence-id derived from
+    # the message bytes, so a blind retry of the same bytes reuses the id and
+    # Fordefi deduplicates the create.
+    digest = bytearray(hashlib.sha256(transaction.message_data()).digest()[:16])
+    digest[6] = (digest[6] & 0x0F) | 0x40
+    digest[8] = (digest[8] & 0x3F) | 0x80
+    assert respx.calls[0].request.headers["x-idempotence-id"] == str(uuid.UUID(bytes=bytes(digest)))
 
 
 @respx.mock

--- a/python/tests/test_fordefi_signer.py
+++ b/python/tests/test_fordefi_signer.py
@@ -2,6 +2,7 @@ import asyncio
 import base64
 import hashlib
 import json
+import logging
 import uuid
 from typing import Any
 
@@ -356,10 +357,11 @@ async def test_sign_transaction_native_polling_timeout_is_broadcast_unconfirmed(
 
 
 @respx.mock
-async def test_sign_transaction_native_cancellation_carries_the_transaction_id() -> None:
-    """The re-raised CancelledError must carry the provider transaction id.
-
-    Observed inside the cancelled task: awaiting the task itself yields a fresh
+async def test_sign_transaction_native_cancellation_carries_the_transaction_id(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The re-raised CancelledError must carry the provider transaction id, and
+    the id must also be logged: awaiting the cancelled task yields a fresh
     CancelledError from the task machinery, without the message."""
     keypair = Keypair()
     signer = make_signer(keypair, chain="solana_devnet")
@@ -384,9 +386,11 @@ async def test_sign_transaction_native_cancellation_carries_the_transaction_id()
     task = asyncio.create_task(run())
     await polling.wait()
     task.cancel()
-    with pytest.raises(asyncio.CancelledError):
-        await task
+    with caplog.at_level(logging.WARNING, logger="solana_keychain"):
+        with pytest.raises(asyncio.CancelledError):
+            await task
     assert observed and "tx-1" in observed[0]
+    assert "tx-1" in caplog.text
 
 
 @respx.mock

--- a/python/tests/test_fordefi_signer.py
+++ b/python/tests/test_fordefi_signer.py
@@ -1,3 +1,4 @@
+import asyncio
 import base64
 import hashlib
 import json
@@ -354,6 +355,31 @@ async def test_sign_transaction_native_polling_timeout_is_broadcast_unconfirmed(
         await signer.sign_transaction(create_test_transaction(keypair.pubkey()))
     assert excinfo.value.code == SignerErrorCode.BROADCAST_UNCONFIRMED
     assert excinfo.value.provider_transaction_id == "tx-1"
+
+
+@respx.mock
+async def test_sign_transaction_native_cancellation_carries_the_transaction_id() -> None:
+    """Cancellation must stay a CancelledError for asyncio's task machinery, but
+    the caller still needs the provider transaction id to reconcile with Fordefi
+    before retrying, so the re-raised error carries it in its message."""
+    keypair = Keypair()
+    signer = make_signer(keypair, chain="solana_devnet")
+    polling = asyncio.Event()
+
+    async def hang(_request: httpx.Request) -> httpx.Response:
+        polling.set()
+        await asyncio.Event().wait()
+        raise AssertionError("unreachable")
+
+    respx.post(TRANSACTIONS_URL).mock(return_value=httpx.Response(200, json={"id": "tx-1"}))
+    respx.get(f"{TRANSACTIONS_URL}/tx-1").mock(side_effect=hang)
+
+    task = asyncio.create_task(signer.sign_transaction(create_test_transaction(keypair.pubkey())))
+    await polling.wait()
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError) as excinfo:
+        await task
+    assert "tx-1" in str(excinfo.value)
 
 
 @respx.mock

--- a/python/tests/test_fordefi_signer.py
+++ b/python/tests/test_fordefi_signer.py
@@ -338,6 +338,20 @@ async def test_sign_message_polling_timeout() -> None:
 
 
 @respx.mock
+async def test_sign_transaction_native_polling_timeout_is_broadcast_unconfirmed() -> None:
+    keypair = Keypair()
+    signer = make_signer(keypair, chain="solana_devnet", max_poll_attempts=3)
+    respx.post(TRANSACTIONS_URL).mock(return_value=httpx.Response(200, json={"id": "tx-1"}))
+    respx.get(f"{TRANSACTIONS_URL}/tx-1").mock(
+        return_value=status_response("waiting_for_signing_trigger")
+    )
+    with pytest.raises(SignerError) as excinfo:
+        await signer.sign_transaction(create_test_transaction(keypair.pubkey()))
+    assert excinfo.value.code == SignerErrorCode.BROADCAST_UNCONFIRMED
+    assert excinfo.value.provider_transaction_id == "tx-1"
+
+
+@respx.mock
 async def test_sign_transaction_black_box_success() -> None:
     keypair = Keypair()
     signer = make_signer(keypair)
@@ -414,7 +428,8 @@ async def test_sign_transaction_native_missing_raw_transaction() -> None:
     mock_sign_flow(status_response("completed"))
     with pytest.raises(SignerError) as excinfo:
         await signer.sign_transaction(create_test_transaction(keypair.pubkey()))
-    assert excinfo.value.code == SignerErrorCode.SIGNING_FAILED
+    assert excinfo.value.code == SignerErrorCode.BROADCAST_UNCONFIRMED
+    assert excinfo.value.provider_transaction_id == "tx-1"
 
 
 @respx.mock
@@ -428,7 +443,8 @@ async def test_sign_transaction_native_verifies_against_returned_message() -> No
     mock_sign_flow(status_response("completed", raw_transaction=raw_transaction))
     with pytest.raises(SignerError) as excinfo:
         await signer.sign_transaction(transaction)
-    assert excinfo.value.code == SignerErrorCode.SIGNING_FAILED
+    assert excinfo.value.code == SignerErrorCode.BROADCAST_UNCONFIRMED
+    assert excinfo.value.provider_transaction_id == "tx-1"
 
 
 @respx.mock

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -46,7 +46,7 @@ openfort = [
     "dep:hex",
 ]
 utila = ["dep:reqwest", "dep:jsonwebtoken", "dep:chrono", "dep:tokio"]
-fordefi = ["dep:reqwest", "dep:p256", "dep:tokio"]
+fordefi = ["dep:reqwest", "dep:p256", "dep:sha2", "dep:tokio"]
 all = [
     "memory",
     "vault",

--- a/rust/src/error.rs
+++ b/rust/src/error.rs
@@ -42,9 +42,38 @@ pub enum SignerError {
     #[error("IO error")]
     IoError(String),
 
+    /// The provider may have executed the transaction, but the outcome could not
+    /// be confirmed. Raised by broadcast-managed signers (Fordefi native mode,
+    /// Crossmint) for any failure after the provider has accepted the
+    /// transaction. Retrying blindly risks a duplicate spend; check the provider
+    /// transaction id first.
+    #[error("Broadcast unconfirmed; the provider may have executed the transaction (provider transaction id: {provider_tx_id})")]
+    BroadcastUnconfirmed {
+        provider_tx_id: String,
+        detail: String,
+    },
+
     /// Generic error
     #[error("Signer error")]
     Other(String),
+}
+
+impl SignerError {
+    pub(crate) fn detail_string(&self) -> String {
+        match self {
+            Self::InvalidPrivateKey(detail)
+            | Self::InvalidPublicKey(detail)
+            | Self::SigningFailed(detail)
+            | Self::RemoteApiError(detail)
+            | Self::HttpError(detail)
+            | Self::SerializationError(detail)
+            | Self::ConfigError(detail)
+            | Self::NotAvailable(detail)
+            | Self::IoError(detail)
+            | Self::Other(detail) => detail.clone(),
+            Self::BroadcastUnconfirmed { detail, .. } => detail.clone(),
+        }
+    }
 }
 
 impl From<std::io::Error> for SignerError {
@@ -99,6 +128,12 @@ impl fmt::Debug for SignerError {
             SignerError::ConfigError(_) => write!(f, "SignerError::ConfigError([REDACTED])"),
             SignerError::NotAvailable(_) => write!(f, "SignerError::NotAvailable([REDACTED])"),
             SignerError::IoError(_) => write!(f, "SignerError::IoError([REDACTED])"),
+            SignerError::BroadcastUnconfirmed { provider_tx_id, .. } => {
+                write!(
+                    f,
+                    "SignerError::BroadcastUnconfirmed(provider_tx_id: {provider_tx_id}, [REDACTED])"
+                )
+            }
             SignerError::Other(_) => write!(f, "SignerError::Other([REDACTED])"),
         }
     }
@@ -122,6 +157,10 @@ mod tests {
             SignerError::NotAvailable(secret.to_string()),
             SignerError::IoError(secret.to_string()),
             SignerError::Other(secret.to_string()),
+            SignerError::BroadcastUnconfirmed {
+                provider_tx_id: "tx-id".to_string(),
+                detail: secret.to_string(),
+            },
         ];
 
         for err in cases {
@@ -175,5 +214,19 @@ mod tests {
             format!("{}", SignerError::Other("x".to_string())),
             "Signer error"
         );
+    }
+
+    #[test]
+    fn test_broadcast_unconfirmed_surfaces_tx_id_but_not_detail() {
+        let err = SignerError::BroadcastUnconfirmed {
+            provider_tx_id: "provider-tx-123".to_string(),
+            detail: "sensitive-detail".to_string(),
+        };
+        let display = format!("{err}");
+        assert!(display.contains("provider-tx-123"));
+        assert!(!display.contains("sensitive-detail"));
+        let debug = format!("{err:?}");
+        assert!(debug.contains("provider-tx-123"));
+        assert!(!debug.contains("sensitive-detail"));
     }
 }

--- a/rust/src/fordefi/mod.rs
+++ b/rust/src/fordefi/mod.rs
@@ -492,7 +492,25 @@ impl FordefiSigner {
         self.validate_native_auto_transaction(transaction)?;
         let message_data = transaction.message_data();
         let tx_id = self.submit_solana_transaction(&message_data).await?;
-        let result = self.poll_for_result(&tx_id, true).await?;
+        // Once the submit is accepted Fordefi is already broadcasting
+        // (push_mode: "auto"), so any later failure leaves an on-chain outcome
+        // this client cannot rule out. Report those as BroadcastUnconfirmed
+        // carrying the Fordefi transaction id instead of a generic error a
+        // caller might blindly retry into a duplicate spend.
+        self.finish_native_broadcast(transaction, &tx_id)
+            .await
+            .map_err(|error| SignerError::BroadcastUnconfirmed {
+                provider_tx_id: tx_id,
+                detail: error.detail_string(),
+            })
+    }
+
+    async fn finish_native_broadcast(
+        &self,
+        transaction: &mut Transaction,
+        tx_id: &str,
+    ) -> Result<SignedTransaction, SignerError> {
+        let result = self.poll_for_result(tx_id, true).await?;
 
         let raw_tx_b64 = result.raw_transaction.as_ref().ok_or_else(|| {
             SignerError::SigningFailed(
@@ -1715,8 +1733,12 @@ mod tests {
 
         let mut tx = create_test_transaction(&pubkey);
         let result = signer.sign_transaction(&mut tx).await;
-        assert!(result.is_err());
-        assert!(matches!(result.unwrap_err(), SignerError::SigningFailed(_)));
+        match result.unwrap_err() {
+            SignerError::BroadcastUnconfirmed { provider_tx_id, .. } => {
+                assert_eq!(provider_tx_id, "native-tx-no-raw");
+            }
+            other => panic!("Expected BroadcastUnconfirmed, got: {other:?}"),
+        }
     }
 
     #[tokio::test]
@@ -1746,8 +1768,19 @@ mod tests {
 
         let mut tx = create_test_transaction(&pubkey);
         let result = signer.sign_transaction(&mut tx).await;
-        assert!(result.is_err());
-        assert!(matches!(result.unwrap_err(), SignerError::SigningFailed(_)));
+        match result.unwrap_err() {
+            SignerError::BroadcastUnconfirmed {
+                provider_tx_id,
+                detail,
+            } => {
+                assert_eq!(provider_tx_id, "native-tx-fail");
+                assert!(
+                    detail.contains("aborted"),
+                    "detail must carry the state, got: {detail}"
+                );
+            }
+            other => panic!("Expected BroadcastUnconfirmed, got: {other:?}"),
+        }
     }
 
     #[tokio::test]
@@ -1823,6 +1856,47 @@ mod tests {
         assert!(matches!(result.unwrap_err(), SignerError::SigningFailed(_)));
     }
 
+    #[tokio::test]
+    async fn test_fordefi_native_sign_transaction_poll_timeout_is_broadcast_unconfirmed() {
+        let mock_server = MockServer::start().await;
+        let keypair = create_test_keypair();
+        let pubkey = keypair_pubkey(&keypair);
+        let signer = create_native_test_signer(&mock_server.uri(), pubkey);
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/transactions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "native-tx-pending"
+            })))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/api/v1/transactions/native-tx-pending"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "state": "pending_signature"
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let mut tx = create_test_transaction(&pubkey);
+        let result = signer.sign_transaction(&mut tx).await;
+        match result.unwrap_err() {
+            SignerError::BroadcastUnconfirmed {
+                provider_tx_id,
+                detail,
+            } => {
+                assert_eq!(provider_tx_id, "native-tx-pending");
+                assert!(
+                    detail.contains("timeout"),
+                    "detail must carry the cause, got: {detail}"
+                );
+            }
+            other => panic!("Expected BroadcastUnconfirmed, got: {other:?}"),
+        }
+    }
+
     // --- Wire transaction parsing tests ---
 
     #[tokio::test]
@@ -1856,11 +1930,12 @@ mod tests {
 
         let mut tx = create_test_transaction(&pubkey);
         let result = signer.sign_transaction(&mut tx).await;
-        assert!(result.is_err());
-        assert!(matches!(
-            result.unwrap_err(),
-            SignerError::SerializationError(_)
-        ));
+        match result.unwrap_err() {
+            SignerError::BroadcastUnconfirmed { provider_tx_id, .. } => {
+                assert_eq!(provider_tx_id, "native-tx-malformed");
+            }
+            other => panic!("Expected BroadcastUnconfirmed, got: {other:?}"),
+        }
     }
 
     // --- Custom request-signer (FordefiRequestSigner) tests ---

--- a/rust/src/fordefi/mod.rs
+++ b/rust/src/fordefi/mod.rs
@@ -8,6 +8,7 @@ mod request_signer;
 mod types;
 
 use base64::{engine::general_purpose::STANDARD, Engine};
+use sha2::{Digest, Sha256};
 use std::str::FromStr;
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -233,11 +234,33 @@ impl FordefiSigner {
     // Submit helpers
     // -----------------------------------------------------------------------
 
+    /// Derives the `x-idempotence-id` for a native create: a UUID built from the
+    /// first 16 bytes of SHA-256(message bytes), so retrying the same message
+    /// reuses the same id and Fordefi deduplicates the create instead of
+    /// broadcasting a second transaction.
+    fn idempotence_id_from_message(message_bytes: &[u8]) -> String {
+        let digest = Sha256::digest(message_bytes);
+        let mut id = [0u8; 16];
+        id.copy_from_slice(&digest[..16]);
+        id[6] = (id[6] & 0x0f) | 0x40;
+        id[8] = (id[8] & 0x3f) | 0x80;
+        let hex: String = id.iter().map(|byte| format!("{byte:02x}")).collect();
+        format!(
+            "{}-{}-{}-{}-{}",
+            &hex[0..8],
+            &hex[8..12],
+            &hex[12..16],
+            &hex[16..20],
+            &hex[20..32]
+        )
+    }
+
     /// POST a serialized request body to `/api/v1/transactions` with P-256
     /// request signing. Returns the Fordefi transaction ID.
     async fn submit_request<T: serde::Serialize>(
         &self,
         request: &T,
+        idempotence_id: Option<&str>,
     ) -> Result<String, SignerError> {
         let path = "/api/v1/transactions";
         let body = serde_json::to_string(request)?;
@@ -248,16 +271,17 @@ impl FordefiSigner {
         let signature = self.sign_request(path, timestamp, &body).await?;
 
         let url = format!("{}{}", self.api_base_url, path);
-        let response = self
+        let mut builder = self
             .client
             .post(&url)
             .header("Authorization", format!("Bearer {}", self.access_token))
             .header("x-signature", &signature)
             .header("x-timestamp", timestamp.to_string())
-            .header("Content-Type", "application/json")
-            .body(body)
-            .send()
-            .await?;
+            .header("Content-Type", "application/json");
+        if let Some(id) = idempotence_id {
+            builder = builder.header("x-idempotence-id", id);
+        }
+        let response = builder.body(body).send().await?;
 
         if !response.status().is_success() {
             return Err(Self::extract_api_error(response, "submit_request").await);
@@ -282,7 +306,7 @@ impl FordefiSigner {
             },
         };
 
-        self.submit_request(&request).await
+        self.submit_request(&request, None).await
     }
 
     /// Submit a native Solana transaction request.
@@ -306,7 +330,11 @@ impl FordefiSigner {
             },
         };
 
-        self.submit_request(&request).await
+        self.submit_request(
+            &request,
+            Some(&Self::idempotence_id_from_message(data_bytes)),
+        )
+        .await
     }
 
     /// Submit a native Solana message request.
@@ -328,7 +356,7 @@ impl FordefiSigner {
             },
         };
 
-        self.submit_request(&request).await
+        self.submit_request(&request, None).await
     }
 
     // -----------------------------------------------------------------------
@@ -482,6 +510,10 @@ impl FordefiSigner {
     /// superfluous, so the returned serialized-transaction string is intentionally
     /// empty — only the signature is returned. Callers that need the exact
     /// broadcast bytes can serialize the (now Fordefi-signed) `transaction`.
+    ///
+    /// Each native create carries an `x-idempotence-id` derived from the message
+    /// bytes, so retrying the exact same bytes cannot create a second Fordefi
+    /// transaction; a retry built with a fresh blockhash is a new transaction.
     ///
     /// Only legacy transactions are supported: a versioned (v0) transaction
     /// returned by Fordefi fails to deserialize with a [`SignerError::SerializationError`].
@@ -1663,9 +1695,14 @@ mod tests {
         let wire_bytes = build_mock_wire_transaction(&keypair, &message_data);
         let wire_b64 = STANDARD.encode(&wire_bytes);
 
+        // The native create must carry a deterministic x-idempotence-id derived
+        // from the message bytes, so a blind retry of the same bytes reuses the
+        // id and Fordefi deduplicates the create.
+        let expected_idempotence_id = FordefiSigner::idempotence_id_from_message(&message_data);
         Mock::given(method("POST"))
             .and(path("/api/v1/transactions"))
             .and(header("Authorization", "Bearer test-token"))
+            .and(header("x-idempotence-id", expected_idempotence_id.as_str()))
             .and(wiremock::matchers::body_partial_json(serde_json::json!({
                 "type": "solana_transaction",
                 "details": {

--- a/rust/src/fordefi/mod.rs
+++ b/rust/src/fordefi/mod.rs
@@ -234,10 +234,8 @@ impl FordefiSigner {
     // Submit helpers
     // -----------------------------------------------------------------------
 
-    /// Derives the `x-idempotence-id` for a native create: a UUID built from the
-    /// first 16 bytes of SHA-256(message bytes), so retrying the same message
-    /// reuses the same id and Fordefi deduplicates the create instead of
-    /// broadcasting a second transaction.
+    /// A UUID derived from SHA-256(message bytes), so a retry of the same bytes
+    /// reuses the id and Fordefi deduplicates the create.
     fn idempotence_id_from_message(message_bytes: &[u8]) -> String {
         let digest = Sha256::digest(message_bytes);
         let mut id = [0u8; 16];
@@ -512,8 +510,7 @@ impl FordefiSigner {
     /// broadcast bytes can serialize the (now Fordefi-signed) `transaction`.
     ///
     /// Each native create carries an `x-idempotence-id` derived from the message
-    /// bytes, so retrying the exact same bytes cannot create a second Fordefi
-    /// transaction; a retry built with a fresh blockhash is a new transaction.
+    /// bytes, so retrying the exact same bytes cannot create a second transaction.
     ///
     /// Only legacy transactions are supported: a versioned (v0) transaction
     /// returned by Fordefi fails to deserialize with a [`SignerError::SerializationError`].
@@ -1695,9 +1692,6 @@ mod tests {
         let wire_bytes = build_mock_wire_transaction(&keypair, &message_data);
         let wire_b64 = STANDARD.encode(&wire_bytes);
 
-        // The native create must carry a deterministic x-idempotence-id derived
-        // from the message bytes, so a blind retry of the same bytes reuses the
-        // id and Fordefi deduplicates the create.
         let expected_idempotence_id = FordefiSigner::idempotence_id_from_message(&message_data);
         Mock::given(method("POST"))
             .and(path("/api/v1/transactions"))

--- a/typescript/packages/core/src/errors.ts
+++ b/typescript/packages/core/src/errors.ts
@@ -2,6 +2,13 @@
  * Custom error codes for solana-keychain, specific to this library
  */
 export const SignerErrorCode = {
+    /**
+     * The provider may have executed the transaction, but the outcome could not
+     * be confirmed. Raised by broadcast-managed signers for any failure after
+     * the provider has accepted the transaction; `context.providerTransactionId`
+     * carries the provider-side id to check before retrying.
+     */
+    BROADCAST_UNCONFIRMED: 'SIGNER_BROADCAST_UNCONFIRMED',
     CONFIG_ERROR: 'SIGNER_CONFIG_ERROR',
     EXPECTED_SOLANA_SIGNER: 'SIGNER_EXPECTED_SOLANA_SIGNER',
     HTTP_ERROR: 'SIGNER_HTTP_ERROR',

--- a/typescript/packages/fordefi/src/__tests__/fordefi-signer.test.ts
+++ b/typescript/packages/fordefi/src/__tests__/fordefi-signer.test.ts
@@ -571,7 +571,9 @@ describe('FordefiSigner', () => {
                 signatures: { [MOCK_ADDRESS]: null },
             } as never;
             await expect(signer.signAndSendTransactions([mockTx])).rejects.toMatchObject({
-                code: 'SIGNER_SIGNING_FAILED',
+                code: 'SIGNER_BROADCAST_UNCONFIRMED',
+                context: expect.objectContaining({ providerTransactionId: 'tx-no-raw' }) as object,
+                message: expect.stringContaining('tx-no-raw') as string,
             });
         });
 
@@ -587,7 +589,8 @@ describe('FordefiSigner', () => {
                 signatures: { [MOCK_ADDRESS]: null },
             } as never;
             await expect(signer.signAndSendTransactions([mockTx])).rejects.toMatchObject({
-                code: 'SIGNER_SIGNING_FAILED',
+                code: 'SIGNER_BROADCAST_UNCONFIRMED',
+                context: expect.objectContaining({ providerTransactionId: 'tx-fail' }) as object,
             });
         });
     });

--- a/typescript/packages/fordefi/src/__tests__/fordefi-signer.test.ts
+++ b/typescript/packages/fordefi/src/__tests__/fordefi-signer.test.ts
@@ -301,8 +301,6 @@ describe('FordefiSigner', () => {
             expect(postOpts.headers).toHaveProperty('Authorization', 'Bearer test-token');
             expect(postOpts.headers).toHaveProperty('x-signature');
             expect(postOpts.headers).toHaveProperty('x-timestamp');
-            // Black box never broadcasts, so a duplicate create is harmless and
-            // carries no idempotence id.
             expect(postOpts.headers).not.toHaveProperty('x-idempotence-id');
         });
 
@@ -502,12 +500,6 @@ describe('FordefiSigner', () => {
             expect(body.details).not.toHaveProperty('signatures');
         });
 
-        /**
-         * The native create must carry a deterministic x-idempotence-id derived
-         * from the message bytes: a blind retry of the same bytes reuses the id,
-         * so Fordefi deduplicates the create instead of broadcasting a second
-         * transfer.
-         */
         it('sends a deterministic x-idempotence-id on the native create', async () => {
             const messageBytes = new Uint8Array(32).fill(0xab);
             const digest = createHash('sha256').update(messageBytes).digest().subarray(0, 16);

--- a/typescript/packages/fordefi/src/__tests__/fordefi-signer.test.ts
+++ b/typescript/packages/fordefi/src/__tests__/fordefi-signer.test.ts
@@ -1,4 +1,4 @@
-import { generateKeyPairSync } from 'node:crypto';
+import { createHash, generateKeyPairSync } from 'node:crypto';
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -301,6 +301,9 @@ describe('FordefiSigner', () => {
             expect(postOpts.headers).toHaveProperty('Authorization', 'Bearer test-token');
             expect(postOpts.headers).toHaveProperty('x-signature');
             expect(postOpts.headers).toHaveProperty('x-timestamp');
+            // Black box never broadcasts, so a duplicate create is harmless and
+            // carries no idempotence id.
+            expect(postOpts.headers).not.toHaveProperty('x-idempotence-id');
         });
 
         it('should return the raw Fordefi signature directly without wire-tx round-trip', async () => {
@@ -497,6 +500,35 @@ describe('FordefiSigner', () => {
             expect(body.details.push_mode).toBe('auto');
             expect(body.details).toHaveProperty('data');
             expect(body.details).not.toHaveProperty('signatures');
+        });
+
+        /**
+         * The native create must carry a deterministic x-idempotence-id derived
+         * from the message bytes: a blind retry of the same bytes reuses the id,
+         * so Fordefi deduplicates the create instead of broadcasting a second
+         * transfer.
+         */
+        it('sends a deterministic x-idempotence-id on the native create', async () => {
+            const messageBytes = new Uint8Array(32).fill(0xab);
+            const digest = createHash('sha256').update(messageBytes).digest().subarray(0, 16);
+            digest[6] = (digest[6]! & 0x0f) | 0x40;
+            digest[8] = (digest[8]! & 0x3f) | 0x80;
+            const hex = digest.toString('hex');
+            const expectedId = `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20, 32)}`;
+
+            const returnedMessage = new Uint8Array(32).fill(0xcd);
+            const wireTx = mockWireTransaction(returnedMessage);
+            vi.mocked(fetch)
+                .mockResolvedValueOnce(mockVaultResponse())
+                .mockResolvedValueOnce(mockCreateTxResponse('tx-native'))
+                .mockResolvedValueOnce(mockPollResponse('completed', MOCK_SIGNATURE_BASE64, wireTx));
+
+            const signer = await FordefiSigner.create(nativeConfig);
+            const mockTx = { messageBytes, signatures: { [MOCK_ADDRESS]: null } } as never;
+            await signer.signAndSendTransactions([mockTx]);
+
+            const postOpts = vi.mocked(fetch).mock.calls[1]![1] as RequestInit;
+            expect(postOpts.headers).toHaveProperty('x-idempotence-id', expectedId);
         });
 
         it('should reject partial-signer usage before submitting native remote work', async () => {

--- a/typescript/packages/fordefi/src/fordefi-signer.ts
+++ b/typescript/packages/fordefi/src/fordefi-signer.ts
@@ -141,6 +141,11 @@ export interface FordefiSignerConfig {
  * Native mode may replace the recent blockhash and fees before signing and
  * broadcasts with `push_mode: 'auto'`, so it must be used through Kit's
  * {@link TransactionSendingSigner} flow rather than as a partial signer.
+ *
+ * Native mode is not retry-safe: any failure after Fordefi accepts the
+ * submission rejects with `BROADCAST_UNCONFIRMED` carrying
+ * `context.providerTransactionId`; check that transaction with Fordefi before
+ * retrying.
  */
 export interface FordefiNativeSigner<TAddress extends string = string>
     extends SolanaSigner<TAddress>, TransactionSendingSigner<TAddress> {}
@@ -490,37 +495,62 @@ export class FordefiSigner<TAddress extends string = string> implements SolanaSi
 
                 const base64Data = Buffer.from(transaction.messageBytes).toString('base64');
                 const txId = await this.submitSolanaTransaction(base64Data);
-                const result = await this.pollForResult(txId, { pushable: true });
-                if (!result.raw_transaction) {
-                    return throwSignerError(SignerErrorCode.SIGNING_FAILED, {
-                        message: 'Fordefi solana_transaction response missing raw_transaction',
+                // Once the submit is accepted Fordefi is already broadcasting
+                // (push_mode 'auto'), so any later failure leaves an on-chain
+                // outcome this client cannot rule out. Report those as
+                // BROADCAST_UNCONFIRMED carrying the Fordefi transaction id
+                // instead of a generic error a caller might blindly retry into
+                // a duplicate spend.
+                try {
+                    return await this.finishNativeBroadcast(txId, config);
+                } catch (error) {
+                    return throwSignerError(SignerErrorCode.BROADCAST_UNCONFIRMED, {
+                        cause: error,
+                        message: `Fordefi may have executed the transaction, but the outcome could not be confirmed (provider transaction id: ${txId})`,
+                        providerTransactionId: txId,
                     });
                 }
-
-                const signedWireTx = result.raw_transaction as Base64EncodedWireTransaction;
-                const sigDict = extractSignatureFromWireTransaction({
-                    base64WireTransaction: signedWireTx,
-                    signerAddress: this.address,
-                });
-                const signerSignature = sigDict[this.address];
-                if (!signerSignature) {
-                    return throwSignerError(SignerErrorCode.SIGNING_FAILED, {
-                        address: this.address,
-                        message: 'Fordefi wire transaction did not contain the configured vault signature',
-                    });
-                }
-
-                const { messageBytes, transactionSignature } = FordefiSigner.extractWireTransactionParts(signedWireTx);
-                await assertSignatureValid({
-                    data: messageBytes,
-                    signature: signerSignature,
-                    signerAddress: this.address,
-                });
-                config?.abortSignal?.throwIfAborted();
-                return transactionSignature;
             },
             this.requestDelayMs,
         );
+    }
+
+    /**
+     * Poll a submitted native transaction to completion and extract and verify
+     * the vault's signature from the returned wire bytes.
+     */
+    private async finishNativeBroadcast(
+        txId: string,
+        config?: TransactionSendingSignerConfig,
+    ): Promise<SignatureBytes> {
+        const result = await this.pollForResult(txId, { pushable: true });
+        if (!result.raw_transaction) {
+            return throwSignerError(SignerErrorCode.SIGNING_FAILED, {
+                message: 'Fordefi solana_transaction response missing raw_transaction',
+            });
+        }
+
+        const signedWireTx = result.raw_transaction as Base64EncodedWireTransaction;
+        const sigDict = extractSignatureFromWireTransaction({
+            base64WireTransaction: signedWireTx,
+            signerAddress: this.address,
+        });
+        const signerSignature = sigDict[this.address];
+        if (!signerSignature) {
+            return throwSignerError(SignerErrorCode.SIGNING_FAILED, {
+                address: this.address,
+                message: 'Fordefi wire transaction did not contain the configured vault signature',
+            });
+        }
+
+        const { messageBytes, transactionSignature } = FordefiSigner.extractWireTransactionParts(signedWireTx);
+        await assertSignatureValid({
+            data: messageBytes,
+            signature: signerSignature,
+            signerAddress: this.address,
+        });
+        config?.abortSignal?.throwIfAborted();
+        return transactionSignature;
     }
 
     /**

--- a/typescript/packages/fordefi/src/fordefi-signer.ts
+++ b/typescript/packages/fordefi/src/fordefi-signer.ts
@@ -1,4 +1,4 @@
-import { createPrivateKey, createSign, type KeyObject } from 'node:crypto';
+import { createHash, createPrivateKey, createSign, type KeyObject } from 'node:crypto';
 
 import { Address, assertIsAddress } from '@solana/addresses';
 import { getBase58Decoder } from '@solana/codecs-strings';
@@ -44,6 +44,20 @@ const DEFAULT_BASE_URL = 'https://api.fordefi.com';
 const DEFAULT_POLL_INTERVAL_MS = 2000;
 const DEFAULT_MAX_POLL_ATTEMPTS = 50;
 const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
+
+/**
+ * The x-idempotence-id for a native create: a UUID built from the first 16
+ * bytes of SHA-256(message bytes), so retrying the same message reuses the
+ * same id and Fordefi deduplicates the create instead of broadcasting a
+ * second transaction.
+ */
+function idempotenceIdFromMessage(messageBytes: Uint8Array): string {
+    const digest = createHash('sha256').update(messageBytes).digest().subarray(0, 16);
+    digest[6] = (digest[6]! & 0x0f) | 0x40;
+    digest[8] = (digest[8]! & 0x3f) | 0x80;
+    const hex = digest.toString('hex');
+    return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20, 32)}`;
+}
 
 /** Terminal success states for pushable transactions (solana_transaction with push_mode auto). */
 const PUSHABLE_SUCCESS_STATES = new Set(['completed']);
@@ -145,7 +159,10 @@ export interface FordefiSignerConfig {
  * Native mode is not retry-safe: any failure after Fordefi accepts the
  * submission rejects with `BROADCAST_UNCONFIRMED` carrying
  * `context.providerTransactionId`; check that transaction with Fordefi before
- * retrying.
+ * retrying. Each native create carries an `x-idempotence-id` derived from the
+ * message bytes, so retrying the exact same bytes cannot create a second
+ * Fordefi transaction; a retry built with a fresh blockhash is a new
+ * transaction.
  */
 export interface FordefiNativeSigner<TAddress extends string = string>
     extends SolanaSigner<TAddress>, TransactionSendingSigner<TAddress> {}
@@ -575,12 +592,15 @@ export class FordefiSigner<TAddress extends string = string> implements SolanaSi
      */
     private async submitTransaction(
         requestBody: FordefiBlackBoxSignatureRequest | FordefiSolanaMessageRequest | FordefiSolanaTransactionRequest,
+        idempotenceId?: string,
     ): Promise<string> {
         const apiPath = '/api/v1/transactions';
         const createResponse = await this.request<FordefiCreateTransactionResponse>(
             'POST',
             apiPath,
             JSON.stringify(requestBody),
+            this.requestTimeoutMs,
+            idempotenceId,
         );
         return createResponse.id;
     }
@@ -619,7 +639,7 @@ export class FordefiSigner<TAddress extends string = string> implements SolanaSi
             type: 'solana_transaction',
             vault_id: this.vaultId,
         };
-        return await this.submitTransaction(requestBody);
+        return await this.submitTransaction(requestBody, idempotenceIdFromMessage(Buffer.from(base64Data, 'base64')));
     }
 
     /**
@@ -738,6 +758,7 @@ export class FordefiSigner<TAddress extends string = string> implements SolanaSi
         apiPath: string,
         body?: string,
         timeoutMs = this.requestTimeoutMs,
+        idempotenceId?: string,
     ): Promise<T> {
         const headers: Record<string, string> = {
             Authorization: `Bearer ${this.accessToken}`,
@@ -747,6 +768,9 @@ export class FordefiSigner<TAddress extends string = string> implements SolanaSi
             headers['Content-Type'] = 'application/json';
             headers['x-signature'] = await this.signRequest(apiPath, timestamp, body);
             headers['x-timestamp'] = timestamp.toString();
+        }
+        if (idempotenceId !== undefined) {
+            headers['x-idempotence-id'] = idempotenceId;
         }
 
         return await fetchSignerJson<T>({

--- a/typescript/packages/fordefi/src/fordefi-signer.ts
+++ b/typescript/packages/fordefi/src/fordefi-signer.ts
@@ -46,10 +46,8 @@ const DEFAULT_MAX_POLL_ATTEMPTS = 50;
 const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
 
 /**
- * The x-idempotence-id for a native create: a UUID built from the first 16
- * bytes of SHA-256(message bytes), so retrying the same message reuses the
- * same id and Fordefi deduplicates the create instead of broadcasting a
- * second transaction.
+ * A UUID derived from SHA-256(message bytes), so a retry of the same bytes
+ * reuses the id and Fordefi deduplicates the create.
  */
 function idempotenceIdFromMessage(messageBytes: Uint8Array): string {
     const digest = createHash('sha256').update(messageBytes).digest().subarray(0, 16);
@@ -161,7 +159,6 @@ export interface FordefiSignerConfig {
  * `context.providerTransactionId`; check that transaction with Fordefi before
  * retrying. Each native create carries an `x-idempotence-id` derived from the
  * message bytes, so retrying the exact same bytes cannot create a second
- * Fordefi transaction; a retry built with a fresh blockhash is a new
  * transaction.
  */
 export interface FordefiNativeSigner<TAddress extends string = string>


### PR DESCRIPTION
## Problem

Fordefi native mode submits with `push_mode: "auto"`, so Fordefi is already broadcasting once the create call is accepted. Every failure after that point - poll timeout (the mundane one: default 50x2000ms budget while Fordefi is slow), terminal failure state, missing/malformed `raw_transaction`, signature mismatch - surfaced as a generic `SIGNING_FAILED` / `REMOTE_API_ERROR` / `SERIALIZATION_ERROR`, and the provider transaction id was structurally unreachable: the redaction rules render only generic messages (Rust `Display` says "Signing failed", Python keeps `detail` private, Go returns only the code message).

A caller therefore cannot distinguish "never submitted" from "submitted, outcome unknown". The natural reaction is to retry, and Solana replay protection does not help: Fordefi rewrites the blockhash, so the retry is a different message the cluster will not deduplicate - a duplicate spend.

Sign-only backends (the other 12) are retry-safe by construction: a failure means no signature was delivered and nothing reached the chain. This class only exists for broadcast-managed signers. Fireblocks' broadcast mode (`PROGRAM_CALL`) is already rejected at config time for exactly this reason.

## Fix

New error code in all four languages: **`SIGNER_BROADCAST_UNCONFIRMED`**, carrying the provider transaction id as structured data:

- Rust: `SignerError::BroadcastUnconfirmed { provider_tx_id, detail }` - id in `Display`/`Debug`, detail redacted as before
- Python: `SignerErrorCode.BROADCAST_UNCONFIRMED` + public `provider_transaction_id` attribute, id appended to the generic message
- Go: `CodeBroadcastUnconfirmed` + exported `ProviderTxID` field and `NewBroadcastUnconfirmedError` constructor, id rendered by `Error()`
- TypeScript: `SignerErrorCode.BROADCAST_UNCONFIRMED` + `context.providerTransactionId`, original error kept as `cause`

The transaction id is deliberately exposed in the rendered message: it contains no secret material and is the caller's only handle to check the outcome with Fordefi before retrying. Detail redaction is unchanged everywhere.

Fordefi native mode now maps every post-accept failure to the new code. The black-box path (default mode) and `sign_message` are untouched - they broadcast nothing. Docs on the signing entry points now state that native mode is not retry-safe.

Update: Fordefi's create-transaction endpoint does document an optional `x-idempotence-id` header, so the earlier "no evidence the provider accepts one" premise was wrong. Native creates now send a deterministic id derived from the submitted message bytes (UUID from the first 16 bytes of SHA-256), so a blind retry of the exact same bytes reuses the id and Fordefi deduplicates the create. A retry built with a fresh blockhash is still a new transaction, which is what `BROADCAST_UNCONFIRMED` protects against. Black-box and message paths broadcast nothing and send no id.

Intentionally out of scope: any resume/poll API (transaction lifecycle does not belong in a signing library). Crossmint, the other broadcast-managed backend, gets the same treatment in a follow-up - its signing paths are being rewritten in #231 and stacking on that avoids conflicting changes.

## Breaking change notes

- Rust: new `SignerError` variant breaks exhaustive `match` (enum is not `#[non_exhaustive]`); needs a changelog entry on release.
- Behavior: Fordefi native post-accept failures change code from `SIGNING_FAILED`/`REMOTE_API_ERROR`/`SERIALIZATION_ERROR` to `BROADCAST_UNCONFIRMED`. Callers matching the old codes on this path must update - that is the point of the change.

## Testing

- New tests per language: poll timeout / failed state / missing and malformed wire transaction on the native path all yield `BROADCAST_UNCONFIRMED` with the transaction id reachable and rendered; error-surface tests prove the id appears in output while detail stays redacted.
- Rust: fordefi suite on sdk-v2/v3/v4 (51 each), clippy `-D warnings` on `all`, fmt
- Python: 451 unit tests, ruff, mypy strict
- Go: `go test -race` all modules, vet, golangci-lint
- TypeScript: core 31 + fordefi 60 tests, workspace typecheck, eslint, prettier
