### PR TITLE
test(fordefi): read pem content from env and self-transfer on devnet

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -91,7 +91,10 @@ CDP_SOLANA_ADDRESS=YourSolanaPublicKeyBase58Here
 
 # Fordefi Configuration (for SIGNER_TYPE=fordefi)
 FORDEFI_ACCESS_TOKEN=your-fordefi-api-token
-FORDEFI_PRIVATE_KEY_PEM_PATH=./secret/private.pem
+FORDEFI_PRIVATE_KEY_PEM="-----BEGIN EC PRIVATE KEY-----
+your-ecdsa-p256-private-key-here
+-----END EC PRIVATE KEY-----"
+# FORDEFI_API_BASE_URL=https://api.fordefi.com  # Optional, defaults to this
 # Native Solana mode
 FORDEFI_VAULT_ID=your-solana-vault-uuid
 FORDEFI_PUBLIC_KEY=YourSolanaVaultPublicKeyBase58Here

--- a/go/signers/fordefi/integration_test.go
+++ b/go/signers/fordefi/integration_test.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"encoding/base64"
 	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/gagliardetto/solana-go"
@@ -21,19 +20,11 @@ import (
 // .env) or CI with Doppler secrets.
 func integrationSigner(t *testing.T) *Signer {
 	t.Helper()
-	pemPath := requireEnv(t, "FORDEFI_PRIVATE_KEY_PEM_PATH")
-	if !filepath.IsAbs(pemPath) {
-		pemPath = filepath.Join("..", "..", "..", pemPath)
-	}
-	pemBytes, err := os.ReadFile(pemPath)
-	if err != nil {
-		t.Fatalf("failed to read FORDEFI_PRIVATE_KEY_PEM_PATH: %v", err)
-	}
 	s, err := New(context.Background(), Config{
 		AccessToken:   requireEnv(t, "FORDEFI_ACCESS_TOKEN"),
 		VaultID:       requireEnv(t, "FORDEFI_BB_VAULT_ID"),
 		PublicKey:     requireEnv(t, "FORDEFI_BB_PUBLIC_KEY"),
-		PrivateKeyPEM: string(pemBytes),
+		PrivateKeyPEM: requireEnv(t, "FORDEFI_PRIVATE_KEY_PEM"),
 		APIBaseURL:    os.Getenv("FORDEFI_API_BASE_URL"),
 	})
 	if err != nil {

--- a/python/tests/integration/test_live_signers.py
+++ b/python/tests/integration/test_live_signers.py
@@ -8,7 +8,6 @@ substring-matches marker keywords, and every test here carries ``parametrize``.
 """
 
 import os
-from pathlib import Path
 
 import pytest
 from solders.pubkey import Pubkey
@@ -130,15 +129,6 @@ async def make_fireblocks_signer() -> SolanaSigner:
     )
 
 
-def _resolve_pem_path(raw: str) -> Path:
-    """Relative PEM paths are resolved against the repo root, so the same
-    ``.env`` value works for every language's integration suite."""
-    path = Path(raw)
-    if path.is_absolute():
-        return path
-    return Path(__file__).parents[3] / path
-
-
 async def make_fordefi_signer() -> SolanaSigner:
     from solana_keychain.fordefi import FordefiSignerConfig, create_fordefi_signer
     from solana_keychain.fordefi.signer import DEFAULT_API_BASE_URL
@@ -147,15 +137,14 @@ async def make_fordefi_signer() -> SolanaSigner:
         "FORDEFI_ACCESS_TOKEN",
         "FORDEFI_BB_VAULT_ID",
         "FORDEFI_BB_PUBLIC_KEY",
-        "FORDEFI_PRIVATE_KEY_PEM_PATH",
+        "FORDEFI_PRIVATE_KEY_PEM",
     )
-    private_key_pem = _resolve_pem_path(env["FORDEFI_PRIVATE_KEY_PEM_PATH"]).read_text()
     return await create_fordefi_signer(
         FordefiSignerConfig(
             access_token=env["FORDEFI_ACCESS_TOKEN"],
             vault_id=env["FORDEFI_BB_VAULT_ID"],
             public_key=env["FORDEFI_BB_PUBLIC_KEY"],
-            private_key_pem=private_key_pem,
+            private_key_pem=env["FORDEFI_PRIVATE_KEY_PEM"],
             api_base_url=optional_env("FORDEFI_API_BASE_URL") or DEFAULT_API_BASE_URL,
         )
     )

--- a/rust/src/tests/test_fordefi_integration.rs
+++ b/rust/src/tests/test_fordefi_integration.rs
@@ -1,8 +1,9 @@
 pub const FORDEFI_ACCESS_TOKEN: &str = "FORDEFI_ACCESS_TOKEN";
 pub const FORDEFI_VAULT_ID: &str = "FORDEFI_VAULT_ID";
-pub const FORDEFI_PRIVATE_KEY_PEM_PATH: &str = "FORDEFI_PRIVATE_KEY_PEM_PATH";
+pub const FORDEFI_PRIVATE_KEY_PEM: &str = "FORDEFI_PRIVATE_KEY_PEM";
 pub const FORDEFI_PUBLIC_KEY: &str = "FORDEFI_PUBLIC_KEY";
 pub const FORDEFI_CHAIN: &str = "FORDEFI_CHAIN";
+pub const FORDEFI_API_BASE_URL: &str = "FORDEFI_API_BASE_URL";
 // Black box vault credentials — a black box vault signs raw bytes and is distinct
 // from the Solana (native-mode) vault above. Mirrors the TypeScript integration tests.
 pub const FORDEFI_BB_VAULT_ID: &str = "FORDEFI_BB_VAULT_ID";
@@ -21,19 +22,6 @@ mod tests {
     use crate::tests::litesvm_util::{get_latest_blockhash, simulate_transaction, start_litesvm};
     use crate::traits::SolanaSigner;
     use std::env;
-    use std::path::{Path, PathBuf};
-
-    fn resolve_pem_path(raw: &str) -> PathBuf {
-        let p = Path::new(raw);
-        if p.is_absolute() {
-            p.to_path_buf()
-        } else {
-            Path::new(env!("CARGO_MANIFEST_DIR"))
-                .parent()
-                .expect("CARGO_MANIFEST_DIR has no parent")
-                .join(p)
-        }
-    }
 
     /// Build a `FordefiSigner` for the given vault, sharing the access token and
     /// request-signing key from the environment. `chain` selects black box mode
@@ -45,10 +33,8 @@ mod tests {
     ) -> FordefiSigner {
         let access_token = env::var(FORDEFI_ACCESS_TOKEN)
             .expect("FORDEFI_ACCESS_TOKEN must be set for integration tests");
-        let pem_path = env::var(FORDEFI_PRIVATE_KEY_PEM_PATH)
-            .expect("FORDEFI_PRIVATE_KEY_PEM_PATH must be set for integration tests");
-        let private_key_pem =
-            std::fs::read_to_string(resolve_pem_path(&pem_path)).expect("Failed to read PEM file");
+        let private_key_pem = env::var(FORDEFI_PRIVATE_KEY_PEM)
+            .expect("FORDEFI_PRIVATE_KEY_PEM must be set for integration tests");
 
         FordefiSigner::from_config(FordefiSignerConfig {
             access_token,
@@ -56,7 +42,7 @@ mod tests {
             private_key_pem: Some(private_key_pem),
             request_signer: None,
             public_key,
-            api_base_url: None,
+            api_base_url: env::var(FORDEFI_API_BASE_URL).ok(),
             poll_interval_ms: None,
             max_poll_attempts: None,
             http_client_config: None,
@@ -181,11 +167,11 @@ mod tests {
         let rpc_url = env::var("SOLANA_RPC_URL")
             .unwrap_or_else(|_| "https://api.devnet.solana.com".to_string());
 
-        // Recipient: use env var or a throwaway address
+        // Recipient: explicit env var, else self-transfer so the vault only pays fees
         let to = env::var("DEVNET_RECIPIENT")
             .ok()
             .and_then(|s| Pubkey::from_str(&s).ok())
-            .unwrap_or_else(Pubkey::new_unique);
+            .unwrap_or(from);
 
         let lamports: u64 = 100_000_000; // 0.1 SOL
 
@@ -271,7 +257,7 @@ mod tests {
         let to = env::var("DEVNET_RECIPIENT")
             .ok()
             .and_then(|s| Pubkey::from_str(&s).ok())
-            .unwrap_or_else(Pubkey::new_unique);
+            .unwrap_or(from);
 
         let lamports: u64 = 100_000_000; // 0.1 SOL
 

--- a/typescript/packages/fordefi/.env.example
+++ b/typescript/packages/fordefi/.env.example
@@ -1,6 +1,8 @@
 # Fordefi Integration Tests — shared
 FORDEFI_ACCESS_TOKEN=your-fordefi-api-token
-FORDEFI_PRIVATE_KEY_PEM_PATH=./secret/private.pem
+FORDEFI_PRIVATE_KEY_PEM="-----BEGIN EC PRIVATE KEY-----
+your-ecdsa-p256-private-key-here
+-----END EC PRIVATE KEY-----"
 
 # Devnet integration test (native Solana mode — requires a regular Solana vault)
 FORDEFI_VAULT_ID=your-solana-vault-uuid

--- a/typescript/packages/fordefi/README.md
+++ b/typescript/packages/fordefi/README.md
@@ -103,7 +103,7 @@ Required env vars (shared):
 
 ```
 FORDEFI_ACCESS_TOKEN=<api-token>
-FORDEFI_PRIVATE_KEY_PEM_PATH=<path-to-pem>
+FORDEFI_PRIVATE_KEY_PEM=<pem-content>
 ```
 
 Black box vault:

--- a/typescript/packages/fordefi/src/__tests__/setup.ts
+++ b/typescript/packages/fordefi/src/__tests__/setup.ts
@@ -1,17 +1,6 @@
-import * as fs from 'node:fs';
-import * as path from 'node:path';
-import { fileURLToPath } from 'node:url';
-
 import type { SolanaSigner } from '@solana/keychain-core';
 import { SignerTestConfig, TestScenario } from '@solana/keychain-test-utils';
 import { createFordefiSigner } from '../fordefi-signer';
-
-export function resolvePemPath(raw: string): string {
-    if (path.isAbsolute(raw)) return raw;
-    const here = path.dirname(fileURLToPath(import.meta.url));
-    const repoRoot = path.resolve(here, '..', '..', '..', '..', '..');
-    return path.resolve(repoRoot, raw);
-}
 
 const SIGNER_TYPE = 'fordefi';
 // LiteSVM integration tests use the black_box signing path (raw bytes, no
@@ -21,7 +10,7 @@ const REQUIRED_ENV_VARS = [
     'FORDEFI_ACCESS_TOKEN',
     'FORDEFI_BB_VAULT_ID',
     'FORDEFI_BB_PUBLIC_KEY',
-    'FORDEFI_PRIVATE_KEY_PEM_PATH',
+    'FORDEFI_PRIVATE_KEY_PEM',
 ];
 
 const CONFIG: SignerTestConfig<SolanaSigner> = {
@@ -30,9 +19,10 @@ const CONFIG: SignerTestConfig<SolanaSigner> = {
     createSigner: () =>
         createFordefiSigner({
             accessToken: process.env.FORDEFI_ACCESS_TOKEN!,
+            apiBaseUrl: process.env.FORDEFI_API_BASE_URL,
             maxPollAttempts: 110,
             pollIntervalMs: 1000,
-            privateKeyPem: fs.readFileSync(resolvePemPath(process.env.FORDEFI_PRIVATE_KEY_PEM_PATH!), 'utf8'),
+            privateKeyPem: process.env.FORDEFI_PRIVATE_KEY_PEM!,
             publicKey: process.env.FORDEFI_BB_PUBLIC_KEY!,
             vaultId: process.env.FORDEFI_BB_VAULT_ID!,
         }),


### PR DESCRIPTION
## Summary
- Fordefi integration suites (Rust, TypeScript, Python, Go) now take `FORDEFI_PRIVATE_KEY_PEM` with the key content instead of `FORDEFI_PRIVATE_KEY_PEM_PATH`, matching the Fireblocks/Dfns pattern; CI injects Doppler secrets as env vars and never writes files, so a path variable could not work there.
- Rust and TypeScript integration tests honor `FORDEFI_API_BASE_URL`, which the Go and Python suites already supported.
- The two Rust devnet transfer tests default their recipient to the sending vault itself, so repeated runs cost only fees; `DEVNET_RECIPIENT` still overrides.
- `.env.example` and the package README document the new variable.

## Test Plan
- All four Fordefi live integration suites run green locally against the live API: Rust 7/7 (including both devnet transfers confirmed on-chain), TypeScript 3/3, Python 3/3, Go 3/3.
- After merge: add the `FORDEFI_*` secrets to Doppler (`keychain`/`stg_github`) and set the `CI_SIGNER_FORDEFI_ENABLED=true` repo variable to enable the suites in CI.