### PR TITLE
fix(python): reject unsupported message versions in remote transaction checks

### DIFF
--- a/python/src/solana_keychain/crossmint/signer.py
+++ b/python/src/solana_keychain/crossmint/signer.py
@@ -9,6 +9,7 @@ from urllib.parse import quote
 import base58
 import httpx
 from solders.keypair import Keypair
+from solders.message import Message, MessageV0
 from solders.pubkey import Pubkey
 from solders.signature import Signature
 from solders.transaction import Transaction, VersionedTransaction
@@ -334,6 +335,11 @@ class CrossmintSigner(SolanaSigner):
             ) from None
 
         message = transaction.message
+        if not isinstance(message, (Message, MessageV0)):
+            raise SignerError(
+                SignerErrorCode.SIGNING_FAILED,
+                "Crossmint returned a transaction with an unsupported message version",
+            )
         num_required = message.header.num_required_signatures
         account_keys = list(message.account_keys)
         if len(account_keys) < num_required:

--- a/python/src/solana_keychain/utila/signer.py
+++ b/python/src/solana_keychain/utila/signer.py
@@ -17,6 +17,7 @@ except ImportError as error:  # pragma: no cover
     ) from error
 
 import httpx
+from solders.message import Message, MessageV0
 from solders.pubkey import Pubkey
 from solders.signature import Signature
 from solders.transaction import Transaction, VersionedTransaction
@@ -312,6 +313,11 @@ class UtilaSigner(SolanaSigner):
             ) from None
 
         message = transaction.message
+        if not isinstance(message, (Message, MessageV0)):
+            raise SignerError(
+                SignerErrorCode.SIGNING_FAILED,
+                "Utila returned a transaction with an unsupported message version",
+            )
         if signed_message_bytes(message) != expected_message:
             raise SignerError(
                 SignerErrorCode.SIGNING_FAILED,


### PR DESCRIPTION
## Summary
- `solders` 0.29.0 (released within our `>=0.26,<1` range) added `MessageV1` to the versioned-transaction message union, breaking strict mypy on `main` at the `signed_message_bytes` call sites in the Utila and Crossmint signers.
- Both call sites now explicitly reject transaction messages that are not legacy or v0 with a `SIGNING_FAILED` error instead of assuming the union shape. `signed_message_bytes` only knows the legacy and v0 signing prefixes, so guessing at the v1 wire format during signature verification would be worse than failing loud.
- No `solders` floor bump needed: only `Message` and `MessageV0` are imported, both available across the supported range.

## Test Plan
- `mypy` clean (67 files) with solders 0.29.0 installed.
- `ruff check` + `ruff format --check` clean.
- Utila + Crossmint unit suites: 63 passed.

Unblocks Python CI on all open PRs (e.g. #242).