### PR TITLE
feat(ts)!: model managed-broadcast signers in a shared core SolanaSendingSigner type

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,7 +106,8 @@ See [typescript/README.md](typescript/README.md) for the full package list and u
 ### Gotchas
 
 - **Async construction:** always `await createXSigner(...)` — direct class construction is deprecated and skips `init()`.
-- **`signMessages` quirks (parity with Rust):** `CrossmintSigner` rejects with "not supported". `CdpSigner` requires UTF-8 message bytes.
+- **Managed-broadcast backends (Crossmint, Fordefi native mode):** implement `SolanaSendingSigner` from core — `signAndSendTransactions()` only, with **no** `signTransactions`/`signMessages` (Crossmint) because Kit classifies signers by duck-typed method presence. They are excluded from `@solana/keychain-kit-plugin` at the type level.
+- **`signMessages` quirks (parity with Rust):** `CrossmintSigner` does not expose `signMessages` at all (Rust returns `SigningFailed`). `CdpSigner` requires UTF-8 message bytes.
 - **HTTPS enforced:** all `apiBaseUrl` config fields must reject non-HTTPS URLs — validate with `assertHttpsUrl()` from `@solana/keychain-core`.
 - **Remote API calls:** go through `fetchSignerJson()` from `@solana/keychain-core` — it owns the HTTP_ERROR/REMOTE_API_ERROR/PARSING_ERROR pipeline, response sanitization (`sanitizeRemoteErrorResponse()`), redirect rejection, and a default 60s timeout. Batch signing uses core `signBatchStaggered()` + `validateRequestDelayMs()`.
 - **Integration tests:** use `runSignerIntegrationTest` + per-package `setup.ts`; spun up via `just ts-test-integration` (loads `.env`, starts local Vault).

--- a/docs/ADDING_SIGNERS.md
+++ b/docs/ADDING_SIGNERS.md
@@ -857,6 +857,13 @@ export { YourSigner } from '@solana/keychain-your-signer';
 
 **g) `typescript/scripts/test-treeshake-umbrella.mjs`** — add your package to `SIGNER_MARKERS` (two distinctive strings that appear in your built `dist/` output — verify with grep before picking them) and your factory to the `FACTORIES` list. Without this, your backend leaking into other factories' bundles goes undetected.
 
+**h) Managed-broadcast (sending-signer) backends only** — if your backend rewrites the transaction message and/or broadcasts server-side, its signature cannot be applied to the caller's transaction, so it must be a `SolanaSendingSigner` (see `@solana/keychain-core`) instead of a `SolanaSigner`. That changes the checklist:
+
+- The signer class implements `signAndSendTransactions()` and exposes **no** `signTransactions` (nor `signMessages`, unless the backend genuinely signs messages) — Kit classifies signers by duck-typed method presence, so throwing methods are not enough. See Crossmint, or Fordefi's own-property pattern for a package serving both shapes.
+- Add a typed `createKeychainSigner` overload in `keychain/src/create-keychain-signer.ts` returning your sending-signer type (Crossmint and Fordefi-native have precedents), in addition to the switch case.
+- Add your backend to the exclusions in `KeychainKitPluginConfig` (`typescript/packages/kit-plugin/src/keychain-plugin.ts`) — sending signers cannot serve as a Kit client `payer`/`identity` — and mention it in the kit-plugin README.
+- Assert the guard directions in unit tests: `isTransactionPartialSigner()` false and `isTransactionSendingSigner()` true for your instances.
+
 ### README
 
 Show `createXSigner()` as the primary usage pattern in all examples:

--- a/typescript/packages/core/README.md
+++ b/typescript/packages/core/README.md
@@ -25,6 +25,20 @@ interface SolanaSigner {
 }
 ```
 
+**`SolanaSendingSigner`** - Interface for managed-broadcast backends. A backend belongs in this category when it rewrites the transaction message and/or broadcasts server-side, so its signature cannot be applied to the caller's transaction. Such signers expose `signAndSendTransactions()` (Kit's `TransactionSendingSigner`) and deliberately **no** `signTransactions` or `signMessages` — Kit classifies signers by duck-typed method presence, and a present-but-throwing method would make Kit misroute the transaction and fail at runtime. Backends that also support message signing intersect `MessagePartialSigner` per package:
+
+```typescript
+import { SolanaSendingSigner } from '@solana/keychain-core';
+
+interface SolanaSendingSigner {
+    address: Address;
+    isAvailable(): Promise<boolean>;
+    signAndSendTransactions(transactions: readonly Transaction[]): Promise<readonly SignatureBytes[]>;
+}
+```
+
+Runtime guards: `isSolanaSigner()`, `assertIsSolanaSigner()`, and `isSolanaSendingSigner()`.
+
 ### Error Handling
 
 ```typescript

--- a/typescript/packages/core/src/__tests__/guards.test.ts
+++ b/typescript/packages/core/src/__tests__/guards.test.ts
@@ -1,0 +1,44 @@
+import type { Address } from '@solana/addresses';
+import { describe, expect, it } from 'vitest';
+
+import { isSolanaSendingSigner, isSolanaSigner } from '../utils.js';
+
+const ADDRESS = '11111111111111111111111111111111' as Address;
+
+const partialSigner = {
+    address: ADDRESS,
+    isAvailable: async () => true,
+    signMessages: async () => [],
+    signTransactions: async () => [],
+};
+
+const sendingSigner = {
+    address: ADDRESS,
+    isAvailable: async () => true,
+    signAndSendTransactions: async () => [],
+};
+
+describe('isSolanaSigner', () => {
+    it('accepts a partial signer', () => {
+        expect(isSolanaSigner(partialSigner)).toBe(true);
+    });
+
+    it('rejects a sending-only signer', () => {
+        expect(isSolanaSigner(sendingSigner)).toBe(false);
+    });
+});
+
+describe('isSolanaSendingSigner', () => {
+    it('accepts a sending signer', () => {
+        expect(isSolanaSendingSigner(sendingSigner)).toBe(true);
+    });
+
+    it('rejects a partial signer', () => {
+        expect(isSolanaSendingSigner(partialSigner)).toBe(false);
+    });
+
+    it('rejects a signer without isAvailable', () => {
+        const { isAvailable: _unused, ...withoutIsAvailable } = sendingSigner;
+        expect(isSolanaSendingSigner(withoutIsAvailable as never)).toBe(false);
+    });
+});

--- a/typescript/packages/core/src/types.ts
+++ b/typescript/packages/core/src/types.ts
@@ -4,6 +4,7 @@ import type {
     SignableMessage,
     SignatureDictionary,
     TransactionPartialSigner,
+    TransactionSendingSigner,
 } from '@solana/signers';
 import type { Transaction, TransactionWithinSizeLimit, TransactionWithLifetime } from '@solana/transactions';
 
@@ -52,4 +53,36 @@ export interface SolanaSigner<TAddress extends string = string>
     signTransactions(
         transactions: readonly (Transaction & TransactionWithinSizeLimit & TransactionWithLifetime)[],
     ): Promise<readonly SignatureDictionary[]>;
+}
+
+/**
+ * Unified interface for managed-broadcast signers.
+ *
+ * A backend belongs in this category when it rewrites the transaction message
+ * (e.g. gas sponsorship, its own blockhash or fees) and/or broadcasts
+ * server-side, so its signature cannot be applied to the caller's transaction.
+ * Such a backend must not expose `signTransactions` at all: Kit's signer
+ * classification is duck-typed on method presence, and a present-but-throwing
+ * method makes Kit partial-sign the transaction and fail at runtime. Use these
+ * signers through `signAndSendTransactionMessageWithSigners()` (or
+ * `signAndSendTransactions()` directly); the returned bytes identify the
+ * transaction the provider landed.
+ *
+ * This interface deliberately does not include {@link MessagePartialSigner}.
+ * Intersect it per backend only when the backend genuinely signs messages
+ * (Fordefi native mode does; Crossmint does not).
+ */
+export interface SolanaSendingSigner<TAddress extends string = string> extends TransactionSendingSigner<TAddress> {
+    /**
+     * Get the public key address of this signer
+     */
+    readonly address: Address<TAddress>;
+
+    /**
+     * Check if the signer is available and healthy.
+     * For remote signers, this performs an API health check.
+     *
+     * @throws {SignerError} Some implementations may throw for configuration or initialization errors.
+     */
+    isAvailable(): Promise<boolean>;
 }

--- a/typescript/packages/core/src/utils.ts
+++ b/typescript/packages/core/src/utils.ts
@@ -2,11 +2,16 @@ import { Address, assertIsAddress, getAddressEncoder } from '@solana/addresses';
 import { ReadonlyUint8Array } from '@solana/codecs-core';
 import { getBase64Encoder } from '@solana/codecs-strings';
 import { SignatureBytes, verifySignature } from '@solana/keys';
-import { isMessagePartialSigner, isTransactionPartialSigner, SignatureDictionary } from '@solana/signers';
+import {
+    isMessagePartialSigner,
+    isTransactionPartialSigner,
+    isTransactionSendingSigner,
+    SignatureDictionary,
+} from '@solana/signers';
 import { Base64EncodedWireTransaction, getTransactionDecoder } from '@solana/transactions';
 
 import { SignerErrorCode, throwSignerError } from './errors.js';
-import { SolanaSigner } from './types.js';
+import { SolanaSendingSigner, SolanaSigner } from './types.js';
 
 interface AssertSignatureValidOptions {
     data: ReadonlyUint8Array;
@@ -172,6 +177,19 @@ export function isSolanaSigner<TAddress extends string>(value: {
         isMessagePartialSigner(value) &&
         isTransactionPartialSigner(value)
     );
+}
+
+/**
+ * Checks if the given value is a SolanaSendingSigner (a managed-broadcast
+ * signer). Such signers expose `signAndSendTransactions` and, by design, no
+ * `signTransactions`, so they are never also a {@link SolanaSigner}.
+ * @param value - The value to check
+ * @returns True if the value is a SolanaSendingSigner, false otherwise
+ */
+export function isSolanaSendingSigner<TAddress extends string>(value: {
+    address: Address<TAddress>;
+}): value is SolanaSendingSigner<TAddress> {
+    return 'address' in value && 'isAvailable' in value && isTransactionSendingSigner(value);
 }
 
 /**

--- a/typescript/packages/crossmint/README.md
+++ b/typescript/packages/crossmint/README.md
@@ -33,8 +33,8 @@ const signer = await createCrossmintSigner({
 ## Behavior Notes
 
 1. Crossmint executes transactions server-side and sponsors gas, which makes it the fee payer, so the message it signs generally differs from the one you submitted. Use `signAndSendTransactions()` (or `signAndSendTransactionMessageWithSigners()`): the returned value is the landed transaction's fee-payer signature, the identifier you can pass to `getTransaction`/`confirmTransaction`, not a signature over your message bytes. Under sponsorship the fee payer is Crossmint's sponsor key; your wallet's own signature is verified internally before the identifier is returned.
-2. `signTransactions` rejects with `SIGNER_CONFIG_ERROR`. A signature dictionary would claim to cover your message, which it does not.
-3. `signMessages` is intentionally unsupported and throws a signer error.
+2. The signer is a `CrossmintSendingSigner` (`SolanaSendingSigner` from `@solana/keychain-core`): it exposes **no** `signTransactions` and **no** `signMessages`. Kit classifies signers by method presence, so their absence is what routes the signer through Kit's sending flow instead of partial signing. Crossmint does not support message signing for Solana wallets.
+3. Because it is a sending signer, it cannot be installed as a Kit client `payer`/`identity` (`@solana/keychain-kit-plugin` rejects the config at compile time). Call it directly, or via `signAndSendTransactionMessageWithSigners()`.
 
 ```typescript
 const [signature] = await signer.signAndSendTransactions([transaction]);

--- a/typescript/packages/crossmint/src/__tests__/crossmint-signer.integration.test.ts
+++ b/typescript/packages/crossmint/src/__tests__/crossmint-signer.integration.test.ts
@@ -1,6 +1,5 @@
 import {
     type Blockhash,
-    createSignableMessage,
     createTransactionMessage,
     pipe,
     setTransactionMessageFeePayerSigner,
@@ -59,11 +58,11 @@ describe('CrossmintSigner Integration', () => {
         },
     );
 
-    it.skipIf(!process.env.CROSSMINT_API_KEY)('returns not supported for signMessages', async () => {
-        const { createSigner } = await getConfig(['signMessage']);
+    it.skipIf(!process.env.CROSSMINT_API_KEY)('does not expose partial-signer methods', async () => {
+        const { createSigner } = await getConfig([]);
         const signer = await createSigner();
-        const message = createSignableMessage(new Uint8Array([1, 2, 3]));
-        await expect(signer.signMessages([message])).rejects.toThrow('not supported');
+        expect('signMessages' in signer).toBe(false);
+        expect('signTransactions' in signer).toBe(false);
     });
 
     it.skipIf(!process.env.CROSSMINT_API_KEY)('checks availability', async () => {

--- a/typescript/packages/crossmint/src/__tests__/crossmint-signer.test.ts
+++ b/typescript/packages/crossmint/src/__tests__/crossmint-signer.test.ts
@@ -17,8 +17,8 @@ vi.mock('@solana/transactions', async importOriginal => {
     };
 });
 
-import { assertIsSolanaSigner, assertSignatureValid } from '@solana/keychain-core';
-import { isTransactionSendingSigner } from '@solana/signers';
+import { assertSignatureValid, isSolanaSendingSigner, isSolanaSigner } from '@solana/keychain-core';
+import { isMessagePartialSigner, isTransactionPartialSigner, isTransactionSendingSigner } from '@solana/signers';
 import { getTransactionDecoder } from '@solana/transactions';
 import { createCrossmintSigner } from '../crossmint-signer.js';
 
@@ -110,7 +110,7 @@ describe('CrossmintSigner', () => {
             const signer = await createCrossmintSigner(mockConfig);
 
             expect(signer.address).toBe(MOCK_ADDRESS);
-            assertIsSolanaSigner(signer);
+            expect(isSolanaSendingSigner(signer)).toBe(true);
             expect(fetch).toHaveBeenCalledWith(
                 'https://api.test.crossmint.com/api/2025-06-09/wallets/userId%3Atest-user%3Asolana%3Asmart',
                 expect.objectContaining({
@@ -205,20 +205,22 @@ describe('CrossmintSigner', () => {
         });
     });
 
-    describe('signMessages', () => {
-        it('returns not supported error', async () => {
+    describe('signer classification', () => {
+        it('is a sending signer in both directions of every guard', async () => {
             vi.mocked(fetch).mockResolvedValueOnce(mockWalletResponse());
             const signer = await createCrossmintSigner(mockConfig);
+            const guardInput = signer as unknown as { [key: string]: unknown; address: typeof signer.address };
 
-            const message = {
-                content: new Uint8Array([1, 2, 3]),
-                signatures: {},
-            };
-
-            await expect(signer.signMessages([message])).rejects.toMatchObject({
-                code: 'SIGNER_SIGNING_FAILED',
-                message: expect.stringContaining('not supported'),
-            });
+            // Kit classifies by method presence, so the absent methods are the
+            // contract: a present-but-throwing signTransactions/signMessages
+            // would make Kit partial-sign and fail at runtime.
+            expect('signTransactions' in signer).toBe(false);
+            expect('signMessages' in signer).toBe(false);
+            expect(isTransactionPartialSigner(guardInput)).toBe(false);
+            expect(isMessagePartialSigner(guardInput)).toBe(false);
+            expect(isTransactionSendingSigner(guardInput)).toBe(true);
+            expect(isSolanaSigner(signer)).toBe(false);
+            expect(isSolanaSendingSigner(signer)).toBe(true);
         });
     });
 
@@ -333,24 +335,6 @@ describe('CrossmintSigner', () => {
                 signature: MOCK_SIGNATURE_BYTES,
                 signerAddress: signer.address,
             });
-        });
-
-        /**
-         * Crossmint sponsors gas, so it is the fee payer and the message it signs
-         * differs from the caller's. A signature dictionary keyed to this address
-         * would assert the signature covers the caller's message, which it does not.
-         */
-        it('rejects signTransactions so a rewritten signature is never applied to caller bytes', async () => {
-            vi.mocked(fetch).mockResolvedValueOnce(mockWalletResponse());
-            const signer = await createCrossmintSigner(mockConfig);
-
-            await expect(
-                (signer as unknown as { signTransactions: (t: unknown[]) => Promise<unknown> }).signTransactions([
-                    createMockTransaction(),
-                ]),
-            ).rejects.toMatchObject({ code: 'SIGNER_CONFIG_ERROR' });
-            // Rejected locally: no transaction may be created server-side.
-            expect(vi.mocked(fetch)).toHaveBeenCalledTimes(1);
         });
 
         /**
@@ -494,6 +478,53 @@ describe('CrossmintSigner', () => {
             );
             // The wallet address remains the signer's public identity.
             expect(signer.address).toBe(MOCK_ADDRESS);
+        });
+
+        /**
+         * A submitted approval may carry its identity only as a `server:<address>`
+         * locator, with no `address` field — the same identity format `pending`
+         * entries use.
+         */
+        it('locates a submitted approval identified only by its server locator', async () => {
+            const DELEGATED_ADDRESS = 'SysvarC1ock11111111111111111111111111111111';
+            // No candidate holds a slot signature, so extraction falls through to
+            // approvals.submitted.
+            vi.mocked(getTransactionDecoder).mockReturnValue({
+                decode: vi.fn(() => createDecodedTransaction({ signerAddress: 'someone-else' })),
+            } as any);
+            vi.mocked(fetch)
+                .mockResolvedValueOnce(mockWalletResponse())
+                .mockResolvedValueOnce(
+                    new Response(
+                        JSON.stringify({
+                            id: 'tx-locator-only',
+                            status: 'success',
+                            approvals: {
+                                submitted: [
+                                    {
+                                        signature: MOCK_SIGNATURE_B58,
+                                        signer: { locator: `server:${DELEGATED_ADDRESS}` },
+                                    },
+                                ],
+                            },
+                            onChain: { transaction: MOCK_SERIALIZED_TRANSACTION_B58 },
+                        }),
+                        { status: 201 },
+                    ),
+                );
+
+            const signer = await createCrossmintSigner({
+                ...mockConfig,
+                maxPollAttempts: 1,
+                pollIntervalMs: 1,
+                signer: `server:${DELEGATED_ADDRESS}`,
+            });
+            const results = await signer.signAndSendTransactions([createMockTransaction()]);
+
+            expect(results[0]).toEqual(MOCK_SIGNATURE_BYTES);
+            expect(assertSignatureValid).toHaveBeenCalledWith(
+                expect.objectContaining({ signerAddress: DELEGATED_ADDRESS }),
+            );
         });
 
         /**

--- a/typescript/packages/crossmint/src/__tests__/crossmint-signer.test.ts
+++ b/typescript/packages/crossmint/src/__tests__/crossmint-signer.test.ts
@@ -367,6 +367,39 @@ describe('CrossmintSigner', () => {
             expect(vi.mocked(fetch).mock.calls.length).toBeLessThan(6);
         });
 
+        /**
+         * `AbortSignal.any` requires Node.js >= 20.3 while the package supports
+         * >= 18, so the abort-plus-timeout composition must also work without it.
+         */
+        it('honors the abort signal on runtimes without AbortSignal.any', async () => {
+            const originalAny = AbortSignal.any;
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (AbortSignal as any).any = undefined;
+            try {
+                const controller = new AbortController();
+                vi.mocked(fetch)
+                    .mockResolvedValueOnce(mockWalletResponse())
+                    .mockImplementation(async (_input, init) => {
+                        controller.abort();
+                        expect(init?.signal?.aborted).toBe(true);
+                        return new Response(JSON.stringify({ id: 'tx-abort', status: 'pending' }), { status: 201 });
+                    });
+
+                const signer = await createCrossmintSigner({
+                    ...mockConfig,
+                    maxPollAttempts: 50,
+                    pollIntervalMs: 1,
+                });
+
+                await expect(
+                    signer.signAndSendTransactions([createMockTransaction()], { abortSignal: controller.signal }),
+                ).rejects.toThrow();
+                expect(vi.mocked(fetch).mock.calls.length).toBeLessThan(6);
+            } finally {
+                AbortSignal.any = originalAny;
+            }
+        });
+
         it('exposes a TransactionSendingSigner so Kit routes it through send, not partial signing', async () => {
             vi.mocked(fetch).mockResolvedValueOnce(mockWalletResponse());
             const signer = await createCrossmintSigner(mockConfig);

--- a/typescript/packages/crossmint/src/__tests__/setup.ts
+++ b/typescript/packages/crossmint/src/__tests__/setup.ts
@@ -1,11 +1,20 @@
-import type { SolanaSigner } from '@solana/keychain-core';
-import { SignerTestConfig, TestScenario } from '@solana/keychain-test-utils';
-import { createCrossmintSigner } from '../crossmint-signer.js';
+import type { TestScenario } from '@solana/keychain-test-utils';
+import { createCrossmintSigner, type CrossmintSendingSigner } from '../crossmint-signer.js';
 
 const SIGNER_TYPE = 'crossmint';
 const REQUIRED_ENV_VARS = ['CROSSMINT_API_KEY', 'CROSSMINT_WALLET_LOCATOR'];
 
-const CONFIG: SignerTestConfig<SolanaSigner> = {
+// Crossmint is a sending signer with no partial-signer methods, so its config
+// does not satisfy `SignerTestConfig` and the shared LiteSVM runner does not
+// apply; the integration test drives the signer directly.
+interface CrossmintTestConfig {
+    createSigner: () => Promise<CrossmintSendingSigner>;
+    requiredEnvVars: string[];
+    signerType: string;
+    testScenarios?: TestScenario[];
+}
+
+const CONFIG: CrossmintTestConfig = {
     signerType: SIGNER_TYPE,
     requiredEnvVars: REQUIRED_ENV_VARS,
     createSigner: async () =>
@@ -24,7 +33,7 @@ const CONFIG: SignerTestConfig<SolanaSigner> = {
         }),
 };
 
-export async function getConfig(scenarios: TestScenario[]): Promise<SignerTestConfig<SolanaSigner>> {
+export async function getConfig(scenarios: TestScenario[]): Promise<CrossmintTestConfig> {
     return {
         ...CONFIG,
         testScenarios: scenarios,

--- a/typescript/packages/crossmint/src/crossmint-signer.ts
+++ b/typescript/packages/crossmint/src/crossmint-signer.ts
@@ -3,29 +3,23 @@ import { getBase16Encoder, getBase58Decoder, getBase58Encoder, getBase64Encoder 
 import {
     assertHttpsUrl,
     assertSignatureValid,
-    createSignerError,
+    DEFAULT_FETCH_TIMEOUT_MS,
     ED25519_SIGNATURE_LENGTH,
     fetchSignerJson,
     normalizeBaseUrl,
     sanitizeRemoteErrorResponse,
     SignerError,
     SignerErrorCode,
-    SolanaSigner,
+    SolanaSendingSigner,
     throwSignerError,
     validateRequestDelayMs,
 } from '@solana/keychain-core';
 import { SignatureBytes } from '@solana/keys';
-import {
-    SignableMessage,
-    SignatureDictionary,
-    TransactionSendingSigner,
-    TransactionSendingSignerConfig,
-} from '@solana/signers';
+import { TransactionSendingSignerConfig } from '@solana/signers';
 import {
     getBase64EncodedWireTransaction,
     getTransactionDecoder,
     Transaction,
-    TransactionWithinSizeLimit,
     TransactionWithLifetime,
 } from '@solana/transactions';
 
@@ -42,11 +36,12 @@ import type {
  *
  * Crossmint rewrites transactions to sponsor gas, so the message it signs
  * generally differs from the caller's and its signatures cannot be applied to the
- * caller's transaction. Hence Kit's {@link TransactionSendingSigner} flow rather
- * than a partial signer.
+ * caller's transaction. Hence Kit's sending-signer flow rather than a partial
+ * signer: no `signTransactions`, and no `signMessages` either — Crossmint does
+ * not support message signing for Solana wallets, and Kit classifies signers by
+ * method presence.
  */
-export interface CrossmintSendingSigner<TAddress extends string = string>
-    extends SolanaSigner<TAddress>, TransactionSendingSigner<TAddress> {}
+export type CrossmintSendingSigner<TAddress extends string = string> = SolanaSendingSigner<TAddress>;
 
 export async function createCrossmintSigner<TAddress extends string = string>(
     config: CrossmintSignerConfig,
@@ -70,10 +65,14 @@ let base64Encoder: ReturnType<typeof getBase64Encoder> | undefined;
  * its signatures cover Crossmint's bytes, not the caller's `messageBytes`.
  * The returned value is the landed transaction's fee-payer signature, the
  * identifier Solana RPC looks it up by, which is why this signer implements
- * {@link TransactionSendingSigner} instead of returning signature dictionaries
+ * {@link SolanaSendingSigner} instead of returning signature dictionaries
  * keyed to the caller's message.
  */
 class CrossmintSigner<TAddress extends string = string> implements CrossmintSendingSigner<TAddress> {
+    // No signTransactions/signMessages: Kit classifies signers by duck-typed
+    // method presence, so a present-but-throwing method would make Kit
+    // partial-sign transactions (or collect message signatures) and fail at
+    // runtime. See SolanaSendingSigner in @solana/keychain-core.
     readonly address: Address<TAddress>;
     private readonly apiKey: string;
     private readonly walletLocator: string;
@@ -162,12 +161,12 @@ class CrossmintSigner<TAddress extends string = string> implements CrossmintSend
                 signer = `server:${derived}`;
             }
         }
-        if (signer?.startsWith('server:')) {
-            const encoded = signer.slice('server:'.length).trim();
+        const locatorAddress = addressFromServerLocator(signer);
+        if (locatorAddress) {
             try {
-                assertIsAddress(encoded);
-                if (!delegatedAddresses.includes(encoded)) {
-                    delegatedAddresses.push(encoded);
+                assertIsAddress(locatorAddress);
+                if (!delegatedAddresses.includes(locatorAddress)) {
+                    delegatedAddresses.push(locatorAddress);
                 }
             } catch {
                 // A locator that is not an address contributes no candidate.
@@ -211,28 +210,8 @@ class CrossmintSigner<TAddress extends string = string> implements CrossmintSend
         });
     }
 
-    async signMessages(_messages: readonly SignableMessage[]): Promise<readonly SignatureDictionary[]> {
-        return await Promise.reject(
-            createSignerError(SignerErrorCode.SIGNING_FAILED, {
-                message: 'Crossmint signMessages is not supported for Solana wallets in this signer',
-            }),
-        );
-    }
-
-    async signTransactions(
-        _transactions: readonly (Transaction & TransactionWithinSizeLimit & TransactionWithLifetime)[],
-    ): Promise<readonly SignatureDictionary[]> {
-        return await Promise.reject(
-            createSignerError(SignerErrorCode.CONFIG_ERROR, {
-                address: this.address,
-                message:
-                    'Crossmint rewrites and broadcasts transactions server-side, so its signature does not cover the caller message; use signAndSendTransactions() or signAndSendTransactionMessageWithSigners()',
-            }),
-        );
-    }
-
     async signAndSendTransactions(
-        transactions: readonly (Transaction & TransactionWithinSizeLimit & TransactionWithLifetime)[],
+        transactions: readonly (Transaction | (Transaction & TransactionWithLifetime))[],
         config?: TransactionSendingSignerConfig,
     ): Promise<readonly SignatureBytes[]> {
         config?.abortSignal?.throwIfAborted();
@@ -247,7 +226,7 @@ class CrossmintSigner<TAddress extends string = string> implements CrossmintSend
         const results: SignatureBytes[] = [];
         for (const [index, transaction] of transactions.entries()) {
             if (this.requestDelayMs > 0 && index > 0) {
-                await new Promise(resolve => setTimeout(resolve, this.requestDelayMs));
+                await sleep(this.requestDelayMs, config?.abortSignal);
             }
             config?.abortSignal?.throwIfAborted();
             results.push(await this.signTransactionManaged(transaction, config?.abortSignal));
@@ -268,11 +247,8 @@ class CrossmintSigner<TAddress extends string = string> implements CrossmintSend
      * `abortSignal` stops this client from waiting; it cannot recall work Crossmint
      * has already accepted, so an aborted transaction may still land server-side.
      */
-    private async signTransactionManaged(
-        transaction: Transaction & TransactionWithinSizeLimit & TransactionWithLifetime,
-        abortSignal?: AbortSignal,
-    ): Promise<SignatureBytes> {
-        let response = await this.createTransaction(transaction);
+    private async signTransactionManaged(transaction: Transaction, abortSignal?: AbortSignal): Promise<SignatureBytes> {
+        let response = await this.createTransaction(transaction, abortSignal);
         let approvalSubmitted = false;
 
         for (let attempt = 0; attempt < this.maxPollAttempts; attempt++) {
@@ -285,7 +261,7 @@ class CrossmintSigner<TAddress extends string = string> implements CrossmintSend
                 !approvalSubmitted &&
                 pending !== undefined
             ) {
-                response = await this.submitApproval(response, pending);
+                response = await this.submitApproval(response, pending, abortSignal);
                 approvalSubmitted = true;
                 // Re-evaluate the new status immediately; approvalSubmitted
                 // ensures the approval is signed and submitted at most once.
@@ -296,9 +272,8 @@ class CrossmintSigner<TAddress extends string = string> implements CrossmintSend
                 return terminalSignature;
             }
 
-            await new Promise(resolve => setTimeout(resolve, this.pollIntervalMs));
-            abortSignal?.throwIfAborted();
-            response = await this.getTransaction(response.id);
+            await sleep(this.pollIntervalMs, abortSignal);
+            response = await this.getTransaction(response.id, abortSignal);
         }
 
         const terminalSignature = await this.resolveTerminalStatus(response, transaction, approvalSubmitted);
@@ -313,7 +288,7 @@ class CrossmintSigner<TAddress extends string = string> implements CrossmintSend
 
     private async resolveTerminalStatus(
         response: CrossmintTransactionResponse,
-        transaction: Transaction & TransactionWithinSizeLimit & TransactionWithLifetime,
+        transaction: Transaction,
         approvalSubmitted: boolean,
     ): Promise<SignatureBytes | undefined> {
         const status = response.status as CrossmintTransactionStatus;
@@ -358,6 +333,7 @@ class CrossmintSigner<TAddress extends string = string> implements CrossmintSend
     private async submitApproval(
         response: CrossmintTransactionResponse,
         pending: { message?: string; signer?: { locator?: string } },
+        abortSignal?: AbortSignal,
     ): Promise<CrossmintTransactionResponse> {
         const message = pending.message;
         if (!message) {
@@ -374,14 +350,20 @@ class CrossmintSigner<TAddress extends string = string> implements CrossmintSend
         const signatureB58 = base58Decoder.decode(signatureBytes);
 
         const path = `/${API_VERSION}/wallets/${encodeURIComponent(this.walletLocator)}/transactions/${encodeURIComponent(response.id)}/approvals`;
-        const result = await this.request(path, 'POST', {
-            approvals: [{ signature: signatureB58, signer: this.signer }],
-        });
+        const result = await this.request(
+            path,
+            'POST',
+            {
+                approvals: [{ signature: signatureB58, signer: this.signer }],
+            },
+            abortSignal,
+        );
         return parseTransactionResponse(result, 'submit approval');
     }
 
     private async createTransaction(
-        transaction: Transaction & TransactionWithinSizeLimit & TransactionWithLifetime,
+        transaction: Transaction,
+        abortSignal?: AbortSignal,
     ): Promise<CrossmintTransactionResponse> {
         const wireTransaction = getBase64EncodedWireTransaction(transaction);
         base64Encoder ||= getBase64Encoder();
@@ -397,17 +379,25 @@ class CrossmintSigner<TAddress extends string = string> implements CrossmintSend
         };
 
         const path = `/${API_VERSION}/wallets/${encodeURIComponent(this.walletLocator)}/transactions`;
-        const response = await this.request(path, 'POST', body);
+        const response = await this.request(path, 'POST', body, abortSignal);
         return parseTransactionResponse(response, 'create transaction');
     }
 
-    private async getTransaction(transactionId: string): Promise<CrossmintTransactionResponse> {
+    private async getTransaction(
+        transactionId: string,
+        abortSignal?: AbortSignal,
+    ): Promise<CrossmintTransactionResponse> {
         const path = `/${API_VERSION}/wallets/${encodeURIComponent(this.walletLocator)}/transactions/${encodeURIComponent(transactionId)}`;
-        const response = await this.request(path, 'GET');
+        const response = await this.request(path, 'GET', undefined, abortSignal);
         return parseTransactionResponse(response, 'get transaction');
     }
 
-    private async request(path: string, method: 'GET' | 'POST', body?: unknown): Promise<unknown> {
+    private async request(
+        path: string,
+        method: 'GET' | 'POST',
+        body?: unknown,
+        abortSignal?: AbortSignal,
+    ): Promise<unknown> {
         const url = `${this.apiBaseUrl}${path}`;
         const headers: Record<string, string> = {
             'X-API-KEY': this.apiKey,
@@ -421,6 +411,11 @@ class CrossmintSigner<TAddress extends string = string> implements CrossmintSend
                 body: body != null ? JSON.stringify(body) : undefined,
                 headers,
                 method,
+                // Combine with the default timeout: fetchSignerJson only applies
+                // its own timeout when no signal is supplied.
+                ...(abortSignal
+                    ? { signal: AbortSignal.any([abortSignal, AbortSignal.timeout(DEFAULT_FETCH_TIMEOUT_MS)]) }
+                    : {}),
             },
             providerName: 'Crossmint',
             url,
@@ -429,16 +424,27 @@ class CrossmintSigner<TAddress extends string = string> implements CrossmintSend
 
     private async extractSignature(
         response: CrossmintTransactionResponse,
-        transaction: Transaction & TransactionWithinSizeLimit & TransactionWithLifetime,
+        transaction: Transaction,
     ): Promise<SignatureBytes> {
         let embeddedError: unknown;
         if (response.onChain?.transaction) {
+            let executedTransaction: Transaction | undefined;
             try {
-                return await this.transactionIdFromExecuted(response, response.onChain.transaction);
+                base58Encoder ||= getBase58Encoder();
+                executedTransaction = getTransactionDecoder().decode(
+                    base58Encoder.encode(response.onChain.transaction),
+                );
             } catch (error) {
-                // Keep this error as the cause: it names the check that failed,
-                // where the txId path only reports a mismatch.
                 embeddedError = error;
+            }
+            if (executedTransaction) {
+                try {
+                    return await this.transactionIdFromExecuted(response, executedTransaction);
+                } catch (error) {
+                    // Keep this error as the cause: it names the check that failed,
+                    // where the txId path only reports a mismatch.
+                    embeddedError = error;
+                }
             }
         }
 
@@ -481,14 +487,11 @@ class CrossmintSigner<TAddress extends string = string> implements CrossmintSend
      */
     private async transactionIdFromExecuted(
         response: CrossmintTransactionResponse,
-        serializedTransaction: string,
+        executedTransaction: Transaction,
     ): Promise<SignatureBytes> {
-        base58Encoder ||= getBase58Encoder();
-        const decoded = getTransactionDecoder().decode(base58Encoder.encode(serializedTransaction));
-
         const participant =
-            (await this.verifiedSignatureFromSlots(decoded)) ??
-            (await this.verifiedSignatureFromApprovals(response, decoded.messageBytes));
+            (await this.verifiedSignatureFromSlots(executedTransaction)) ??
+            (await this.verifiedSignatureFromApprovals(response, executedTransaction));
         if (!participant) {
             throwSignerError(SignerErrorCode.SIGNING_FAILED, {
                 address: this.address,
@@ -496,7 +499,7 @@ class CrossmintSigner<TAddress extends string = string> implements CrossmintSend
             });
         }
 
-        const [feePayer, feePayerSignature] = Object.entries(decoded.signatures)[0] ?? [];
+        const [feePayer, feePayerSignature] = Object.entries(executedTransaction.signatures)[0] ?? [];
         if (participant.address === feePayer) {
             return participant.signature;
         }
@@ -507,7 +510,7 @@ class CrossmintSigner<TAddress extends string = string> implements CrossmintSend
         }
         try {
             await assertSignatureValid({
-                data: decoded.messageBytes,
+                data: executedTransaction.messageBytes,
                 signature: feePayerSignature,
                 signerAddress: feePayer as Address,
             });
@@ -528,19 +531,22 @@ class CrossmintSigner<TAddress extends string = string> implements CrossmintSend
      */
     private async verifiedSignatureFromApprovals(
         response: CrossmintTransactionResponse,
-        executedMessage: Transaction['messageBytes'],
+        executedTransaction: Transaction,
     ): Promise<{ address: Address; signature: SignatureBytes } | undefined> {
         const submitted = response.approvals?.submitted;
         if (!submitted?.length) return undefined;
 
         const candidates = this.verificationCandidates();
         for (const entry of submitted) {
-            const address = entry.signer?.address;
+            // The identity may arrive as `address`, or only as a
+            // `server:<address>` locator (the same identity format used by
+            // `pending` entries).
+            const address = entry.signer?.address ?? addressFromServerLocator(entry.signer?.locator);
             const signature = decodeSignatureString(entry.signature);
             if (!address || !signature || !candidates.includes(address as Address)) continue;
             try {
                 await assertSignatureValid({
-                    data: executedMessage,
+                    data: executedTransaction.messageBytes,
                     signature,
                     signerAddress: address as Address,
                 });
@@ -567,18 +573,18 @@ class CrossmintSigner<TAddress extends string = string> implements CrossmintSend
     }
 
     private async verifiedSignatureFromSlots(
-        decodedTransaction: Transaction,
+        executedTransaction: Transaction,
     ): Promise<{ address: Address; signature: SignatureBytes } | undefined> {
         // Verify against the bytes Crossmint signed, which differ from the caller's
         // messageBytes once it rewrites to sponsor gas. Require a verifying signature,
         // not just presence in a slot: the wallet address can occupy a slot it never
         // signed. The signature is only ever returned as a send result.
         for (const candidate of this.verificationCandidates()) {
-            const signature = decodedTransaction.signatures[candidate];
+            const signature = executedTransaction.signatures[candidate];
             if (!signature) continue;
             try {
                 await assertSignatureValid({
-                    data: decodedTransaction.messageBytes,
+                    data: executedTransaction.messageBytes,
                     signature,
                     signerAddress: candidate,
                 });
@@ -625,6 +631,29 @@ function parseTransactionResponse(payload: unknown, context: string): CrossmintT
         });
     }
     return transaction as CrossmintTransactionResponse;
+}
+
+/** Extract the base58 address from a `server:<address>` signer locator. */
+function addressFromServerLocator(locator?: string): string | undefined {
+    if (!locator?.startsWith('server:')) return undefined;
+    const encoded = locator.slice('server:'.length).trim();
+    return encoded || undefined;
+}
+
+/** Resolve after `ms`, or reject with the abort reason as soon as `abortSignal` fires. */
+async function sleep(ms: number, abortSignal?: AbortSignal): Promise<void> {
+    abortSignal?.throwIfAborted();
+    await new Promise<void>((resolve, reject) => {
+        const timer = setTimeout(() => {
+            abortSignal?.removeEventListener('abort', onAbort);
+            resolve();
+        }, ms);
+        function onAbort() {
+            clearTimeout(timer);
+            reject(abortSignal?.reason instanceof Error ? abortSignal.reason : new Error(String(abortSignal?.reason)));
+        }
+        abortSignal?.addEventListener('abort', onAbort, { once: true });
+    });
 }
 
 function decodeSignatureString(value?: string): SignatureBytes | undefined {

--- a/typescript/packages/crossmint/src/crossmint-signer.ts
+++ b/typescript/packages/crossmint/src/crossmint-signer.ts
@@ -414,7 +414,7 @@ class CrossmintSigner<TAddress extends string = string> implements CrossmintSend
                 // Combine with the default timeout: fetchSignerJson only applies
                 // its own timeout when no signal is supplied.
                 ...(abortSignal
-                    ? { signal: AbortSignal.any([abortSignal, AbortSignal.timeout(DEFAULT_FETCH_TIMEOUT_MS)]) }
+                    ? { signal: anyAbortSignal([abortSignal, AbortSignal.timeout(DEFAULT_FETCH_TIMEOUT_MS)]) }
                     : {}),
             },
             providerName: 'Crossmint',
@@ -638,6 +638,28 @@ function addressFromServerLocator(locator?: string): string | undefined {
     if (!locator?.startsWith('server:')) return undefined;
     const encoded = locator.slice('server:'.length).trim();
     return encoded || undefined;
+}
+
+/**
+ * `AbortSignal.any` with a fallback for runtimes that lack it
+ * (`AbortSignal.any` requires Node.js >= 20.3; the package supports >= 18).
+ */
+function anyAbortSignal(signals: readonly AbortSignal[]): AbortSignal {
+    if (typeof AbortSignal.any === 'function') {
+        return AbortSignal.any([...signals]);
+    }
+    const controller = new AbortController();
+    for (const signal of signals) {
+        if (signal.aborted) {
+            controller.abort(signal.reason);
+            break;
+        }
+        signal.addEventListener('abort', () => controller.abort(signal.reason), {
+            once: true,
+            signal: controller.signal,
+        });
+    }
+    return controller.signal;
 }
 
 /** Resolve after `ms`, or reject with the abort reason as soon as `abortSignal` fires. */

--- a/typescript/packages/fordefi/README.md
+++ b/typescript/packages/fordefi/README.md
@@ -16,7 +16,7 @@ The signer supports two modes determined by whether `chain` is provided:
 
 Set `chain` to use Fordefi's native Solana transaction type. Fordefi may modify the transaction (e.g. updating the blockhash or adding compute budget instructions) and broadcasts it on-chain automatically (`push_mode: 'auto'`). Use this with a **Solana vault**.
 
-> **Note:** Native mode is a Kit `TransactionSendingSigner`, because Fordefi may sign a different message than the one supplied by the caller and broadcasts it itself. Use `signAndSendTransactionMessageWithSigners()` or `signAndSendTransactions()`. Calling the partial-signer method `signTransactions()` in native mode fails locally before any transaction is submitted.
+> **Note:** Native mode is a Kit `TransactionSendingSigner` (`FordefiNativeSigner`, built on `SolanaSendingSigner` from `@solana/keychain-core`), because Fordefi may sign a different message than the one supplied by the caller and broadcasts it itself. Use `signAndSendTransactionMessageWithSigners()` or `signAndSendTransactions()`. Native instances expose **no** `signTransactions` — Kit classifies signers by method presence, so its absence is what routes the signer through Kit's sending flow — but message signing (`signMessages`) still works. Black-box instances are the mirror image: `signTransactions` and no `signAndSendTransactions`.
 
 ```typescript
 import { createFordefiSigner } from '@solana/keychain-fordefi';

--- a/typescript/packages/fordefi/src/__tests__/fordefi-signer.test.ts
+++ b/typescript/packages/fordefi/src/__tests__/fordefi-signer.test.ts
@@ -47,7 +47,7 @@ const TEST_PEM = testPrivateKey.export({ type: 'sec1', format: 'pem' }) as strin
 const MOCK_SIGNATURE_BYTES = new Uint8Array(64).fill(0xab);
 const MOCK_SIGNATURE_BASE64 = Buffer.from(MOCK_SIGNATURE_BYTES).toString('base64');
 
-const mockConfig: FordefiSignerConfig = {
+const mockConfig: FordefiSignerConfig & { chain?: undefined } = {
     accessToken: 'test-token',
     apiBaseUrl: 'https://api.test.fordefi.com',
     privateKeyPem: TEST_PEM,
@@ -223,7 +223,7 @@ describe('FordefiSigner', () => {
 
     describe('custom requestSigner', () => {
         // Config using a custom request signer instead of a PEM key.
-        const customConfig: FordefiSignerConfig = {
+        const customConfig: FordefiSignerConfig & { chain?: undefined } = {
             accessToken: 'test-token',
             apiBaseUrl: 'https://api.test.fordefi.com',
             publicKey: MOCK_ADDRESS,

--- a/typescript/packages/fordefi/src/__tests__/fordefi-signer.test.ts
+++ b/typescript/packages/fordefi/src/__tests__/fordefi-signer.test.ts
@@ -2,8 +2,14 @@ import { createHash, generateKeyPairSync } from 'node:crypto';
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { assertIsSolanaSigner, assertSignatureValid, extractSignatureFromWireTransaction } from '@solana/keychain-core';
-import { isTransactionSendingSigner } from '@solana/signers';
+import {
+    assertIsSolanaSigner,
+    assertSignatureValid,
+    extractSignatureFromWireTransaction,
+    isSolanaSendingSigner,
+    isSolanaSigner,
+} from '@solana/keychain-core';
+import { isTransactionPartialSigner, isTransactionSendingSigner } from '@solana/signers';
 
 vi.mock('@solana/keychain-core', async importOriginal => {
     const mod = await importOriginal<typeof import('@solana/keychain-core')>();
@@ -523,18 +529,19 @@ describe('FordefiSigner', () => {
             expect(postOpts.headers).toHaveProperty('x-idempotence-id', expectedId);
         });
 
-        it('should reject partial-signer usage before submitting native remote work', async () => {
+        it('does not expose the partial-signer method in native mode', async () => {
             setupCreateVaultMock();
             const signer = await FordefiSigner.create(nativeConfig);
-            const mockTx = {
-                messageBytes: new Uint8Array(32),
-                signatures: { [MOCK_ADDRESS]: null },
-            } as never;
+            const guardInput = signer as unknown as { [key: string]: unknown; address: typeof signer.address };
 
-            await expect(signer.signTransactions([mockTx])).rejects.toMatchObject({
-                code: 'SIGNER_CONFIG_ERROR',
-            });
-            expect(fetch).toHaveBeenCalledTimes(1);
+            // Kit classifies by method presence: a present-but-throwing
+            // signTransactions would make Kit partial-sign and fail at runtime.
+            expect(signer.signTransactions).toBeUndefined();
+            expect('signTransactions' in signer).toBe(false);
+            expect(isTransactionPartialSigner(guardInput)).toBe(false);
+            expect(isTransactionSendingSigner(guardInput)).toBe(true);
+            expect(isSolanaSigner(guardInput)).toBe(false);
+            expect(isSolanaSendingSigner(guardInput)).toBe(true);
         });
 
         it('should reject native multi-signer auto-broadcast before submitting remote work', async () => {
@@ -557,11 +564,13 @@ describe('FordefiSigner', () => {
         it('should not expose TransactionSendingSigner in black box mode', async () => {
             setupCreateVaultMock();
             const signer = await FordefiSigner.create(mockConfig);
-            expect(
-                isTransactionSendingSigner(
-                    signer as unknown as { [key: string]: unknown; address: typeof signer.address },
-                ),
-            ).toBe(false);
+            const guardInput = signer as unknown as { [key: string]: unknown; address: typeof signer.address };
+
+            expect('signAndSendTransactions' in signer).toBe(false);
+            expect(isTransactionSendingSigner(guardInput)).toBe(false);
+            expect(isTransactionPartialSigner(guardInput)).toBe(true);
+            expect(isSolanaSigner(guardInput)).toBe(true);
+            expect(isSolanaSendingSigner(guardInput)).toBe(false);
         });
 
         it('should poll through intermediate pushable states', async () => {

--- a/typescript/packages/fordefi/src/fordefi-signer.ts
+++ b/typescript/packages/fordefi/src/fordefi-signer.ts
@@ -11,14 +11,17 @@ import {
     normalizeBaseUrl,
     signBatchStaggered,
     SignerErrorCode,
+    SolanaSendingSigner,
     SolanaSigner,
     throwSignerError,
     validateRequestDelayMs,
 } from '@solana/keychain-core';
 import { SignatureBytes } from '@solana/keys';
 import {
+    MessagePartialSigner,
     SignableMessage,
     SignatureDictionary,
+    TransactionPartialSigner,
     TransactionSendingSigner,
     TransactionSendingSignerConfig,
 } from '@solana/signers';
@@ -153,6 +156,8 @@ export interface FordefiSignerConfig {
  * Native mode may replace the recent blockhash and fees before signing and
  * broadcasts with `push_mode: 'auto'`, so it must be used through Kit's
  * {@link TransactionSendingSigner} flow rather than as a partial signer.
+ * Native instances expose no `signTransactions` — Kit classifies signers by
+ * duck-typed method presence — but do sign messages.
  *
  * Native mode is not retry-safe: any failure after Fordefi accepts the
  * submission rejects with `BROADCAST_UNCONFIRMED` carrying
@@ -162,7 +167,7 @@ export interface FordefiSignerConfig {
  * transaction.
  */
 export interface FordefiNativeSigner<TAddress extends string = string>
-    extends SolanaSigner<TAddress>, TransactionSendingSigner<TAddress> {}
+    extends SolanaSendingSigner<TAddress>, MessagePartialSigner<TAddress> {}
 
 /**
  * Create and initialize a Fordefi-backed signer.
@@ -177,8 +182,10 @@ export async function createFordefiSigner<TAddress extends string = string>(
 ): Promise<SolanaSigner<TAddress>>;
 export async function createFordefiSigner<TAddress extends string = string>(
     config: FordefiSignerConfig,
-): Promise<SolanaSigner<TAddress>> {
-    return await FordefiSigner.create(config);
+): Promise<FordefiNativeSigner<TAddress> | SolanaSigner<TAddress>> {
+    // The instance's own properties expose the mode-appropriate signing
+    // method, which the class type cannot express statically.
+    return (await FordefiSigner.create(config)) as unknown as SolanaSigner<TAddress>;
 }
 
 /**
@@ -189,9 +196,10 @@ export async function createFordefiSigner<TAddress extends string = string>(
  *
  * Prefer `createFordefiSigner()`. Class export will be removed in a future version.
  */
-export class FordefiSigner<TAddress extends string = string> implements SolanaSigner<TAddress> {
+export class FordefiSigner<TAddress extends string = string> implements MessagePartialSigner<TAddress> {
     readonly address: Address<TAddress>;
     declare signAndSendTransactions?: TransactionSendingSigner<TAddress>['signAndSendTransactions'];
+    declare signTransactions?: TransactionPartialSigner<TAddress>['signTransactions'];
     private readonly accessToken: string;
     private readonly apiBaseUrl: string;
     private readonly chain?: SolanaChainUniqueId;
@@ -216,10 +224,16 @@ export class FordefiSigner<TAddress extends string = string> implements SolanaSi
         this.vaultId = config.vaultId;
         this.address = address;
 
-        // Keep this method off black-box instances so Kit does not misclassify
-        // them as sending signers. Native instances expose it as an own property.
+        // Kit classifies signers by duck-typed method presence, so each mode
+        // exposes exactly the method it can honor as an own property: native
+        // mode rewrites and auto-broadcasts, so it is a sending signer and
+        // must not present a partial-signer method; black-box mode signs the
+        // caller's exact bytes, so it is a partial signer and must not
+        // present a sending method.
         if (this.chain) {
             this.signAndSendTransactions = this.signAndSendNativeTransactions.bind(this);
+        } else {
+            this.signTransactions = this.signBlackBoxTransactions.bind(this);
         }
     }
 
@@ -231,7 +245,7 @@ export class FordefiSigner<TAddress extends string = string> implements SolanaSi
     ): Promise<FordefiNativeSigner<TAddress> & FordefiSigner<TAddress>>;
     static async create<TAddress extends string = string>(
         config: FordefiSignerConfig,
-    ): Promise<FordefiSigner<TAddress>>;
+    ): Promise<FordefiSigner<TAddress> & SolanaSigner<TAddress>>;
     static async create<TAddress extends string = string>(
         config: FordefiSignerConfig,
     ): Promise<FordefiSigner<TAddress>> {
@@ -420,17 +434,13 @@ export class FordefiSigner<TAddress extends string = string> implements SolanaSi
         );
     }
 
-    async signTransactions(
+    /**
+     * Partial-signer path for black-box mode; attached as an own property only
+     * when `chain` is unset.
+     */
+    private async signBlackBoxTransactions(
         transactions: readonly (Transaction & TransactionWithinSizeLimit & TransactionWithLifetime)[],
     ): Promise<readonly SignatureDictionary[]> {
-        if (this.chain) {
-            return throwSignerError(SignerErrorCode.CONFIG_ERROR, {
-                address: this.address,
-                message:
-                    'Fordefi native Solana mode modifies and auto-broadcasts transactions; use signAndSendTransactions() or signAndSendTransactionMessageWithSigners()',
-            });
-        }
-
         return await signBatchStaggered(
             transactions,
             async transaction => {

--- a/typescript/packages/fordefi/src/fordefi-signer.ts
+++ b/typescript/packages/fordefi/src/fordefi-signer.ts
@@ -178,8 +178,11 @@ export async function createFordefiSigner<TAddress extends string = string>(
     config: FordefiSignerConfig & { chain: SolanaChainUniqueId },
 ): Promise<FordefiNativeSigner<TAddress>>;
 export async function createFordefiSigner<TAddress extends string = string>(
-    config: FordefiSignerConfig,
+    config: FordefiSignerConfig & { chain?: undefined },
 ): Promise<SolanaSigner<TAddress>>;
+export async function createFordefiSigner<TAddress extends string = string>(
+    config: FordefiSignerConfig,
+): Promise<FordefiNativeSigner<TAddress> | SolanaSigner<TAddress>>;
 export async function createFordefiSigner<TAddress extends string = string>(
     config: FordefiSignerConfig,
 ): Promise<FordefiNativeSigner<TAddress> | SolanaSigner<TAddress>> {
@@ -244,8 +247,11 @@ export class FordefiSigner<TAddress extends string = string> implements MessageP
         config: FordefiSignerConfig & { chain: SolanaChainUniqueId },
     ): Promise<FordefiNativeSigner<TAddress> & FordefiSigner<TAddress>>;
     static async create<TAddress extends string = string>(
-        config: FordefiSignerConfig,
+        config: FordefiSignerConfig & { chain?: undefined },
     ): Promise<FordefiSigner<TAddress> & SolanaSigner<TAddress>>;
+    static async create<TAddress extends string = string>(
+        config: FordefiSignerConfig,
+    ): Promise<FordefiSigner<TAddress> & (FordefiNativeSigner<TAddress> | SolanaSigner<TAddress>)>;
     static async create<TAddress extends string = string>(
         config: FordefiSignerConfig,
     ): Promise<FordefiSigner<TAddress>> {

--- a/typescript/packages/keychain/README.md
+++ b/typescript/packages/keychain/README.md
@@ -46,6 +46,21 @@ await signer.signTransactions([transaction]);
 
 The `backend` field determines which signer is created. TypeScript narrows the config type automatically — you get full autocomplete for each backend's required fields.
 
+**Managed-broadcast backends** (Crossmint always; Fordefi when `chain` enables native mode) rewrite the transaction and/or broadcast it server-side, so they return a `SolanaSendingSigner` with `signAndSendTransactions()` instead of `signTransactions()`:
+
+```typescript
+const crossmint = await createKeychainSigner({
+    backend: 'crossmint',
+    apiKey: '...',
+    walletLocator: '...',
+});
+
+// Returns the signature identifying the transaction Crossmint landed.
+const [signature] = await crossmint.signAndSendTransactions([transaction]);
+```
+
+With Kit, use `signAndSendTransactionMessageWithSigners()` for these backends; the partial-signer helpers below apply to every other backend.
+
 ### Resolve Address Without Signing
 
 Use `resolveAddress` to get a signer's Solana address without initializing the full signing pipeline:
@@ -169,7 +184,7 @@ try {
 
 ## Common Interface
 
-All signers implement `SolanaSigner`, which is compatible with `@solana/kit` and `@solana/signers`:
+Most signers implement `SolanaSigner`, which is compatible with `@solana/kit` and `@solana/signers`:
 
 ```typescript
 interface SolanaSigner<TAddress extends string = string> {
@@ -179,6 +194,8 @@ interface SolanaSigner<TAddress extends string = string> {
     isAvailable(): Promise<boolean>;
 }
 ```
+
+Managed-broadcast signers (Crossmint, Fordefi native mode) implement `SolanaSendingSigner` instead — Kit's `TransactionSendingSigner` plus `address` and `isAvailable()` — and deliberately expose no `signTransactions`, because Kit classifies signers by method presence. Use `isSolanaSigner()` / `isSolanaSendingSigner()` from `@solana/keychain-core` to distinguish them at runtime.
 
 ## License
 

--- a/typescript/packages/keychain/src/__tests__/create-keychain-signer.test.ts
+++ b/typescript/packages/keychain/src/__tests__/create-keychain-signer.test.ts
@@ -189,6 +189,25 @@ describe('createKeychainSigner', () => {
         }
     });
 
+    it('preserves the Crossmint sending-signer type', async () => {
+        const mod = await import('@solana/keychain-crossmint');
+        const factory = mod.createCrossmintSigner as ReturnType<typeof vi.fn>;
+        const mockSigner = {
+            address: TEST_ADDRESS,
+            isAvailable: vi.fn().mockResolvedValue(true),
+            signAndSendTransactions: vi.fn().mockResolvedValue([]),
+        };
+        factory.mockResolvedValue(mockSigner);
+
+        const signer = await createKeychainSigner({
+            apiKey: 'key',
+            backend: 'crossmint',
+            walletLocator: 'loc',
+        });
+
+        expect(signer.signAndSendTransactions).toBe(mockSigner.signAndSendTransactions);
+    });
+
     it('preserves the native Fordefi TransactionSendingSigner type', async () => {
         const mod = await import('@solana/keychain-fordefi');
         const factory = mod.createFordefiSigner as ReturnType<typeof vi.fn>;

--- a/typescript/packages/keychain/src/create-keychain-signer.ts
+++ b/typescript/packages/keychain/src/create-keychain-signer.ts
@@ -33,7 +33,12 @@ export function createKeychainSigner(
 export function createKeychainSigner(
     config: FordefiSignerConfig & { backend: 'fordefi'; chain: SolanaChainUniqueId },
 ): Promise<FordefiNativeSigner>;
-export function createKeychainSigner(config: KeychainSignerConfig): Promise<SolanaSigner>;
+export function createKeychainSigner(
+    config:
+        | Exclude<KeychainSignerConfig, { backend: 'crossmint' | 'fordefi' }>
+        | (FordefiSignerConfig & { backend: 'fordefi'; chain?: undefined }),
+): Promise<SolanaSigner>;
+export function createKeychainSigner(config: KeychainSignerConfig): Promise<SolanaSendingSigner | SolanaSigner>;
 export async function createKeychainSigner(config: KeychainSignerConfig): Promise<SolanaSendingSigner | SolanaSigner> {
     switch (config.backend) {
         case 'aws-kms': {

--- a/typescript/packages/keychain/src/create-keychain-signer.ts
+++ b/typescript/packages/keychain/src/create-keychain-signer.ts
@@ -1,5 +1,6 @@
-import type { SolanaSigner } from '@solana/keychain-core';
+import type { SolanaSendingSigner, SolanaSigner } from '@solana/keychain-core';
 import { SignerErrorCode, throwSignerError } from '@solana/keychain-core';
+import type { CrossmintSendingSigner, CrossmintSignerConfig } from '@solana/keychain-crossmint';
 import type { FordefiNativeSigner, FordefiSignerConfig, SolanaChainUniqueId } from '@solana/keychain-fordefi';
 
 import type { KeychainSignerConfig } from './types.js';
@@ -27,10 +28,13 @@ function stripBackend<T extends { backend: string }>({ backend: _, ...rest }: T)
  * ```
  */
 export function createKeychainSigner(
+    config: CrossmintSignerConfig & { backend: 'crossmint' },
+): Promise<CrossmintSendingSigner>;
+export function createKeychainSigner(
     config: FordefiSignerConfig & { backend: 'fordefi'; chain: SolanaChainUniqueId },
 ): Promise<FordefiNativeSigner>;
 export function createKeychainSigner(config: KeychainSignerConfig): Promise<SolanaSigner>;
-export async function createKeychainSigner(config: KeychainSignerConfig): Promise<SolanaSigner> {
+export async function createKeychainSigner(config: KeychainSignerConfig): Promise<SolanaSendingSigner | SolanaSigner> {
     switch (config.backend) {
         case 'aws-kms': {
             const { createAwsKmsSigner } = await import('@solana/keychain-aws-kms');

--- a/typescript/packages/keychain/src/index.ts
+++ b/typescript/packages/keychain/src/index.ts
@@ -9,7 +9,7 @@ export type { BackendName, KeychainSignerConfig } from './types.js';
 // Individual config types (flat re-exports)
 export type { AwsKmsSignerConfig } from '@solana/keychain-aws-kms';
 export type { CdpSignerConfig } from '@solana/keychain-cdp';
-export type { CrossmintSignerConfig } from '@solana/keychain-crossmint';
+export type { CrossmintSendingSigner, CrossmintSignerConfig } from '@solana/keychain-crossmint';
 export type { DfnsSignerConfig } from '@solana/keychain-dfns';
 export type { FireblocksSignerConfig } from '@solana/keychain-fireblocks';
 export type { FordefiNativeSigner, FordefiSignerConfig } from '@solana/keychain-fordefi';

--- a/typescript/packages/kit-plugin/README.md
+++ b/typescript/packages/kit-plugin/README.md
@@ -31,6 +31,20 @@ client.identity; // same signer instance
 
 Only the backend a configuration dispatches to is bundled — backend packages are loaded with dynamic `import()`.
 
+## Managed-broadcast backends are excluded
+
+Crossmint, and Fordefi in native mode (`chain` set), rewrite and broadcast transactions server-side. They are Kit `TransactionSendingSigner`s with no `signTransactions`, so they cannot serve as a client `payer` or `identity` — client send flows build, sign, and broadcast themselves, and Kit routes a sending signer only through `signAndSendTransactionMessageWithSigners()`. These plugins reject such configs at compile time (`KeychainKitPluginConfig`). Use the signer directly instead:
+
+```ts
+import { signAndSendTransactionMessageWithSigners } from '@solana/signers';
+import { createKeychainSigner } from '@solana/keychain';
+
+const crossmint = await createKeychainSigner({ backend: 'crossmint', apiKey, walletLocator });
+const signature = await signAndSendTransactionMessageWithSigners(transactionMessage);
+```
+
+Fordefi in black-box mode (no `chain`) is a regular partial signer and remains supported.
+
 ## Plugin variants
 
 | Plugin                    | Sets                                          |

--- a/typescript/packages/kit-plugin/src/__tests__/keychain-plugin.test.ts
+++ b/typescript/packages/kit-plugin/src/__tests__/keychain-plugin.test.ts
@@ -49,6 +49,33 @@ describe('keychainIdentity', () => {
     });
 });
 
+describe('managed-broadcast exclusion', () => {
+    it('rejects managed-broadcast configs at the type level', () => {
+        // Building the plugin never constructs a signer — that happens when the
+        // plugin is applied to a client — so these calls are side-effect free.
+        // @ts-expect-error Crossmint broadcasts server-side and cannot be a client payer/identity
+        keychainSigner({ apiKey: 'k', backend: 'crossmint', walletLocator: 'w' });
+        keychainPayer({
+            accessToken: 't',
+            backend: 'fordefi',
+            // @ts-expect-error Fordefi native mode (chain set) broadcasts server-side
+            chain: 'solana_mainnet',
+            privateKeyPem: 'p',
+            publicKey: 'x',
+            vaultId: 'v',
+        });
+        // Fordefi black-box mode (no chain) is a partial signer and stays accepted.
+        const plugin = keychainIdentity({
+            accessToken: 't',
+            backend: 'fordefi',
+            privateKeyPem: 'p',
+            publicKey: 'x',
+            vaultId: 'v',
+        });
+        expect(typeof plugin).toBe('function');
+    });
+});
+
 describe('composition', () => {
     it('allows separate payer and identity signers on one client', async () => {
         const otherSeed = new Uint8Array(32).fill(9);

--- a/typescript/packages/kit-plugin/src/index.ts
+++ b/typescript/packages/kit-plugin/src/index.ts
@@ -1,1 +1,2 @@
 export { keychainIdentity, keychainPayer, keychainSigner } from './keychain-plugin.js';
+export type { KeychainKitPluginConfig } from './keychain-plugin.js';

--- a/typescript/packages/kit-plugin/src/keychain-plugin.ts
+++ b/typescript/packages/kit-plugin/src/keychain-plugin.ts
@@ -1,6 +1,20 @@
-import type { KeychainSignerConfig } from '@solana/keychain';
+import type { FordefiSignerConfig, KeychainSignerConfig } from '@solana/keychain';
 import { createKeychainSigner } from '@solana/keychain';
 import { extendClient } from '@solana/kit';
+
+/**
+ * Backend configurations these plugins accept: every keychain backend except
+ * the managed-broadcast ones — Crossmint, and Fordefi in native mode (`chain`
+ * set). Those backends rewrite and broadcast transactions server-side, so
+ * they expose `signAndSendTransactions` and no `signTransactions`, and cannot
+ * serve as a client `payer` or `identity`: client send flows build, sign, and
+ * broadcast themselves, and Kit routes a sending signer only through
+ * `signAndSendTransactionMessageWithSigners()`. Create those signers with
+ * `createKeychainSigner()` and use that function directly instead.
+ */
+export type KeychainKitPluginConfig =
+    | Exclude<KeychainSignerConfig, { backend: 'crossmint' | 'fordefi' }>
+    | (FordefiSignerConfig & { backend: 'fordefi'; chain?: undefined });
 
 /**
  * Creates a keychain signer from a backend-tagged configuration and sets it
@@ -29,7 +43,7 @@ import { extendClient } from '@solana/kit';
  * @see {@link keychainPayer}
  * @see {@link keychainIdentity}
  */
-export function keychainSigner(config: KeychainSignerConfig) {
+export function keychainSigner(config: KeychainKitPluginConfig) {
     return async <TClient extends object>(client: TClient) => {
         const signer = await createKeychainSigner(config);
         return extendClient(client, { identity: signer, payer: signer });
@@ -58,7 +72,7 @@ export function keychainSigner(config: KeychainSignerConfig) {
  * @see {@link keychainIdentity}
  * @see {@link keychainSigner}
  */
-export function keychainPayer(config: KeychainSignerConfig) {
+export function keychainPayer(config: KeychainKitPluginConfig) {
     return async <TClient extends object>(client: TClient) => {
         const payer = await createKeychainSigner(config);
         return extendClient(client, { payer });
@@ -88,7 +102,7 @@ export function keychainPayer(config: KeychainSignerConfig) {
  * @see {@link keychainPayer}
  * @see {@link keychainSigner}
  */
-export function keychainIdentity(config: KeychainSignerConfig) {
+export function keychainIdentity(config: KeychainKitPluginConfig) {
     return async <TClient extends object>(client: TClient) => {
         const identity = await createKeychainSigner(config);
         return extendClient(client, { identity });


### PR DESCRIPTION
Closes DEV-906

> [!WARNING]
> **Do not merge.** Stacked on #231 (`fix/crossmint-managed-broadcast-result`) and intentionally based there — this PR shows only the DEV-906 delta. It will be rebased and retargeted to `main` after #231 addresses its open review findings and merges.

## What

Models managed-broadcast signers (Crossmint, Fordefi native mode) in a shared core type and enforces the distinction against Kit's duck-typed signer classification.

- **Core**: new `SolanaSendingSigner` (`address` + `isAvailable()` + Kit `TransactionSendingSigner`, no baked-in `MessagePartialSigner`) with a category docblock, plus an `isSolanaSendingSigner()` guard. `CrossmintSendingSigner` and `FordefiNativeSigner` are now defined in terms of it.
- **Enforcement**: Kit's `isTransactionPartialSigner`/`isMessagePartialSigner` are method-presence checks, so present-but-throwing methods made Kit partial-sign and fail at runtime. Crossmint no longer has `signTransactions` or `signMessages` at all; Fordefi attaches `signTransactions` as an own property only on black-box instances, mirroring how `signAndSendTransactions` is native-only. Guard assertions cover both directions for Crossmint, Fordefi native, and Fordefi black-box.
- **Wiring**: `createKeychainSigner` gains the crossmint overload (returns `CrossmintSendingSigner`); `@solana/keychain-kit-plugin` excludes managed-broadcast configs at the type level (`KeychainKitPluginConfig`) — a sending-only signer cannot serve as a client `payer`/`identity` — with `@ts-expect-error` type tests and a positive black-box test. READMEs (core, crossmint, fordefi, keychain, kit-plugin), `docs/ADDING_SIGNERS.md`, and CLAUDE.md updated.
- **Crossmint client cleanup**: `abortSignal` forwarded into create/get/approval requests via `AbortSignal.any` (preserving the default fetch timeout); poll and `requestDelayMs` sleeps are abort-aware; `server:<address>` locator fallback when reading submitted approvals; the returned transaction is decoded once and shared between the slot-scan and approvals paths.

## Deliberately out of scope

The two open review findings on #231 (approval-signature-as-return-value, raw non-`SignerError` rethrow) are untouched here — those lines are byte-identical to #231 — so they land in #231 and this branch rebases cleanly on top.

## Breaking changes

- `@solana/keychain-crossmint`: `CrossmintSendingSigner` no longer has `signTransactions`/`signMessages`; use `signAndSendTransactions()`.
- `@solana/keychain-fordefi`: native-mode signers no longer expose `signTransactions`; the `FordefiSigner` class types both signing methods as optional (mode-dependent own properties).
- `@solana/keychain-kit-plugin`: `keychainSigner`/`keychainPayer`/`keychainIdentity` no longer accept crossmint or fordefi-native configs.
- `@solana/keychain`: `createKeychainSigner({ backend: 'crossmint' })` now returns `CrossmintSendingSigner`.

## Testing

`just ts-build`, `just ts-test`, `just ts-fmt`, `just ts-treeshake`, and `pnpm typecheck` all pass (verified twice, independently of the implementation pass).
