### PR TITLE
fix(deps): bump h2 to 0.4.16 for RUSTSEC-2026-0258

### DIFF
--- a/rust/.cargo/audit.toml
+++ b/rust/.cargo/audit.toml
@@ -12,4 +12,8 @@ ignore = [
     "RUSTSEC-2026-0098",
     # rustls-webpki 0.101.x is pinned by the transitive rustls 0.21 TLS stack.
     "RUSTSEC-2026-0099",
+    # h2 0.3.x has no patched release and is an inactive optional dependency of
+    # aws-smithy-http-client; the hyper-014 feature that would build it is never enabled.
+    # h2 0.4.x is on the patched 0.4.16.
+    "RUSTSEC-2026-0258",
 ]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -912,7 +912,7 @@ dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "h2 0.3.27",
- "h2 0.4.14",
+ "h2 0.4.16",
  "http 0.2.12",
  "http 1.4.0",
  "http-body 0.4.6",
@@ -2687,9 +2687,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2935,7 +2935,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.14",
+ "h2 0.4.16",
  "http 1.4.0",
  "http-body 1.0.1",
  "httparse",


### PR DESCRIPTION
## Summary
- The nightly `Security` workflow started failing on `main` after RUSTSEC-2026-0258 was published on 2026-08-17: h2 below 0.4.16 accepts and queues empty DATA frames without limit, which can grow memory without bound or panic on length overflow.
- Bumps h2 0.4.14 to the patched 0.4.16 in `rust/Cargo.lock`. That is the copy actually built (hyper 1.x via reqwest and wiremock).
- Adds `RUSTSEC-2026-0258` to `rust/.cargo/audit.toml` for the second lockfile entry, h2 0.3.27. The 0.3.x line has no patched release (the advisory lists `>= 0.4.16` only), and that entry is an inactive optional dependency of `aws-smithy-http-client` behind its `hyper-014` feature. `cargo tree -i h2@0.3.27` finds no match, so it is never compiled, but cargo-audit reads the lockfile and cannot see feature activation.

## Test Plan
- `cargo audit` in `rust/` exits 0.
- Before the ignore, `cargo audit` reports only h2 0.3.27, confirming the 0.4.x bump resolved the built copy.
- `cargo metadata --locked` succeeds, so the lockfile is consistent.
- `cargo check --locked --all-targets` succeeds.

## Follow-up
- Drop the `RUSTSEC-2026-0258` ignore once `aws-smithy-http-client` stops carrying the optional h2 0.3 dependency.