### PR TITLE
fix(memory): reject a CryptoKeyPair whose public key does not match its private key

### DIFF
--- a/typescript/packages/memory/src/__tests__/memory-signer.test.ts
+++ b/typescript/packages/memory/src/__tests__/memory-signer.test.ts
@@ -2,7 +2,7 @@ import { writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { assertIsSolanaSigner } from '@solana/keychain-core';
+import { assertIsSolanaSigner, assertSignatureValid } from '@solana/keychain-core';
 import {
     blockhash,
     compileTransaction,
@@ -101,6 +101,32 @@ describe('createMemorySigner', () => {
             const signer = await createMemorySignerFromKeyPair(keyPair);
             expect(typeof signer.address).toBe('string');
             assertIsSolanaSigner(signer);
+        });
+
+        it('rejects a CryptoKeyPair whose public key does not match its private key', async () => {
+            const pairA = await generateKeyPair();
+            const pairB = await generateKeyPair();
+            await expect(
+                createMemorySignerFromKeyPair({ privateKey: pairB.privateKey, publicKey: pairA.publicKey }),
+            ).rejects.toMatchObject({ code: 'SIGNER_INVALID_PRIVATE_KEY' });
+        });
+
+        it('is unaffected by mutating the caller CryptoKeyPair after construction', async () => {
+            const keyPair = { ...(await generateKeyPair()) };
+            const signer = await createMemorySignerFromKeyPair(keyPair);
+            const addressBefore = signer.address;
+
+            keyPair.privateKey = (await generateKeyPair()).privateKey;
+
+            const message = { content: new Uint8Array([1, 2, 3, 4]), signatures: {} };
+            const [dict] = await signer.signMessages([message]);
+            const sig = dict?.[addressBefore];
+            expect(sig).toBeInstanceOf(Uint8Array);
+            await assertSignatureValid({
+                data: message.content,
+                signature: sig!,
+                signerAddress: addressBefore,
+            });
         });
 
         it('wraps KeyPairSigner without exposing the underlying keyPair', async () => {

--- a/typescript/packages/memory/src/__tests__/memory-signer.test.ts
+++ b/typescript/packages/memory/src/__tests__/memory-signer.test.ts
@@ -103,6 +103,12 @@ describe('createMemorySigner', () => {
             assertIsSolanaSigner(signer);
         });
 
+        it.each([null, {}])('rejects %o as a keyPair with a config error', async invalid => {
+            await expect(createMemorySignerFromKeyPair(invalid as unknown as CryptoKeyPair)).rejects.toMatchObject({
+                code: 'SIGNER_CONFIG_ERROR',
+            });
+        });
+
         it('rejects a CryptoKeyPair whose public key does not match its private key', async () => {
             const pairA = await generateKeyPair();
             const pairB = await generateKeyPair();

--- a/typescript/packages/memory/src/memory-signer.ts
+++ b/typescript/packages/memory/src/memory-signer.ts
@@ -130,28 +130,17 @@ async function resolveKeyPairSigner(config: MemorySignerConfig): Promise<KeyPair
  * `CryptoKeyPair` afterwards cannot re-point the signer's key.
  */
 async function keyPairSignerFromCryptoKeyPair(keyPair: CryptoKeyPair): Promise<KeyPairSigner> {
-    const { privateKey, publicKey } = keyPair;
-
-    let matches: boolean;
+    const probe = new Uint8Array(32); // fixed: the correspondence check needs no entropy
     try {
-        const probe = crypto.getRandomValues(new Uint8Array(32));
-        const probeSignature = await signBytes(privateKey, probe);
-        matches = await verifySignature(publicKey, probeSignature, probe);
-    } catch (error) {
-        throwSignerError(SignerErrorCode.CONFIG_ERROR, {
-            cause: error,
-            message: 'Failed to create signer from keyPair — keyPair must be a valid Ed25519 CryptoKeyPair',
-        });
-    }
-    if (!matches) {
-        throwSignerError(SignerErrorCode.INVALID_PRIVATE_KEY, {
-            message: 'keyPair public key does not match its private key',
-        });
-    }
-
-    try {
+        const { privateKey, publicKey } = keyPair;
+        if (!(await verifySignature(publicKey, await signBytes(privateKey, probe), probe))) {
+            throwSignerError(SignerErrorCode.INVALID_PRIVATE_KEY, {
+                message: 'keyPair public key does not match its private key',
+            });
+        }
         return await createSignerFromKeyPair({ privateKey, publicKey });
     } catch (error) {
+        if (error instanceof SignerError) throw error;
         throwSignerError(SignerErrorCode.CONFIG_ERROR, {
             cause: error,
             message: 'Failed to create signer from keyPair — keyPair must be a valid Ed25519 CryptoKeyPair',

--- a/typescript/packages/memory/src/memory-signer.ts
+++ b/typescript/packages/memory/src/memory-signer.ts
@@ -1,4 +1,5 @@
 import { SignerError, SignerErrorCode, SolanaSigner, throwSignerError } from '@solana/keychain-core';
+import { signBytes, verifySignature } from '@solana/keys';
 import {
     createKeyPairSignerFromBytes,
     createKeyPairSignerFromPrivateKeyBytes,
@@ -100,14 +101,7 @@ async function resolveKeyPairSigner(config: MemorySignerConfig): Promise<KeyPair
     }
 
     if (config.keyPair !== undefined) {
-        try {
-            return await createSignerFromKeyPair(config.keyPair);
-        } catch (error) {
-            throwSignerError(SignerErrorCode.CONFIG_ERROR, {
-                cause: error,
-                message: 'Failed to create signer from keyPair — keyPair must be a valid Ed25519 CryptoKeyPair',
-            });
-        }
+        return await keyPairSignerFromCryptoKeyPair(config.keyPair);
     }
 
     try {
@@ -124,6 +118,43 @@ async function resolveKeyPairSigner(config: MemorySignerConfig): Promise<KeyPair
         throwSignerError(SignerErrorCode.INVALID_PRIVATE_KEY, {
             cause: error,
             message: 'Invalid private key bytes',
+        });
+    }
+}
+
+/**
+ * The other config sources validate that the public key matches the private key
+ * upstream, but `createSignerFromKeyPair` derives the address from `publicKey`
+ * and signs with `privateKey` without checking they correspond. Prove the match
+ * with a probe signature, and pass a fresh pair object so mutating the caller's
+ * `CryptoKeyPair` afterwards cannot re-point the signer's key.
+ */
+async function keyPairSignerFromCryptoKeyPair(keyPair: CryptoKeyPair): Promise<KeyPairSigner> {
+    const { privateKey, publicKey } = keyPair;
+
+    let matches: boolean;
+    try {
+        const probe = crypto.getRandomValues(new Uint8Array(32));
+        const probeSignature = await signBytes(privateKey, probe);
+        matches = await verifySignature(publicKey, probeSignature, probe);
+    } catch (error) {
+        throwSignerError(SignerErrorCode.CONFIG_ERROR, {
+            cause: error,
+            message: 'Failed to create signer from keyPair — keyPair must be a valid Ed25519 CryptoKeyPair',
+        });
+    }
+    if (!matches) {
+        throwSignerError(SignerErrorCode.INVALID_PRIVATE_KEY, {
+            message: 'keyPair public key does not match its private key',
+        });
+    }
+
+    try {
+        return await createSignerFromKeyPair({ privateKey, publicKey });
+    } catch (error) {
+        throwSignerError(SignerErrorCode.CONFIG_ERROR, {
+            cause: error,
+            message: 'Failed to create signer from keyPair — keyPair must be a valid Ed25519 CryptoKeyPair',
         });
     }
 }


### PR DESCRIPTION
## Problem

The memory signer's `keyPair` config source passed the pair straight to `createSignerFromKeyPair`, which derives `address` from `publicKey` and signs with `privateKey` without checking they correspond. The other three sources (raw bytes, base58/U8Array string, keypair file) are validated upstream - `createKeyPairFromBytes` proves the seed matches the public key - so a hand-assembled `{ publicKey: A, privateKey: B }` was the one input of four that could advertise address A while producing signatures only B can verify. The upstream signer closures also capture the caller's pair object, so replacing its `privateKey` after construction re-pointed signing while `address` stayed stale (`Object.freeze` protects the wrapper, not the pair).

Impact is limited: the failure is loud (a B-signature in A's slot never passes validator verification), no generator produces mismatched pairs, and the other language implementations derive the public key from the private key so they cannot express a mismatch. This closes a consistency gap, not an exploit.

## Fix

In the `keyPair` branch, prove the match with a probe: sign 32 random bytes with `privateKey` and verify with `publicKey` - the same guard the byte-based path gets upstream. Mismatches reject with `SIGNER_INVALID_PRIVATE_KEY`; broken/non-Ed25519 pairs keep rejecting with `SIGNER_CONFIG_ERROR` as before. The validated keys are passed on as a fresh pair object, so mutating the caller's `CryptoKeyPair` afterwards cannot affect the signer.

A probe signature is used deliberately instead of exporting and comparing key bytes: `exportKey` throws `CANNOT_EXPORT_NON_EXTRACTABLE_KEY` on non-extractable private keys, which are the `generateKeyPair()` default and the package's documented usage.

## Testing

- New: mismatched pair rejected with `SIGNER_INVALID_PRIVATE_KEY`; mutating the caller's pair after construction leaves the signer signing under its original address (verified signature).
- Package tests 28 passed, typecheck, eslint, prettier, build, umbrella treeshake all green.