### PR TITLE
fix(rust): refuse redirects and centralize the signer HTTP client builder

### DIFF
--- a/rust/src/cdp/mod.rs
+++ b/rust/src/cdp/mod.rs
@@ -136,14 +136,7 @@ impl CdpSigner {
             .unwrap_or_else(|| format!("https://{CDP_API_HOST}"));
         let api_host = extract_host(&base_url)?;
         let http_client_config = config.http_client_config.unwrap_or_default();
-        let builder = reqwest::Client::builder();
-        let builder = builder
-            .timeout(http_client_config.resolved_request_timeout())
-            .connect_timeout(http_client_config.resolved_connect_timeout())
-            .https_only(true);
-        let client = builder
-            .build()
-            .map_err(|e| SignerError::ConfigError(format!("Failed to build HTTP client: {e}")))?;
+        let client = http_client_config.build_client()?;
 
         Ok(Self {
             api_key_id: config.api_key_id,

--- a/rust/src/crossmint/mod.rs
+++ b/rust/src/crossmint/mod.rs
@@ -5,7 +5,7 @@ mod types;
 use crate::sdk_adapter::{Pubkey, Signature, Transaction, VersionedTransaction};
 use crate::traits::{SignTransactionResult, SignedTransaction};
 use crate::transaction_util::TransactionUtil;
-use crate::{error::SignerError, traits::SolanaSigner};
+use crate::{error::SignerError, http_client_config::HttpClientConfig, traits::SolanaSigner};
 use std::str::FromStr;
 use types::{
     CreateTransactionParams, CreateTransactionRequest, TransactionResponse, WalletResponse,
@@ -102,10 +102,11 @@ impl CrossmintSigner {
             ));
         }
 
-        let client = reqwest::Client::builder()
-            .timeout(CLIENT_TIMEOUT)
-            .build()
-            .map_err(|e| SignerError::ConfigError(format!("Failed to build HTTP client: {e}")))?;
+        let client = HttpClientConfig {
+            request_timeout: Some(CLIENT_TIMEOUT),
+            connect_timeout: None,
+        }
+        .build_client()?;
 
         let (signing_key, signer) = if let Some(secret) = &config.signer_secret {
             let key = Self::derive_signing_key(secret, &config.api_key)?;

--- a/rust/src/dfns/mod.rs
+++ b/rust/src/dfns/mod.rs
@@ -62,12 +62,11 @@ impl DfnsSigner {
     /// Create a new DfnsSigner from a configuration object.
     pub fn from_config(config: DfnsSignerConfig) -> Self {
         let http_client_config = config.http_client_config.unwrap_or_default();
-        let builder = reqwest::Client::builder().user_agent("solana-keychain");
-        let builder = builder
-            .timeout(http_client_config.resolved_request_timeout())
-            .connect_timeout(http_client_config.resolved_connect_timeout())
-            .https_only(true);
-        let client = builder.build().expect("Failed to build HTTP client");
+        let client = http_client_config
+            .client_builder()
+            .user_agent("solana-keychain")
+            .build()
+            .expect("Failed to build HTTP client");
 
         Self {
             auth_token: config.auth_token,

--- a/rust/src/fireblocks/mod.rs
+++ b/rust/src/fireblocks/mod.rs
@@ -86,12 +86,9 @@ impl FireblocksSigner {
     /// Create a new FireblocksSigner from a configuration object.
     pub fn from_config(config: FireblocksSignerConfig) -> Self {
         let http_client_config = config.http_client_config.unwrap_or_default();
-        let builder = reqwest::Client::builder();
-        let builder = builder
-            .timeout(http_client_config.resolved_request_timeout())
-            .connect_timeout(http_client_config.resolved_connect_timeout())
-            .https_only(true);
-        let client = builder.build().expect("Failed to build HTTP client");
+        let client = http_client_config
+            .build_client()
+            .expect("Failed to build HTTP client");
         let signing_key = jwt::parse_encoding_key(&config.private_key_pem)
             .ok()
             .map(Arc::new);

--- a/rust/src/fordefi/mod.rs
+++ b/rust/src/fordefi/mod.rs
@@ -200,16 +200,7 @@ impl FordefiSigner {
             .map_err(|_| SignerError::InvalidPublicKey("Invalid Solana public key".to_string()))?;
 
         let http = config.http_client_config.unwrap_or_default();
-        let builder = reqwest::Client::builder()
-            .timeout(http.resolved_request_timeout())
-            .connect_timeout(http.resolved_connect_timeout());
-
-        #[cfg(not(test))]
-        let builder = builder.https_only(true);
-
-        let client = builder
-            .build()
-            .map_err(|e| SignerError::ConfigError(format!("Failed to build HTTP client: {e}")))?;
+        let client = http.build_client()?;
 
         Ok(Self {
             access_token: config.access_token,
@@ -784,6 +775,21 @@ mod tests {
         FordefiSigner::build(config)
     }
 
+    /// `from_config` against a plain-HTTP wiremock server: the production
+    /// client is HTTPS-only, so the vault round-trip needs a test client
+    /// (which keeps the no-redirect policy).
+    async fn from_config_with_test_client(
+        config: FordefiSignerConfig,
+    ) -> Result<FordefiSigner, SignerError> {
+        let mut signer = FordefiSigner::build(config)?;
+        signer.client = reqwest::Client::builder()
+            .redirect(crate::http_client_config::no_redirect_policy())
+            .build()
+            .expect("Failed to build test HTTP client");
+        signer.verify_vault_address_with_timeout().await?;
+        Ok(signer)
+    }
+
     fn base_test_config() -> FordefiSignerConfig {
         FordefiSignerConfig {
             access_token: "test-token".to_string(),
@@ -1009,7 +1015,7 @@ mod tests {
             .await;
 
         let signer =
-            FordefiSigner::from_config(verified_test_config(&mock_server.uri(), public_key))
+            from_config_with_test_client(verified_test_config(&mock_server.uri(), public_key))
                 .await
                 .unwrap();
 
@@ -1034,7 +1040,7 @@ mod tests {
             .await;
 
         let signer =
-            FordefiSigner::from_config(verified_test_config(&mock_server.uri(), public_key))
+            from_config_with_test_client(verified_test_config(&mock_server.uri(), public_key))
                 .await
                 .unwrap();
 
@@ -1057,7 +1063,7 @@ mod tests {
             .mount(&mock_server)
             .await;
 
-        let result = FordefiSigner::from_config(verified_test_config(
+        let result = from_config_with_test_client(verified_test_config(
             &mock_server.uri(),
             configured_public_key,
         ))
@@ -1082,7 +1088,8 @@ mod tests {
             .await;
 
         let result =
-            FordefiSigner::from_config(verified_test_config(&mock_server.uri(), public_key)).await;
+            from_config_with_test_client(verified_test_config(&mock_server.uri(), public_key))
+                .await;
 
         assert!(matches!(result.unwrap_err(), SignerError::ConfigError(_)));
     }
@@ -1104,7 +1111,8 @@ mod tests {
             .await;
 
         let result =
-            FordefiSigner::from_config(verified_test_config(&mock_server.uri(), public_key)).await;
+            from_config_with_test_client(verified_test_config(&mock_server.uri(), public_key))
+                .await;
 
         assert!(matches!(
             result.unwrap_err(),
@@ -1129,7 +1137,8 @@ mod tests {
             .await;
 
         let result =
-            FordefiSigner::from_config(verified_test_config(&mock_server.uri(), public_key)).await;
+            from_config_with_test_client(verified_test_config(&mock_server.uri(), public_key))
+                .await;
 
         assert!(matches!(
             result.unwrap_err(),
@@ -1150,7 +1159,8 @@ mod tests {
             .await;
 
         let result =
-            FordefiSigner::from_config(verified_test_config(&mock_server.uri(), public_key)).await;
+            from_config_with_test_client(verified_test_config(&mock_server.uri(), public_key))
+                .await;
 
         assert!(matches!(
             result.unwrap_err(),
@@ -1954,7 +1964,7 @@ mod tests {
             .mount(&mock_server)
             .await;
 
-        let signer = FordefiSigner::from_config(config).await.unwrap();
+        let signer = from_config_with_test_client(config).await.unwrap();
         assert_eq!(
             signer
                 .sign_request("/api/v1/vaults", 123, "")

--- a/rust/src/http_client_config.rs
+++ b/rust/src/http_client_config.rs
@@ -26,11 +26,102 @@ impl HttpClientConfig {
         self.connect_timeout
             .unwrap_or(Self::DEFAULT_CONNECT_TIMEOUT)
     }
+
+    /// Shared `reqwest` builder for every remote-signer client: resolved
+    /// timeouts, HTTPS-only, and a policy that refuses every redirect.
+    ///
+    /// Backends must start from this builder so no client silently regains
+    /// reqwest's default redirect-following, which would replay
+    /// provider-specific credential headers (X-Vault-Token, X-Stamp,
+    /// X-API-KEY, ...) to the redirect target: reqwest only strips the four
+    /// standard sensitive headers on a cross-host hop.
+    #[cfg(any(
+        feature = "vault",
+        feature = "privy",
+        feature = "turnkey",
+        feature = "fireblocks",
+        feature = "cdp",
+        feature = "dfns",
+        feature = "para",
+        feature = "crossmint",
+        feature = "openfort",
+        feature = "utila",
+        feature = "fordefi"
+    ))]
+    pub(crate) fn client_builder(&self) -> reqwest::ClientBuilder {
+        reqwest::Client::builder()
+            .timeout(self.resolved_request_timeout())
+            .connect_timeout(self.resolved_connect_timeout())
+            .https_only(true)
+            .redirect(no_redirect_policy())
+    }
+
+    /// `client_builder()` finished into a client, with the error mapped to
+    /// [`SignerError::ConfigError`].
+    #[cfg(any(
+        feature = "vault",
+        feature = "privy",
+        feature = "turnkey",
+        feature = "fireblocks",
+        feature = "cdp",
+        feature = "dfns",
+        feature = "para",
+        feature = "crossmint",
+        feature = "openfort",
+        feature = "utila",
+        feature = "fordefi"
+    ))]
+    pub(crate) fn build_client(&self) -> Result<reqwest::Client, crate::error::SignerError> {
+        self.client_builder().build().map_err(|e| {
+            crate::error::SignerError::ConfigError(format!("Failed to build HTTP client: {e}"))
+        })
+    }
+}
+
+/// A redirect policy that fails the request instead of following.
+///
+/// Deliberately an error rather than `Policy::none()`: with `none()` the 3xx
+/// comes back as a normal response and status-code branches would try to parse
+/// its body, reporting a misleading error.
+#[cfg(any(
+    feature = "vault",
+    feature = "privy",
+    feature = "turnkey",
+    feature = "fireblocks",
+    feature = "cdp",
+    feature = "dfns",
+    feature = "para",
+    feature = "crossmint",
+    feature = "openfort",
+    feature = "utila",
+    feature = "fordefi"
+))]
+pub(crate) fn no_redirect_policy() -> reqwest::redirect::Policy {
+    reqwest::redirect::Policy::custom(|attempt| {
+        attempt.error("redirects are not followed: a signer request carries provider credentials")
+    })
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(any(
+        feature = "vault",
+        feature = "privy",
+        feature = "turnkey",
+        feature = "fireblocks",
+        feature = "cdp",
+        feature = "dfns",
+        feature = "para",
+        feature = "crossmint",
+        feature = "openfort",
+        feature = "utila",
+        feature = "fordefi"
+    ))]
+    use wiremock::{
+        matchers::{method, path},
+        Mock, MockServer, ResponseTemplate,
+    };
 
     #[test]
     fn test_defaults_are_applied_when_unset() {
@@ -53,5 +144,61 @@ mod tests {
         };
         assert_eq!(config.resolved_request_timeout(), Duration::from_secs(42));
         assert_eq!(config.resolved_connect_timeout(), Duration::from_secs(7));
+    }
+
+    // The policy is exercised against plain-HTTP mock servers, so the client
+    // under test carries only the redirect policy; https_only is covered by
+    // the production builder and would reject the mock URL before any
+    // redirect could happen.
+    #[cfg(any(
+        feature = "vault",
+        feature = "privy",
+        feature = "turnkey",
+        feature = "fireblocks",
+        feature = "cdp",
+        feature = "dfns",
+        feature = "para",
+        feature = "crossmint",
+        feature = "openfort",
+        feature = "utila",
+        feature = "fordefi"
+    ))]
+    #[tokio::test]
+    async fn test_no_redirect_policy_fails_instead_of_following() {
+        let target = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/collect"))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(0)
+            .mount(&target)
+            .await;
+
+        let origin = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/sign"))
+            .respond_with(
+                ResponseTemplate::new(307)
+                    .insert_header("Location", format!("{}/collect", target.uri()).as_str()),
+            )
+            .expect(1)
+            .mount(&origin)
+            .await;
+
+        let client = reqwest::Client::builder()
+            .redirect(no_redirect_policy())
+            .build()
+            .unwrap();
+
+        let result = client
+            .post(format!("{}/sign", origin.uri()))
+            .header("X-Vault-Token", "secret-token")
+            .send()
+            .await;
+
+        let error = result.expect_err("a redirect must fail the request, not be followed");
+        assert!(
+            error.is_redirect(),
+            "expected a redirect error, got: {error}"
+        );
     }
 }

--- a/rust/src/openfort/mod.rs
+++ b/rust/src/openfort/mod.rs
@@ -252,11 +252,9 @@ impl OpenfortSigner {
         }
         let api_host = extract_host(&base_url)?;
         let http_client_config = config.http_client_config.unwrap_or_default();
-        let client = reqwest::Client::builder()
+        let client = http_client_config
+            .client_builder()
             .use_rustls_tls()
-            .timeout(http_client_config.resolved_request_timeout())
-            .connect_timeout(http_client_config.resolved_connect_timeout())
-            .https_only(true)
             .build()
             .map_err(|e| SignerError::ConfigError(format!("Failed to build HTTP client: {e}")))?;
 

--- a/rust/src/para/mod.rs
+++ b/rust/src/para/mod.rs
@@ -5,7 +5,7 @@ mod types;
 use crate::sdk_adapter::{Pubkey, Signature, Transaction};
 use crate::traits::{SignTransactionResult, SignedTransaction};
 use crate::transaction_util::TransactionUtil;
-use crate::{error::SignerError, traits::SolanaSigner};
+use crate::{error::SignerError, http_client_config::HttpClientConfig, traits::SolanaSigner};
 use std::str::FromStr;
 use types::{SignRawRequest, SignRawResponse, WalletResponse};
 
@@ -90,12 +90,11 @@ impl ParaSigner {
             }
         }
 
-        let builder = reqwest::Client::builder()
-            .timeout(CLIENT_TIMEOUT)
-            .https_only(true);
-        let client = builder
-            .build()
-            .map_err(|e| SignerError::ConfigError(format!("Failed to build HTTP client: {e}")))?;
+        let client = HttpClientConfig {
+            request_timeout: Some(CLIENT_TIMEOUT),
+            connect_timeout: None,
+        }
+        .build_client()?;
 
         Ok(Self {
             api_key: config.api_key,

--- a/rust/src/privy/mod.rs
+++ b/rust/src/privy/mod.rs
@@ -74,12 +74,9 @@ impl PrivySigner {
     /// Create a new PrivySigner from a configuration object.
     pub fn from_config(config: PrivySignerConfig) -> Self {
         let http_client_config = config.http_client_config.unwrap_or_default();
-        let builder = reqwest::Client::builder();
-        let builder = builder
-            .timeout(http_client_config.resolved_request_timeout())
-            .connect_timeout(http_client_config.resolved_connect_timeout())
-            .https_only(true);
-        let client = builder.build().expect("Failed to build HTTP client");
+        let client = http_client_config
+            .build_client()
+            .expect("Failed to build HTTP client");
 
         let authorization_request_expiry_ms = match config.authorization_request_expiry {
             PrivyAuthorizationRequestExpiry::Default => {

--- a/rust/src/turnkey/mod.rs
+++ b/rust/src/turnkey/mod.rs
@@ -79,14 +79,7 @@ impl TurnkeySigner {
         let http_client_config = config.http_client_config.unwrap_or_default();
         let pubkey = Pubkey::from_str(&config.public_key)
             .map_err(|e| SignerError::InvalidPublicKey(format!("Invalid public key: {e}")))?;
-        let builder = reqwest::Client::builder();
-        let builder = builder
-            .timeout(http_client_config.resolved_request_timeout())
-            .connect_timeout(http_client_config.resolved_connect_timeout())
-            .https_only(true);
-        let client = builder
-            .build()
-            .map_err(|e| SignerError::ConfigError(format!("Failed to build HTTP client: {e}")))?;
+        let client = http_client_config.build_client()?;
 
         Ok(Self {
             api_public_key: config.api_public_key,

--- a/rust/src/utila/mod.rs
+++ b/rust/src/utila/mod.rs
@@ -116,14 +116,7 @@ impl UtilaSigner {
         })?;
 
         let http_client_config = config.http_client_config.unwrap_or_default();
-        let builder = reqwest::Client::builder()
-            .timeout(http_client_config.resolved_request_timeout())
-            .connect_timeout(http_client_config.resolved_connect_timeout());
-        #[cfg(not(test))]
-        let builder = builder.https_only(true);
-        let client = builder
-            .build()
-            .map_err(|e| SignerError::ConfigError(format!("Failed to build HTTP client: {e}")))?;
+        let client = http_client_config.build_client()?;
 
         let designated_signers = config
             .designated_signers

--- a/rust/src/vault/mod.rs
+++ b/rust/src/vault/mod.rs
@@ -89,14 +89,7 @@ impl VaultSigner {
     /// Creates a new Vault signer from a configuration object.
     pub fn from_config(config: VaultSignerConfig) -> Result<Self, SignerError> {
         let http_client_config = config.http_client_config.unwrap_or_default();
-        let builder = Client::builder();
-        let builder = builder
-            .timeout(http_client_config.resolved_request_timeout())
-            .connect_timeout(http_client_config.resolved_connect_timeout())
-            .https_only(true);
-        let client = builder
-            .build()
-            .map_err(|e| SignerError::ConfigError(format!("Failed to build HTTP client: {e}")))?;
+        let client = http_client_config.build_client()?;
 
         Self::with_client(
             client,
@@ -116,8 +109,10 @@ impl VaultSigner {
     /// development Vault instance.
     ///
     /// The caller is responsible for whatever security posture the
-    /// supplied client carries (HTTPS-only, cert pinning, etc.); this
-    /// constructor does not enforce `https_only`.
+    /// supplied client carries (HTTPS-only, cert pinning, redirect policy,
+    /// etc.); this constructor does not enforce `https_only` and does not
+    /// replace the client's redirect policy. Requests carry `X-Vault-Token`,
+    /// so a client that follows redirects replays it to the redirect target.
     ///
     /// To avoid pulling `reqwest` into your own dependency tree at a
     /// version that may diverge from `solana-keychain`'s, prefer
@@ -531,6 +526,41 @@ mod tests {
 
         let result = signer.sign_message(b"hello").await;
         assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            SignerError::RemoteApiError(_)
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_sign_message_refuses_redirects() {
+        let target = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(0)
+            .mount(&target)
+            .await;
+
+        let origin = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/transit/sign/test-key"))
+            .respond_with(ResponseTemplate::new(307).insert_header(
+                "Location",
+                format!("{}/v1/transit/sign/test-key", target.uri()).as_str(),
+            ))
+            .expect(1)
+            .mount(&origin)
+            .await;
+
+        let mut signer = create_test_signer_with_pubkey(&origin.uri(), TEST_PUBKEY.to_string());
+        signer.client = Arc::new(
+            Client::builder()
+                .redirect(crate::http_client_config::no_redirect_policy())
+                .build()
+                .unwrap(),
+        );
+
+        let result = signer.sign_message(b"hello").await;
         assert!(matches!(
             result.unwrap_err(),
             SignerError::RemoteApiError(_)


### PR DESCRIPTION
## Problem

reqwest's default redirect policy (`Policy::limited(10)`) follows cross-origin redirects and strips only the four standard sensitive headers (`Authorization`, `Cookie`, `Proxy-Authorization`, `WWW-Authenticate`) on a host change. Every provider-specific credential header this library sends - `X-Vault-Token`, `X-Stamp`, `X-API-KEY`, `x-wallet-auth`, `privy-*`, `x-signature`, `x-dfns-useraction` - survived a cross-origin 307/308 hop, along with the signed request body.

Eleven backends each built their own `reqwest::Client` and none set a redirect policy. The other three languages already treat no-redirect as mandatory: TypeScript uses `redirect: 'error'`, Python `follow_redirects=False` plus an explicit 3xx rejection, Go a `CheckRedirect` that errors. Rust was the outlier - and the only language without a shared client builder, which is how the drift happened.

Exploitability is limited (it requires a redirect from an endpoint the operator already trusts: open redirect, compromised proxy, hostile self-hosted endpoint), so this is defense-in-depth - but it is also cross-language parity.

## Fix

- New shared builder on `HttpClientConfig` (`client_builder()` / `build_client()`): resolved timeouts, `https_only(true)`, and a redirect policy that **fails the request**. All eleven backends now build from it; dfns chains its `user_agent` and openfort its `use_rustls_tls` on top.
- The policy errors deliberately instead of `Policy::none()`: with `none()` the 3xx comes back as a normal response, and utila + crossmint branch on `status >= 400`, so they would JSON-parse a redirect body into a misleading error.
- Two adjacent defects fixed by the consolidation:
  - **Crossmint never set `https_only`** (only a string-prefix check on the configured URL), so a redirect to `http://` would have replayed `X-API-KEY` in cleartext.
  - **Utila and Fordefi gated `https_only` behind `#[cfg(not(test))]`**, shipping a test-shaped hole in the production build definition. Fordefi's constructor tests (the reason for the gate) now inject a plain-HTTP test client that keeps the no-redirect policy; the production builder is unconditional.
- `with_client` escape hatches keep the caller's client untouched; their docs now state the caller owns redirect handling and name the credential header at stake.

## Testing

- New shared-level test: two wiremock servers, origin replies 307 to the target; the request fails with a redirect error and the target asserts zero hits.
- New vault end-to-end test: signing against a redirecting server fails with `RemoteApiError` and the redirect target is never contacted (`.expect(0)`).
- Full suite on sdk-v2/v3/v4 (313 each), clippy `-D warnings` on `all`, fmt.