### PR TITLE
fix(turnkey): sign transactions via the policy-aware sign_transaction activity

### DIFF
--- a/go/signers/turnkey/signer.go
+++ b/go/signers/turnkey/signer.go
@@ -19,8 +19,9 @@ import (
 
 // Turnkey API paths.
 const (
-	signRawPayloadPath = "/public/v1/submit/sign_raw_payload"
-	whoAmIPath         = "/public/v1/query/whoami"
+	signRawPayloadPath  = "/public/v1/submit/sign_raw_payload"
+	signTransactionPath = "/public/v1/submit/sign_transaction"
+	whoAmIPath          = "/public/v1/query/whoami"
 )
 
 // Signer signs with an Ed25519 private key held by Turnkey, authenticating each
@@ -84,18 +85,67 @@ func (s *Signer) SignMessage(ctx context.Context, message []byte) (solana.Signat
 	return s.signBytes(ctx, message)
 }
 
-// SignTransaction signs the transaction's message bytes remotely, inserts the
-// signature at this signer's required-signer position, and returns the encoded
-// transaction with its completeness.
+// SignTransaction signs tx via the sign_transaction activity, submitting the
+// full wire transaction so Turnkey's policy engine can evaluate solana.tx
+// conditions. Policies must allow ACTIVITY_TYPE_SIGN_TRANSACTION_V2.
 func (s *Signer) SignTransaction(ctx context.Context, tx *solana.Transaction) (core.SignedTransaction, error) {
 	msg, err := tx.Message.MarshalBinary()
 	if err != nil {
 		return core.SignedTransaction{}, core.WrapSignerError(core.CodeSerializationError, "failed to serialize transaction message", err)
 	}
-	sig, err := s.signBytes(ctx, msg)
+	unsignedWire, err := tx.MarshalBinary()
+	if err != nil {
+		return core.SignedTransaction{}, core.WrapSignerError(core.CodeSerializationError, "failed to serialize transaction", err)
+	}
+
+	req := signTransactionRequest{
+		Type:           "ACTIVITY_TYPE_SIGN_TRANSACTION_V2",
+		TimestampMs:    strconv.FormatInt(time.Now().UnixMilli(), 10),
+		OrganizationID: s.organizationID,
+		Parameters: signTransactionParameters{
+			SignWith:            s.privateKeyID,
+			Type:                "TRANSACTION_TYPE_SOLANA",
+			UnsignedTransaction: hex.EncodeToString(unsignedWire),
+		},
+	}
+	body, err := json.Marshal(req)
+	if err != nil {
+		return core.SignedTransaction{}, core.WrapSignerError(core.CodeSerializationError, "failed to serialize sign request", err)
+	}
+
+	result, err := s.postActivity(ctx, signTransactionPath, body)
 	if err != nil {
 		return core.SignedTransaction{}, err
 	}
+	if result == nil || result.SignTransactionResult == nil {
+		return core.SignedTransaction{}, core.NewSignerError(core.CodeSigningFailed, "invalid response from Turnkey API")
+	}
+
+	signedWire, err := hex.DecodeString(result.SignTransactionResult.SignedTransaction)
+	if err != nil {
+		return core.SignedTransaction{}, core.WrapSignerError(core.CodeSerializationError,
+			"failed to decode signed transaction returned by Turnkey", err)
+	}
+	returned, err := solana.TransactionFromBytes(signedWire)
+	if err != nil {
+		return core.SignedTransaction{}, core.WrapSignerError(core.CodeSerializationError,
+			"failed to deserialize signed transaction returned by Turnkey", err)
+	}
+
+	position, err := core.SigningPosition(returned, s.publicKey)
+	if err != nil {
+		return core.SignedTransaction{}, err
+	}
+	if position >= len(returned.Signatures) {
+		return core.SignedTransaction{}, core.NewSignerError(core.CodeSigningFailed,
+			"Turnkey signature slot missing from returned transaction")
+	}
+	sig := returned.Signatures[position]
+	if !core.VerifyEd25519(s.publicKey, msg, sig) {
+		return core.SignedTransaction{}, core.NewSignerError(core.CodeSigningFailed,
+			"signature verification failed — the returned signature does not match the public key")
+	}
+
 	if err := core.AddSignature(tx, s.publicKey, sig); err != nil {
 		return core.SignedTransaction{}, err
 	}
@@ -104,6 +154,30 @@ func (s *Signer) SignTransaction(ctx context.Context, tx *solana.Transaction) (c
 		return core.SignedTransaction{}, err
 	}
 	return core.Classify(tx, encoded, sig), nil
+}
+
+// postActivity sends a stamped activity request and returns the result.
+// Turnkey populates result only under ACTIVITY_STATUS_COMPLETED; anything
+// else (e.g. CONSENSUS_NEEDED under a quorum policy) carries no signature.
+func (s *Signer) postActivity(ctx context.Context, path string, body []byte) (*activityResult, error) {
+	respBody, err := s.post(ctx, path, body)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp activityResponse
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		return nil, core.WrapSignerError(core.CodeSerializationError, "failed to parse sign response", err)
+	}
+	if resp.Activity.Status != "ACTIVITY_STATUS_COMPLETED" {
+		status := resp.Activity.Status
+		if status == "" {
+			status = "<missing>"
+		}
+		return nil, core.NewSignerError(core.CodeSigningFailed,
+			"Turnkey activity is not completed (status: "+status+")")
+	}
+	return resp.Activity.Result, nil
 }
 
 // IsAvailable reports whether the Turnkey API is reachable and the API
@@ -138,27 +212,10 @@ func (s *Signer) signBytes(ctx context.Context, message []byte) (solana.Signatur
 		return solana.Signature{}, core.WrapSignerError(core.CodeSerializationError, "failed to serialize sign request", err)
 	}
 
-	respBody, err := s.post(ctx, signRawPayloadPath, body)
+	result, err := s.postActivity(ctx, signRawPayloadPath, body)
 	if err != nil {
 		return solana.Signature{}, err
 	}
-
-	var resp activityResponse
-	if err := json.Unmarshal(respBody, &resp); err != nil {
-		return solana.Signature{}, core.WrapSignerError(core.CodeSerializationError, "failed to parse sign response", err)
-	}
-	// Turnkey executes activities optimistically and populates result only once
-	// the activity reaches ACTIVITY_STATUS_COMPLETED; anything else (e.g.
-	// CONSENSUS_NEEDED under a quorum policy) carries no signature.
-	if resp.Activity.Status != "ACTIVITY_STATUS_COMPLETED" {
-		status := resp.Activity.Status
-		if status == "" {
-			status = "<missing>"
-		}
-		return solana.Signature{}, core.NewSignerError(core.CodeSigningFailed,
-			"Turnkey activity is not completed (status: "+status+")")
-	}
-	result := resp.Activity.Result
 	if result == nil || result.SignRawPayloadResult == nil {
 		return solana.Signature{}, core.NewSignerError(core.CodeSigningFailed, "invalid response from Turnkey API")
 	}

--- a/go/signers/turnkey/signer_test.go
+++ b/go/signers/turnkey/signer_test.go
@@ -71,13 +71,20 @@ func signResultBody(sig []byte) string {
 // body, counting calls and checking method/path/headers.
 func signServer(t *testing.T, status int, body string, calls *int32) *httptest.Server {
 	t.Helper()
+	return signServerAt(t, signRawPayloadPath, status, body, calls)
+}
+
+// signServerAt serves a fixed activity response at wantPath, counting calls
+// and checking method/path/headers.
+func signServerAt(t *testing.T, wantPath string, status int, body string, calls *int32) *httptest.Server {
+	t.Helper()
 	return httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		atomic.AddInt32(calls, 1)
 		if r.Method != http.MethodPost {
 			t.Errorf("method = %s, want POST", r.Method)
 		}
-		if r.URL.Path != signRawPayloadPath {
-			t.Errorf("path = %s, want %s", r.URL.Path, signRawPayloadPath)
+		if r.URL.Path != wantPath {
+			t.Errorf("path = %s, want %s", r.URL.Path, wantPath)
 		}
 		if ct := r.Header.Get("Content-Type"); ct != "application/json" {
 			t.Errorf("Content-Type = %q, want application/json", ct)
@@ -257,8 +264,19 @@ func TestSignTransaction(t *testing.T) {
 	}
 	sig := ed25519.Sign(priv, msg)
 
+	signedTx := *tx
+	var sigVal solana.Signature
+	copy(sigVal[:], sig)
+	signedTx.Signatures = []solana.Signature{sigVal}
+	signedWire, err := signedTx.MarshalBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := `{"activity":{"status":"ACTIVITY_STATUS_COMPLETED","result":{"signTransactionResult":{"signedTransaction":"` +
+		hex.EncodeToString(signedWire) + `"}}}}`
+
 	var calls int32
-	srv := signServer(t, http.StatusOK, signResultBody(sig), &calls)
+	srv := signServerAt(t, signTransactionPath, http.StatusOK, body, &calls)
 	defer srv.Close()
 
 	s, err := New(testConfig(t, pub.String(), srv))
@@ -347,6 +365,75 @@ func TestSignInvalidHex(t *testing.T) {
 	}
 	if code, _ := core.CodeOf(err); code != core.CodeSerializationError {
 		t.Errorf("got %s, want SERIALIZATION_ERROR", code)
+	}
+}
+
+func TestSignTransactionRejectsSignatureOverDifferentBytes(t *testing.T) {
+	priv := testutils.TestPrivateKey()
+	pub := testutils.TestPublicKey()
+	tx, err := testutils.CreateTestTransaction(pub)
+	if err != nil {
+		t.Fatal(err)
+	}
+	otherTx, err := testutils.CreateTestTransaction(pub)
+	if err != nil {
+		t.Fatal(err)
+	}
+	otherTx.Message.RecentBlockhash = solana.Hash{1}
+	otherMsg, err := otherTx.Message.MarshalBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var sigVal solana.Signature
+	copy(sigVal[:], ed25519.Sign(priv, otherMsg))
+	otherTx.Signatures = []solana.Signature{sigVal}
+	signedWire, err := otherTx.MarshalBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := `{"activity":{"status":"ACTIVITY_STATUS_COMPLETED","result":{"signTransactionResult":{"signedTransaction":"` +
+		hex.EncodeToString(signedWire) + `"}}}}`
+
+	var calls int32
+	srv := signServerAt(t, signTransactionPath, http.StatusOK, body, &calls)
+	defer srv.Close()
+
+	s, err := New(testConfig(t, pub.String(), srv))
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = s.SignTransaction(context.Background(), tx)
+	if err == nil {
+		t.Fatal("expected a signature over different bytes to be rejected")
+	}
+	if code, _ := core.CodeOf(err); code != core.CodeSigningFailed {
+		t.Errorf("got %s, want SIGNING_FAILED", code)
+	}
+}
+
+func TestSignTransactionRejectsNonCompletedActivity(t *testing.T) {
+	pub := testutils.TestPublicKey()
+	tx, err := testutils.CreateTestTransaction(pub)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var calls int32
+	srv := signServerAt(t, signTransactionPath, http.StatusOK,
+		`{"activity":{"status":"ACTIVITY_STATUS_CONSENSUS_NEEDED"}}`, &calls)
+	defer srv.Close()
+
+	s, err := New(testConfig(t, pub.String(), srv))
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = s.SignTransaction(context.Background(), tx)
+	if err == nil {
+		t.Fatal("expected error for non-completed activity")
+	}
+	var se *core.SignerError
+	if !errors.As(err, &se) || !strings.Contains(se.Detail(), "ACTIVITY_STATUS_CONSENSUS_NEEDED") {
+		t.Errorf("error must name the received status, got %v", err)
 	}
 }
 

--- a/go/signers/turnkey/types.go
+++ b/go/signers/turnkey/types.go
@@ -1,7 +1,7 @@
 // Package turnkey provides a SolanaSigner backed by the Turnkey API. Every
 // request body is authenticated by stamping it with the P-256 ECDSA API
-// private key (X-Stamp header); Ed25519 signatures are produced remotely by
-// Turnkey via the sign_raw_payload activity.
+// private key (X-Stamp header). Transactions are signed remotely via the
+// sign_transaction activity (policy-aware); messages via sign_raw_payload.
 package turnkey
 
 import (
@@ -66,6 +66,21 @@ type signParameters struct {
 	HashFunction string `json:"hashFunction"`
 }
 
+// signTransactionRequest is the ACTIVITY_TYPE_SIGN_TRANSACTION_V2 request body.
+type signTransactionRequest struct {
+	Type           string                    `json:"type"`
+	TimestampMs    string                    `json:"timestampMs"`
+	OrganizationID string                    `json:"organizationId"`
+	Parameters     signTransactionParameters `json:"parameters"`
+}
+
+// signTransactionParameters are the sign_transaction activity parameters.
+type signTransactionParameters struct {
+	SignWith            string `json:"signWith"`
+	Type                string `json:"type"`
+	UnsignedTransaction string `json:"unsignedTransaction"`
+}
+
 // activityResponse is the envelope returned by the submit endpoints.
 type activityResponse struct {
 	Activity activity `json:"activity"`
@@ -77,9 +92,15 @@ type activity struct {
 	Result *activityResult `json:"result"`
 }
 
-// activityResult carries the (optional) raw-payload sign result.
+// activityResult carries the (optional) sign results.
 type activityResult struct {
-	SignRawPayloadResult *signResult `json:"signRawPayloadResult"`
+	SignRawPayloadResult  *signResult            `json:"signRawPayloadResult"`
+	SignTransactionResult *signTransactionResult `json:"signTransactionResult"`
+}
+
+// signTransactionResult holds the hex-encoded signed wire transaction.
+type signTransactionResult struct {
+	SignedTransaction string `json:"signedTransaction"`
 }
 
 // signResult holds the hex-encoded r and s signature components.

--- a/python/src/solana_keychain/turnkey/signer.py
+++ b/python/src/solana_keychain/turnkey/signer.py
@@ -25,6 +25,7 @@ from solana_keychain.core.signer import SignedTransaction, SolanaSigner
 from solana_keychain.core.transaction_util import (
     add_signature_to_transaction,
     classify_signed_transaction,
+    get_signing_keypair_position,
     serialize_transaction,
 )
 
@@ -174,14 +175,7 @@ class TurnkeySigner(SolanaSigner):
         }
         response = await self._post_stamped("/public/v1/submit/sign_raw_payload", request)
 
-        activity = response.get("activity") if isinstance(response, dict) else None
-        status = activity.get("status") if isinstance(activity, dict) else None
-        if status != "ACTIVITY_STATUS_COMPLETED":
-            raise SignerError(
-                SignerErrorCode.SIGNING_FAILED,
-                f"Turnkey activity is not completed (status: {status or '<missing>'})",
-            )
-        result = activity.get("result") if isinstance(activity, dict) else None
+        result = self._completed_activity_result(response)
         sign_result = result.get("signRawPayloadResult") if isinstance(result, dict) else None
         if (
             not isinstance(sign_result, dict)
@@ -201,8 +195,60 @@ class TurnkeySigner(SolanaSigner):
             )
         return signature
 
+    @staticmethod
+    def _completed_activity_result(response: Any) -> Any:
+        activity = response.get("activity") if isinstance(response, dict) else None
+        status = activity.get("status") if isinstance(activity, dict) else None
+        if status != "ACTIVITY_STATUS_COMPLETED":
+            raise SignerError(
+                SignerErrorCode.SIGNING_FAILED,
+                f"Turnkey activity is not completed (status: {status or '<missing>'})",
+            )
+        return activity.get("result") if isinstance(activity, dict) else None
+
     async def sign_transaction(self, transaction: Transaction) -> SignedTransaction:
-        signature = await self._sign_bytes(transaction.message_data())
+        """Sign via the ``sign_transaction`` activity, submitting the full wire
+        transaction so Turnkey's policy engine can evaluate ``solana.tx``
+        conditions. Policies must allow ``ACTIVITY_TYPE_SIGN_TRANSACTION_V2``."""
+        request = {
+            "type": "ACTIVITY_TYPE_SIGN_TRANSACTION_V2",
+            "timestampMs": str(int(time.time() * 1000)),
+            "organizationId": self._organization_id,
+            "parameters": {
+                "signWith": self._private_key_id,
+                "type": "TRANSACTION_TYPE_SOLANA",
+                "unsignedTransaction": bytes(transaction).hex(),
+            },
+        }
+        response = await self._post_stamped("/public/v1/submit/sign_transaction", request)
+
+        result = self._completed_activity_result(response)
+        sign_result = result.get("signTransactionResult") if isinstance(result, dict) else None
+        signed_hex = sign_result.get("signedTransaction") if isinstance(sign_result, dict) else None
+        if not isinstance(signed_hex, str):
+            raise SignerError(SignerErrorCode.SIGNING_FAILED, "Invalid response from Turnkey API")
+        try:
+            signed = Transaction.from_bytes(bytes.fromhex(signed_hex))
+        except Exception:
+            raise SignerError(
+                SignerErrorCode.SERIALIZATION_ERROR,
+                "Failed to decode signed transaction returned by Turnkey",
+            ) from None
+
+        position = get_signing_keypair_position(signed, self._pubkey)
+        signatures = signed.signatures
+        if position >= len(signatures):
+            raise SignerError(
+                SignerErrorCode.SIGNING_FAILED,
+                "Turnkey signature slot missing from returned transaction",
+            )
+        signature = signatures[position]
+        if not signature.verify(self._pubkey, transaction.message_data()):
+            raise SignerError(
+                SignerErrorCode.SIGNING_FAILED,
+                "Signature verification failed — the returned signature does not match "
+                "the public key",
+            )
         add_signature_to_transaction(transaction, self._pubkey, signature)
         return classify_signed_transaction(
             transaction, serialize_transaction(transaction), signature

--- a/python/tests/test_turnkey_signer.py
+++ b/python/tests/test_turnkey_signer.py
@@ -9,6 +9,7 @@ from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
 from solders.keypair import Keypair
+from solders.transaction import Transaction
 
 from solana_keychain import SignerError, SignerErrorCode
 from solana_keychain.turnkey import TurnkeySigner, TurnkeySignerConfig, create_turnkey_signer
@@ -16,6 +17,7 @@ from tests.util import create_test_transaction
 
 API_BASE_URL = "https://turnkey.example.com"
 SIGN_URL = f"{API_BASE_URL}/public/v1/submit/sign_raw_payload"
+SIGN_TRANSACTION_URL = f"{API_BASE_URL}/public/v1/submit/sign_transaction"
 WHOAMI_URL = f"{API_BASE_URL}/public/v1/query/whoami"
 ORGANIZATION_ID = "test-org-id"
 PRIVATE_KEY_ID = "test-key-id"
@@ -46,6 +48,31 @@ def make_signer(
             api_base_url=API_BASE_URL,
         )
     )
+
+
+def mock_sign_transaction_response(signed_transaction_hex: str) -> None:
+    respx.post(SIGN_TRANSACTION_URL).mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "activity": {
+                    "status": "ACTIVITY_STATUS_COMPLETED",
+                    "result": {
+                        "signTransactionResult": {"signedTransaction": signed_transaction_hex}
+                    },
+                }
+            },
+        )
+    )
+
+
+def signed_transaction_hex(keypair: Keypair, transaction: Any) -> str:
+    signed = Transaction(
+        from_keypairs=[keypair],
+        message=transaction.message,
+        recent_blockhash=transaction.message.recent_blockhash,
+    )
+    return bytes(signed).hex()
 
 
 def mock_sign_response(r_hex: str, s_hex: str) -> None:
@@ -274,8 +301,8 @@ async def test_sign_transaction_success() -> None:
     keypair = Keypair()
     transaction = create_test_transaction(keypair.pubkey())
     signature = keypair.sign_message(transaction.message_data())
-    sig_bytes = bytes(signature)
-    mock_sign_response(sig_bytes[:32].hex(), sig_bytes[32:].hex())
+    unsigned_hex = bytes(transaction).hex()
+    mock_sign_transaction_response(signed_transaction_hex(keypair, transaction))
 
     signer = make_signer(str(keypair.pubkey()))
     result = await signer.sign_transaction(transaction)
@@ -283,6 +310,53 @@ async def test_sign_transaction_success() -> None:
     assert result.is_complete
     assert result.signature == signature
     assert list(transaction.signatures) == [signature]
+
+    parsed: dict[str, Any] = json.loads(respx.calls.last.request.content)
+    assert parsed["type"] == "ACTIVITY_TYPE_SIGN_TRANSACTION_V2"
+    assert parsed["parameters"]["type"] == "TRANSACTION_TYPE_SOLANA"
+    assert parsed["parameters"]["unsignedTransaction"] == unsigned_hex
+
+
+@respx.mock
+async def test_sign_transaction_rejects_signature_over_different_bytes() -> None:
+    keypair = Keypair()
+    transaction = create_test_transaction(keypair.pubkey())
+    other_transaction = create_test_transaction(keypair.pubkey())
+    mock_sign_transaction_response(signed_transaction_hex(keypair, other_transaction))
+
+    signer = make_signer(str(keypair.pubkey()))
+    with pytest.raises(SignerError) as excinfo:
+        await signer.sign_transaction(transaction)
+    assert excinfo.value.code == SignerErrorCode.SIGNING_FAILED
+
+
+@respx.mock
+async def test_sign_transaction_rejects_undecodable_signed_transaction() -> None:
+    keypair = Keypair()
+    transaction = create_test_transaction(keypair.pubkey())
+    mock_sign_transaction_response("not-hex")
+
+    signer = make_signer(str(keypair.pubkey()))
+    with pytest.raises(SignerError) as excinfo:
+        await signer.sign_transaction(transaction)
+    assert excinfo.value.code == SignerErrorCode.SERIALIZATION_ERROR
+
+
+@respx.mock
+async def test_sign_transaction_rejects_non_completed_activity() -> None:
+    keypair = Keypair()
+    transaction = create_test_transaction(keypair.pubkey())
+    respx.post(SIGN_TRANSACTION_URL).mock(
+        return_value=httpx.Response(
+            200, json={"activity": {"status": "ACTIVITY_STATUS_CONSENSUS_NEEDED"}}
+        )
+    )
+
+    signer = make_signer(str(keypair.pubkey()))
+    with pytest.raises(SignerError) as excinfo:
+        await signer.sign_transaction(transaction)
+    assert excinfo.value.code == SignerErrorCode.SIGNING_FAILED
+    assert "ACTIVITY_STATUS_CONSENSUS_NEEDED" in excinfo.value._detail
 
 
 @respx.mock

--- a/rust/src/turnkey/mod.rs
+++ b/rust/src/turnkey/mod.rs
@@ -12,7 +12,10 @@ use crate::{
 use base64::Engine;
 use p256::ecdsa::signature::Signer as P256Signer;
 use std::str::FromStr;
-use types::{ActivityResponse, SignParameters, SignRequest, WhoAmIRequest};
+use types::{
+    ActivityResponse, SignParameters, SignRequest, SignTransactionParameters,
+    SignTransactionRequest, WhoAmIRequest,
+};
 
 /// Turnkey-based signer using Turnkey's API
 #[derive(Clone)]
@@ -101,26 +104,17 @@ impl TurnkeySigner {
         })
     }
 
-    /// Sign message bytes using Turnkey API and return just the signature
-    async fn sign_bytes(&self, message: &[u8]) -> Result<Signature, SignerError> {
-        let hex_message = hex::encode(message);
-
-        let request = SignRequest {
-            activity_type: "ACTIVITY_TYPE_SIGN_RAW_PAYLOAD_V2".to_string(),
-            timestamp_ms: chrono::Utc::now().timestamp_millis().to_string(),
-            organization_id: self.organization_id.clone(),
-            parameters: SignParameters {
-                sign_with: self.private_key_id.clone(),
-                payload: hex_message,
-                encoding: "PAYLOAD_ENCODING_HEXADECIMAL".to_string(),
-                hash_function: "HASH_FUNCTION_NOT_APPLICABLE".to_string(),
-            },
-        };
-
-        let body = serde_json::to_string(&request)?;
+    /// POST a stamped activity request and return the parsed response.
+    /// Turnkey populates `result` only under ACTIVITY_STATUS_COMPLETED;
+    /// anything else (e.g. CONSENSUS_NEEDED) carries no signature.
+    async fn post_activity(
+        &self,
+        path: &str,
+        body: String,
+    ) -> Result<ActivityResponse, SignerError> {
         let stamp = self.create_stamp(&body)?;
 
-        let url = format!("{}/public/v1/submit/sign_raw_payload", self.api_base_url);
+        let url = format!("{}{}", self.api_base_url, path);
         let response = self
             .client
             .post(&url)
@@ -149,15 +143,35 @@ impl TurnkeySigner {
         let response_text = response.text().await?;
         let response: ActivityResponse = serde_json::from_str(&response_text)?;
 
-        // Turnkey executes activities optimistically and populates `result` only
-        // once the activity reaches ACTIVITY_STATUS_COMPLETED; anything else
-        // (e.g. CONSENSUS_NEEDED under a quorum policy) carries no signature.
         let status = response.activity.status.as_deref().unwrap_or("<missing>");
         if status != "ACTIVITY_STATUS_COMPLETED" {
             return Err(SignerError::SigningFailed(format!(
                 "Turnkey activity is not completed (status: {status})"
             )));
         }
+
+        Ok(response)
+    }
+
+    /// Sign message bytes using Turnkey API and return just the signature
+    async fn sign_bytes(&self, message: &[u8]) -> Result<Signature, SignerError> {
+        let hex_message = hex::encode(message);
+
+        let request = SignRequest {
+            activity_type: "ACTIVITY_TYPE_SIGN_RAW_PAYLOAD_V2".to_string(),
+            timestamp_ms: chrono::Utc::now().timestamp_millis().to_string(),
+            organization_id: self.organization_id.clone(),
+            parameters: SignParameters {
+                sign_with: self.private_key_id.clone(),
+                payload: hex_message,
+                encoding: "PAYLOAD_ENCODING_HEXADECIMAL".to_string(),
+                hash_function: "HASH_FUNCTION_NOT_APPLICABLE".to_string(),
+            },
+        };
+        let body = serde_json::to_string(&request)?;
+        let response = self
+            .post_activity("/public/v1/submit/sign_raw_payload", body)
+            .await?;
 
         if let Some(result) = response.activity.result {
             if let Some(sign_result) = result.sign_raw_payload_result {
@@ -210,11 +224,64 @@ impl TurnkeySigner {
         ))
     }
 
+    /// Sign via the `sign_transaction` activity, submitting the full wire
+    /// transaction so Turnkey's policy engine can evaluate `solana.tx`
+    /// conditions. Policies must allow `ACTIVITY_TYPE_SIGN_TRANSACTION_V2`.
     async fn sign_and_serialize(
         &self,
         transaction: &mut Transaction,
     ) -> Result<SignedTransaction, SignerError> {
-        let signature = self.sign_bytes(&transaction.message_data()).await?;
+        let unsigned_wire = bincode::serialize(transaction).map_err(|e| {
+            SignerError::SerializationError(format!("Failed to serialize transaction: {e}"))
+        })?;
+
+        let request = SignTransactionRequest {
+            activity_type: "ACTIVITY_TYPE_SIGN_TRANSACTION_V2".to_string(),
+            timestamp_ms: chrono::Utc::now().timestamp_millis().to_string(),
+            organization_id: self.organization_id.clone(),
+            parameters: SignTransactionParameters {
+                sign_with: self.private_key_id.clone(),
+                transaction_type: "TRANSACTION_TYPE_SOLANA".to_string(),
+                unsigned_transaction: hex::encode(&unsigned_wire),
+            },
+        };
+        let body = serde_json::to_string(&request)?;
+        let response = self
+            .post_activity("/public/v1/submit/sign_transaction", body)
+            .await?;
+
+        let signed_hex = response
+            .activity
+            .result
+            .and_then(|result| result.sign_transaction_result)
+            .map(|result| result.signed_transaction)
+            .ok_or_else(|| {
+                SignerError::SigningFailed("Invalid response from Turnkey API".to_string())
+            })?;
+
+        let signed_wire = hex::decode(&signed_hex).map_err(|e| {
+            SignerError::SerializationError(format!(
+                "Failed to decode signed transaction returned by Turnkey: {e}"
+            ))
+        })?;
+        let returned: Transaction = bincode::deserialize(&signed_wire).map_err(|e| {
+            SignerError::SerializationError(format!(
+                "Failed to deserialize signed transaction returned by Turnkey: {e}"
+            ))
+        })?;
+
+        let position = TransactionUtil::get_signing_keypair_position(&returned, &self.public_key)?;
+        let signature = returned.signatures.get(position).copied().ok_or_else(|| {
+            SignerError::SigningFailed(
+                "Turnkey signature slot missing from returned transaction".to_string(),
+            )
+        })?;
+
+        if !signature.verify(&self.public_key.to_bytes(), &transaction.message_data()) {
+            return Err(SignerError::SigningFailed(
+                "Signature verification failed — the returned signature does not match the public key".to_string(),
+            ));
+        }
 
         TransactionUtil::add_signature_to_transaction(transaction, &self.public_key, signature)?;
 
@@ -497,24 +564,19 @@ mod tests {
 
         let mut tx = create_test_transaction(&keypair_pubkey(&keypair));
 
-        // The signature that Turnkey API will return (signing the message_data)
         let signature = keypair.sign_message(&tx.message_data());
-        let sig_bytes = signature.as_ref();
+        let mut signed_tx = tx.clone();
+        signed_tx.signatures = vec![signature];
+        let signed_hex = hex::encode(bincode::serialize(&signed_tx).unwrap());
 
-        // Split into r and s
-        let r_hex = hex::encode(&sig_bytes[0..32]);
-        let s_hex = hex::encode(&sig_bytes[32..64]);
-
-        // Mock the sign endpoint
         Mock::given(method("POST"))
-            .and(path("/public/v1/submit/sign_raw_payload"))
+            .and(path("/public/v1/submit/sign_transaction"))
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
                 "activity": {
                     "status": "ACTIVITY_STATUS_COMPLETED",
                     "result": {
-                        "signRawPayloadResult": {
-                            "r": r_hex,
-                            "s": s_hex
+                        "signTransactionResult": {
+                            "signedTransaction": signed_hex
                         }
                     }
                 }
@@ -543,6 +605,94 @@ mod tests {
 
         // Verify the transaction is properly serialized
         assert!(!serialized_tx.is_empty());
+        assert_eq!(tx.signatures, vec![signature]);
+    }
+
+    #[tokio::test]
+    async fn test_turnkey_sign_transaction_rejects_signature_over_different_bytes() {
+        let mock_server = MockServer::start().await;
+        let keypair = create_test_keypair();
+        let (api_public_key, api_private_key) = create_test_api_keys();
+
+        let mut tx = create_test_transaction(&keypair_pubkey(&keypair));
+        let mut other_tx = create_test_transaction(&keypair_pubkey(&keypair));
+        other_tx.signatures = vec![keypair.sign_message(&other_tx.message_data())];
+        let signed_hex = hex::encode(bincode::serialize(&other_tx).unwrap());
+
+        Mock::given(method("POST"))
+            .and(path("/public/v1/submit/sign_transaction"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "activity": {
+                    "status": "ACTIVITY_STATUS_COMPLETED",
+                    "result": {
+                        "signTransactionResult": {
+                            "signedTransaction": signed_hex
+                        }
+                    }
+                }
+            })))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let mut signer = TurnkeySigner::new(
+            api_public_key,
+            api_private_key,
+            "test-org-id".to_string(),
+            "test-key-id".to_string(),
+            keypair.pubkey().to_string(),
+        )
+        .unwrap();
+        signer.client = reqwest::Client::new();
+        signer.api_base_url = mock_server.uri();
+
+        let result = signer.sign_transaction(&mut tx).await;
+        match result.unwrap_err() {
+            SignerError::SigningFailed(message) => {
+                assert!(
+                    message.contains("verification failed"),
+                    "expected a verification failure, got: {message}"
+                );
+            }
+            other => panic!("Expected SigningFailed, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_turnkey_sign_transaction_rejects_non_completed_activity() {
+        let mock_server = MockServer::start().await;
+        let keypair = create_test_keypair();
+        let (api_public_key, api_private_key) = create_test_api_keys();
+
+        let mut tx = create_test_transaction(&keypair_pubkey(&keypair));
+
+        Mock::given(method("POST"))
+            .and(path("/public/v1/submit/sign_transaction"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "activity": { "status": "ACTIVITY_STATUS_CONSENSUS_NEEDED" }
+            })))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let mut signer = TurnkeySigner::new(
+            api_public_key,
+            api_private_key,
+            "test-org-id".to_string(),
+            "test-key-id".to_string(),
+            keypair.pubkey().to_string(),
+        )
+        .unwrap();
+        signer.client = reqwest::Client::new();
+        signer.api_base_url = mock_server.uri();
+
+        let result = signer.sign_transaction(&mut tx).await;
+        match result.unwrap_err() {
+            SignerError::SigningFailed(message) => {
+                assert!(message.contains("ACTIVITY_STATUS_CONSENSUS_NEEDED"));
+            }
+            other => panic!("Expected SigningFailed, got: {other:?}"),
+        }
     }
 
     #[tokio::test]

--- a/rust/src/turnkey/types.rs
+++ b/rust/src/turnkey/types.rs
@@ -34,10 +34,36 @@ pub struct Activity {
     pub result: Option<ActivityResult>,
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SignTransactionRequest {
+    #[serde(rename = "type")]
+    pub activity_type: String,
+    pub timestamp_ms: String,
+    pub organization_id: String,
+    pub parameters: SignTransactionParameters,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SignTransactionParameters {
+    pub sign_with: String,
+    #[serde(rename = "type")]
+    pub transaction_type: String,
+    pub unsigned_transaction: String,
+}
+
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ActivityResult {
     pub sign_raw_payload_result: Option<SignResult>,
+    pub sign_transaction_result: Option<SignTransactionResult>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SignTransactionResult {
+    pub signed_transaction: String,
 }
 
 #[derive(Deserialize)]


### PR DESCRIPTION
## Problem

For `sign_transaction`, Python, Rust, and Go sent the bare message bytes to `ACTIVITY_TYPE_SIGN_RAW_PAYLOAD_V2`. Turnkey's [policy language](https://docs.turnkey.com/features/policies/language) is explicit that raw-payload activities expose only `hash_function` and `encoding` to policy conditions - the payload itself is not policy-visible - while `solana.tx` (account keys, instructions, transfers, blockhash) is parsed and evaluated only on the `SIGN_TRANSACTION` path. Turnkey's own changelog states raw signing "does not use our Policy Engine."

Consequence: every transaction-content policy an organization configures at Turnkey (transfer limits, program allowlists, quorum rules) was **silently bypassed** in three of our four languages. The TypeScript signer has always sent `ACTIVITY_TYPE_SIGN_TRANSACTION_V2`, so the same policy setup behaved differently per language - a team that validated policies against TS and deployed Go/Python/Rust got no enforcement.

No key compromise and no forgery: all languages verify the returned signature locally. The bypassed layer is Turnkey-side authorization.

## Fix

Python/Rust/Go transaction signing now mirrors TypeScript:
- Submit the **full wire transaction** (hex) as `ACTIVITY_TYPE_SIGN_TRANSACTION_V2` / `TRANSACTION_TYPE_SOLANA` to `/public/v1/submit/sign_transaction`.
- Decode the returned signed transaction, extract this signer's signature by its required-signer position (the r/s left-pad quirk is raw-payload-only and does not apply here).
- Verify the signature against the **caller's original message bytes** before inserting it into the caller's transaction - other signers' partial signatures on the caller's copy are untouched.
- The activity-status gate from #240 covers the new endpoint (shared `post_activity`/`_completed_activity_result`/`postActivity` helper per language).
- `sign_message` stays on `sign_raw_payload` - arbitrary bytes have no transaction semantics.

## BREAKING (behavioral)

Turnkey denies activities by default. An organization whose ALLOW policies cover only `ACTIVITY_TYPE_SIGN_RAW_PAYLOAD_V2` will see transaction signing rejected after upgrading, until it also allows `ACTIVITY_TYPE_SIGN_TRANSACTION_V2`. Undetectable client-side in advance. Root-user API keys (no policy evaluation) and orgs already using the TS signer are unaffected. Needs a loud changelog entry at release.

## Testing

- Per language: success round-trip asserting the exact request shape (activity type, `TRANSACTION_TYPE_SOLANA`, unsigned wire hex); rejection of a signature over different bytes; rejection of a non-completed activity on the new path; undecodable signed transaction (Python).
- Rust 17 turnkey tests x sdk-v2/v3/v4, clippy `-D warnings` on `all`; Python 453 + ruff + mypy strict; Go `-race` + vet + golangci-lint.
- Turnkey live integration suites (CI creds) exercise the new endpoint against the real API in all three languages.
