### PR TITLE
fix(privy): sign transactions via the policy-aware signTransaction RPC

### DIFF
--- a/go/signers/privy/signer.go
+++ b/go/signers/privy/signer.go
@@ -87,18 +87,61 @@ func (s *Signer) SignMessage(ctx context.Context, message []byte) (solana.Signat
 	return s.signBytes(ctx, message)
 }
 
-// SignTransaction signs the transaction's message bytes with the Privy wallet,
-// inserts the signature at this signer's required-signer position, and returns
-// the encoded transaction with its completeness.
+// SignTransaction signs tx via Privy's signTransaction RPC, submitting the
+// full wire transaction so wallet policies with transaction conditions apply.
+// Policies must allow the signTransaction method.
 func (s *Signer) SignTransaction(ctx context.Context, tx *solana.Transaction) (core.SignedTransaction, error) {
 	msg, err := tx.Message.MarshalBinary()
 	if err != nil {
 		return core.SignedTransaction{}, core.WrapSignerError(core.CodeSerializationError, "failed to serialize transaction message", err)
 	}
-	sig, err := s.signBytes(ctx, msg)
+	unsignedWire, err := tx.MarshalBinary()
+	if err != nil {
+		return core.SignedTransaction{}, core.WrapSignerError(core.CodeSerializationError, "failed to serialize transaction", err)
+	}
+
+	request := signTransactionRequest{
+		Method:    "signTransaction",
+		ChainType: "solana",
+		Params: signTransactionParams{
+			Transaction: base64.StdEncoding.EncodeToString(unsignedWire),
+			Encoding:    "base64",
+		},
+	}
+	body, err := s.postRPC(ctx, request)
 	if err != nil {
 		return core.SignedTransaction{}, err
 	}
+
+	var signResp signTransactionResponse
+	if err := json.Unmarshal(body, &signResp); err != nil {
+		return core.SignedTransaction{}, core.WrapSignerError(core.CodeSerializationError, "failed to parse privy signing response", err)
+	}
+	signedWire, err := base64.StdEncoding.DecodeString(signResp.Data.SignedTransaction)
+	if err != nil {
+		return core.SignedTransaction{}, core.NewSignerError(core.CodeSerializationError,
+			"failed to decode signed transaction returned by privy")
+	}
+	returned, err := solana.TransactionFromBytes(signedWire)
+	if err != nil {
+		return core.SignedTransaction{}, core.WrapSignerError(core.CodeSerializationError,
+			"failed to deserialize signed transaction returned by privy", err)
+	}
+
+	position, err := core.SigningPosition(returned, s.pubkey)
+	if err != nil {
+		return core.SignedTransaction{}, err
+	}
+	if position >= len(returned.Signatures) {
+		return core.SignedTransaction{}, core.NewSignerError(core.CodeSigningFailed,
+			"privy signature slot missing from returned transaction")
+	}
+	sig := returned.Signatures[position]
+	if !core.VerifyEd25519(s.pubkey, msg, sig) {
+		return core.SignedTransaction{}, core.NewSignerError(core.CodeSigningFailed,
+			"signature verification failed: the returned signature does not match the public key")
+	}
+
 	if err := core.AddSignature(tx, s.pubkey, sig); err != nil {
 		return core.SignedTransaction{}, err
 	}
@@ -107,6 +150,34 @@ func (s *Signer) SignTransaction(ctx context.Context, tx *solana.Transaction) (c
 		return core.SignedTransaction{}, err
 	}
 	return core.Classify(tx, encoded, sig), nil
+}
+
+// postRPC sends a wallet RPC request with Privy auth and
+// authorization-signature headers and returns the response body on 2xx.
+func (s *Signer) postRPC(ctx context.Context, request any) ([]byte, error) {
+	url := s.apiBaseURL + "/wallets/" + s.walletID + "/rpc"
+	reqBody, err := json.Marshal(request)
+	if err != nil {
+		return nil, core.WrapSignerError(core.CodeSerializationError, "failed to serialize privy signing request", err)
+	}
+	authHeaders, err := s.prepareAuthorizationHeaders(http.MethodPost, url, request)
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(reqBody))
+	if err != nil {
+		return nil, core.WrapSignerError(core.CodeHTTPError, "failed to build privy signing request", err)
+	}
+	req.Header.Set("Authorization", s.authHeader())
+	req.Header.Set("privy-app-id", s.appID)
+	req.Header.Set("Content-Type", "application/json")
+	if authHeaders.signature != "" {
+		req.Header.Set("privy-authorization-signature", authHeaders.signature)
+	}
+	if authHeaders.requestExpiry != "" {
+		req.Header.Set("privy-request-expiry", authHeaders.requestExpiry)
+	}
+	return s.do(req, "privy signing")
 }
 
 // IsAvailable re-fetches the wallet from the Privy API and reports whether it
@@ -161,7 +232,6 @@ func (s *Signer) fetchPublicKey(ctx context.Context) (solana.PublicKey, error) {
 // sending the bytes base64-encoded and decoding the base64 signature from the
 // response, then verifies it locally.
 func (s *Signer) signBytes(ctx context.Context, message []byte) (solana.Signature, error) {
-	url := s.apiBaseURL + "/wallets/" + s.walletID + "/rpc"
 	request := signMessageRequest{
 		Method:    "signMessage",
 		ChainType: "solana",
@@ -170,29 +240,7 @@ func (s *Signer) signBytes(ctx context.Context, message []byte) (solana.Signatur
 			Encoding: "base64",
 		},
 	}
-	reqBody, err := json.Marshal(request)
-	if err != nil {
-		return solana.Signature{}, core.WrapSignerError(core.CodeSerializationError, "failed to serialize privy signing request", err)
-	}
-	authHeaders, err := s.prepareAuthorizationHeaders(http.MethodPost, url, request)
-	if err != nil {
-		return solana.Signature{}, err
-	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(reqBody))
-	if err != nil {
-		return solana.Signature{}, core.WrapSignerError(core.CodeHTTPError, "failed to build privy signing request", err)
-	}
-	req.Header.Set("Authorization", s.authHeader())
-	req.Header.Set("privy-app-id", s.appID)
-	req.Header.Set("Content-Type", "application/json")
-	if authHeaders.signature != "" {
-		req.Header.Set("privy-authorization-signature", authHeaders.signature)
-	}
-	if authHeaders.requestExpiry != "" {
-		req.Header.Set("privy-request-expiry", authHeaders.requestExpiry)
-	}
-
-	body, err := s.do(req, "privy signing")
+	body, err := s.postRPC(ctx, request)
 	if err != nil {
 		return solana.Signature{}, err
 	}

--- a/go/signers/privy/signer_test.go
+++ b/go/signers/privy/signer_test.go
@@ -145,6 +145,69 @@ func addRPCRoute(t *testing.T, mux *http.ServeMux, respond func(w http.ResponseW
 	})
 }
 
+// addSignTransactionRPCRoute registers the wallet RPC route asserting the
+// signTransaction request shape.
+func addSignTransactionRPCRoute(t *testing.T, mux *http.ServeMux, respond func(w http.ResponseWriter, unsignedWire []byte)) {
+	t.Helper()
+	mux.HandleFunc("POST "+rpcPath, func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("failed to read signing request body: %v", err)
+		}
+		var got map[string]any
+		if err := json.Unmarshal(body, &got); err != nil {
+			t.Errorf("failed to decode signing request: %v", err)
+		}
+		params, _ := got["params"].(map[string]any)
+		encoded, _ := params["transaction"].(string)
+		want := map[string]any{
+			"method":     "signTransaction",
+			"chain_type": "solana",
+			"params": map[string]any{
+				"transaction": encoded,
+				"encoding":    "base64",
+			},
+		}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("signing request body = %s, want exactly %s", body, mustJSON(t, want))
+		}
+		unsignedWire, err := base64.StdEncoding.DecodeString(encoded)
+		if err != nil {
+			t.Errorf("request transaction is not valid base64: %v", err)
+		}
+		respond(w, unsignedWire)
+	})
+}
+
+// signedTransactionResponse signs the unsigned wire transaction with priv and
+// writes the signTransaction response body.
+func signedTransactionResponse(t *testing.T, w http.ResponseWriter, priv ed25519.PrivateKey, unsignedWire []byte) {
+	t.Helper()
+	tx, err := solana.TransactionFromBytes(unsignedWire)
+	if err != nil {
+		t.Errorf("failed to decode unsigned wire transaction: %v", err)
+		return
+	}
+	msg, err := tx.Message.MarshalBinary()
+	if err != nil {
+		t.Errorf("failed to serialize message: %v", err)
+		return
+	}
+	tx.Signatures = []solana.Signature{signWith(priv, msg)}
+	signedWire, err := tx.MarshalBinary()
+	if err != nil {
+		t.Errorf("failed to serialize signed transaction: %v", err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"method": "signTransaction",
+		"data": map[string]any{
+			"signed_transaction": base64.StdEncoding.EncodeToString(signedWire),
+			"encoding":           "base64",
+		},
+	})
+}
+
 func mustJSON(t *testing.T, v any) string {
 	t.Helper()
 	b, err := json.Marshal(v)
@@ -614,6 +677,67 @@ func TestSignMessageRemoteErrorBodyDiscarded(t *testing.T) {
 
 // TestSignTransaction checks that signing a transaction inserts the signature
 // at position 0 and yields a complete encoded transaction.
+func TestSignTransactionRejectsSignatureOverDifferentBytes(t *testing.T) {
+	priv := testutils.TestPrivateKey()
+	pub := testutils.TestPublicKey()
+	tx, err := testutils.CreateTestTransaction(pub)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mux := http.NewServeMux()
+	addWalletRoute(t, mux, pub.String())
+	addSignTransactionRPCRoute(t, mux, func(w http.ResponseWriter, unsignedWire []byte) {
+		other, err := solana.TransactionFromBytes(unsignedWire)
+		if err != nil {
+			t.Errorf("failed to decode unsigned wire transaction: %v", err)
+			return
+		}
+		other.Message.RecentBlockhash = solana.Hash{1}
+		otherWire, err := other.MarshalBinary()
+		if err != nil {
+			t.Errorf("failed to serialize perturbed transaction: %v", err)
+			return
+		}
+		signedTransactionResponse(t, w, priv, otherWire)
+	})
+
+	s := newTestSigner(t, mux)
+	_, err = s.SignTransaction(context.Background(), tx)
+	if err == nil {
+		t.Fatal("expected a signature over different bytes to be rejected")
+	}
+	if code, _ := core.CodeOf(err); code != core.CodeSigningFailed {
+		t.Errorf("got %s, want SIGNING_FAILED", code)
+	}
+}
+
+func TestSignTransactionRejectsMissingSignedTransaction(t *testing.T) {
+	pub := testutils.TestPublicKey()
+	tx, err := testutils.CreateTestTransaction(pub)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mux := http.NewServeMux()
+	addWalletRoute(t, mux, pub.String())
+	addSignTransactionRPCRoute(t, mux, func(w http.ResponseWriter, _ []byte) {
+		writeJSON(w, http.StatusOK, map[string]any{
+			"method": "signTransaction",
+			"data":   map[string]any{},
+		})
+	})
+
+	s := newTestSigner(t, mux)
+	_, err = s.SignTransaction(context.Background(), tx)
+	if err == nil {
+		t.Fatal("expected error for a response without signed_transaction")
+	}
+	if code, _ := core.CodeOf(err); code != core.CodeSerializationError {
+		t.Errorf("got %s, want SERIALIZATION_ERROR", code)
+	}
+}
+
 func TestSignTransaction(t *testing.T) {
 	priv := testutils.TestPrivateKey()
 	pub := testutils.TestPublicKey()
@@ -629,8 +753,8 @@ func TestSignTransaction(t *testing.T) {
 
 	mux := http.NewServeMux()
 	addWalletRoute(t, mux, pub.String())
-	addRPCRoute(t, mux, func(w http.ResponseWriter, message []byte) {
-		signatureResponse(w, signWith(priv, message))
+	addSignTransactionRPCRoute(t, mux, func(w http.ResponseWriter, unsignedWire []byte) {
+		signedTransactionResponse(t, w, priv, unsignedWire)
 	})
 
 	s := newTestSigner(t, mux)

--- a/go/signers/privy/types.go
+++ b/go/signers/privy/types.go
@@ -78,6 +78,31 @@ type signMessageData struct {
 	Encoding  string `json:"encoding"`
 }
 
+// signTransactionRequest is the wallet RPC signTransaction request body.
+type signTransactionRequest struct {
+	Method    string                `json:"method"`
+	ChainType string                `json:"chain_type"`
+	Params    signTransactionParams `json:"params"`
+}
+
+// signTransactionParams carries the base64-encoded wire transaction.
+type signTransactionParams struct {
+	Transaction string `json:"transaction"`
+	Encoding    string `json:"encoding"`
+}
+
+// signTransactionResponse is the wallet RPC signTransaction response body.
+type signTransactionResponse struct {
+	Method string              `json:"method"`
+	Data   signTransactionData `json:"data"`
+}
+
+// signTransactionData carries the base64-encoded signed wire transaction.
+type signTransactionData struct {
+	SignedTransaction string `json:"signed_transaction"`
+	Encoding          string `json:"encoding"`
+}
+
 // walletResponse is the wallet info response; for Solana wallets the address is
 // the public key. Only the fields the signer reads are declared; unknown fields
 // are ignored.

--- a/python/src/solana_keychain/privy/signer.py
+++ b/python/src/solana_keychain/privy/signer.py
@@ -2,6 +2,7 @@
 
 import base64
 from dataclasses import dataclass, field
+from typing import Any
 from urllib.parse import quote
 
 import httpx
@@ -15,6 +16,7 @@ from solana_keychain.core.signer import SignedTransaction, SolanaSigner
 from solana_keychain.core.transaction_util import (
     add_signature_to_transaction,
     classify_signed_transaction,
+    get_signing_keypair_position,
     serialize_transaction,
 )
 from solana_keychain.privy.authorization import (
@@ -110,14 +112,8 @@ class PrivySigner(SolanaSigner):
                 SignerErrorCode.INVALID_PUBLIC_KEY, "Invalid public key from Privy API"
             ) from None
 
-    async def _sign_bytes(self, message: bytes) -> Signature:
-        public_key = self._initialized_pubkey()
+    async def _post_rpc(self, request: dict[str, Any]) -> Any:
         url = f"{self._api_base_url}/wallets/{quote(self._wallet_id, safe='')}/rpc"
-        request = {
-            "method": "signMessage",
-            "chain_type": "solana",
-            "params": {"message": base64.b64encode(message).decode("ascii"), "encoding": "base64"},
-        }
         authorization_signature, request_expiry = prepare_authorization_headers(
             app_id=self._app_id,
             authorization_config=self._authorization_context,
@@ -133,7 +129,7 @@ class PrivySigner(SolanaSigner):
         if request_expiry is not None:
             headers["privy-request-expiry"] = request_expiry
 
-        response = await fetch_signer_json(
+        return await fetch_signer_json(
             url=url,
             provider_name="Privy",
             method="POST",
@@ -141,6 +137,15 @@ class PrivySigner(SolanaSigner):
             json_body=request,
             client=self._http_client,
         )
+
+    async def _sign_bytes(self, message: bytes) -> Signature:
+        public_key = self._initialized_pubkey()
+        request = {
+            "method": "signMessage",
+            "chain_type": "solana",
+            "params": {"message": base64.b64encode(message).decode("ascii"), "encoding": "base64"},
+        }
+        response = await self._post_rpc(request)
 
         data = response.get("data") if isinstance(response, dict) else None
         signature_b64 = data.get("signature") if isinstance(data, dict) else None
@@ -166,8 +171,49 @@ class PrivySigner(SolanaSigner):
         return signature
 
     async def sign_transaction(self, transaction: Transaction) -> SignedTransaction:
-        signature = await self._sign_bytes(transaction.message_data())
-        add_signature_to_transaction(transaction, self._initialized_pubkey(), signature)
+        """Sign via Privy's ``signTransaction`` RPC, submitting the full wire
+        transaction so wallet policies with transaction conditions apply.
+        Policies must allow the ``signTransaction`` method."""
+        public_key = self._initialized_pubkey()
+        request = {
+            "method": "signTransaction",
+            "chain_type": "solana",
+            "params": {
+                "transaction": base64.b64encode(bytes(transaction)).decode("ascii"),
+                "encoding": "base64",
+            },
+        }
+        response = await self._post_rpc(request)
+
+        data = response.get("data") if isinstance(response, dict) else None
+        signed_b64 = data.get("signed_transaction") if isinstance(data, dict) else None
+        if not isinstance(signed_b64, str):
+            raise SignerError(
+                SignerErrorCode.REMOTE_API_ERROR, "No signed_transaction in Privy response"
+            )
+        try:
+            signed = Transaction.from_bytes(base64.b64decode(signed_b64, validate=True))
+        except Exception:
+            raise SignerError(
+                SignerErrorCode.SERIALIZATION_ERROR,
+                "Failed to decode signed transaction returned by Privy",
+            ) from None
+
+        position = get_signing_keypair_position(signed, public_key)
+        signatures = signed.signatures
+        if position >= len(signatures):
+            raise SignerError(
+                SignerErrorCode.SIGNING_FAILED,
+                "Privy signature slot missing from returned transaction",
+            )
+        signature = signatures[position]
+        if not signature.verify(public_key, transaction.message_data()):
+            raise SignerError(
+                SignerErrorCode.SIGNING_FAILED,
+                "Signature verification failed — the returned signature does not match "
+                "the public key",
+            )
+        add_signature_to_transaction(transaction, public_key, signature)
         return classify_signed_transaction(
             transaction, serialize_transaction(transaction), signature
         )

--- a/python/tests/test_privy_signer.py
+++ b/python/tests/test_privy_signer.py
@@ -9,6 +9,7 @@ from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives.serialization import load_pem_private_key
 from solders.keypair import Keypair
+from solders.transaction import Transaction
 
 from solana_keychain import SignerError, SignerErrorCode
 from solana_keychain.privy import (
@@ -65,6 +66,27 @@ def mock_wallet_response(address: str, chain_type: str = "solana") -> None:
             200, json={"id": WALLET_ID, "address": address, "chain_type": chain_type}
         )
     )
+
+
+def mock_sign_transaction_response(signed_transaction_b64: str) -> None:
+    respx.post(RPC_URL).mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "method": "signTransaction",
+                "data": {"signed_transaction": signed_transaction_b64, "encoding": "base64"},
+            },
+        )
+    )
+
+
+def signed_transaction_b64(keypair: Keypair, transaction: Any) -> str:
+    signed = Transaction(
+        from_keypairs=[keypair],
+        message=transaction.message,
+        recent_blockhash=transaction.message.recent_blockhash,
+    )
+    return base64.b64encode(bytes(signed)).decode("ascii")
 
 
 def mock_sign_response(signature_b64: str) -> None:
@@ -335,13 +357,57 @@ async def test_sign_transaction_success() -> None:
     signer = await initialized_signer(keypair)
     transaction = create_test_transaction(keypair.pubkey())
     signature = keypair.sign_message(transaction.message_data())
-    mock_sign_response(base64.b64encode(bytes(signature)).decode())
+    unsigned_b64 = base64.b64encode(bytes(transaction)).decode("ascii")
+    mock_sign_transaction_response(signed_transaction_b64(keypair, transaction))
 
     result = await signer.sign_transaction(transaction)
 
     assert result.is_complete
     assert result.signature == signature
     assert list(transaction.signatures) == [signature]
+
+    parsed: dict[str, Any] = json.loads(respx.calls.last.request.content)
+    assert parsed["method"] == "signTransaction"
+    assert parsed["params"] == {"transaction": unsigned_b64, "encoding": "base64"}
+
+
+@respx.mock
+async def test_sign_transaction_rejects_signature_over_different_bytes() -> None:
+    keypair = Keypair()
+    signer = await initialized_signer(keypair)
+    transaction = create_test_transaction(keypair.pubkey())
+    other_transaction = create_test_transaction(keypair.pubkey())
+    mock_sign_transaction_response(signed_transaction_b64(keypair, other_transaction))
+
+    with pytest.raises(SignerError) as excinfo:
+        await signer.sign_transaction(transaction)
+    assert excinfo.value.code == SignerErrorCode.SIGNING_FAILED
+
+
+@respx.mock
+async def test_sign_transaction_rejects_undecodable_signed_transaction() -> None:
+    keypair = Keypair()
+    signer = await initialized_signer(keypair)
+    transaction = create_test_transaction(keypair.pubkey())
+    mock_sign_transaction_response("not-base64!!!")
+
+    with pytest.raises(SignerError) as excinfo:
+        await signer.sign_transaction(transaction)
+    assert excinfo.value.code == SignerErrorCode.SERIALIZATION_ERROR
+
+
+@respx.mock
+async def test_sign_transaction_rejects_missing_signed_transaction() -> None:
+    keypair = Keypair()
+    signer = await initialized_signer(keypair)
+    transaction = create_test_transaction(keypair.pubkey())
+    respx.post(RPC_URL).mock(
+        return_value=httpx.Response(200, json={"method": "signTransaction", "data": {}})
+    )
+
+    with pytest.raises(SignerError) as excinfo:
+        await signer.sign_transaction(transaction)
+    assert excinfo.value.code == SignerErrorCode.REMOTE_API_ERROR
 
 
 @respx.mock

--- a/rust/src/privy/mod.rs
+++ b/rust/src/privy/mod.rs
@@ -16,7 +16,10 @@ pub use authorization::{
 };
 use base64::{engine::general_purpose::STANDARD, Engine};
 use std::str::FromStr;
-use types::{SignMessageParams, SignMessageRequest, SignMessageResponse, WalletResponse};
+use types::{
+    SignMessageParams, SignMessageRequest, SignMessageResponse, SignTransactionParams,
+    SignTransactionRequest, SignTransactionResponse, WalletResponse,
+};
 
 /// Privy-based signer using Privy's wallet API
 #[derive(Clone)]
@@ -183,27 +186,17 @@ impl PrivySigner {
         })
     }
 
-    /// Sign message bytes using Privy API
-    async fn sign_bytes(&self, serialized: &[u8]) -> Result<Signature, SignerError> {
-        let public_key = self.initialized_pubkey()?;
-
+    /// POST a wallet RPC request with Privy auth and authorization-signature
+    /// headers, returning the response body on 2xx.
+    async fn post_rpc<T: serde::Serialize>(&self, request: &T) -> Result<String, SignerError> {
         let url = format!("{}/wallets/{}/rpc", self.api_base_url, self.wallet_id);
-
-        let request = SignMessageRequest {
-            method: "signMessage",
-            chain_type: "solana",
-            params: SignMessageParams {
-                message: STANDARD.encode(serialized),
-                encoding: "base64",
-            },
-        };
 
         let authorization_headers = prepare_privy_authorization_headers(
             &self.app_id,
             self.authorization_context.as_ref(),
             "POST",
             &url,
-            &request,
+            request,
             self.authorization_request_expiry_ms,
         )?;
 
@@ -221,7 +214,7 @@ impl PrivySigner {
             request_builder = request_builder.header("privy-request-expiry", request_expiry);
         }
 
-        let response = request_builder.json(&request).send().await?;
+        let response = request_builder.json(request).send().await?;
 
         if !response.status().is_success() {
             let status = response.status().as_u16();
@@ -231,15 +224,31 @@ impl PrivySigner {
                 .unwrap_or_else(|_| "Failed to read error response".to_string());
 
             #[cfg(feature = "unsafe-debug")]
-            log::error!("Privy API sign_message error - status: {status}, response: {_error_text}");
+            log::error!("Privy API rpc error - status: {status}, response: {_error_text}");
 
             #[cfg(not(feature = "unsafe-debug"))]
-            log::error!("Privy API sign_message error - status: {status}");
+            log::error!("Privy API rpc error - status: {status}");
 
             return Err(SignerError::RemoteApiError(format!("API error {status}")));
         }
 
-        let response_text = response.text().await?;
+        Ok(response.text().await?)
+    }
+
+    /// Sign message bytes using Privy API
+    async fn sign_bytes(&self, serialized: &[u8]) -> Result<Signature, SignerError> {
+        let public_key = self.initialized_pubkey()?;
+
+        let request = SignMessageRequest {
+            method: "signMessage",
+            chain_type: "solana",
+            params: SignMessageParams {
+                message: STANDARD.encode(serialized),
+                encoding: "base64",
+            },
+        };
+
+        let response_text = self.post_rpc(&request).await?;
         let sign_response: SignMessageResponse = serde_json::from_str(&response_text)?;
 
         let decoded_response = STANDARD
@@ -264,12 +273,55 @@ impl PrivySigner {
         Ok(sig)
     }
 
+    /// Sign via Privy's `signTransaction` RPC, submitting the full wire
+    /// transaction so wallet policies with transaction conditions apply.
+    /// Policies must allow the `signTransaction` method.
     async fn sign_and_serialize(
         &self,
         transaction: &mut Transaction,
     ) -> Result<SignedTransaction, SignerError> {
         let public_key = self.initialized_pubkey()?;
-        let signature = self.sign_bytes(&transaction.message_data()).await?;
+
+        let unsigned_wire = bincode::serialize(transaction).map_err(|e| {
+            SignerError::SerializationError(format!("Failed to serialize transaction: {e}"))
+        })?;
+        let request = SignTransactionRequest {
+            method: "signTransaction",
+            chain_type: "solana",
+            params: SignTransactionParams {
+                transaction: STANDARD.encode(&unsigned_wire),
+                encoding: "base64",
+            },
+        };
+
+        let response_text = self.post_rpc(&request).await?;
+        let sign_response: SignTransactionResponse = serde_json::from_str(&response_text)?;
+
+        let signed_wire = STANDARD
+            .decode(&sign_response.data.signed_transaction)
+            .map_err(|_| {
+                SignerError::SerializationError(
+                    "Failed to decode signed transaction returned by Privy".to_string(),
+                )
+            })?;
+        let returned: Transaction = bincode::deserialize(&signed_wire).map_err(|e| {
+            SignerError::SerializationError(format!(
+                "Failed to deserialize signed transaction returned by Privy: {e}"
+            ))
+        })?;
+
+        let position = TransactionUtil::get_signing_keypair_position(&returned, &public_key)?;
+        let signature = returned.signatures.get(position).copied().ok_or_else(|| {
+            SignerError::SigningFailed(
+                "Privy signature slot missing from returned transaction".to_string(),
+            )
+        })?;
+
+        if !signature.verify(&public_key.to_bytes(), &transaction.message_data()) {
+            return Err(SignerError::SigningFailed(
+                "Signature verification failed — the returned signature does not match the public key".to_string(),
+            ));
+        }
 
         TransactionUtil::add_signature_to_transaction(transaction, &public_key, signature)?;
 
@@ -575,9 +627,9 @@ mod tests {
         Mock::given(method("POST"))
             .and(path("/wallets/test-wallet-id/rpc"))
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-                "method": "signMessage",
+                "method": "signTransaction",
                 "data": {
-                    "signature": STANDARD.encode(signature),
+                    "signed_transaction": STANDARD.encode(bincode::serialize(&signed_tx).unwrap()),
                     "encoding": "base64"
                 }
             })))
@@ -603,6 +655,50 @@ mod tests {
 
         // Verify the transaction is properly serialized
         assert!(!serialized_tx.is_empty());
+        assert_eq!(tx.signatures, vec![signature]);
+    }
+
+    #[tokio::test]
+    async fn test_privy_sign_transaction_rejects_signature_over_different_bytes() {
+        let mock_server = MockServer::start().await;
+        let keypair = create_test_keypair();
+
+        let mut tx = create_test_transaction(&keypair_pubkey(&keypair));
+        let mut other_tx = create_test_transaction(&keypair_pubkey(&keypair));
+        other_tx.signatures = vec![keypair.sign_message(&other_tx.message_data())];
+
+        Mock::given(method("POST"))
+            .and(path("/wallets/test-wallet-id/rpc"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "method": "signTransaction",
+                "data": {
+                    "signed_transaction": STANDARD.encode(bincode::serialize(&other_tx).unwrap()),
+                    "encoding": "base64"
+                }
+            })))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let mut signer = PrivySigner::new(
+            "test-app-id".to_string(),
+            "test-app-secret".to_string(),
+            "test-wallet-id".to_string(),
+        );
+        signer.client = reqwest::Client::new();
+        signer.api_base_url = mock_server.uri();
+        signer.public_key = Some(keypair.pubkey());
+
+        let result = signer.sign_transaction(&mut tx).await;
+        match result.unwrap_err() {
+            SignerError::SigningFailed(message) => {
+                assert!(
+                    message.contains("verification failed"),
+                    "expected a verification failure, got: {message}"
+                );
+            }
+            other => panic!("Expected SigningFailed, got: {other:?}"),
+        }
     }
 
     #[tokio::test]

--- a/rust/src/privy/types.rs
+++ b/rust/src/privy/types.rs
@@ -30,6 +30,33 @@ pub struct SignMessageData {
     pub encoding: String,
 }
 
+#[derive(Serialize)]
+pub struct SignTransactionRequest {
+    pub method: &'static str,
+    pub chain_type: &'static str,
+    pub params: SignTransactionParams,
+}
+
+#[derive(Serialize)]
+pub struct SignTransactionParams {
+    pub transaction: String,
+    pub encoding: &'static str,
+}
+
+#[derive(Deserialize)]
+#[allow(dead_code)]
+pub struct SignTransactionResponse {
+    pub method: String,
+    pub data: SignTransactionData,
+}
+
+#[derive(Deserialize)]
+#[allow(dead_code)]
+pub struct SignTransactionData {
+    pub signed_transaction: String,
+    pub encoding: String,
+}
+
 // Wallet info response
 #[derive(Deserialize)]
 #[allow(dead_code)]


### PR DESCRIPTION
Same defect class as #250, Privy edition.

## Problem

For `sign_transaction`, Python, Rust, and Go sent the transaction's message bytes as a `signMessage` RPC and spliced the returned signature locally. Privy's [policy engine](https://docs.privy.io/controls/policies/overview) evaluates the rules associated with the requested RPC method: transaction-level conditions (program id, recipient, amount) attach to `signTransaction`, while a `signMessage` rule can only condition on message content and byte length. So every transaction-content policy a wallet configures was **not evaluated** in three of our four languages - the TypeScript signer has always sent `signTransaction` and had them enforced. The `privy-authorization-signature` quorum also approved a `signMessage` body rather than the intended transaction method.

No forgery and no key compromise; all languages verify the returned signature locally. The bypassed layer is the wallet's Privy-side policy - and the parity trap: policies validated against the TS signer silently did not apply to Rust/Python/Go.

Nuance worth stating: Privy is default-deny per RPC method, so `signMessage` was not an unguarded hole - a policy-enabled wallet had to explicitly allow it. The defect is that our three implementations forced users into message-only policies that cannot express transaction conditions at all.

## Fix

Python/Rust/Go transaction signing now mirrors TypeScript:
- POST `{"method":"signTransaction","chain_type":"solana","params":{"transaction":"<base64 wire tx>","encoding":"base64"}}` to the wallet RPC.
- Parse `data.signed_transaction`, extract this signer's signature by its required-signer position, verify it against the **caller's original message bytes** (catches any provider-side rewrite loudly), and insert it into the caller's transaction - other signers' partial signatures untouched.
- Authorization headers are computed over the exact new body (the existing header code signs whatever body it is given).
- `sign_message` stays on `signMessage`. Deliberately **no** `signMessage` fallback on failure - that would reintroduce the policy downgrade silently.
- Shared RPC-post helper per language (`_post_rpc`/`post_rpc`/`postRPC`) so both methods build headers identically.

## BREAKING (behavioral)

Privy policies are default-deny per method. A policy-enabled wallet whose policy allows only `signMessage` will see transaction signing denied after upgrading, until it also allows `signTransaction`. Undetectable client-side in advance. Wallets without policies and apps already on the TS signer are unaffected. Needs a loud changelog entry at release.

## Testing

- Per language: success round-trip asserting the exact request body (method, base64 wire transaction); rejection of a signature over different bytes; missing/undecodable `signed_transaction`.
- Rust 21 privy tests x sdk-v2/v3/v4, clippy `-D warnings` on `all`; Python 456 + ruff + mypy strict; Go `-race` + vet + golangci-lint.
- Privy live integration suites (CI creds) exercise the new RPC against the real API in all three languages.
