### PR TITLE
fix(fireblocks): select the vault address by asset instead of taking the first

### DIFF
--- a/go/signers/fireblocks/client.go
+++ b/go/signers/fireblocks/client.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -84,6 +85,7 @@ type vaultAddressesResponse struct {
 
 type vaultAddress struct {
 	Address string `json:"address"`
+	AssetID string `json:"assetId"`
 }
 
 // doRequest sends an authenticated request to the Fireblocks API and returns the
@@ -142,14 +144,44 @@ func (s *Signer) fetchPublicKey(ctx context.Context) (solana.PublicKey, error) {
 	if err := json.Unmarshal(body, &addresses); err != nil {
 		return solana.PublicKey{}, core.WrapSignerError(core.CodeSerializationError, "failed to parse Fireblocks response", err)
 	}
-	if len(addresses.Addresses) == 0 {
-		return solana.PublicKey{}, core.NewSignerError(core.CodeInvalidPublicKey, "invalid public key from Fireblocks")
+	address, err := s.selectVaultAddress(addresses.Addresses)
+	if err != nil {
+		return solana.PublicKey{}, err
 	}
-	pubkey, err := solana.PublicKeyFromBase58(addresses.Addresses[0].Address)
+	pubkey, err := solana.PublicKeyFromBase58(address)
 	if err != nil {
 		return solana.PublicKey{}, core.WrapSignerError(core.CodeInvalidPublicKey, "invalid public key from Fireblocks", err)
 	}
 	return pubkey, nil
+}
+
+// selectVaultAddress picks the address for the configured asset, failing on an
+// empty or ambiguous response: a mistyped vault account or asset id must not
+// yield a working signer bound to an unintended fee payer. Entries without an
+// assetId are kept, since the endpoint is already scoped by asset.
+func (s *Signer) selectVaultAddress(addresses []vaultAddress) (string, error) {
+	unique := make([]string, 0, len(addresses))
+	seen := make(map[string]bool, len(addresses))
+	for _, entry := range addresses {
+		if entry.Address == "" || (entry.AssetID != "" && entry.AssetID != s.assetID) {
+			continue
+		}
+		if !seen[entry.Address] {
+			seen[entry.Address] = true
+			unique = append(unique, entry.Address)
+		}
+	}
+	switch len(unique) {
+	case 1:
+		return unique[0], nil
+	case 0:
+		return "", core.NewSignerError(core.CodeInvalidPublicKey,
+			"Fireblocks returned no address for vault account "+s.vaultAccountID+" asset "+s.assetID)
+	default:
+		return "", core.NewSignerError(core.CodeInvalidPublicKey,
+			"Fireblocks returned "+strconv.Itoa(len(unique))+" addresses for vault account "+
+				s.vaultAccountID+" asset "+s.assetID+"; cannot choose a signing identity")
+	}
 }
 
 // createTransaction creates a signing request in Fireblocks.

--- a/go/signers/fireblocks/signer_test.go
+++ b/go/signers/fireblocks/signer_test.go
@@ -95,6 +95,81 @@ func TestNewDefaultsAndFetchesPubkey(t *testing.T) {
 
 // The unsupported PROGRAM_CALL mode fails New with a config error and, failing
 // closed, no request may reach Fireblocks before the rejection.
+// newSignerWithAddresses serves the given addresses_paginated entries.
+func newSignerWithAddresses(t *testing.T, entries []map[string]string) (*Signer, error) {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc(addressesPath, func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, map[string]any{"addresses": entries})
+	})
+	srv := httptest.NewTLSServer(mux)
+	t.Cleanup(srv.Close)
+
+	return New(context.Background(), Config{
+		APIKey:          testAPIKey,
+		PrivateKeyPEM:   testRSAKey,
+		VaultAccountID:  testVaultID,
+		APIBaseURL:      srv.URL,
+		PollInterval:    time.Millisecond,
+		MaxPollAttempts: 3,
+		HTTPClient:      srv.Client(),
+	})
+}
+
+func TestNewSelectsAddressForConfiguredAsset(t *testing.T) {
+	want := testutils.TestPublicKey().String()
+	s, err := newSignerWithAddresses(t, []map[string]string{
+		{"address": "6dNUL7bY6oNCM4vXfB6HrCa3Wa2QhTVowsPYqzTGMTfd", "assetId": "SOL_TEST"},
+		{"address": want, "assetId": "SOL"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := s.Pubkey().String(); got != want {
+		t.Errorf("pubkey = %s, want the SOL address %s", got, want)
+	}
+}
+
+func TestNewRejectsAmbiguousAddresses(t *testing.T) {
+	_, err := newSignerWithAddresses(t, []map[string]string{
+		{"address": testutils.TestPublicKey().String(), "assetId": "SOL"},
+		{"address": "6dNUL7bY6oNCM4vXfB6HrCa3Wa2QhTVowsPYqzTGMTfd", "assetId": "SOL"},
+	})
+	if err == nil {
+		t.Fatal("expected two addresses for the configured asset to be rejected")
+	}
+	if code, _ := core.CodeOf(err); code != core.CodeInvalidPublicKey {
+		t.Errorf("got %s, want INVALID_PUBLIC_KEY", code)
+	}
+}
+
+func TestNewRejectsNoAddressForConfiguredAsset(t *testing.T) {
+	_, err := newSignerWithAddresses(t, []map[string]string{
+		{"address": testutils.TestPublicKey().String(), "assetId": "SOL_TEST"},
+	})
+	if err == nil {
+		t.Fatal("expected an asset-id mismatch to be rejected")
+	}
+	if code, _ := core.CodeOf(err); code != core.CodeInvalidPublicKey {
+		t.Errorf("got %s, want INVALID_PUBLIC_KEY", code)
+	}
+}
+
+// Duplicate entries for the same address are not ambiguous.
+func TestNewAcceptsDuplicateAddressEntries(t *testing.T) {
+	want := testutils.TestPublicKey().String()
+	s, err := newSignerWithAddresses(t, []map[string]string{
+		{"address": want, "assetId": "SOL"},
+		{"address": want, "assetId": "SOL"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := s.Pubkey().String(); got != want {
+		t.Errorf("pubkey = %s, want %s", got, want)
+	}
+}
+
 func TestNewRejectsProgramCallBeforeAnyNetworkCall(t *testing.T) {
 	var requests atomic.Int64
 	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/go/signers/fireblocks/signer_test.go
+++ b/go/signers/fireblocks/signer_test.go
@@ -98,8 +98,15 @@ func TestNewDefaultsAndFetchesPubkey(t *testing.T) {
 // newSignerWithAddresses serves the given addresses_paginated entries.
 func newSignerWithAddresses(t *testing.T, entries []map[string]string) (*Signer, error) {
 	t.Helper()
+	return newSignerWithAssetAddresses(t, "", addressesPath, entries)
+}
+
+// newSignerWithAssetAddresses serves entries at path for the given configured
+// asset id ("" means the default).
+func newSignerWithAssetAddresses(t *testing.T, assetID, path string, entries []map[string]string) (*Signer, error) {
+	t.Helper()
 	mux := http.NewServeMux()
-	mux.HandleFunc(addressesPath, func(w http.ResponseWriter, _ *http.Request) {
+	mux.HandleFunc(path, func(w http.ResponseWriter, _ *http.Request) {
 		writeJSON(w, map[string]any{"addresses": entries})
 	})
 	srv := httptest.NewTLSServer(mux)
@@ -109,6 +116,7 @@ func newSignerWithAddresses(t *testing.T, entries []map[string]string) (*Signer,
 		APIKey:          testAPIKey,
 		PrivateKeyPEM:   testRSAKey,
 		VaultAccountID:  testVaultID,
+		AssetID:         assetID,
 		APIBaseURL:      srv.URL,
 		PollInterval:    time.Millisecond,
 		MaxPollAttempts: 3,
@@ -127,6 +135,22 @@ func TestNewSelectsAddressForConfiguredAsset(t *testing.T) {
 	}
 	if got := s.Pubkey().String(); got != want {
 		t.Errorf("pubkey = %s, want the SOL address %s", got, want)
+	}
+}
+
+func TestNewSelectsAddressForCustomAssetID(t *testing.T) {
+	want := testutils.TestPublicKey().String()
+	s, err := newSignerWithAssetAddresses(t, "SOL_TEST",
+		"/v1/vault/accounts/"+testVaultID+"/SOL_TEST/addresses_paginated",
+		[]map[string]string{
+			{"address": "6dNUL7bY6oNCM4vXfB6HrCa3Wa2QhTVowsPYqzTGMTfd", "assetId": "SOL"},
+			{"address": want, "assetId": "SOL_TEST"},
+		})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := s.Pubkey().String(); got != want {
+		t.Errorf("pubkey = %s, want the SOL_TEST address %s", got, want)
 	}
 }
 

--- a/python/src/solana_keychain/fireblocks/signer.py
+++ b/python/src/solana_keychain/fireblocks/signer.py
@@ -137,18 +137,45 @@ class FireblocksSigner(SolanaSigner):
         )
         response = await self._get_json(uri)
         addresses = response.get("addresses") if isinstance(response, dict) else None
-        first = addresses[0] if isinstance(addresses, list) and addresses else None
-        address = first.get("address") if isinstance(first, dict) else None
-        if not isinstance(address, str):
-            raise SignerError(
-                SignerErrorCode.INVALID_PUBLIC_KEY, "Invalid public key from Fireblocks"
-            )
+        address = self._select_vault_address(addresses if isinstance(addresses, list) else [])
         try:
             return Pubkey.from_string(address)
         except Exception:
             raise SignerError(
                 SignerErrorCode.INVALID_PUBLIC_KEY, "Invalid public key from Fireblocks"
             ) from None
+
+    def _select_vault_address(self, addresses: list[Any]) -> str:
+        """Pick the address for the configured asset, failing on an empty or
+        ambiguous response: a mistyped vault account or asset id must not yield a
+        working signer bound to an unintended fee payer. Entries without an
+        ``assetId`` are kept, since the endpoint is already scoped by asset.
+        """
+        unique: list[str] = []
+        for entry in addresses:
+            if not isinstance(entry, dict):
+                continue
+            address = entry.get("address")
+            asset_id = entry.get("assetId")
+            if not isinstance(address, str) or not address:
+                continue
+            if isinstance(asset_id, str) and asset_id and asset_id != self._asset_id:
+                continue
+            if address not in unique:
+                unique.append(address)
+        if len(unique) == 1:
+            return unique[0]
+        if not unique:
+            raise SignerError(
+                SignerErrorCode.INVALID_PUBLIC_KEY,
+                f"Fireblocks returned no address for vault account "
+                f"{self._vault_account_id} asset {self._asset_id}",
+            )
+        raise SignerError(
+            SignerErrorCode.INVALID_PUBLIC_KEY,
+            f"Fireblocks returned {len(unique)} addresses for vault account "
+            f"{self._vault_account_id} asset {self._asset_id}; cannot choose a signing identity",
+        )
 
     async def _create_transaction(self, message: bytes) -> str:
         uri = "/v1/transactions"

--- a/python/tests/test_fireblocks_signer.py
+++ b/python/tests/test_fireblocks_signer.py
@@ -145,6 +145,77 @@ async def test_init_rejects_empty_addresses() -> None:
 
 
 @respx.mock
+async def test_init_selects_address_for_configured_asset() -> None:
+    wanted = str(Keypair().pubkey())
+    respx.get(ADDRESSES_URL).mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "addresses": [
+                    {"address": str(Keypair().pubkey()), "assetId": "SOL_TEST"},
+                    {"address": wanted, "assetId": "SOL"},
+                ]
+            },
+        )
+    )
+    signer = make_signer()
+    await signer.init()
+    assert str(signer.pubkey) == wanted
+
+
+@respx.mock
+async def test_init_rejects_ambiguous_addresses() -> None:
+    respx.get(ADDRESSES_URL).mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "addresses": [
+                    {"address": str(Keypair().pubkey()), "assetId": "SOL"},
+                    {"address": str(Keypair().pubkey()), "assetId": "SOL"},
+                ]
+            },
+        )
+    )
+    signer = make_signer()
+    with pytest.raises(SignerError) as excinfo:
+        await signer.init()
+    assert excinfo.value.code == SignerErrorCode.INVALID_PUBLIC_KEY
+
+
+@respx.mock
+async def test_init_rejects_no_address_for_configured_asset() -> None:
+    respx.get(ADDRESSES_URL).mock(
+        return_value=httpx.Response(
+            200,
+            json={"addresses": [{"address": str(Keypair().pubkey()), "assetId": "SOL_TEST"}]},
+        )
+    )
+    signer = make_signer()
+    with pytest.raises(SignerError) as excinfo:
+        await signer.init()
+    assert excinfo.value.code == SignerErrorCode.INVALID_PUBLIC_KEY
+
+
+@respx.mock
+async def test_init_accepts_duplicate_address_entries() -> None:
+    wanted = str(Keypair().pubkey())
+    respx.get(ADDRESSES_URL).mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "addresses": [
+                    {"address": wanted, "assetId": "SOL"},
+                    {"address": wanted, "assetId": "SOL"},
+                ]
+            },
+        )
+    )
+    signer = make_signer()
+    await signer.init()
+    assert str(signer.pubkey) == wanted
+
+
+@respx.mock
 async def test_init_rejects_invalid_address() -> None:
     mock_addresses_response("not-a-pubkey")
     signer = make_signer()

--- a/python/tests/test_fireblocks_signer.py
+++ b/python/tests/test_fireblocks_signer.py
@@ -164,6 +164,27 @@ async def test_init_selects_address_for_configured_asset() -> None:
 
 
 @respx.mock
+async def test_init_selects_address_for_custom_asset_id() -> None:
+    devnet = str(Keypair().pubkey())
+    respx.get(
+        f"{API_BASE_URL}/v1/vault/accounts/{VAULT_ACCOUNT_ID}/SOL_TEST/addresses_paginated"
+    ).mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "addresses": [
+                    {"address": str(Keypair().pubkey()), "assetId": "SOL"},
+                    {"address": devnet, "assetId": "SOL_TEST"},
+                ]
+            },
+        )
+    )
+    signer = make_signer(asset_id="SOL_TEST")
+    await signer.init()
+    assert str(signer.pubkey) == devnet
+
+
+@respx.mock
 async def test_init_rejects_ambiguous_addresses() -> None:
     respx.get(ADDRESSES_URL).mock(
         return_value=httpx.Response(

--- a/rust/src/fireblocks/mod.rs
+++ b/rust/src/fireblocks/mod.rs
@@ -631,11 +631,21 @@ p6B5CCtpBPgD01Vm+bT/JQ==
         mock_server: &MockServer,
         entries: serde_json::Value,
     ) -> Result<FireblocksSigner, SignerError> {
+        init_with_asset_addresses(mock_server, "SOL", entries).await
+    }
+
+    /// Serve `entries` for a signer configured with `asset_id` and run `init()`.
+    async fn init_with_asset_addresses(
+        mock_server: &MockServer,
+        asset_id: &str,
+        entries: serde_json::Value,
+    ) -> Result<FireblocksSigner, SignerError> {
         let mut signer = create_test_signer_uninit(&mock_server.uri());
+        signer.asset_id = asset_id.to_string();
         Mock::given(method("GET"))
-            .and(path(
-                "/v1/vault/accounts/test-vault-id/SOL/addresses_paginated",
-            ))
+            .and(path(format!(
+                "/v1/vault/accounts/test-vault-id/{asset_id}/addresses_paginated"
+            )))
             .respond_with(
                 ResponseTemplate::new(200)
                     .set_body_json(serde_json::json!({ "addresses": entries })),
@@ -659,6 +669,22 @@ p6B5CCtpBPgD01Vm+bT/JQ==
         )
         .await
         .expect("init should select the SOL address");
+        assert_eq!(signer.pubkey().to_string(), TEST_PUBKEY);
+    }
+
+    #[tokio::test]
+    async fn test_init_selects_address_for_custom_asset_id() {
+        let mock_server = MockServer::start().await;
+        let signer = init_with_asset_addresses(
+            &mock_server,
+            "SOL_TEST",
+            serde_json::json!([
+                { "address": OTHER_TEST_PUBKEY, "assetId": "SOL" },
+                { "address": TEST_PUBKEY, "assetId": "SOL_TEST" },
+            ]),
+        )
+        .await
+        .expect("init should select the configured asset's address");
         assert_eq!(signer.pubkey().to_string(), TEST_PUBKEY);
     }
 

--- a/rust/src/fireblocks/mod.rs
+++ b/rust/src/fireblocks/mod.rs
@@ -13,7 +13,7 @@ use crate::{
 use std::{str::FromStr, sync::Arc};
 use types::{
     CreateTransactionRequest, CreateTransactionResponse, RawExtraParameters, RawMessage,
-    RawMessageData, TransactionResponse, TransactionSource, VaultAddressesResponse,
+    RawMessageData, TransactionResponse, TransactionSource, VaultAddress, VaultAddressesResponse,
 };
 
 use crate::signature_util::EXPECTED_SIGNATURE_LENGTH;
@@ -186,13 +186,45 @@ impl FireblocksSigner {
                 SignerError::SerializationError("Failed to parse Fireblocks response".to_string())
             })?;
 
-        let address = addresses_response.addresses.first().ok_or_else(|| {
-            SignerError::InvalidPublicKey("Invalid public key from Fireblocks".to_string())
-        })?;
+        let address = self.select_vault_address(&addresses_response.addresses)?;
 
-        Pubkey::from_str(&address.address).map_err(|_| {
+        Pubkey::from_str(&address).map_err(|_| {
             SignerError::InvalidPublicKey("Invalid public key from Fireblocks".to_string())
         })
+    }
+
+    /// Pick the address for the configured asset, failing on an empty or
+    /// ambiguous response: a mistyped vault account or asset id must not yield a
+    /// working signer bound to an unintended fee payer. Entries without an
+    /// `assetId` are kept, since the endpoint is already scoped by asset.
+    fn select_vault_address(&self, addresses: &[VaultAddress]) -> Result<String, SignerError> {
+        let mut unique: Vec<&str> = Vec::with_capacity(addresses.len());
+        for entry in addresses {
+            if entry.address.is_empty() {
+                continue;
+            }
+            if let Some(asset_id) = entry.asset_id.as_deref() {
+                if !asset_id.is_empty() && asset_id != self.asset_id {
+                    continue;
+                }
+            }
+            if !unique.contains(&entry.address.as_str()) {
+                unique.push(&entry.address);
+            }
+        }
+        match unique.as_slice() {
+            [address] => Ok((*address).to_string()),
+            [] => Err(SignerError::InvalidPublicKey(format!(
+                "Fireblocks returned no address for vault account {} asset {}",
+                self.vault_account_id, self.asset_id
+            ))),
+            _ => Err(SignerError::InvalidPublicKey(format!(
+                "Fireblocks returned {} addresses for vault account {} asset {}; cannot choose a signing identity",
+                unique.len(),
+                self.vault_account_id,
+                self.asset_id
+            ))),
+        }
     }
 
     /// Sign raw bytes using RAW operation
@@ -504,6 +536,7 @@ p6B5CCtpBPgD01Vm+bT/JQ==
 -----END PRIVATE KEY-----"#;
 
     const TEST_PUBKEY: &str = "7EcDhSYGxXyscszYEp35KHN8vvw3svAuLKTzXwCFLtV";
+    const OTHER_TEST_PUBKEY: &str = "6dNUL7bY6oNCM4vXfB6HrCa3Wa2QhTVowsPYqzTGMTfd";
 
     fn test_signing_key() -> Arc<jsonwebtoken::EncodingKey> {
         Arc::new(jwt::parse_encoding_key(TEST_RSA_KEY).expect("failed to parse test RSA key"))
@@ -590,6 +623,89 @@ p6B5CCtpBPgD01Vm+bT/JQ==
 
         let result = signer.init().await;
         assert!(result.is_ok());
+        assert_eq!(signer.pubkey().to_string(), TEST_PUBKEY);
+    }
+
+    /// Serve `entries` from addresses_paginated and run `init()`.
+    async fn init_with_addresses(
+        mock_server: &MockServer,
+        entries: serde_json::Value,
+    ) -> Result<FireblocksSigner, SignerError> {
+        let mut signer = create_test_signer_uninit(&mock_server.uri());
+        Mock::given(method("GET"))
+            .and(path(
+                "/v1/vault/accounts/test-vault-id/SOL/addresses_paginated",
+            ))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({ "addresses": entries })),
+            )
+            .expect(1)
+            .mount(mock_server)
+            .await;
+        signer.init().await?;
+        Ok(signer)
+    }
+
+    #[tokio::test]
+    async fn test_init_selects_address_for_configured_asset() {
+        let mock_server = MockServer::start().await;
+        let signer = init_with_addresses(
+            &mock_server,
+            serde_json::json!([
+                { "address": OTHER_TEST_PUBKEY, "assetId": "SOL_TEST" },
+                { "address": TEST_PUBKEY, "assetId": "SOL" },
+            ]),
+        )
+        .await
+        .expect("init should select the SOL address");
+        assert_eq!(signer.pubkey().to_string(), TEST_PUBKEY);
+    }
+
+    #[tokio::test]
+    async fn test_init_rejects_ambiguous_addresses() {
+        let mock_server = MockServer::start().await;
+        let result = init_with_addresses(
+            &mock_server,
+            serde_json::json!([
+                { "address": TEST_PUBKEY, "assetId": "SOL" },
+                { "address": OTHER_TEST_PUBKEY, "assetId": "SOL" },
+            ]),
+        )
+        .await;
+        assert!(matches!(
+            result.unwrap_err(),
+            SignerError::InvalidPublicKey(_)
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_init_rejects_no_address_for_configured_asset() {
+        let mock_server = MockServer::start().await;
+        let result = init_with_addresses(
+            &mock_server,
+            serde_json::json!([{ "address": TEST_PUBKEY, "assetId": "SOL_TEST" }]),
+        )
+        .await;
+        assert!(matches!(
+            result.unwrap_err(),
+            SignerError::InvalidPublicKey(_)
+        ));
+    }
+
+    /// Duplicate entries for the same address are not ambiguous.
+    #[tokio::test]
+    async fn test_init_accepts_duplicate_address_entries() {
+        let mock_server = MockServer::start().await;
+        let signer = init_with_addresses(
+            &mock_server,
+            serde_json::json!([
+                { "address": TEST_PUBKEY, "assetId": "SOL" },
+                { "address": TEST_PUBKEY, "assetId": "SOL" },
+            ]),
+        )
+        .await
+        .expect("duplicate entries for one address must be accepted");
         assert_eq!(signer.pubkey().to_string(), TEST_PUBKEY);
     }
 

--- a/rust/src/fireblocks/types.rs
+++ b/rust/src/fireblocks/types.rs
@@ -87,4 +87,5 @@ pub struct VaultAddressesResponse {
 #[serde(rename_all = "camelCase")]
 pub struct VaultAddress {
     pub address: String,
+    pub asset_id: Option<String>,
 }

--- a/typescript/packages/fireblocks/src/__tests__/fireblocks-signer.test.ts
+++ b/typescript/packages/fireblocks/src/__tests__/fireblocks-signer.test.ts
@@ -353,6 +353,30 @@ describe('FireblocksSigner', () => {
             expect(signer.address).toBe(wanted.address);
         });
 
+        it('selects the address for a custom assetId, not the default', async () => {
+            const devnet = await generateKeyPairSigner();
+            const mainnet = await generateKeyPairSigner();
+            mockFetch.mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({
+                    addresses: [
+                        { address: mainnet.address, assetId: 'SOL' },
+                        { address: devnet.address, assetId: 'SOL_TEST' },
+                    ],
+                }),
+            });
+
+            const signer = new FireblocksSigner({
+                apiKey: TEST_API_KEY,
+                assetId: 'SOL_TEST',
+                privateKeyPem: TEST_RSA_PRIVATE_KEY,
+                vaultAccountId: TEST_VAULT_ACCOUNT_ID,
+            });
+            await signer.init();
+
+            expect(signer.address).toBe(devnet.address);
+        });
+
         it('rejects an ambiguous address response', async () => {
             const first = await generateKeyPairSigner();
             const second = await generateKeyPairSigner();

--- a/typescript/packages/fireblocks/src/__tests__/fireblocks-signer.test.ts
+++ b/typescript/packages/fireblocks/src/__tests__/fireblocks-signer.test.ts
@@ -326,8 +326,97 @@ describe('FireblocksSigner', () => {
 
             await expect(signer.init()).rejects.toMatchObject({
                 code: 'SIGNER_INVALID_PUBLIC_KEY',
-                message: expect.stringContaining('No addresses found in Fireblocks vault'),
+                message: expect.stringContaining('returned no address'),
             });
+        });
+
+        it('selects the address for the configured asset', async () => {
+            const wanted = await generateKeyPairSigner();
+            const other = await generateKeyPairSigner();
+            mockFetch.mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({
+                    addresses: [
+                        { address: other.address, assetId: 'SOL_TEST' },
+                        { address: wanted.address, assetId: 'SOL' },
+                    ],
+                }),
+            });
+
+            const signer = new FireblocksSigner({
+                apiKey: TEST_API_KEY,
+                privateKeyPem: TEST_RSA_PRIVATE_KEY,
+                vaultAccountId: TEST_VAULT_ACCOUNT_ID,
+            });
+            await signer.init();
+
+            expect(signer.address).toBe(wanted.address);
+        });
+
+        it('rejects an ambiguous address response', async () => {
+            const first = await generateKeyPairSigner();
+            const second = await generateKeyPairSigner();
+            mockFetch.mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({
+                    addresses: [
+                        { address: first.address, assetId: 'SOL' },
+                        { address: second.address, assetId: 'SOL' },
+                    ],
+                }),
+            });
+
+            const signer = new FireblocksSigner({
+                apiKey: TEST_API_KEY,
+                privateKeyPem: TEST_RSA_PRIVATE_KEY,
+                vaultAccountId: TEST_VAULT_ACCOUNT_ID,
+            });
+
+            await expect(signer.init()).rejects.toMatchObject({
+                code: 'SIGNER_INVALID_PUBLIC_KEY',
+                message: expect.stringContaining('cannot choose a signing identity'),
+            });
+        });
+
+        it('rejects a response with no address for the configured asset', async () => {
+            const other = await generateKeyPairSigner();
+            mockFetch.mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({ addresses: [{ address: other.address, assetId: 'SOL_TEST' }] }),
+            });
+
+            const signer = new FireblocksSigner({
+                apiKey: TEST_API_KEY,
+                privateKeyPem: TEST_RSA_PRIVATE_KEY,
+                vaultAccountId: TEST_VAULT_ACCOUNT_ID,
+            });
+
+            await expect(signer.init()).rejects.toMatchObject({
+                code: 'SIGNER_INVALID_PUBLIC_KEY',
+                message: expect.stringContaining('returned no address'),
+            });
+        });
+
+        it('accepts duplicate entries for the same address', async () => {
+            const wanted = await generateKeyPairSigner();
+            mockFetch.mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({
+                    addresses: [
+                        { address: wanted.address, assetId: 'SOL' },
+                        { address: wanted.address, assetId: 'SOL' },
+                    ],
+                }),
+            });
+
+            const signer = new FireblocksSigner({
+                apiKey: TEST_API_KEY,
+                privateKeyPem: TEST_RSA_PRIVATE_KEY,
+                vaultAccountId: TEST_VAULT_ACCOUNT_ID,
+            });
+            await signer.init();
+
+            expect(signer.address).toBe(wanted.address);
         });
 
         it('should not re-initialize if already initialized', async () => {

--- a/typescript/packages/fireblocks/src/fireblocks-signer.ts
+++ b/typescript/packages/fireblocks/src/fireblocks-signer.ts
@@ -22,6 +22,7 @@ import type {
     CreateTransactionResponse,
     FireblocksSignerConfig,
     TransactionResponse,
+    VaultAddress,
     VaultAddressesResponse,
 } from './types.js';
 import { FireblocksTransactionStatus, isTerminalStatus } from './types.js';
@@ -179,22 +180,42 @@ export class FireblocksSigner<TAddress extends string = string> implements Solan
         const uri = `/v1/vault/accounts/${encodeURIComponent(this.vaultAccountId)}/${encodeURIComponent(this.assetId)}/addresses_paginated`;
         const addressesResponse = await this.request<VaultAddressesResponse>('GET', uri);
 
-        const firstAddress = addressesResponse.addresses?.[0]?.address;
-        if (!firstAddress) {
-            throwSignerError(SignerErrorCode.INVALID_PUBLIC_KEY, {
-                message: 'No addresses found in Fireblocks vault',
-            });
-        }
+        const address = this.selectVaultAddress(addressesResponse.addresses ?? []);
 
         try {
-            assertIsAddress(firstAddress);
-            return firstAddress;
+            assertIsAddress(address);
+            return address;
         } catch (error) {
             throwSignerError(SignerErrorCode.INVALID_PUBLIC_KEY, {
                 cause: error,
                 message: 'Invalid address from Fireblocks',
             });
         }
+    }
+
+    /**
+     * Pick the address for the configured asset, failing on an empty or ambiguous
+     * response: a mistyped vault account or asset id must not yield a working
+     * signer bound to an unintended fee payer. Entries without an `assetId` are
+     * kept, since the endpoint is already scoped by asset.
+     */
+    private selectVaultAddress(addresses: readonly VaultAddress[]): string {
+        const unique = [
+            ...new Set(
+                addresses
+                    .filter(entry => entry.address && (!entry.assetId || entry.assetId === this.assetId))
+                    .map(entry => entry.address),
+            ),
+        ];
+        if (unique.length === 1) {
+            return unique[0]!;
+        }
+        throwSignerError(SignerErrorCode.INVALID_PUBLIC_KEY, {
+            message:
+                unique.length === 0
+                    ? `Fireblocks returned no address for vault account ${this.vaultAccountId} asset ${this.assetId}`
+                    : `Fireblocks returned ${unique.length} addresses for vault account ${this.vaultAccountId} asset ${this.assetId}; cannot choose a signing identity`,
+        });
     }
 
     /**

--- a/typescript/packages/fireblocks/src/types.ts
+++ b/typescript/packages/fireblocks/src/types.ts
@@ -108,6 +108,7 @@ export interface VaultAddressesResponse {
 
 export interface VaultAddress {
     address: string;
+    assetId?: string;
 }
 
 /**


### PR DESCRIPTION
## Problem

All four implementations resolved the signer's identity as `addresses[0]` from `addresses_paginated`, with no validation, and modelled each entry as `{ address }` only - `assetId`, `type`, `tag` and `paging.after` were discarded, so an ambiguous or truncated response was undetectable.

The realistic trigger is misconfiguration rather than a hostile provider: `vaultAccountId` is a short numeric string (`"0"` vs `"10"`), and `SOL` vs `SOL_TEST` differs by a suffix. Either mistake produced a **working** signer bound to an unintended identity, silently - and that identity is used as the fee payer. Fireblocks is the only provider-resolved backend here that indexes into a list; Privy, Utila, Crossmint and Dfns all dereference a uniquely-identified wallet.

Nothing is forgeable: the returned signature is always verified against the resolved key. The reachable harm is identity substitution, so severity is low - but it fails silently today, and the precedent for fixing it is already in the repo (Fordefi verifies vault ownership during `init()`).

## Fix

Filter candidate addresses by the configured asset id and accept only a **single distinct** address. An empty or ambiguous result fails with `INVALID_PUBLIC_KEY` naming the vault account and asset, instead of picking an entry.

Two deliberate leniencies:
- Entries **without** an `assetId` are kept. The endpoint is already scoped by asset in its path, and older/partial responses may omit the field; rejecting them would break working setups for no security gain.
- Duplicate entries for the **same** address are not ambiguous (Fireblocks can return multiple entries per address, e.g. per tag).

`assetId` is now modelled in the response types in all four languages. **No configuration or public API changes** - this is internal validation only.

## Not done here (deliberately)

The finding also asked for a required expected-pubkey config field and revalidation before every signature. A *required* field breaks the public API in all four languages for every existing user, and re-fetching the address on each sign adds a network round-trip to defend against mid-session rotation. An *optional* `expectedPublicKey` pin is a reasonable follow-up if wanted; it is not in this PR.

## Testing

Four new tests per language: correct address selected when a foreign-asset entry comes first; ambiguous (two distinct addresses for the configured asset) rejected; no entry for the configured asset rejected; duplicate entries for one address accepted.

Rust 319 tests x sdk-v2/v3/v4 + clippy `-D warnings` + fmt; Python 457 + ruff + mypy strict; Go `-race` + vet + golangci-lint across all modules; TypeScript 44 + typecheck + eslint + prettier + build.
