### PR TITLE
fix(go)!: guard batch signing against broadcast-managed signers

### DIFF
--- a/go/core/batch.go
+++ b/go/core/batch.go
@@ -48,13 +48,9 @@ func SignMessages(ctx context.Context, s Signer, messages [][]byte, opts BatchOp
 }
 
 // SignTransactions signs each transaction with s concurrently, preserving order.
-// See SignMessages for error and concurrency semantics.
-//
-// Signers that broadcast server-side (see TransactionBroadcaster) are rejected:
-// this helper collapses the batch into a single nil, err result on the first
-// failure, which would hide which transactions a provider already executed and
-// invite a whole-batch retry into duplicate spends. Call SignTransaction per
-// transaction instead and track each provider transaction id.
+// See SignMessages for error and concurrency semantics. Broadcasting signers
+// (see TransactionBroadcaster) are rejected: the single nil, err result would
+// hide which transactions the provider already executed.
 func SignTransactions(ctx context.Context, s Signer, txs []*solana.Transaction, opts BatchOptions) ([]SignedTransaction, error) {
 	if b, ok := s.(TransactionBroadcaster); ok && b.BroadcastsTransactions() {
 		return nil, NewSignerError(CodeConfigError,

--- a/go/core/batch.go
+++ b/go/core/batch.go
@@ -49,7 +49,17 @@ func SignMessages(ctx context.Context, s Signer, messages [][]byte, opts BatchOp
 
 // SignTransactions signs each transaction with s concurrently, preserving order.
 // See SignMessages for error and concurrency semantics.
+//
+// Signers that broadcast server-side (see TransactionBroadcaster) are rejected:
+// this helper collapses the batch into a single nil, err result on the first
+// failure, which would hide which transactions a provider already executed and
+// invite a whole-batch retry into duplicate spends. Call SignTransaction per
+// transaction instead and track each provider transaction id.
 func SignTransactions(ctx context.Context, s Signer, txs []*solana.Transaction, opts BatchOptions) ([]SignedTransaction, error) {
+	if b, ok := s.(TransactionBroadcaster); ok && b.BroadcastsTransactions() {
+		return nil, NewSignerError(CodeConfigError,
+			"this signer broadcasts transactions server-side; batch signing hides which transactions already executed, call SignTransaction per transaction instead")
+	}
 	out := make([]SignedTransaction, len(txs))
 	g, ctx := errgroup.WithContext(ctx)
 	if opts.MaxConcurrency > 0 {

--- a/go/core/batch_test.go
+++ b/go/core/batch_test.go
@@ -34,9 +34,8 @@ func (c *countingSigner) SignTransaction(context.Context, *solana.Transaction) (
 
 func (c *countingSigner) IsAvailable(context.Context) bool { return true }
 
-// broadcastingSigner marks itself as a server-side broadcaster with a
-// configurable answer, mirroring mode-dependent backends (Fordefi native vs
-// black box).
+// broadcastingSigner reports broadcasting with a configurable answer,
+// mirroring mode-dependent backends.
 type broadcastingSigner struct {
 	countingSigner
 	broadcasts bool
@@ -49,10 +48,8 @@ func (b *broadcastingSigner) SignTransaction(context.Context, *solana.Transactio
 	return SignedTransaction{}, nil
 }
 
-// TestSignTransactionsRejectsBroadcastingSigners guards the duplicate-spend
-// contract: SignTransactions collapses the batch into one nil, err result on
-// the first failure, hiding which transactions a broadcasting provider already
-// executed, so such signers must be rejected before any remote work starts.
+// Broadcasting signers must be rejected before any remote work: the single
+// nil, err batch result hides which transactions already executed.
 func TestSignTransactionsRejectsBroadcastingSigners(t *testing.T) {
 	s := &broadcastingSigner{broadcasts: true}
 	_, err := SignTransactions(context.Background(), s, []*solana.Transaction{{}}, BatchOptions{})
@@ -64,8 +61,6 @@ func TestSignTransactionsRejectsBroadcastingSigners(t *testing.T) {
 	}
 }
 
-// A signer that reports it does not broadcast in its current configuration
-// still batches normally.
 func TestSignTransactionsAcceptsNonBroadcastingConfiguration(t *testing.T) {
 	s := &broadcastingSigner{broadcasts: false}
 	out, err := SignTransactions(context.Background(), s, []*solana.Transaction{{}, {}}, BatchOptions{})

--- a/go/core/batch_test.go
+++ b/go/core/batch_test.go
@@ -34,6 +34,49 @@ func (c *countingSigner) SignTransaction(context.Context, *solana.Transaction) (
 
 func (c *countingSigner) IsAvailable(context.Context) bool { return true }
 
+// broadcastingSigner marks itself as a server-side broadcaster with a
+// configurable answer, mirroring mode-dependent backends (Fordefi native vs
+// black box).
+type broadcastingSigner struct {
+	countingSigner
+	broadcasts bool
+}
+
+func (b *broadcastingSigner) BroadcastsTransactions() bool { return b.broadcasts }
+
+func (b *broadcastingSigner) SignTransaction(context.Context, *solana.Transaction) (SignedTransaction, error) {
+	b.calls.Add(1)
+	return SignedTransaction{}, nil
+}
+
+// TestSignTransactionsRejectsBroadcastingSigners guards the duplicate-spend
+// contract: SignTransactions collapses the batch into one nil, err result on
+// the first failure, hiding which transactions a broadcasting provider already
+// executed, so such signers must be rejected before any remote work starts.
+func TestSignTransactionsRejectsBroadcastingSigners(t *testing.T) {
+	s := &broadcastingSigner{broadcasts: true}
+	_, err := SignTransactions(context.Background(), s, []*solana.Transaction{{}}, BatchOptions{})
+	if code, ok := CodeOf(err); !ok || code != CodeConfigError {
+		t.Errorf("got code %q (ok=%v), want CodeConfigError", code, ok)
+	}
+	if got := s.calls.Load(); got != 0 {
+		t.Errorf("signer called %d times, want 0 (rejected before any remote work)", got)
+	}
+}
+
+// A signer that reports it does not broadcast in its current configuration
+// still batches normally.
+func TestSignTransactionsAcceptsNonBroadcastingConfiguration(t *testing.T) {
+	s := &broadcastingSigner{broadcasts: false}
+	out, err := SignTransactions(context.Background(), s, []*solana.Transaction{{}, {}}, BatchOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(out) != 2 || s.calls.Load() != 2 {
+		t.Errorf("got %d results and %d calls, want 2 and 2", len(out), s.calls.Load())
+	}
+}
+
 func TestSignMessagesPreservesOrder(t *testing.T) {
 	s := &countingSigner{}
 	messages := [][]byte{{10}, {20}, {30}, {40}}

--- a/go/core/types.go
+++ b/go/core/types.go
@@ -62,6 +62,18 @@ type Signer interface {
 	IsAvailable(ctx context.Context) bool
 }
 
+// TransactionBroadcaster marks signers whose SignTransaction submits and
+// broadcasts the transaction server-side (a managed send) rather than only
+// signing. For such signers a failure does not mean nothing happened: the
+// provider may have already executed the transaction, so callers must
+// reconcile by provider transaction id before retrying. SignTransactions
+// rejects signers reporting true.
+type TransactionBroadcaster interface {
+	// BroadcastsTransactions reports whether SignTransaction broadcasts
+	// server-side in this signer's current configuration.
+	BroadcastsTransactions() bool
+}
+
 // SignatureDictionary maps a signer address to its signature, a convenience for
 // @solana/kit-style callers; it is NOT part of the Signer interface.
 type SignatureDictionary map[solana.PublicKey]solana.Signature

--- a/go/core/types.go
+++ b/go/core/types.go
@@ -62,15 +62,13 @@ type Signer interface {
 	IsAvailable(ctx context.Context) bool
 }
 
-// TransactionBroadcaster marks signers whose SignTransaction submits and
-// broadcasts the transaction server-side (a managed send) rather than only
-// signing. For such signers a failure does not mean nothing happened: the
-// provider may have already executed the transaction, so callers must
-// reconcile by provider transaction id before retrying. SignTransactions
-// rejects signers reporting true.
+// TransactionBroadcaster marks signers whose SignTransaction broadcasts
+// server-side, where a failure does not mean nothing happened; callers must
+// reconcile by provider transaction id before retrying, and SignTransactions
+// rejects them.
 type TransactionBroadcaster interface {
-	// BroadcastsTransactions reports whether SignTransaction broadcasts
-	// server-side in this signer's current configuration.
+	// BroadcastsTransactions reports whether SignTransaction broadcasts in
+	// this signer's current configuration.
 	BroadcastsTransactions() bool
 }
 

--- a/go/signers/crossmint/signer.go
+++ b/go/signers/crossmint/signer.go
@@ -171,9 +171,8 @@ func (s *Signer) verificationCandidates() []solana.PublicKey {
 // Pubkey returns the Crossmint wallet's Solana public key.
 func (s *Signer) Pubkey() solana.PublicKey { return s.publicKey }
 
-// BroadcastsTransactions is always true: Crossmint executes every transaction
-// server-side, so core batch helpers must reject this signer (see
-// core.TransactionBroadcaster).
+// BroadcastsTransactions is always true: Crossmint executes every
+// transaction server-side.
 func (s *Signer) BroadcastsTransactions() bool { return true }
 
 // String renders the signer without any secret material.

--- a/go/signers/crossmint/signer.go
+++ b/go/signers/crossmint/signer.go
@@ -48,7 +48,10 @@ type Signer struct {
 }
 
 // Ensure Signer satisfies the core contract at compile time.
-var _ core.Signer = (*Signer)(nil)
+var (
+	_ core.Signer                 = (*Signer)(nil)
+	_ core.TransactionBroadcaster = (*Signer)(nil)
+)
 
 // New builds a Crossmint signer and resolves the wallet's public key, so the
 // returned signer is ready to use.
@@ -167,6 +170,11 @@ func (s *Signer) verificationCandidates() []solana.PublicKey {
 
 // Pubkey returns the Crossmint wallet's Solana public key.
 func (s *Signer) Pubkey() solana.PublicKey { return s.publicKey }
+
+// BroadcastsTransactions is always true: Crossmint executes every transaction
+// server-side, so core batch helpers must reject this signer (see
+// core.TransactionBroadcaster).
+func (s *Signer) BroadcastsTransactions() bool { return true }
 
 // String renders the signer without any secret material.
 func (s Signer) String() string {

--- a/go/signers/fordefi/signer.go
+++ b/go/signers/fordefi/signer.go
@@ -43,7 +43,10 @@ type Signer struct {
 }
 
 // Ensure Signer satisfies the core contract at compile time.
-var _ core.Signer = (*Signer)(nil)
+var (
+	_ core.Signer                 = (*Signer)(nil)
+	_ core.TransactionBroadcaster = (*Signer)(nil)
+)
 
 // New builds a Fordefi signer and verifies that the configured PublicKey
 // actually belongs to the configured VaultID (without this check a
@@ -153,6 +156,11 @@ func (s *Signer) verifyVaultOwnership(ctx context.Context) error {
 
 // Pubkey returns the vault's Solana public key (verified during New).
 func (s *Signer) Pubkey() solana.PublicKey { return s.pubkey }
+
+// BroadcastsTransactions reports whether SignTransaction auto-broadcasts:
+// native mode (Chain set) submits with push_mode "auto", so core batch helpers
+// must reject it (see core.TransactionBroadcaster).
+func (s *Signer) BroadcastsTransactions() bool { return s.chain != "" }
 
 // String renders the signer without any secret material.
 func (s Signer) String() string {

--- a/go/signers/fordefi/signer.go
+++ b/go/signers/fordefi/signer.go
@@ -200,10 +200,11 @@ func (s *Signer) SignMessage(ctx context.Context, message []byte) (solana.Signat
 //
 // Native mode (Chain set) submits the message with push_mode "auto": Fordefi
 // may replace the blockhash (and optionally fees), signs, and broadcasts the
-// transaction itself. tx is replaced with the Fordefi-signed transaction and
-// the returned EncodedTransaction is empty — the transaction is already
-// on-chain, so there is nothing for the caller to send. Only transactions
-// whose sole required signer is the configured vault are supported.
+// transaction itself. tx is left untouched and the returned EncodedTransaction
+// is empty — the transaction is already on-chain, so there is nothing for the
+// caller to send; the returned signature is the on-chain identifier. Only
+// transactions whose sole required signer is the configured vault are
+// supported.
 //
 // Native mode is not retry-safe: any failure after Fordefi accepts the
 // submission returns CodeBroadcastUnconfirmed carrying the Fordefi transaction
@@ -308,8 +309,8 @@ func (s *Signer) requireSoleRequiredSigner(tx *solana.Transaction) error {
 
 // signTransactionNative signs tx via the native solana_transaction path.
 // Fordefi may modify the transaction (at minimum the blockhash), so the
-// signature is verified against the returned message bytes and tx is replaced
-// with the returned transaction.
+// signature is verified against the returned message bytes; tx is left
+// untouched.
 func (s *Signer) signTransactionNative(ctx context.Context, tx *solana.Transaction) (core.SignedTransaction, error) {
 	if err := s.requireSoleRequiredSigner(tx); err != nil {
 		return core.SignedTransaction{}, err
@@ -339,7 +340,7 @@ func (s *Signer) signTransactionNative(ctx context.Context, tx *solana.Transacti
 	// cannot rule out. Report those as CodeBroadcastUnconfirmed carrying the
 	// Fordefi transaction id instead of a generic error a caller might blindly
 	// retry into a duplicate spend.
-	signed, err := s.finishNativeBroadcast(ctx, tx, txID)
+	signed, err := s.finishNativeBroadcast(ctx, txID)
 	if err != nil {
 		detail := err.Error()
 		var se *core.SignerError
@@ -353,7 +354,7 @@ func (s *Signer) signTransactionNative(ctx context.Context, tx *solana.Transacti
 
 // finishNativeBroadcast polls a submitted native transaction to completion and
 // extracts and verifies the vault's signature from the returned wire bytes.
-func (s *Signer) finishNativeBroadcast(ctx context.Context, tx *solana.Transaction, txID string) (core.SignedTransaction, error) {
+func (s *Signer) finishNativeBroadcast(ctx context.Context, txID string) (core.SignedTransaction, error) {
 	result, err := s.pollForResult(ctx, txID, true)
 	if err != nil {
 		return core.SignedTransaction{}, err
@@ -394,6 +395,7 @@ func (s *Signer) finishNativeBroadcast(ctx context.Context, tx *solana.Transacti
 			"signature verification failed against Fordefi-returned message")
 	}
 
-	*tx = *returned
-	return core.Classify(tx, "", signature), nil
+	// The caller's tx is left untouched: the provider chose these bytes, so they
+	// are classified on their own and never installed into the caller's object.
+	return core.Classify(returned, "", signature), nil
 }

--- a/go/signers/fordefi/signer.go
+++ b/go/signers/fordefi/signer.go
@@ -157,9 +157,8 @@ func (s *Signer) verifyVaultOwnership(ctx context.Context) error {
 // Pubkey returns the vault's Solana public key (verified during New).
 func (s *Signer) Pubkey() solana.PublicKey { return s.pubkey }
 
-// BroadcastsTransactions reports whether SignTransaction auto-broadcasts:
-// native mode (Chain set) submits with push_mode "auto", so core batch helpers
-// must reject it (see core.TransactionBroadcaster).
+// BroadcastsTransactions reports whether SignTransaction auto-broadcasts
+// (native mode).
 func (s *Signer) BroadcastsTransactions() bool { return s.chain != "" }
 
 // String renders the signer without any secret material.
@@ -395,7 +394,5 @@ func (s *Signer) finishNativeBroadcast(ctx context.Context, txID string) (core.S
 			"signature verification failed against Fordefi-returned message")
 	}
 
-	// The caller's tx is left untouched: the provider chose these bytes, so they
-	// are classified on their own and never installed into the caller's object.
 	return core.Classify(returned, "", signature), nil
 }

--- a/go/signers/fordefi/signer_test.go
+++ b/go/signers/fordefi/signer_test.go
@@ -555,8 +555,7 @@ func nativeConfig(t *testing.T) Config {
 	return cfg
 }
 
-// Native mode broadcasts server-side, so core batch helpers must reject it;
-// black box only signs, so it may batch.
+// Native mode broadcasts, so batch helpers must reject it; black box may batch.
 func TestBroadcastsTransactionsFollowsMode(t *testing.T) {
 	pub := testutils.TestPublicKey()
 	native := newTestSigner(t, nativeConfig(t), pub.String(), func(*http.ServeMux) {})

--- a/go/signers/fordefi/signer_test.go
+++ b/go/signers/fordefi/signer_test.go
@@ -649,8 +649,10 @@ func TestSignTransactionNativeSuccess(t *testing.T) {
 	if !res.IsComplete() {
 		t.Error("returned transaction is fully signed, want Complete")
 	}
-	if len(tx.Signatures) == 0 || tx.Signatures[0] != signature {
-		t.Error("caller's transaction must be replaced with the Fordefi-signed one")
+	for _, sig := range tx.Signatures {
+		if !sig.IsZero() {
+			t.Error("the caller's transaction must be left untouched by provider-chosen bytes")
+		}
 	}
 }
 

--- a/go/signers/fordefi/signer_test.go
+++ b/go/signers/fordefi/signer_test.go
@@ -555,6 +555,20 @@ func nativeConfig(t *testing.T) Config {
 	return cfg
 }
 
+// Native mode broadcasts server-side, so core batch helpers must reject it;
+// black box only signs, so it may batch.
+func TestBroadcastsTransactionsFollowsMode(t *testing.T) {
+	pub := testutils.TestPublicKey()
+	native := newTestSigner(t, nativeConfig(t), pub.String(), func(*http.ServeMux) {})
+	if !native.BroadcastsTransactions() {
+		t.Error("native mode must report broadcasting")
+	}
+	blackBox := newTestSigner(t, baseConfig(t), pub.String(), func(*http.ServeMux) {})
+	if blackBox.BroadcastsTransactions() {
+		t.Error("black-box mode must not report broadcasting")
+	}
+}
+
 func TestSignTransactionNativeSuccess(t *testing.T) {
 	priv := testutils.TestPrivateKey()
 	pub := testutils.TestPublicKey()

--- a/python/tests/test_fordefi_signer.py
+++ b/python/tests/test_fordefi_signer.py
@@ -17,6 +17,7 @@ from cryptography.hazmat.primitives.serialization import (
     PrivateFormat,
 )
 from solders.keypair import Keypair
+from solders.signature import Signature
 
 from solana_keychain import SignerError, SignerErrorCode
 from solana_keychain.fordefi import (
@@ -454,6 +455,9 @@ async def test_sign_transaction_native_success() -> None:
     assert result.signature == signature
     assert result.encoded_transaction == ""
     assert result.is_complete
+    assert all(sig == Signature.default() for sig in transaction.signatures), (
+        "the caller's transaction must be left untouched by provider-chosen bytes"
+    )
     body = json.loads(respx.calls[0].request.content)
     assert body["type"] == "solana_transaction"
     assert body["details"]["type"] == "solana_serialized_transaction_message"

--- a/rust/src/fordefi/mod.rs
+++ b/rust/src/fordefi/mod.rs
@@ -725,6 +725,11 @@ impl SolanaSigner for FordefiSigner {
         tx: &mut Transaction,
     ) -> Result<SignTransactionResult, SignerError> {
         let signed_transaction = self.sign_and_serialize(tx).await?;
+        if self.chain.is_some() {
+            // Native mode has already broadcast the transaction, so it is
+            // complete regardless of the caller's untouched signature slots.
+            return Ok(SignTransactionResult::Complete(signed_transaction));
+        }
         Ok(TransactionUtil::classify_signed_transaction(
             tx,
             signed_transaction,
@@ -1707,7 +1712,13 @@ mod tests {
             "native sign_transaction failed: {:?}",
             result.err()
         );
-        let (serialized_tx, sig) = result.unwrap().into_signed_transaction();
+        let result = result.unwrap();
+        assert!(
+            matches!(result, SignTransactionResult::Complete(_)),
+            "a broadcast native transaction is complete even though the caller's \
+             signature slots stay untouched"
+        );
+        let (serialized_tx, sig) = result.into_signed_transaction();
         // Native mode auto-broadcasts, so no re-sendable wire tx is returned.
         assert!(
             serialized_tx.is_empty(),

--- a/rust/src/fordefi/mod.rs
+++ b/rust/src/fordefi/mod.rs
@@ -483,8 +483,7 @@ impl FordefiSigner {
     /// Fordefi will modify the transaction (at minimum updating the blockhash, and
     /// optionally adding priority fees), so we verify the signature against the
     /// returned message bytes, not the original. The caller's `transaction` is
-    /// left untouched: the provider chose the broadcast bytes, so they are never
-    /// installed into it.
+    /// left untouched.
     ///
     /// Because native mode uses `push_mode: "auto"`, Fordefi has already broadcast
     /// the transaction on-chain by the time this returns. Re-sending it would be
@@ -556,11 +555,8 @@ impl FordefiSigner {
             ));
         }
 
-        // Native mode auto-broadcasts (push_mode: "auto"), so there is nothing for
-        // the caller to send, and the caller's transaction is left untouched: the
-        // provider chose these bytes, so they are never installed into it. Return
-        // an empty serialized transaction; the signature is the on-chain
-        // identifier.
+        // Auto-broadcast leaves nothing to send; the signature is the on-chain
+        // identifier and the caller's transaction stays untouched.
         Ok((String::new(), signature))
     }
 

--- a/rust/src/fordefi/mod.rs
+++ b/rust/src/fordefi/mod.rs
@@ -71,8 +71,8 @@ pub struct FordefiSignerConfig {
 ///   API types. Fordefi will modify the transaction (at minimum updating the blockhash,
 ///   and optionally adding priority fees) and **auto-broadcasts** it on-chain
 ///   (`push_mode: "auto"`). Because the transaction is already submitted, the returned
-///   serialized transaction is **empty** — only the signature is returned. The caller's
-///   `&mut Transaction` is updated to the Fordefi-signed transaction.
+///   serialized transaction is **empty** — only the signature, the on-chain
+///   identifier, is returned. The caller's `&mut Transaction` is left untouched.
 pub struct FordefiSigner {
     access_token: String,
     vault_id: String,
@@ -483,13 +483,14 @@ impl FordefiSigner {
     /// Fordefi will modify the transaction (at minimum updating the blockhash, and
     /// optionally adding priority fees), so we verify the signature against the
     /// returned message bytes, not the original. The caller's `transaction` is
-    /// replaced with the Fordefi-returned transaction.
+    /// left untouched: the provider chose the broadcast bytes, so they are never
+    /// installed into it.
     ///
     /// Because native mode uses `push_mode: "auto"`, Fordefi has already broadcast
     /// the transaction on-chain by the time this returns. Re-sending it would be
     /// superfluous, so the returned serialized-transaction string is intentionally
-    /// empty — only the signature is returned. Callers that need the exact
-    /// broadcast bytes can serialize the (now Fordefi-signed) `transaction`.
+    /// empty — only the signature, usable with RPC transaction lookups, is
+    /// returned.
     ///
     /// Each native create carries an `x-idempotence-id` derived from the message
     /// bytes, so retrying the exact same bytes cannot create a second transaction.
@@ -508,19 +509,15 @@ impl FordefiSigner {
         // this client cannot rule out. Report those as BroadcastUnconfirmed
         // carrying the Fordefi transaction id instead of a generic error a
         // caller might blindly retry into a duplicate spend.
-        self.finish_native_broadcast(transaction, &tx_id)
-            .await
-            .map_err(|error| SignerError::BroadcastUnconfirmed {
+        self.finish_native_broadcast(&tx_id).await.map_err(|error| {
+            SignerError::BroadcastUnconfirmed {
                 provider_tx_id: tx_id,
                 detail: error.detail_string(),
-            })
+            }
+        })
     }
 
-    async fn finish_native_broadcast(
-        &self,
-        transaction: &mut Transaction,
-        tx_id: &str,
-    ) -> Result<SignedTransaction, SignerError> {
+    async fn finish_native_broadcast(&self, tx_id: &str) -> Result<SignedTransaction, SignerError> {
         let result = self.poll_for_result(tx_id, true).await?;
 
         let raw_tx_b64 = result.raw_transaction.as_ref().ok_or_else(|| {
@@ -559,12 +556,11 @@ impl FordefiSigner {
             ));
         }
 
-        // Replace the caller's transaction with the Fordefi-signed one
-        *transaction = returned_tx;
-
         // Native mode auto-broadcasts (push_mode: "auto"), so there is nothing for
-        // the caller to send. Return an empty serialized transaction rather than
-        // re-broadcastable bytes; the signature is still returned.
+        // the caller to send, and the caller's transaction is left untouched: the
+        // provider chose these bytes, so they are never installed into it. Return
+        // an empty serialized transaction; the signature is the on-chain
+        // identifier.
         Ok((String::new(), signature))
     }
 
@@ -1718,6 +1714,10 @@ mod tests {
             "native mode should return an empty serialized transaction"
         );
         assert!(sig.verify(&pubkey.to_bytes(), &message_data));
+        assert!(
+            tx.signatures.iter().all(|s| *s == Signature::default()),
+            "the caller's transaction must be left untouched by provider-chosen bytes"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
Stacked on #254; top of the broadcast-signer stack (#231 <- #241 <- #245 <- #254 <- this).

## What

Two remaining broadcast-signer hardenings:

### 1. Go batch guard (breaking for Go)

`core.SignTransactions` runs every item concurrently and collapses the batch into a single `nil, err` result on the first failure. For a signer that broadcasts server-side, that hides which transactions the provider already executed, and the natural whole-batch retry duplicates them.

New `core.TransactionBroadcaster` marker interface (`BroadcastsTransactions() bool`), implemented by Fordefi (`true` in native mode) and Crossmint (always `true`), with compile-time assertions. `core.SignTransactions` rejects such signers with `CONFIG_ERROR` before any remote work, pointing callers at per-transaction `SignTransaction` calls where `BROADCAST_UNCONFIRMED` and its provider transaction id stay per-item. This is the Go counterpart of the TypeScript guard that already routes these signers away from batch partial signing.

Breaking: Go callers batching Fordefi-native or Crossmint signers through `core.SignTransactions` now get `CONFIG_ERROR`; that is the point of the change. `SignMessages` is untouched (nothing broadcasts there).

### 2. Native Fordefi no longer overwrites the caller's transaction (Rust + Go)

Native mode replaced the caller's transaction object with the provider-returned wire bytes (`*transaction = returned_tx` / `*tx = *returned`); Python and TypeScript never did. The result already expresses everything the caller needs: empty encoded transaction, completeness, and the verified signature identifying the landed transaction. Installing provider-chosen bytes into the caller's object is never needed, so it no longer happens; docs updated, and the native success tests in all languages that expose the caller object now pin it staying untouched.

## Testing

- Go core: broadcasting signer rejected with `CONFIG_ERROR` before any sign call; a mode-dependent signer reporting false still batches. Fordefi: native reports broadcasting, black box does not. `go test -race` + vet + gofmt on core, fordefi, crossmint.
- Rust: fordefi suite on sdk-v2/v3/v4, fmt clean.
- Python: 473 tests, ruff, mypy strict.
- TypeScript: unaffected (guard already exists there).