### PR TITLE
feat(signers): expose broadcast transaction capability

### DIFF
--- a/python/src/solana_keychain/core/signer.py
+++ b/python/src/solana_keychain/core/signer.py
@@ -30,6 +30,12 @@ class SolanaSigner(ABC):
     def pubkey(self) -> Pubkey:
         """The public key of this signer."""
 
+    @property
+    def broadcasts_transactions(self) -> bool:
+        """Whether the provider may execute transactions server-side, requiring
+        reconciliation by provider transaction ID before retrying."""
+        return False
+
     @abstractmethod
     async def sign_transaction(self, transaction: Transaction) -> SignedTransaction:
         """Sign ``transaction`` (modified in place) and return the encoded result."""

--- a/python/src/solana_keychain/crossmint/signer.py
+++ b/python/src/solana_keychain/crossmint/signer.py
@@ -231,6 +231,10 @@ class CrossmintSigner(SolanaSigner):
     def pubkey(self) -> Pubkey:
         return self._initialized_pubkey()
 
+    @property
+    def broadcasts_transactions(self) -> bool:
+        return True
+
     async def _create_transaction(
         self, transaction_b58: str, idempotency_key: str
     ) -> dict[str, Any]:

--- a/python/src/solana_keychain/fordefi/signer.py
+++ b/python/src/solana_keychain/fordefi/signer.py
@@ -187,6 +187,10 @@ class FordefiSigner(SolanaSigner):
     def pubkey(self) -> Pubkey:
         return self._public_key
 
+    @property
+    def broadcasts_transactions(self) -> bool:
+        return self._chain is not None
+
     async def _sign_request(self, path: str, timestamp: int, body: str) -> str:
         return await self._request_signer.sign_request(f"{path}|{timestamp}|{body}".encode())
 

--- a/python/tests/test_crossmint_signer.py
+++ b/python/tests/test_crossmint_signer.py
@@ -73,6 +73,10 @@ def test_parse_api_key() -> None:
     assert excinfo.value.code == SignerErrorCode.CONFIG_ERROR
 
 
+def test_broadcasts_transactions() -> None:
+    assert make_signer().broadcasts_transactions
+
+
 def test_derive_signing_key_is_deterministic_and_env_scoped() -> None:
     key_one = derive_signing_key(SIGNER_SECRET, API_KEY)
     key_two = derive_signing_key(SIGNER_SECRET, API_KEY)

--- a/python/tests/test_fordefi_signer.py
+++ b/python/tests/test_fordefi_signer.py
@@ -83,6 +83,12 @@ class StaticRequestSigner(FordefiRequestSigner):
         return "static-signature"
 
 
+def test_broadcasts_transactions_by_mode() -> None:
+    keypair = Keypair()
+    assert not make_signer(keypair).broadcasts_transactions
+    assert make_signer(keypair, chain="solana_mainnet").broadcasts_transactions
+
+
 @pytest.mark.parametrize("field", ["access_token", "vault_id", "public_key"])
 def test_config_rejects_empty_required_field(field: str) -> None:
     with pytest.raises(SignerError) as excinfo:

--- a/python/tests/test_memory_signer.py
+++ b/python/tests/test_memory_signer.py
@@ -21,6 +21,10 @@ def test_create_from_u8_array() -> None:
     assert str(create_test_signer().pubkey) == TEST_PUBKEY
 
 
+def test_does_not_broadcast_transactions() -> None:
+    assert not create_test_signer().broadcasts_transactions
+
+
 def test_create_from_config() -> None:
     keypair = Keypair.from_base58_string(TEST_KEYPAIR_BASE58)
     signer = MemorySigner.from_config(MemorySignerConfig(keypair=keypair))

--- a/rust/src/crossmint/mod.rs
+++ b/rust/src/crossmint/mod.rs
@@ -837,6 +837,10 @@ impl SolanaSigner for CrossmintSigner {
         self.public_key
     }
 
+    fn broadcasts_transactions(&self) -> bool {
+        true
+    }
+
     async fn sign_transaction(
         &self,
         tx: &mut Transaction,
@@ -905,6 +909,12 @@ mod tests {
         );
         signer.wallet_locator = wallet_locator.to_string();
         signer
+    }
+
+    #[test]
+    fn test_broadcasts_transactions() {
+        let signer = create_test_signer("https://example.com", 1, 1);
+        assert!(signer.broadcasts_transactions());
     }
 
     fn build_url_and_path(wallet_locator: &str, segments: &[&str]) -> (String, String) {

--- a/rust/src/fordefi/mod.rs
+++ b/rust/src/fordefi/mod.rs
@@ -716,6 +716,10 @@ impl SolanaSigner for FordefiSigner {
         self.public_key
     }
 
+    fn broadcasts_transactions(&self) -> bool {
+        self.chain.is_some()
+    }
+
     async fn sign_transaction(
         &self,
         tx: &mut Transaction,
@@ -876,6 +880,13 @@ mod tests {
             test_request_signer(),
             Some(SolanaChainUniqueId::SolanaMainnet),
         )
+    }
+
+    #[test]
+    fn test_broadcasts_transactions_by_mode() {
+        let pubkey = Pubkey::new_unique();
+        assert!(!create_test_signer("https://example.com", pubkey).broadcasts_transactions());
+        assert!(create_native_test_signer("https://example.com", pubkey).broadcasts_transactions());
     }
 
     /// Build a mock wire transaction: [1 byte sig_count][64-byte signature][message bytes]

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -442,6 +442,46 @@ impl SolanaSigner for Signer {
         }
     }
 
+    fn broadcasts_transactions(&self) -> bool {
+        match self {
+            #[cfg(feature = "memory")]
+            Signer::Memory(s) => s.broadcasts_transactions(),
+
+            #[cfg(feature = "vault")]
+            Signer::Vault(s) => s.broadcasts_transactions(),
+
+            #[cfg(feature = "privy")]
+            Signer::Privy(s) => s.broadcasts_transactions(),
+
+            #[cfg(feature = "turnkey")]
+            Signer::Turnkey(s) => s.broadcasts_transactions(),
+
+            #[cfg(feature = "aws_kms")]
+            Signer::AwsKms(s) => s.broadcasts_transactions(),
+
+            #[cfg(feature = "fireblocks")]
+            Signer::Fireblocks(s) => s.broadcasts_transactions(),
+
+            #[cfg(feature = "gcp_kms")]
+            Signer::GcpKms(s) => s.broadcasts_transactions(),
+
+            #[cfg(feature = "cdp")]
+            Signer::Cdp(s) => s.broadcasts_transactions(),
+            #[cfg(feature = "dfns")]
+            Signer::Dfns(s) => s.broadcasts_transactions(),
+            #[cfg(feature = "openfort")]
+            Signer::Openfort(s) => s.broadcasts_transactions(),
+            #[cfg(feature = "para")]
+            Signer::Para(s) => s.broadcasts_transactions(),
+            #[cfg(feature = "crossmint")]
+            Signer::Crossmint(s) => s.broadcasts_transactions(),
+            #[cfg(feature = "utila")]
+            Signer::Utila(s) => s.broadcasts_transactions(),
+            #[cfg(feature = "fordefi")]
+            Signer::Fordefi(s) => s.broadcasts_transactions(),
+        }
+    }
+
     async fn sign_transaction(
         &self,
         tx: &mut sdk_adapter::Transaction,
@@ -563,5 +603,28 @@ impl SolanaSigner for Signer {
             #[cfg(feature = "fordefi")]
             Signer::Fordefi(s) => s.is_available().await,
         }
+    }
+}
+
+#[cfg(all(test, feature = "crossmint"))]
+mod signer_tests {
+    use super::*;
+
+    #[test]
+    fn unified_signer_surfaces_broadcast_capability() {
+        let signer = Signer::Crossmint(
+            CrossmintSigner::new(CrossmintSignerConfig {
+                api_key: "test-api-key".to_string(),
+                wallet_locator: "test-wallet".to_string(),
+                signer_secret: None,
+                signer: None,
+                api_base_url: Some("https://example.com".to_string()),
+                poll_interval_ms: None,
+                max_poll_attempts: None,
+            })
+            .unwrap(),
+        );
+
+        assert!(signer.broadcasts_transactions());
     }
 }

--- a/rust/src/memory/mod.rs
+++ b/rust/src/memory/mod.rs
@@ -149,6 +149,11 @@ mod tests {
         assert_eq!(pubkey.to_string(), TEST_PUBKEY);
     }
 
+    #[test]
+    fn test_does_not_broadcast_transactions() {
+        assert!(!create_test_signer().broadcasts_transactions());
+    }
+
     #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_sign_message() {

--- a/rust/src/traits.rs
+++ b/rust/src/traits.rs
@@ -29,6 +29,11 @@ pub trait SolanaSigner: Send + Sync {
     /// Get the public key of this signer
     fn pubkey(&self) -> Pubkey;
 
+    /// Returns `true` when the provider may execute the transaction server-side, requiring reconciliation by provider transaction ID before retrying.
+    fn broadcasts_transactions(&self) -> bool {
+        false
+    }
+
     /// Sign a Solana transaction
     ///
     /// # Arguments


### PR DESCRIPTION
## Summary
- add a default broadcast capability marker to the Rust trait and Python ABC
- report Crossmint and native-mode Fordefi as broadcast-managed signers
- delegate the capability through the unified Rust Signer and add regression coverage

## Test Plan
- just rust-test
- just rust-fmt
- just py-test
- just py-fmt