### PR TITLE
feat(signers)!: reject versioned wire transactions from providers

### DIFF
--- a/go/core/txutil.go
+++ b/go/core/txutil.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"encoding/base64"
+	"fmt"
 
 	"github.com/gagliardetto/solana-go"
 )
@@ -15,6 +16,21 @@ func Serialize(tx *solana.Transaction) (string, error) {
 		return "", WrapSignerError(CodeSerializationError, "failed to serialize transaction", err)
 	}
 	return base64.StdEncoding.EncodeToString(b), nil
+}
+
+// AssertUnversionedWireTransaction rejects a wire transaction whose envelope carries
+// a version prefix. Legacy and v0 envelopes both open with a compact-u16 signature
+// count, capped at 12 signatures, so the high bit of the first byte is never set. v1
+// moves its signatures to the tail and puts 0x80|version at offset zero, a layout the
+// signature-slot readers here cannot interpret.
+func AssertUnversionedWireTransaction(provider string, wireBytes []byte) error {
+	if len(wireBytes) == 0 || wireBytes[0]&0x80 == 0 {
+		return nil
+	}
+	return NewSignerError(CodeSerializationError, fmt.Sprintf(
+		"%s returned a v%d transaction envelope, which is not supported yet (only legacy and v0 transactions can be verified)",
+		provider, wireBytes[0]&0x7f,
+	))
 }
 
 // SigningPosition returns the index in the transaction's required-signer list where

--- a/go/core/txutil_test.go
+++ b/go/core/txutil_test.go
@@ -108,3 +108,35 @@ func TestClassifyPartialWhenMultiSig(t *testing.T) {
 		t.Error("Classify should report Partial")
 	}
 }
+
+func TestAssertUnversionedWireTransactionAcceptsLegacyEnvelope(t *testing.T) {
+	payer := testPublicKey()
+	tx, err := createTestTransaction(payer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wire, err := tx.MarshalBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := AssertUnversionedWireTransaction("Provider", wire); err != nil {
+		t.Fatalf("rejected a legacy envelope: %v", err)
+	}
+}
+
+func TestAssertUnversionedWireTransactionRejectsV1Envelope(t *testing.T) {
+	err := AssertUnversionedWireTransaction("Provider", []byte{0x81, 0x01})
+	if err == nil {
+		t.Fatal("a 0x81 prefix is a v1 envelope this module cannot verify")
+	}
+	code, ok := CodeOf(err)
+	if !ok || code != CodeSerializationError {
+		t.Errorf("want %s, got %s", CodeSerializationError, code)
+	}
+}
+
+func TestAssertUnversionedWireTransactionIgnoresEmptyBytes(t *testing.T) {
+	if err := AssertUnversionedWireTransaction("Provider", nil); err != nil {
+		t.Fatalf("empty bytes must defer to the decoder: %v", err)
+	}
+}

--- a/go/signers/cdp/signer.go
+++ b/go/signers/cdp/signer.go
@@ -185,6 +185,9 @@ func (s *Signer) SignTransaction(ctx context.Context, tx *solana.Transaction) (c
 		return core.SignedTransaction{}, core.WrapSignerError(core.CodeSerializationError,
 			"failed to decode base64 signed transaction from CDP", err)
 	}
+	if err := core.AssertUnversionedWireTransaction("CDP", signedBytes); err != nil {
+		return core.SignedTransaction{}, err
+	}
 	signedTx, err := solana.TransactionFromBytes(signedBytes)
 	if err != nil {
 		return core.SignedTransaction{}, core.WrapSignerError(core.CodeSerializationError,

--- a/go/signers/crossmint/signer.go
+++ b/go/signers/crossmint/signer.go
@@ -392,6 +392,9 @@ func (s *Signer) signatureFromApprovals(response transactionResponse, serialized
 	if err != nil {
 		return solana.Signature{}, nil, false
 	}
+	if err := core.AssertUnversionedWireTransaction("Crossmint", raw); err != nil {
+		return solana.Signature{}, nil, false
+	}
 	tx, err := solana.TransactionFromBytes(raw)
 	if err != nil {
 		return solana.Signature{}, nil, false
@@ -529,6 +532,9 @@ func (s *Signer) extractSignatureFromSerializedTransaction(serializedTransaction
 	if err != nil {
 		return solana.Signature{}, nil, core.WrapSignerError(core.CodeSerializationError,
 			"failed to decode Crossmint onChain.transaction as base58", err)
+	}
+	if err := core.AssertUnversionedWireTransaction("Crossmint", raw); err != nil {
+		return solana.Signature{}, nil, err
 	}
 	tx, err := solana.TransactionFromBytes(raw)
 	if err != nil {

--- a/go/signers/fordefi/signer.go
+++ b/go/signers/fordefi/signer.go
@@ -368,6 +368,9 @@ func (s *Signer) finishNativeBroadcast(ctx context.Context, txID string) (core.S
 		return core.SignedTransaction{}, core.WrapSignerError(core.CodeSerializationError,
 			"failed to decode raw_transaction base64", err)
 	}
+	if err := core.AssertUnversionedWireTransaction("Fordefi", wireBytes); err != nil {
+		return core.SignedTransaction{}, err
+	}
 	returned, err := solana.TransactionFromBytes(wireBytes)
 	if err != nil {
 		return core.SignedTransaction{}, core.WrapSignerError(core.CodeSerializationError,

--- a/go/signers/privy/signer.go
+++ b/go/signers/privy/signer.go
@@ -122,6 +122,9 @@ func (s *Signer) SignTransaction(ctx context.Context, tx *solana.Transaction) (c
 		return core.SignedTransaction{}, core.NewSignerError(core.CodeSerializationError,
 			"failed to decode signed transaction returned by privy")
 	}
+	if err := core.AssertUnversionedWireTransaction("Privy", signedWire); err != nil {
+		return core.SignedTransaction{}, err
+	}
 	returned, err := solana.TransactionFromBytes(signedWire)
 	if err != nil {
 		return core.SignedTransaction{}, core.WrapSignerError(core.CodeSerializationError,

--- a/go/signers/turnkey/signer.go
+++ b/go/signers/turnkey/signer.go
@@ -126,6 +126,9 @@ func (s *Signer) SignTransaction(ctx context.Context, tx *solana.Transaction) (c
 		return core.SignedTransaction{}, core.WrapSignerError(core.CodeSerializationError,
 			"failed to decode signed transaction returned by Turnkey", err)
 	}
+	if err := core.AssertUnversionedWireTransaction("Turnkey", signedWire); err != nil {
+		return core.SignedTransaction{}, err
+	}
 	returned, err := solana.TransactionFromBytes(signedWire)
 	if err != nil {
 		return core.SignedTransaction{}, core.WrapSignerError(core.CodeSerializationError,

--- a/go/signers/utila/signer.go
+++ b/go/signers/utila/signer.go
@@ -243,13 +243,16 @@ func terminalStateError(state transactionState) error {
 // extractSignatureFromRawTransaction decodes the base64 wire transaction Utila
 // returned, requires its message bytes to equal the locally requested message,
 // locates this wallet's required-signer position, and verifies the signature
-// before surfacing it. solana-go's Transaction decodes legacy and versioned
-// messages alike, so both wire formats share this one path.
+// before surfacing it. solana-go's Transaction decodes legacy and v0 messages
+// alike, so those two wire formats share this one path.
 func (s *Signer) extractSignatureFromRawTransaction(rawTransaction string, expectedMessage []byte) (solana.Signature, error) {
 	raw, err := base64.StdEncoding.DecodeString(rawTransaction)
 	if err != nil {
 		return solana.Signature{}, core.WrapSignerError(core.CodeSerializationError,
 			"Failed to decode Utila rawTransaction as base64", err)
+	}
+	if err := core.AssertUnversionedWireTransaction("Utila", raw); err != nil {
+		return solana.Signature{}, err
 	}
 	tx, err := solana.TransactionFromBytes(raw)
 	if err != nil {

--- a/python/src/solana_keychain/cdp/signer.py
+++ b/python/src/solana_keychain/cdp/signer.py
@@ -23,6 +23,7 @@ from solana_keychain.core.signer import SignedTransaction, SolanaSigner
 from solana_keychain.core.transaction_util import (
     ED25519_SIGNATURE_LENGTH,
     add_signature_to_transaction,
+    assert_unversioned_wire_transaction,
     classify_signed_transaction,
     get_signing_keypair_position,
     serialize_transaction,
@@ -163,6 +164,7 @@ class CdpSigner(SolanaSigner):
                 SignerErrorCode.SERIALIZATION_ERROR,
                 "Failed to decode base64 signed transaction from CDP",
             ) from None
+        assert_unversioned_wire_transaction("CDP", signed_bytes)
         try:
             signed_transaction = Transaction.from_bytes(signed_bytes)
         except Exception:

--- a/python/src/solana_keychain/core/__init__.py
+++ b/python/src/solana_keychain/core/__init__.py
@@ -10,6 +10,7 @@ from solana_keychain.core.signer import SignedTransaction, SolanaSigner
 from solana_keychain.core.transaction_util import (
     ED25519_SIGNATURE_LENGTH,
     add_signature_to_transaction,
+    assert_unversioned_wire_transaction,
     classify_signed_transaction,
     get_signing_keypair_position,
     has_all_required_signatures,
@@ -26,6 +27,7 @@ __all__ = [
     "SolanaSigner",
     "add_signature_to_transaction",
     "assert_https_url",
+    "assert_unversioned_wire_transaction",
     "classify_signed_transaction",
     "fetch_signer_json",
     "get_signing_keypair_position",

--- a/python/src/solana_keychain/core/transaction_util.py
+++ b/python/src/solana_keychain/core/transaction_util.py
@@ -25,6 +25,23 @@ def idempotency_key_from_message(message_bytes: bytes) -> str:
     return str(uuid.UUID(bytes=bytes(digest)))
 
 
+def assert_unversioned_wire_transaction(provider: str, wire_bytes: bytes) -> None:
+    """Reject a wire transaction whose envelope carries a version prefix.
+
+    Legacy and v0 envelopes both open with a compact-u16 signature count, capped
+    at 12 signatures, so the high bit of the first byte is never set. v1 moves its
+    signatures to the tail and puts ``0x80 | version`` at offset zero, a layout
+    the signature-slot readers here cannot interpret.
+    """
+    if not wire_bytes or not wire_bytes[0] & 0x80:
+        return
+    raise SignerError(
+        SignerErrorCode.SERIALIZATION_ERROR,
+        f"{provider} returned a v{wire_bytes[0] & 0x7F} transaction envelope, which is not "
+        "supported yet (only legacy and v0 transactions can be verified)",
+    )
+
+
 def serialize_transaction(transaction: Transaction) -> str:
     """Encode a transaction to base64(bincode(tx))."""
     try:

--- a/python/src/solana_keychain/crossmint/signer.py
+++ b/python/src/solana_keychain/crossmint/signer.py
@@ -20,6 +20,7 @@ from solana_keychain.core.signer import SignedTransaction, SolanaSigner
 from solana_keychain.core.transaction_util import (
     ED25519_SIGNATURE_LENGTH,
     add_signature_to_transaction,
+    assert_unversioned_wire_transaction,
     classify_signed_transaction,
     idempotency_key_from_message,
     serialize_transaction,
@@ -364,6 +365,7 @@ class CrossmintSigner(SolanaSigner):
                 SignerErrorCode.SERIALIZATION_ERROR,
                 "Failed to decode Crossmint onChain.transaction as base58",
             ) from None
+        assert_unversioned_wire_transaction("Crossmint", transaction_bytes)
         try:
             transaction = VersionedTransaction.from_bytes(transaction_bytes)
         except Exception:
@@ -425,7 +427,9 @@ class CrossmintSigner(SolanaSigner):
         if not isinstance(submitted, list) or not submitted:
             return None
         try:
-            transaction = VersionedTransaction.from_bytes(base58.b58decode(serialized_transaction))
+            transaction_bytes = base58.b58decode(serialized_transaction)
+            assert_unversioned_wire_transaction("Crossmint", transaction_bytes)
+            transaction = VersionedTransaction.from_bytes(transaction_bytes)
         except Exception:
             return None
         try:

--- a/python/src/solana_keychain/fordefi/signer.py
+++ b/python/src/solana_keychain/fordefi/signer.py
@@ -30,6 +30,7 @@ from solana_keychain.core.signer import SignedTransaction, SolanaSigner
 from solana_keychain.core.transaction_util import (
     ED25519_SIGNATURE_LENGTH,
     add_signature_to_transaction,
+    assert_unversioned_wire_transaction,
     classify_signed_transaction,
     get_signing_keypair_position,
     idempotency_key_from_message,
@@ -419,6 +420,7 @@ class FordefiSigner(SolanaSigner):
             raise SignerError(
                 SignerErrorCode.SERIALIZATION_ERROR, "Failed to decode raw_transaction base64"
             ) from None
+        assert_unversioned_wire_transaction("Fordefi", wire_bytes)
         try:
             returned = Transaction.from_bytes(wire_bytes)
         except Exception:

--- a/python/src/solana_keychain/privy/signer.py
+++ b/python/src/solana_keychain/privy/signer.py
@@ -15,6 +15,7 @@ from solana_keychain.core.http import assert_https_url, fetch_signer_json, norma
 from solana_keychain.core.signer import SignedTransaction, SolanaSigner
 from solana_keychain.core.transaction_util import (
     add_signature_to_transaction,
+    assert_unversioned_wire_transaction,
     classify_signed_transaction,
     get_signing_keypair_position,
     serialize_transaction,
@@ -192,7 +193,15 @@ class PrivySigner(SolanaSigner):
                 SignerErrorCode.REMOTE_API_ERROR, "No signed_transaction in Privy response"
             )
         try:
-            signed = Transaction.from_bytes(base64.b64decode(signed_b64, validate=True))
+            signed_wire = base64.b64decode(signed_b64, validate=True)
+        except Exception:
+            raise SignerError(
+                SignerErrorCode.SERIALIZATION_ERROR,
+                "Failed to decode signed transaction returned by Privy",
+            ) from None
+        assert_unversioned_wire_transaction("Privy", signed_wire)
+        try:
+            signed = Transaction.from_bytes(signed_wire)
         except Exception:
             raise SignerError(
                 SignerErrorCode.SERIALIZATION_ERROR,

--- a/python/src/solana_keychain/turnkey/signer.py
+++ b/python/src/solana_keychain/turnkey/signer.py
@@ -24,6 +24,7 @@ from solana_keychain.core.http import assert_https_url, fetch_signer_json, norma
 from solana_keychain.core.signer import SignedTransaction, SolanaSigner
 from solana_keychain.core.transaction_util import (
     add_signature_to_transaction,
+    assert_unversioned_wire_transaction,
     classify_signed_transaction,
     get_signing_keypair_position,
     serialize_transaction,
@@ -228,7 +229,15 @@ class TurnkeySigner(SolanaSigner):
         if not isinstance(signed_hex, str):
             raise SignerError(SignerErrorCode.SIGNING_FAILED, "Invalid response from Turnkey API")
         try:
-            signed = Transaction.from_bytes(bytes.fromhex(signed_hex))
+            signed_wire = bytes.fromhex(signed_hex)
+        except Exception:
+            raise SignerError(
+                SignerErrorCode.SERIALIZATION_ERROR,
+                "Failed to decode signed transaction returned by Turnkey",
+            ) from None
+        assert_unversioned_wire_transaction("Turnkey", signed_wire)
+        try:
+            signed = Transaction.from_bytes(signed_wire)
         except Exception:
             raise SignerError(
                 SignerErrorCode.SERIALIZATION_ERROR,

--- a/python/src/solana_keychain/utila/signer.py
+++ b/python/src/solana_keychain/utila/signer.py
@@ -27,6 +27,7 @@ from solana_keychain.core.http import assert_https_url, fetch_signer_json, norma
 from solana_keychain.core.signer import SignedTransaction, SolanaSigner
 from solana_keychain.core.transaction_util import (
     add_signature_to_transaction,
+    assert_unversioned_wire_transaction,
     classify_signed_transaction,
     serialize_transaction,
     signed_message_bytes,
@@ -304,6 +305,7 @@ class UtilaSigner(SolanaSigner):
                 SignerErrorCode.SERIALIZATION_ERROR,
                 "Failed to decode Utila rawTransaction as base64",
             ) from None
+        assert_unversioned_wire_transaction("Utila", transaction_bytes)
         try:
             transaction = VersionedTransaction.from_bytes(transaction_bytes)
         except Exception:

--- a/python/tests/test_transaction_util.py
+++ b/python/tests/test_transaction_util.py
@@ -110,3 +110,27 @@ def test_signed_message_bytes_leaves_legacy_messages_unchanged() -> None:
     keypair = Keypair()
     transaction = create_test_transaction(keypair.pubkey())
     assert signed_message_bytes(transaction.message) == transaction.message_data()
+
+
+def test_assert_unversioned_accepts_a_real_legacy_wire_transaction() -> None:
+    from solana_keychain.core import assert_unversioned_wire_transaction
+
+    keypair = Keypair()
+    transaction = create_test_transaction(keypair.pubkey())
+    assert_unversioned_wire_transaction("Provider", bytes(transaction))
+
+
+def test_assert_unversioned_rejects_a_v1_envelope_naming_the_version() -> None:
+    from solana_keychain.core import assert_unversioned_wire_transaction
+
+    with pytest.raises(SignerError) as excinfo:
+        assert_unversioned_wire_transaction("Provider", b"\x81\x01")
+    assert excinfo.value.code == SignerErrorCode.SERIALIZATION_ERROR
+    assert "Provider" in excinfo.value._detail
+    assert "v1" in excinfo.value._detail
+
+
+def test_assert_unversioned_ignores_empty_bytes() -> None:
+    from solana_keychain.core import assert_unversioned_wire_transaction
+
+    assert_unversioned_wire_transaction("Provider", b"")

--- a/rust/src/cdp/mod.rs
+++ b/rust/src/cdp/mod.rs
@@ -371,6 +371,7 @@ impl CdpSigner {
                 )
             })?;
 
+        TransactionUtil::reject_versioned_wire_transaction("CDP", &signed_bytes)?;
         let signed_tx: Transaction = bincode::deserialize(&signed_bytes).map_err(|_e| {
             #[cfg(feature = "unsafe-debug")]
             log::error!("Failed to deserialize signed transaction: {_e}");

--- a/rust/src/crossmint/mod.rs
+++ b/rust/src/crossmint/mod.rs
@@ -608,6 +608,7 @@ impl CrossmintSigner {
                 ))
             })?;
 
+        TransactionUtil::reject_versioned_wire_transaction("Crossmint", &bytes)?;
         let transaction: VersionedTransaction = bincode::deserialize(&bytes).map_err(|e| {
             SignerError::SerializationError(format!(
                 "Failed to deserialize Crossmint onChain.transaction: {e}"
@@ -664,6 +665,7 @@ impl CrossmintSigner {
             return None;
         }
         let bytes = bs58::decode(serialized_transaction).into_vec().ok()?;
+        TransactionUtil::reject_versioned_wire_transaction("Crossmint", &bytes).ok()?;
         let transaction: VersionedTransaction = bincode::deserialize(&bytes).ok()?;
         let executed_message = transaction.message.serialize();
         let candidates = self.verification_candidates();

--- a/rust/src/fordefi/mod.rs
+++ b/rust/src/fordefi/mod.rs
@@ -529,19 +529,11 @@ impl FordefiSigner {
             SignerError::SerializationError(format!("Failed to decode raw_transaction base64: {e}"))
         })?;
 
-        // Deserialize the Fordefi-returned wire transaction with the Solana SDK
-        // (bincode of a Transaction is exactly the Solana wire format).
-        //
-        // NOTE: only *legacy* transactions are supported. A versioned (v0) wire
-        // transaction is prefixed with a version byte (high bit set on the first
-        // byte) that the legacy `Transaction` layout cannot represent, so if Fordefi
-        // ever returns a v0 transaction this deserialization fails rather than
-        // silently mis-parsing. Supporting v0 would mean decoding into
-        // `VersionedTransaction` and threading that type through the signer API.
+        TransactionUtil::reject_versioned_wire_transaction("Fordefi", &wire_bytes)?;
         let returned_tx: Transaction = bincode::deserialize(&wire_bytes).map_err(|e| {
             SignerError::SerializationError(format!(
-                "Failed to deserialize Fordefi wire transaction (versioned/v0 \
-                 transactions are not supported, only legacy): {e}"
+                "Failed to deserialize Fordefi wire transaction (only legacy \
+                 transactions are supported): {e}"
             ))
         })?;
 

--- a/rust/src/privy/mod.rs
+++ b/rust/src/privy/mod.rs
@@ -304,6 +304,7 @@ impl PrivySigner {
                     "Failed to decode signed transaction returned by Privy".to_string(),
                 )
             })?;
+        TransactionUtil::reject_versioned_wire_transaction("Privy", &signed_wire)?;
         let returned: Transaction = bincode::deserialize(&signed_wire).map_err(|e| {
             SignerError::SerializationError(format!(
                 "Failed to deserialize signed transaction returned by Privy: {e}"

--- a/rust/src/transaction_util.rs
+++ b/rust/src/transaction_util.rs
@@ -27,6 +27,28 @@ pub(crate) fn idempotency_key_from_message(message_bytes: &[u8]) -> String {
 pub struct TransactionUtil;
 
 impl TransactionUtil {
+    /// Reject a wire transaction whose envelope carries a version prefix.
+    ///
+    /// Legacy and v0 envelopes both open with a compact-u16 signature count,
+    /// capped at 12 signatures, so the high bit of the first byte is never set.
+    /// v1 moves its signatures to the tail and puts `0x80 | version` at offset
+    /// zero, a layout none of the signature-slot readers here can interpret.
+    pub fn reject_versioned_wire_transaction(
+        provider: &str,
+        wire_bytes: &[u8],
+    ) -> Result<(), SignerError> {
+        let Some(first) = wire_bytes.first() else {
+            return Ok(());
+        };
+        if first & 0x80 == 0 {
+            return Ok(());
+        }
+        Err(SignerError::SerializationError(format!(
+            "{provider} returned a v{} transaction envelope, which is not supported yet (only legacy and v0 transactions can be verified)",
+            first & 0x7f
+        )))
+    }
+
     /// Encodes a Transaction to a base64 serialized String
     pub fn serialize_transaction(transaction: &Transaction) -> Result<String, SignerError> {
         Ok(
@@ -106,5 +128,39 @@ impl TransactionUtil {
         } else {
             SignTransactionResult::Partial(signed_transaction)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_util::create_test_transaction;
+
+    #[test]
+    fn accepts_a_real_legacy_wire_transaction() {
+        let transaction = create_test_transaction(&Pubkey::new_unique());
+        let wire_bytes = bincode::serialize(&transaction).expect("serialize test transaction");
+
+        assert!(
+            TransactionUtil::reject_versioned_wire_transaction("Provider", &wire_bytes).is_ok(),
+            "a legacy envelope opens with a signature count, never a version prefix"
+        );
+    }
+
+    #[test]
+    fn rejects_a_v1_envelope_naming_the_version() {
+        let error = TransactionUtil::reject_versioned_wire_transaction("Provider", &[0x81, 0x01])
+            .expect_err("a 0x81 prefix is a v1 envelope this crate cannot verify");
+
+        let SignerError::SerializationError(detail) = error else {
+            panic!("a version the crate cannot parse is a serialization failure");
+        };
+        assert!(detail.contains("Provider"), "{detail}");
+        assert!(detail.contains("v1"), "{detail}");
+    }
+
+    #[test]
+    fn ignores_empty_bytes_so_the_decoder_reports_the_real_problem() {
+        assert!(TransactionUtil::reject_versioned_wire_transaction("Provider", &[]).is_ok());
     }
 }

--- a/rust/src/turnkey/mod.rs
+++ b/rust/src/turnkey/mod.rs
@@ -257,6 +257,7 @@ impl TurnkeySigner {
                 "Failed to decode signed transaction returned by Turnkey: {e}"
             ))
         })?;
+        TransactionUtil::reject_versioned_wire_transaction("Turnkey", &signed_wire)?;
         let returned: Transaction = bincode::deserialize(&signed_wire).map_err(|e| {
             SignerError::SerializationError(format!(
                 "Failed to deserialize signed transaction returned by Turnkey: {e}"

--- a/rust/src/utila/mod.rs
+++ b/rust/src/utila/mod.rs
@@ -322,6 +322,7 @@ impl UtilaSigner {
             )
         })?;
 
+        TransactionUtil::reject_versioned_wire_transaction("Utila", &bytes)?;
         let signature = match bincode::deserialize::<VersionedTransaction>(&bytes) {
             Ok(transaction) => {
                 let remote_message = transaction.message.serialize();

--- a/typescript/packages/cdp/src/cdp-signer.ts
+++ b/typescript/packages/cdp/src/cdp-signer.ts
@@ -442,6 +442,7 @@ export class CdpSigner<TAddress extends string = string> implements SolanaSigner
                 const signedWireTx = await this.callSignTransaction(wireTransaction);
                 const sigDict = extractSignatureFromWireTransaction({
                     base64WireTransaction: signedWireTx,
+                    providerName: 'CDP',
                     signerAddress: this.address,
                 });
                 await assertSignatureValid({

--- a/typescript/packages/core/README.md
+++ b/typescript/packages/core/README.md
@@ -80,8 +80,20 @@ import { extractSignatureFromWireTransaction } from '@solana/keychain-core';
 const signedTx = await remoteApi.signTransaction(...);
 const sigDict = extractSignatureFromWireTransaction({
     base64WireTransaction: signedTx,
+    providerName: 'MyProvider',
     signerAddress: myAddress
 });
+```
+
+`providerName` names the provider in the error when the returned envelope cannot be read, including a versioned (v1) envelope, which these signature readers reject.
+
+**`assertUnversionedWireTransaction`** - Reject a wire transaction whose envelope carries a version prefix:
+
+```typescript
+import { assertUnversionedWireTransaction } from '@solana/keychain-core';
+
+// Call before decoding provider-returned wire bytes yourself.
+assertUnversionedWireTransaction({ providerName: 'MyProvider', transactionBytes });
 ```
 
 **`createSignatureDictionary`** - Create a signature dictionary from raw signature bytes:

--- a/typescript/packages/core/src/__tests__/assert-unversioned-wire-transaction.test.ts
+++ b/typescript/packages/core/src/__tests__/assert-unversioned-wire-transaction.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+
+import { SignerError, SignerErrorCode } from '../errors.js';
+import { assertUnversionedWireTransaction } from '../utils.js';
+
+const MAX_SIGNATURES = 12;
+
+describe('assertUnversionedWireTransaction', () => {
+    it('accepts every signature count a legacy or v0 envelope can open with', () => {
+        for (let signatureCount = 1; signatureCount <= MAX_SIGNATURES; signatureCount++) {
+            expect(() =>
+                assertUnversionedWireTransaction({
+                    providerName: 'Provider',
+                    transactionBytes: new Uint8Array([signatureCount, 0, 1]),
+                }),
+            ).not.toThrow();
+        }
+    });
+
+    it('rejects a v1 envelope, naming the provider and the version', () => {
+        try {
+            assertUnversionedWireTransaction({
+                providerName: 'Provider',
+                transactionBytes: new Uint8Array([0x81, 0x01]),
+            });
+            expect.unreachable('a 0x81 prefix is a v1 envelope these signature readers cannot interpret');
+        } catch (error) {
+            expect(error).toBeInstanceOf(SignerError);
+            expect((error as SignerError).code).toBe(SignerErrorCode.SERIALIZATION_ERROR);
+            expect((error as SignerError).context?.message).toContain('Provider');
+            expect((error as SignerError).context?.message).toContain('v1');
+        }
+    });
+
+    it('defers to the decoder for empty bytes', () => {
+        expect(() =>
+            assertUnversionedWireTransaction({ providerName: 'Provider', transactionBytes: new Uint8Array() }),
+        ).not.toThrow();
+    });
+});

--- a/typescript/packages/core/src/utils.ts
+++ b/typescript/packages/core/src/utils.ts
@@ -78,7 +78,38 @@ export async function assertSignatureValid({
     }
 }
 
+interface AssertUnversionedWireTransactionOptions {
+    providerName: string;
+    transactionBytes: ReadonlyUint8Array;
+}
+
+/**
+ * Rejects a wire transaction whose envelope carries a version prefix.
+ *
+ * Legacy and v0 envelopes both open with a compact-u16 signature count, capped
+ * at 12 signatures, so the high bit of the first byte is never set. v1 moves its
+ * signatures to the tail and puts `0x80 | version` at offset zero, a layout the
+ * signature readers here cannot interpret.
+ *
+ * @param providerName - The provider that returned the transaction
+ * @param transactionBytes - The serialized wire transaction
+ * @throws {SignerError} If the envelope is versioned
+ */
+export function assertUnversionedWireTransaction({
+    providerName,
+    transactionBytes,
+}: AssertUnversionedWireTransactionOptions): void {
+    const first = transactionBytes[0];
+    if (first === undefined || (first & 0x80) === 0) {
+        return;
+    }
+    throwSignerError(SignerErrorCode.SERIALIZATION_ERROR, {
+        message: `${providerName} returned a v${first & 0x7f} transaction envelope, which is not supported yet (only legacy and v0 transactions can be verified)`,
+    });
+}
+
 interface ExtractSignatureFromTransactionBytesOptions {
+    providerName: string;
     signerAddress: Address;
     transactionBytes: ReadonlyUint8Array;
 }
@@ -88,16 +119,19 @@ interface ExtractSignatureFromTransactionBytesOptions {
  * Useful for remote signers that return the signed transaction as raw bytes,
  * avoiding a base64 encode/decode round-trip.
  *
+ * @param providerName - The provider that returned the transaction
  * @param transactionBytes - The serialized wire transaction
  * @param signerAddress - The address of the signer whose signature to extract
  * @returns SignatureDictionary with only the specified signer's signature
  * @throws {SignerError} If no signature is found for the given address
  */
 export function extractSignatureFromTransactionBytes({
+    providerName,
     signerAddress,
     transactionBytes,
 }: ExtractSignatureFromTransactionBytesOptions): SignatureDictionary {
     assertIsAddress(signerAddress);
+    assertUnversionedWireTransaction({ providerName, transactionBytes });
     const { signatures } = getTransactionDecoder().decode(transactionBytes);
 
     const signature = signatures[signerAddress];
@@ -116,6 +150,7 @@ export function extractSignatureFromTransactionBytes({
 
 interface ExtractSignatureFromWireTransactionOptions {
     base64WireTransaction: Base64EncodedWireTransaction;
+    providerName: string;
     signerAddress: Address;
 }
 
@@ -124,6 +159,7 @@ interface ExtractSignatureFromWireTransactionOptions {
  * Useful for remote signers that return fully signed transactions from their APIs.
  *
  * @param base64WireTransaction - Base64 encoded transaction string
+ * @param providerName - The provider that returned the transaction
  * @param signerAddress - The address of the signer whose signature to extract
  * @returns SignatureDictionary with only the specified signer's signature
  * @throws {SignerError} If no signature is found for the given address
@@ -132,14 +168,20 @@ interface ExtractSignatureFromWireTransactionOptions {
  * ```typescript
  * // Privy API returns a signed transaction
  * const signedTx = await privyApi.signTransaction(...);
- * const sigDict = extractSignatureFromWireTransaction(signedTx, this.address);
+ * const sigDict = extractSignatureFromWireTransaction({
+ *     base64WireTransaction: signedTx,
+ *     providerName: 'Privy',
+ *     signerAddress: this.address,
+ * });
  * ```
  */
 export function extractSignatureFromWireTransaction({
     base64WireTransaction,
+    providerName,
     signerAddress,
 }: ExtractSignatureFromWireTransactionOptions): SignatureDictionary {
     return extractSignatureFromTransactionBytes({
+        providerName,
         signerAddress,
         transactionBytes: getBase64Encoder().encode(base64WireTransaction),
     });

--- a/typescript/packages/crossmint/src/crossmint-signer.ts
+++ b/typescript/packages/crossmint/src/crossmint-signer.ts
@@ -3,6 +3,7 @@ import { getBase16Encoder, getBase58Decoder, getBase58Encoder, getBase64Encoder 
 import {
     assertHttpsUrl,
     assertSignatureValid,
+    assertUnversionedWireTransaction,
     DEFAULT_FETCH_TIMEOUT_MS,
     ED25519_SIGNATURE_LENGTH,
     fetchSignerJson,
@@ -467,9 +468,12 @@ class CrossmintSigner<TAddress extends string = string> implements CrossmintSend
             let executedTransaction: Transaction | undefined;
             try {
                 base58Encoder ||= getBase58Encoder();
-                executedTransaction = getTransactionDecoder().decode(
-                    base58Encoder.encode(response.onChain.transaction),
-                );
+                const executedBytes = base58Encoder.encode(response.onChain.transaction);
+                assertUnversionedWireTransaction({
+                    providerName: 'Crossmint',
+                    transactionBytes: executedBytes,
+                });
+                executedTransaction = getTransactionDecoder().decode(executedBytes);
             } catch (error) {
                 embeddedError = error;
             }

--- a/typescript/packages/fordefi/src/fordefi-signer.ts
+++ b/typescript/packages/fordefi/src/fordefi-signer.ts
@@ -5,6 +5,7 @@ import { getBase58Decoder } from '@solana/codecs-strings';
 import {
     assertHttpsUrl,
     assertSignatureValid,
+    assertUnversionedWireTransaction,
     createSignatureDictionary,
     extractSignatureFromWireTransaction,
     fetchSignerJson,
@@ -552,6 +553,7 @@ export class FordefiSigner<TAddress extends string = string> implements MessageP
         const signedWireTx = result.raw_transaction as Base64EncodedWireTransaction;
         const sigDict = extractSignatureFromWireTransaction({
             base64WireTransaction: signedWireTx,
+            providerName: 'Fordefi',
             signerAddress: this.address,
         });
         const signerSignature = sigDict[this.address];
@@ -816,6 +818,7 @@ export class FordefiSigner<TAddress extends string = string> implements MessageP
         transactionSignature: SignatureBytes;
     } {
         const wireBytes = new Uint8Array(Buffer.from(base64WireTx, 'base64'));
+        assertUnversionedWireTransaction({ providerName: 'Fordefi', transactionBytes: wireBytes });
         let signatureCount = 0;
         let signatureCountSize = 0;
         let shift = 0;

--- a/typescript/packages/privy/src/privy-signer.ts
+++ b/typescript/packages/privy/src/privy-signer.ts
@@ -303,6 +303,7 @@ export class PrivySigner<TAddress extends string = string> implements SolanaSign
                 const signedTx = await this.signTransaction(wireTransaction);
                 const sigDict = extractSignatureFromWireTransaction({
                     base64WireTransaction: signedTx,
+                    providerName: 'Privy',
                     signerAddress: this.address,
                 });
                 await assertSignatureValid({

--- a/typescript/packages/turnkey/src/turnkey-signer.ts
+++ b/typescript/packages/turnkey/src/turnkey-signer.ts
@@ -311,6 +311,7 @@ export class TurnkeySigner<TAddress extends string = string> implements SolanaSi
                 const hexToBytes = getBase16Encoder().encode;
                 const signedTxBytes = hexToBytes(signedTransactionHex);
                 const sigDict = extractSignatureFromTransactionBytes({
+                    providerName: 'Turnkey',
                     signerAddress: this.address,
                     transactionBytes: signedTxBytes,
                 });

--- a/typescript/packages/utila/src/utila-signer.ts
+++ b/typescript/packages/utila/src/utila-signer.ts
@@ -260,6 +260,7 @@ export class UtilaSigner<TAddress extends string = string> implements SolanaSign
 
         const sigDict = extractSignatureFromWireTransaction({
             base64WireTransaction: rawSignedTransaction as Base64EncodedWireTransaction,
+            providerName: 'Utila',
             signerAddress: this.address,
         });
         await assertSignatureValid({


### PR DESCRIPTION
## Summary

Solana's v1 transaction format ([SIMD-0385](https://github.com/solana-foundation/solana-improvement-documents/blob/main/proposals/0385-transaction-v1.md)) inverts the envelope: signatures move to the tail and `0x80 | version` lands at offset zero. Every backend here that round-trips a full serialized transaction through a provider API decodes the response with a reader that assumes the legacy layout (compact-u16 signature count, signatures, message).

Nothing detected the version prefix, so a v1 response surfaced as a misleading failure rather than an accurate one:

- TypeScript Fordefi's hand-rolled parser read `0x81` as the start of a compact-u16 count, consumed the header byte as a continuation, and reported "truncated transaction" (or, for other header values, returned bytes from the wrong offset).
- Rust Fordefi reported "versioned/v0 transactions are not supported", blaming v0 for a v1 envelope.
- The remaining backends produced an opaque deserialization error.

This adds a shared guard per language that rejects a version-prefixed envelope before decoding, naming both the provider and the detected version. Legacy and v0 envelopes are unaffected: they cap at 12 signatures, so the high bit of the first byte is never set, which is the same offset-zero discriminator the SIMD intends for infrastructure.

Wired into every provider-response decode site:

| Language | Sites |
| --- | --- |
| Rust | `TransactionUtil::reject_versioned_wire_transaction` in Privy, Turnkey, CDP, Utila, Fordefi, Crossmint (both paths) |
| TypeScript | `assertUnversionedWireTransaction`, called inside the core signature extractors (covers Privy, Turnkey, CDP, Utila, Fordefi) plus the Crossmint and Fordefi decoders |
| Python | `assert_unversioned_wire_transaction` in the same six backends |
| Go | `core.AssertUnversionedWireTransaction` in the same six backends |

Also corrects two now-inaccurate claims that this change contradicts: the Rust Fordefi comment describing a v0 wire transaction as version-prefixed at offset zero (only v1+ is), and the Go Utila doc claiming solana-go decodes legacy and all versioned messages alike.

This is the fail-loud slice only. It does not add v1 support: that needs an SDK upgrade (Agave 4.2.x in Rust, a kit floor raise in TypeScript, solders' `MessageV1` in Python, a solana-go library decision), a versioned transaction type on the public signing API, and per-provider confirmation that each vendor accepts v1.

## Breaking change

The TypeScript core helpers `extractSignatureFromTransactionBytes` and `extractSignatureFromWireTransaction` now require a `providerName` field, so the rejection error names the provider like every other error in the library.

## Test Plan

- `just rust-test` (all three SDK matrices: 335 passed each)
- `just rust-fmt`
- `just ts-test`, `just ts-fmt`, `just ts-treeshake`
- `just py-test` (480 passed), `just py-fmt`
- `just go-test`, `just go-fmt`

New tests per language cover: a real legacy transaction is accepted (no false positive), a `0x81` envelope is rejected with a serialization error naming provider and version, and empty bytes defer to the decoder.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>