### PR TITLE
feat(rust)!: support v1 transactions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,7 +81,7 @@ One feature per backend (`memory` is default), `all` enables everything. At leas
 - **`sign_message` quirks:** `CrossmintSigner` returns `SigningFailed` (intentionally unsupported). `CdpSigner` only accepts UTF-8 payloads.
 - **Turnkey signature padding:** response `r,s` components must be left-padded to 32 bytes each before concatenation ([rust/src/turnkey/mod.rs](rust/src/turnkey/mod.rs)).
 - **GCP KMS:** PureEdDSA mode with `EC_SIGN_ED25519`.
-- **Transaction serialization:** go through `transaction_util::serialize_wire_transaction` / `deserialize_wire_transaction`, never `bincode` directly. A v1 envelope leads with the message and appends its signatures with no length prefix, which serde cannot express, so `sdk-v4` uses `wincode`; the two codecs agree byte-for-byte on legacy and v0.
+- **Transaction serialization:** go through `transaction_util::serialize_wire_transaction` / `deserialize_wire_transaction`, never `bincode` directly (`sdk-v4` needs `wincode` for v1).
 - **Transaction types:** `sign_transaction` takes a `VersionedTransaction` (legacy, v0 or v1). v1 messages exist only in the solana-sdk 4.x line, so v1 requires `sdk-v4` and is unrepresentable under `sdk-v2`/`sdk-v3`.
 - **Remote-signer tests** use `wiremock`; no live API calls in unit tests.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,7 +81,8 @@ One feature per backend (`memory` is default), `all` enables everything. At leas
 - **`sign_message` quirks:** `CrossmintSigner` returns `SigningFailed` (intentionally unsupported). `CdpSigner` only accepts UTF-8 payloads.
 - **Turnkey signature padding:** response `r,s` components must be left-padded to 32 bytes each before concatenation ([rust/src/turnkey/mod.rs](rust/src/turnkey/mod.rs)).
 - **GCP KMS:** PureEdDSA mode with `EC_SIGN_ED25519`.
-- **Transaction serialization:** all backends use `bincode` before signing.
+- **Transaction serialization:** go through `transaction_util::serialize_wire_transaction` / `deserialize_wire_transaction`, never `bincode` directly. A v1 envelope leads with the message and appends its signatures with no length prefix, which serde cannot express, so `sdk-v4` uses `wincode`; the two codecs agree byte-for-byte on legacy and v0.
+- **Transaction types:** `sign_transaction` takes a `VersionedTransaction` (legacy, v0 or v1). v1 messages exist only in the solana-sdk 4.x line, so v1 requires `sdk-v4` and is unrepresentable under `sdk-v2`/`sdk-v3`.
 - **Remote-signer tests** use `wiremock`; no live API calls in unit tests.
 
 ## TypeScript

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -6743,6 +6743,7 @@ dependencies = [
  "thiserror 2.0.20",
  "tokio",
  "uuid",
+ "wincode",
  "wiremock",
  "zeroize",
 ]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -69,7 +69,7 @@ sdk-v2 = ["dep:solana-sdk"]
 sdk-v3 = ["dep:solana-sdk-v3", "dep:solana-shred-version-v3", "dep:solana-signature"]
 # solana-sdk 4.x bundles solana-signature/solana-shred-version via its `full`
 # feature at internally-consistent versions, so no companion-crate pins needed.
-sdk-v4 = ["dep:solana-sdk-v4"]
+sdk-v4 = ["dep:solana-sdk-v4", "dep:wincode"]
 
 # WARNING: DO NOT ENABLE IN PRODUCTION
 # This feature logs full API error responses which may contain sensitive information
@@ -119,6 +119,10 @@ rsa = { version = "0.9", optional = true }
 
 # Core dependencies (used by all signers for transaction serialization)
 bincode = "1.3"
+# The v1 transaction envelope puts its signatures at the tail with no length
+# prefix, a layout serde/bincode cannot express. wincode is the codec the 4.x SDK
+# uses for it, and it agrees with bincode byte-for-byte on legacy and v0.
+wincode = { version = "0.4.9", optional = true }
 base64 = "0.22.1"
 zeroize = "1.8.2"
 

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -119,9 +119,7 @@ rsa = { version = "0.9", optional = true }
 
 # Core dependencies (used by all signers for transaction serialization)
 bincode = "1.3"
-# The v1 transaction envelope puts its signatures at the tail with no length
-# prefix, a layout serde/bincode cannot express. wincode is the codec the 4.x SDK
-# uses for it, and it agrees with bincode byte-for-byte on legacy and v0.
+# serde cannot express the v1 envelope; wincode can.
 wincode = { version = "0.4.9", optional = true }
 base64 = "0.22.1"
 zeroize = "1.8.2"

--- a/rust/README.md
+++ b/rust/README.md
@@ -306,8 +306,12 @@ pub trait SolanaSigner: Send + Sync {
     /// Get the public key of this signer
     fn pubkey(&self) -> Pubkey;
 
-    /// Sign a Solana transaction (modifies transaction in place)
-    async fn sign_transaction(&self, tx: &mut Transaction) -> Result<Signature, SignerError>;
+    /// Sign a Solana transaction (modifies transaction in place).
+    /// Accepts legacy, v0 and v1; v1 requires the `sdk-v4` feature.
+    async fn sign_transaction(
+        &self,
+        tx: &mut VersionedTransaction,
+    ) -> Result<Signature, SignerError>;
 
     /// Sign arbitrary message bytes
     async fn sign_message(&self, message: &[u8]) -> Result<Signature, SignerError>;
@@ -322,7 +326,7 @@ pub trait SolanaSigner: Send + Sync {
 Fordefi supports two signing modes, which differ in whether Fordefi broadcasts the transaction and in what `sign_transaction` returns:
 
 - **Black box mode** : Signs raw bytes via EdDSA; the wire transaction is assembled locally. Fordefi does **not** broadcast — `sign_transaction` returns the signed serialized transaction, and **you** submit it to an RPC. Use with a Fordefi black box vault.
-- **Native Solana mode** (recommended): Uses Solana-specific API types. Fordefi modifies the transaction (at minimum updating the blockhash, and optionally adding priority fees) and **auto-broadcasts** it on-chain (`push_mode: "auto"`). Because the transaction is already submitted, `sign_transaction` returns an **empty** serialized transaction (only the signature is meaningful) and updates your `&mut Transaction` to the Fordefi-signed one — do not re-send it. The current auto-broadcast request supports only transactions whose sole required signer is the configured Fordefi vault; additional required signers are rejected before submission. Use with a regular Fordefi Solana vault.
+- **Native Solana mode** (recommended): Uses Solana-specific API types. Fordefi modifies the transaction (at minimum updating the blockhash, and optionally adding priority fees) and **auto-broadcasts** it on-chain (`push_mode: "auto"`). Because the transaction is already submitted, `sign_transaction` returns an **empty** serialized transaction (only the signature is meaningful) and updates your `&mut VersionedTransaction` to the Fordefi-signed one — do not re-send it. The current auto-broadcast request supports only transactions whose sole required signer is the configured Fordefi vault; additional required signers are rejected before submission. Use with a regular Fordefi Solana vault.
 
 Construction is async because it fetches the Fordefi vault and verifies that its
 authoritative address matches the configured `public_key` before returning.

--- a/rust/src/aws_kms/mod.rs
+++ b/rust/src/aws_kms/mod.rs
@@ -1,6 +1,6 @@
 //! AWS KMS signer integration using EdDSA (Ed25519) signing
 
-use crate::sdk_adapter::{Pubkey, Signature, Transaction};
+use crate::sdk_adapter::{Pubkey, Signature, VersionedTransaction};
 use crate::traits::{SignTransactionResult, SignedTransaction};
 use crate::{error::SignerError, traits::SolanaSigner, transaction_util::TransactionUtil};
 use aws_config::Region;
@@ -194,9 +194,9 @@ impl AwsKmsSigner {
 
     async fn sign_and_serialize(
         &self,
-        transaction: &mut Transaction,
+        transaction: &mut VersionedTransaction,
     ) -> Result<SignedTransaction, SignerError> {
-        let signature = self.sign_bytes(&transaction.message_data()).await?;
+        let signature = self.sign_bytes(&transaction.message.serialize()).await?;
 
         TransactionUtil::add_signature_to_transaction(transaction, &self.public_key, signature)?;
 
@@ -249,7 +249,7 @@ impl SolanaSigner for AwsKmsSigner {
 
     async fn sign_transaction(
         &self,
-        tx: &mut Transaction,
+        tx: &mut VersionedTransaction,
     ) -> Result<SignTransactionResult, SignerError> {
         let signed_transaction = self.sign_and_serialize(tx).await?;
         Ok(TransactionUtil::classify_signed_transaction(
@@ -816,7 +816,7 @@ mod tests {
         let keypair = create_test_keypair();
 
         let mut tx = create_test_transaction(&keypair.pubkey());
-        let signature = keypair.sign_message(&tx.message_data());
+        let signature = keypair.sign_message(&tx.message.serialize());
 
         Mock::given(any())
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({

--- a/rust/src/cdp/mod.rs
+++ b/rust/src/cdp/mod.rs
@@ -3,7 +3,7 @@
 mod jwt;
 mod types;
 
-use crate::sdk_adapter::{Pubkey, Signature, Transaction};
+use crate::sdk_adapter::{Pubkey, Signature, VersionedTransaction};
 use crate::traits::{SignTransactionResult, SignedTransaction};
 use crate::transaction_util::TransactionUtil;
 use crate::{error::SignerError, http_client_config::HttpClientConfig, traits::SolanaSigner};
@@ -346,16 +346,14 @@ impl CdpSigner {
     /// Sign and serialize a Solana transaction via CDP.
     async fn sign_and_serialize(
         &self,
-        transaction: &mut Transaction,
+        transaction: &mut VersionedTransaction,
     ) -> Result<SignedTransaction, SignerError> {
-        let message_data = transaction.message_data();
+        let message_data = transaction.message.serialize();
         let signer_position =
             TransactionUtil::get_signing_keypair_position(transaction, &self.public_key)?;
 
         // Serialize the full transaction to bytes (Solana wire format)
-        let serialized = bincode::serialize(transaction).map_err(|e| {
-            SignerError::SerializationError(format!("Failed to serialize transaction: {e}"))
-        })?;
+        let serialized = crate::transaction_util::serialize_wire_transaction(transaction)?;
         let base64_tx = STANDARD.encode(&serialized);
 
         let response = self.call_sign_transaction(&base64_tx).await?;
@@ -371,13 +369,14 @@ impl CdpSigner {
                 )
             })?;
 
-        let signed_tx: Transaction = bincode::deserialize(&signed_bytes).map_err(|_e| {
-            #[cfg(feature = "unsafe-debug")]
-            log::error!("Failed to deserialize signed transaction: {_e}");
-            SignerError::SerializationError(
-                "Failed to deserialize signed transaction from CDP".to_string(),
-            )
-        })?;
+        let signed_tx: VersionedTransaction =
+            crate::transaction_util::deserialize_wire_transaction(&signed_bytes).map_err(|_e| {
+                #[cfg(feature = "unsafe-debug")]
+                log::error!("Failed to deserialize signed transaction: {_e}");
+                SignerError::SerializationError(
+                    "Failed to deserialize signed transaction from CDP".to_string(),
+                )
+            })?;
 
         // Extract only our signature from the response and apply it to the original transaction.
         let signature = *signed_tx.signatures.get(signer_position).ok_or_else(|| {
@@ -427,7 +426,7 @@ impl SolanaSigner for CdpSigner {
 
     async fn sign_transaction(
         &self,
-        tx: &mut Transaction,
+        tx: &mut VersionedTransaction,
     ) -> Result<SignTransactionResult, SignerError> {
         let signed_transaction = self.sign_and_serialize(tx).await?;
         Ok(TransactionUtil::classify_signed_transaction(
@@ -745,7 +744,7 @@ mod tests {
         let pubkey = keypair_pubkey(&keypair);
 
         let mut tx = create_test_transaction(&pubkey);
-        let signature = keypair_sign_message(&keypair, &tx.message_data());
+        let signature = keypair_sign_message(&keypair, &tx.message.serialize());
 
         let mut signed_tx = tx.clone();
         signed_tx.signatures = vec![signature];
@@ -794,7 +793,7 @@ mod tests {
         // Simulate a compromised API returning a signature over a different transaction.
         let tampered_recipient = Pubkey::new_unique();
         let mut tampered_tx = create_test_transaction_with_recipient(&pubkey, &tampered_recipient);
-        let tampered_signature = keypair_sign_message(&keypair, &tampered_tx.message_data());
+        let tampered_signature = keypair_sign_message(&keypair, &tampered_tx.message.serialize());
         tampered_tx.signatures = vec![tampered_signature];
 
         let serialized = bincode::serialize(&tampered_tx).unwrap();

--- a/rust/src/cdp/mod.rs
+++ b/rust/src/cdp/mod.rs
@@ -5,7 +5,9 @@ mod types;
 
 use crate::sdk_adapter::{Pubkey, Signature, VersionedTransaction};
 use crate::traits::{SignTransactionResult, SignedTransaction};
-use crate::transaction_util::TransactionUtil;
+use crate::transaction_util::{
+    deserialize_wire_transaction, serialize_wire_transaction, TransactionUtil,
+};
 use crate::{error::SignerError, http_client_config::HttpClientConfig, traits::SolanaSigner};
 use base64::{engine::general_purpose::STANDARD, Engine};
 use serde_json::Value;
@@ -353,7 +355,7 @@ impl CdpSigner {
             TransactionUtil::get_signing_keypair_position(transaction, &self.public_key)?;
 
         // Serialize the full transaction to bytes (Solana wire format)
-        let serialized = crate::transaction_util::serialize_wire_transaction(transaction)?;
+        let serialized = serialize_wire_transaction(transaction)?;
         let base64_tx = STANDARD.encode(&serialized);
 
         let response = self.call_sign_transaction(&base64_tx).await?;
@@ -370,7 +372,7 @@ impl CdpSigner {
             })?;
 
         let signed_tx: VersionedTransaction =
-            crate::transaction_util::deserialize_wire_transaction(&signed_bytes).map_err(|_e| {
+            deserialize_wire_transaction(&signed_bytes).map_err(|_e| {
                 #[cfg(feature = "unsafe-debug")]
                 log::error!("Failed to deserialize signed transaction: {_e}");
                 SignerError::SerializationError(

--- a/rust/src/crossmint/mod.rs
+++ b/rust/src/crossmint/mod.rs
@@ -2,7 +2,7 @@
 
 mod types;
 
-use crate::sdk_adapter::{Pubkey, Signature, Transaction, VersionedTransaction};
+use crate::sdk_adapter::{Pubkey, Signature, VersionedTransaction};
 use crate::traits::SignTransactionResult;
 use crate::transaction_util::TransactionUtil;
 use crate::{error::SignerError, http_client_config::HttpClientConfig, traits::SolanaSigner};
@@ -608,11 +608,12 @@ impl CrossmintSigner {
                 ))
             })?;
 
-        let transaction: VersionedTransaction = bincode::deserialize(&bytes).map_err(|e| {
-            SignerError::SerializationError(format!(
-                "Failed to deserialize Crossmint onChain.transaction: {e}"
-            ))
-        })?;
+        let transaction: VersionedTransaction =
+            crate::transaction_util::deserialize_wire_transaction(&bytes).map_err(|e| {
+                SignerError::SerializationError(format!(
+                    "Failed to deserialize Crossmint onChain.transaction: {e}"
+                ))
+            })?;
 
         let required_signers = usize::from(transaction.message.header().num_required_signatures);
         let signer_keys = transaction.message.static_account_keys();
@@ -664,7 +665,7 @@ impl CrossmintSigner {
             return None;
         }
         let bytes = bs58::decode(serialized_transaction).into_vec().ok()?;
-        let transaction: VersionedTransaction = bincode::deserialize(&bytes).ok()?;
+        let transaction = crate::transaction_util::deserialize_wire_transaction(&bytes).ok()?;
         let executed_message = transaction.message.serialize();
         let candidates = self.verification_candidates();
         for entry in submitted {
@@ -769,7 +770,7 @@ impl CrossmintSigner {
     /// exact same bytes cannot create a second transaction.
     async fn sign_and_serialize(
         &self,
-        transaction: &mut Transaction,
+        transaction: &mut VersionedTransaction,
     ) -> Result<SignTransactionResult, SignerError> {
         if self.public_key == Pubkey::default() {
             return Err(SignerError::ConfigError(
@@ -777,10 +778,8 @@ impl CrossmintSigner {
             ));
         }
 
-        let expected_message = transaction.message_data();
-        let serialized = bincode::serialize(transaction).map_err(|e| {
-            SignerError::SerializationError(format!("Failed to serialize transaction: {e}"))
-        })?;
+        let expected_message = transaction.message.serialize();
+        let serialized = crate::transaction_util::serialize_wire_transaction(transaction)?;
         let transaction_b58 = bs58::encode(serialized).into_string();
         let idempotency_key =
             crate::transaction_util::idempotency_key_from_message(&expected_message);
@@ -843,7 +842,7 @@ impl SolanaSigner for CrossmintSigner {
 
     async fn sign_transaction(
         &self,
-        tx: &mut Transaction,
+        tx: &mut VersionedTransaction,
     ) -> Result<SignTransactionResult, SignerError> {
         self.sign_and_serialize(tx).await
     }
@@ -1129,7 +1128,8 @@ mod tests {
 
         let mut local_tx = create_test_transaction(&signer_pubkey);
         let mut signed_remote_tx = local_tx.clone();
-        let expected_signature = keypair_sign_message(&keypair, &signed_remote_tx.message_data());
+        let expected_signature =
+            keypair_sign_message(&keypair, &signed_remote_tx.message.serialize());
         TransactionUtil::add_signature_to_transaction(
             &mut signed_remote_tx,
             &signer_pubkey,
@@ -1141,7 +1141,7 @@ mod tests {
             bs58::encode(bincode::serialize(&signed_remote_tx).unwrap()).into_string();
 
         let expected_idempotency_key =
-            crate::transaction_util::idempotency_key_from_message(&local_tx.message_data());
+            crate::transaction_util::idempotency_key_from_message(&local_tx.message.serialize());
         Mock::given(method("POST"))
             .and(path("/2025-06-09/wallets/test-wallet/transactions"))
             .and(header("x-api-key", "test-api-key"))
@@ -1194,7 +1194,7 @@ mod tests {
         let mut local_tx = create_test_transaction(&wallet_pubkey);
         let mut rewritten_tx = create_test_transaction(&delegated_pubkey);
         let expected_signature =
-            keypair_sign_message(&delegated_keypair, &rewritten_tx.message_data());
+            keypair_sign_message(&delegated_keypair, &rewritten_tx.message.serialize());
         TransactionUtil::add_signature_to_transaction(
             &mut rewritten_tx,
             &delegated_pubkey,
@@ -1269,7 +1269,7 @@ mod tests {
 
         let mut local_tx = create_test_transaction(&wallet_pubkey);
         let mut rewritten_tx = create_test_transaction(&stranger_pubkey);
-        let signature = keypair_sign_message(&stranger, &rewritten_tx.message_data());
+        let signature = keypair_sign_message(&stranger, &rewritten_tx.message.serialize());
         TransactionUtil::add_signature_to_transaction(
             &mut rewritten_tx,
             &stranger_pubkey,
@@ -1318,8 +1318,11 @@ mod tests {
 
         let mut local_tx = create_test_transaction(&signer_pubkey);
         let mut rewritten_tx = create_test_transaction(&signer_pubkey);
-        assert_ne!(rewritten_tx.message_data(), local_tx.message_data());
-        let expected_signature = keypair_sign_message(&keypair, &rewritten_tx.message_data());
+        assert_ne!(
+            rewritten_tx.message.serialize(),
+            local_tx.message.serialize()
+        );
+        let expected_signature = keypair_sign_message(&keypair, &rewritten_tx.message.serialize());
         TransactionUtil::add_signature_to_transaction(
             &mut rewritten_tx,
             &signer_pubkey,
@@ -1377,14 +1380,16 @@ mod tests {
             .await;
 
         let mut executed_tx = create_test_transaction(&sponsor_pubkey);
-        let sponsor_signature = keypair_sign_message(&sponsor_keypair, &executed_tx.message_data());
+        let sponsor_signature =
+            keypair_sign_message(&sponsor_keypair, &executed_tx.message.serialize());
         TransactionUtil::add_signature_to_transaction(
             &mut executed_tx,
             &sponsor_pubkey,
             sponsor_signature,
         )
         .unwrap();
-        let approval_signature = keypair_sign_message(&wallet_keypair, &executed_tx.message_data());
+        let approval_signature =
+            keypair_sign_message(&wallet_keypair, &executed_tx.message.serialize());
 
         Mock::given(method("POST"))
             .and(path("/2025-06-09/wallets/test-wallet/transactions"))
@@ -1495,7 +1500,8 @@ mod tests {
 
         let recipient = Pubkey::new_unique();
         let mut remote_tx = create_test_transaction_with_recipient(&signer_pubkey, &recipient);
-        let remote_signature = keypair_sign_message(&wallet_keypair, &remote_tx.message_data());
+        let remote_signature =
+            keypair_sign_message(&wallet_keypair, &remote_tx.message.serialize());
         TransactionUtil::add_signature_to_transaction(
             &mut remote_tx,
             &signer_pubkey,
@@ -1547,7 +1553,7 @@ mod tests {
         // onChain.transaction with different message bytes (different recipient)
         let recipient = Pubkey::new_unique();
         let mut remote_tx = create_test_transaction_with_recipient(&signer_pubkey, &recipient);
-        let remote_sig = keypair_sign_message(&keypair, &remote_tx.message_data());
+        let remote_sig = keypair_sign_message(&keypair, &remote_tx.message.serialize());
         TransactionUtil::add_signature_to_transaction(&mut remote_tx, &signer_pubkey, remote_sig)
             .unwrap();
         let remote_on_chain_transaction =
@@ -1684,7 +1690,7 @@ mod tests {
         signer.init().await.unwrap();
 
         let mut tx = create_test_transaction(&signer_pubkey);
-        let expected_signature = keypair_sign_message(&keypair, &tx.message_data());
+        let expected_signature = keypair_sign_message(&keypair, &tx.message.serialize());
         let tx_id = bs58::encode(expected_signature.as_ref()).into_string();
 
         Mock::given(method("GET"))
@@ -1747,7 +1753,7 @@ mod tests {
         signer.init().await.unwrap();
 
         let mut tx = create_test_transaction(&signer_pubkey);
-        let expected_tx_signature = keypair_sign_message(&keypair, &tx.message_data());
+        let expected_tx_signature = keypair_sign_message(&keypair, &tx.message.serialize());
         let tx_id = bs58::encode(expected_tx_signature.as_ref()).into_string();
 
         // Only an approval whose signature covers OUR challenge bytes (and
@@ -1805,7 +1811,7 @@ mod tests {
             .await;
 
         let mut tx = create_test_transaction(&signer_pubkey);
-        let expected_signature = keypair_sign_message(&keypair, &tx.message_data());
+        let expected_signature = keypair_sign_message(&keypair, &tx.message.serialize());
         let tx_id = bs58::encode(expected_signature.as_ref()).into_string();
 
         Mock::given(method("GET"))

--- a/rust/src/crossmint/mod.rs
+++ b/rust/src/crossmint/mod.rs
@@ -4,7 +4,10 @@ mod types;
 
 use crate::sdk_adapter::{Pubkey, Signature, VersionedTransaction};
 use crate::traits::SignTransactionResult;
-use crate::transaction_util::TransactionUtil;
+use crate::transaction_util::{
+    deserialize_wire_transaction, idempotency_key_from_message, serialize_wire_transaction,
+    TransactionUtil,
+};
 use crate::{error::SignerError, http_client_config::HttpClientConfig, traits::SolanaSigner};
 use std::str::FromStr;
 use types::{
@@ -609,7 +612,7 @@ impl CrossmintSigner {
             })?;
 
         let transaction: VersionedTransaction =
-            crate::transaction_util::deserialize_wire_transaction(&bytes).map_err(|e| {
+            deserialize_wire_transaction(&bytes).map_err(|e| {
                 SignerError::SerializationError(format!(
                     "Failed to deserialize Crossmint onChain.transaction: {e}"
                 ))
@@ -665,7 +668,7 @@ impl CrossmintSigner {
             return None;
         }
         let bytes = bs58::decode(serialized_transaction).into_vec().ok()?;
-        let transaction = crate::transaction_util::deserialize_wire_transaction(&bytes).ok()?;
+        let transaction = deserialize_wire_transaction(&bytes).ok()?;
         let executed_message = transaction.message.serialize();
         let candidates = self.verification_candidates();
         for entry in submitted {
@@ -779,10 +782,9 @@ impl CrossmintSigner {
         }
 
         let expected_message = transaction.message.serialize();
-        let serialized = crate::transaction_util::serialize_wire_transaction(transaction)?;
+        let serialized = serialize_wire_transaction(transaction)?;
         let transaction_b58 = bs58::encode(serialized).into_string();
-        let idempotency_key =
-            crate::transaction_util::idempotency_key_from_message(&expected_message);
+        let idempotency_key = idempotency_key_from_message(&expected_message);
 
         let create_response = self
             .create_transaction(transaction_b58, &idempotency_key)
@@ -1140,8 +1142,7 @@ mod tests {
         let on_chain_transaction =
             bs58::encode(bincode::serialize(&signed_remote_tx).unwrap()).into_string();
 
-        let expected_idempotency_key =
-            crate::transaction_util::idempotency_key_from_message(&local_tx.message.serialize());
+        let expected_idempotency_key = idempotency_key_from_message(&local_tx.message.serialize());
         Mock::given(method("POST"))
             .and(path("/2025-06-09/wallets/test-wallet/transactions"))
             .and(header("x-api-key", "test-api-key"))

--- a/rust/src/dfns/mod.rs
+++ b/rust/src/dfns/mod.rs
@@ -4,10 +4,10 @@ mod types;
 use crate::sdk_adapter::{Pubkey, Signature, VersionedTransaction};
 use crate::traits::SignTransactionResult;
 pub use crate::traits::SignedTransaction;
+use crate::transaction_util::{serialize_wire_transaction, TransactionUtil};
 use crate::{
     error::SignerError, http_client_config::HttpClientConfig,
     signature_util::EXPECTED_SIGNATURE_LENGTH, traits::SolanaSigner,
-    transaction_util::TransactionUtil,
 };
 use types::{GenerateSignatureRequest, GenerateSignatureResponse, GetWalletResponse};
 
@@ -243,7 +243,7 @@ impl DfnsSigner {
         &self,
         transaction: &VersionedTransaction,
     ) -> Result<Signature, SignerError> {
-        let tx_bytes = crate::transaction_util::serialize_wire_transaction(transaction)?;
+        let tx_bytes = serialize_wire_transaction(transaction)?;
         let request = GenerateSignatureRequest::Transaction {
             transaction: format!("0x{}", hex::encode(&tx_bytes)),
             blockchain_kind: "Solana".to_string(),

--- a/rust/src/dfns/mod.rs
+++ b/rust/src/dfns/mod.rs
@@ -1,7 +1,7 @@
 mod auth;
 mod types;
 
-use crate::sdk_adapter::{Pubkey, Signature, Transaction};
+use crate::sdk_adapter::{Pubkey, Signature, VersionedTransaction};
 use crate::traits::SignTransactionResult;
 pub use crate::traits::SignedTransaction;
 use crate::{
@@ -241,18 +241,19 @@ impl DfnsSigner {
 
     async fn sign_transaction_bytes(
         &self,
-        transaction: &Transaction,
+        transaction: &VersionedTransaction,
     ) -> Result<Signature, SignerError> {
-        let tx_bytes = bincode::serialize(transaction).map_err(|e| {
-            SignerError::SerializationError(format!("Failed to serialize transaction: {e}"))
-        })?;
+        let tx_bytes = crate::transaction_util::serialize_wire_transaction(transaction)?;
         let request = GenerateSignatureRequest::Transaction {
             transaction: format!("0x{}", hex::encode(&tx_bytes)),
             blockchain_kind: "Solana".to_string(),
         };
         let sig = self.send_signature_request(request).await?;
 
-        if !sig.verify(&self.public_key.to_bytes(), &transaction.message_data()) {
+        if !sig.verify(
+            &self.public_key.to_bytes(),
+            &transaction.message.serialize(),
+        ) {
             return Err(SignerError::SigningFailed(
                 "Signature verification failed — the returned signature does not match the public key".to_string(),
             ));
@@ -286,7 +287,7 @@ impl DfnsSigner {
     /// Sign and serialize a transaction
     async fn sign_and_serialize(
         &self,
-        transaction: &mut Transaction,
+        transaction: &mut VersionedTransaction,
     ) -> Result<SignedTransaction, SignerError> {
         let signature = self.sign_transaction_bytes(transaction).await?;
 
@@ -320,7 +321,7 @@ impl SolanaSigner for DfnsSigner {
 
     async fn sign_transaction(
         &self,
-        tx: &mut Transaction,
+        tx: &mut VersionedTransaction,
     ) -> Result<SignTransactionResult, SignerError> {
         let signed_transaction = self.sign_and_serialize(tx).await?;
         Ok(TransactionUtil::classify_signed_transaction(
@@ -631,7 +632,7 @@ mod tests {
         signer.public_key = keypair_pubkey(&keypair);
 
         let mut transaction = create_test_transaction(&signer.pubkey());
-        let signature = keypair.sign_message(&transaction.message_data());
+        let signature = keypair.sign_message(&transaction.message.serialize());
         let sig_bytes = signature.as_ref();
         let r_hex = hex::encode(&sig_bytes[0..32]);
         let s_hex = hex::encode(&sig_bytes[32..64]);
@@ -687,7 +688,7 @@ mod tests {
         signer.public_key = keypair_pubkey(&different_keypair);
 
         let mut transaction = create_test_transaction(&signer.pubkey());
-        let signature = signing_keypair.sign_message(&transaction.message_data());
+        let signature = signing_keypair.sign_message(&transaction.message.serialize());
         let sig_bytes = signature.as_ref();
         let r_hex = hex::encode(&sig_bytes[0..32]);
         let s_hex = hex::encode(&sig_bytes[32..64]);

--- a/rust/src/fireblocks/mod.rs
+++ b/rust/src/fireblocks/mod.rs
@@ -3,7 +3,7 @@
 mod jwt;
 mod types;
 
-use crate::sdk_adapter::{Pubkey, Signature, Transaction};
+use crate::sdk_adapter::{Pubkey, Signature, VersionedTransaction};
 use crate::traits::SignTransactionResult;
 pub use crate::traits::SignedTransaction;
 use crate::{
@@ -427,10 +427,10 @@ impl FireblocksSigner {
 
     async fn sign_and_serialize(
         &self,
-        transaction: &mut Transaction,
+        transaction: &mut VersionedTransaction,
     ) -> Result<SignedTransaction, SignerError> {
         let public_key = self.initialized_pubkey()?;
-        let message_bytes = transaction.message_data();
+        let message_bytes = transaction.message.serialize();
         let signature = self.sign_raw_bytes(&message_bytes).await?;
 
         TransactionUtil::add_signature_to_transaction(transaction, &public_key, signature)?;
@@ -477,7 +477,7 @@ impl SolanaSigner for FireblocksSigner {
 
     async fn sign_transaction(
         &self,
-        tx: &mut Transaction,
+        tx: &mut VersionedTransaction,
     ) -> Result<SignTransactionResult, SignerError> {
         let signed_transaction = self.sign_and_serialize(tx).await?;
         Ok(TransactionUtil::classify_signed_transaction(

--- a/rust/src/fordefi/mod.rs
+++ b/rust/src/fordefi/mod.rs
@@ -14,7 +14,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::error::SignerError;
 use crate::http_client_config::HttpClientConfig;
-use crate::sdk_adapter::{Pubkey, Signature, Transaction};
+use crate::sdk_adapter::{Pubkey, Signature, VersionedTransaction};
 use crate::traits::{SignTransactionResult, SignedTransaction, SolanaSigner};
 use crate::transaction_util::TransactionUtil;
 pub use request_signer::{FordefiRequestSigner, PemRequestSigner};
@@ -459,9 +459,9 @@ impl FordefiSigner {
     /// Sign a transaction via the black box path: submit → poll → apply signature.
     async fn sign_and_serialize_black_box(
         &self,
-        transaction: &mut Transaction,
+        transaction: &mut VersionedTransaction,
     ) -> Result<SignedTransaction, SignerError> {
-        let message_data = transaction.message_data();
+        let message_data = transaction.message.serialize();
         let signature = self.sign_black_box(&message_data).await?;
 
         if !signature.verify(&self.public_key.to_bytes(), &message_data) {
@@ -498,10 +498,10 @@ impl FordefiSigner {
     /// returned by Fordefi fails to deserialize with a [`SignerError::SerializationError`].
     async fn sign_and_serialize_native(
         &self,
-        transaction: &mut Transaction,
+        transaction: &mut VersionedTransaction,
     ) -> Result<SignedTransaction, SignerError> {
         self.validate_native_auto_transaction(transaction)?;
-        let message_data = transaction.message_data();
+        let message_data = transaction.message.serialize();
         let tx_id = self.submit_solana_transaction(&message_data).await?;
         // Once the submit is accepted Fordefi is already broadcasting
         // (push_mode: "auto"), so any later failure leaves an on-chain outcome
@@ -538,17 +538,18 @@ impl FordefiSigner {
         // ever returns a v0 transaction this deserialization fails rather than
         // silently mis-parsing. Supporting v0 would mean decoding into
         // `VersionedTransaction` and threading that type through the signer API.
-        let returned_tx: Transaction = bincode::deserialize(&wire_bytes).map_err(|e| {
-            SignerError::SerializationError(format!(
-                "Failed to deserialize Fordefi wire transaction (versioned/v0 \
+        let returned_tx: VersionedTransaction =
+            crate::transaction_util::deserialize_wire_transaction(&wire_bytes).map_err(|e| {
+                SignerError::SerializationError(format!(
+                    "Failed to deserialize Fordefi wire transaction (versioned/v0 \
                  transactions are not supported, only legacy): {e}"
-            ))
-        })?;
+                ))
+            })?;
 
         let signature = self.extract_vault_signature(&returned_tx)?;
 
         // Verify against the *returned* message (Fordefi modifies the tx, e.g. blockhash)
-        let returned_message = returned_tx.message_data();
+        let returned_message = returned_tx.message.serialize();
         if !signature.verify(&self.public_key.to_bytes(), &returned_message) {
             return Err(SignerError::SigningFailed(
                 "Signature verification failed against Fordefi-returned message".to_string(),
@@ -565,11 +566,11 @@ impl FordefiSigner {
     /// forwarded through Fordefi's `details.signatures` request field.
     fn validate_native_auto_transaction(
         &self,
-        transaction: &Transaction,
+        transaction: &VersionedTransaction,
     ) -> Result<(), SignerError> {
-        let required_signatures = transaction.message.header.num_required_signatures as usize;
+        let required_signatures = transaction.message.header().num_required_signatures as usize;
         if required_signatures != 1
-            || transaction.message.account_keys.first() != Some(&self.public_key)
+            || transaction.message.static_account_keys().first() != Some(&self.public_key)
         {
             return Err(SignerError::SigningFailed(
                 "Fordefi native auto-broadcast currently supports only transactions whose sole required signer is the configured vault"
@@ -581,7 +582,10 @@ impl FordefiSigner {
 
     /// Locate the configured vault's signature by its required-signer account
     /// position rather than assuming it occupies slot zero.
-    fn extract_vault_signature(&self, returned_tx: &Transaction) -> Result<Signature, SignerError> {
+    fn extract_vault_signature(
+        &self,
+        returned_tx: &VersionedTransaction,
+    ) -> Result<Signature, SignerError> {
         let signer_index =
             TransactionUtil::get_signing_keypair_position(returned_tx, &self.public_key)?;
         returned_tx
@@ -598,7 +602,7 @@ impl FordefiSigner {
     /// Sign a transaction end-to-end, dispatching to black box or native path.
     async fn sign_and_serialize(
         &self,
-        transaction: &mut Transaction,
+        transaction: &mut VersionedTransaction,
     ) -> Result<SignedTransaction, SignerError> {
         if self.chain.is_some() {
             self.sign_and_serialize_native(transaction).await
@@ -722,7 +726,7 @@ impl SolanaSigner for FordefiSigner {
 
     async fn sign_transaction(
         &self,
-        tx: &mut Transaction,
+        tx: &mut VersionedTransaction,
     ) -> Result<SignTransactionResult, SignerError> {
         let signed_transaction = self.sign_and_serialize(tx).await?;
         if self.chain.is_some() {
@@ -1352,7 +1356,7 @@ mod tests {
         let signer = create_test_signer(&mock_server.uri(), pubkey);
 
         let tx = create_test_transaction(&pubkey);
-        let message_data = tx.message_data();
+        let message_data = tx.message.serialize();
         let real_signature = keypair.sign_message(&message_data);
         let sig_b64 = STANDARD.encode(real_signature.as_ref());
 
@@ -1642,9 +1646,8 @@ mod tests {
         let signer = create_native_test_signer("https://test.com", fordefi_pubkey);
 
         let mut returned_tx = create_test_transaction(&keypair_pubkey(&fee_payer));
-        returned_tx.message.account_keys.insert(1, fordefi_pubkey);
-        returned_tx.message.header.num_required_signatures = 2;
-        let returned_message = returned_tx.message_data();
+        crate::test_util::add_required_signer(&mut returned_tx, fordefi_pubkey);
+        let returned_message = returned_tx.message.serialize();
         let fee_payer_signature = fee_payer.sign_message(&returned_message);
         let fordefi_signature = fordefi_keypair.sign_message(&returned_message);
         returned_tx.signatures = vec![fee_payer_signature, fordefi_signature];
@@ -1662,8 +1665,7 @@ mod tests {
         let signer = create_native_test_signer("https://test.com", fordefi_pubkey);
 
         let mut tx = create_test_transaction(&keypair_pubkey(&fee_payer));
-        tx.message.account_keys.insert(1, fordefi_pubkey);
-        tx.message.header.num_required_signatures = 2;
+        crate::test_util::add_required_signer(&mut tx, fordefi_pubkey);
 
         let result = signer.validate_native_auto_transaction(&tx);
         assert!(matches!(result.unwrap_err(), SignerError::SigningFailed(_)));
@@ -1677,7 +1679,7 @@ mod tests {
         let signer = create_native_test_signer(&mock_server.uri(), pubkey);
 
         let tx = create_test_transaction(&pubkey);
-        let message_data = tx.message_data();
+        let message_data = tx.message.serialize();
 
         let wire_bytes = build_mock_wire_transaction(&keypair, &message_data);
         let wire_b64 = STANDARD.encode(&wire_bytes);

--- a/rust/src/fordefi/mod.rs
+++ b/rust/src/fordefi/mod.rs
@@ -16,7 +16,9 @@ use crate::error::SignerError;
 use crate::http_client_config::HttpClientConfig;
 use crate::sdk_adapter::{Pubkey, Signature, VersionedTransaction};
 use crate::traits::{SignTransactionResult, SignedTransaction, SolanaSigner};
-use crate::transaction_util::TransactionUtil;
+use crate::transaction_util::{
+    deserialize_wire_transaction, idempotency_key_from_message, TransactionUtil,
+};
 pub use request_signer::{FordefiRequestSigner, PemRequestSigner};
 use types::{
     BlackBoxDetails, BlackBoxSignatureRequest, CreateTransactionResponse, SolanaMessageDetails,
@@ -308,13 +310,8 @@ impl FordefiSigner {
             },
         };
 
-        self.submit_request(
-            &request,
-            Some(&crate::transaction_util::idempotency_key_from_message(
-                data_bytes,
-            )),
-        )
-        .await
+        self.submit_request(&request, Some(&idempotency_key_from_message(data_bytes)))
+            .await
     }
 
     /// Submit a native Solana message request.
@@ -493,9 +490,6 @@ impl FordefiSigner {
     ///
     /// Each native create carries an `x-idempotence-id` derived from the message
     /// bytes, so retrying the exact same bytes cannot create a second transaction.
-    ///
-    /// Only legacy transactions are supported: a versioned (v0) transaction
-    /// returned by Fordefi fails to deserialize with a [`SignerError::SerializationError`].
     async fn sign_and_serialize_native(
         &self,
         transaction: &mut VersionedTransaction,
@@ -529,20 +523,10 @@ impl FordefiSigner {
             SignerError::SerializationError(format!("Failed to decode raw_transaction base64: {e}"))
         })?;
 
-        // Deserialize the Fordefi-returned wire transaction with the Solana SDK
-        // (bincode of a Transaction is exactly the Solana wire format).
-        //
-        // NOTE: only *legacy* transactions are supported. A versioned (v0) wire
-        // transaction is prefixed with a version byte (high bit set on the first
-        // byte) that the legacy `Transaction` layout cannot represent, so if Fordefi
-        // ever returns a v0 transaction this deserialization fails rather than
-        // silently mis-parsing. Supporting v0 would mean decoding into
-        // `VersionedTransaction` and threading that type through the signer API.
         let returned_tx: VersionedTransaction =
-            crate::transaction_util::deserialize_wire_transaction(&wire_bytes).map_err(|e| {
+            deserialize_wire_transaction(&wire_bytes).map_err(|e| {
                 SignerError::SerializationError(format!(
-                    "Failed to deserialize Fordefi wire transaction (versioned/v0 \
-                 transactions are not supported, only legacy): {e}"
+                    "Failed to deserialize Fordefi wire transaction: {e}"
                 ))
             })?;
 
@@ -776,7 +760,7 @@ impl SolanaSigner for FordefiSigner {
 mod tests {
     use super::*;
     use crate::sdk_adapter::{keypair_pubkey, Keypair, Signer as SdkSigner};
-    use crate::test_util::create_test_transaction;
+    use crate::test_util::{add_required_signer, create_test_transaction};
     use p256::ecdsa::SigningKey;
     use wiremock::{
         matchers::{header, method, path, path_regex},
@@ -1646,7 +1630,7 @@ mod tests {
         let signer = create_native_test_signer("https://test.com", fordefi_pubkey);
 
         let mut returned_tx = create_test_transaction(&keypair_pubkey(&fee_payer));
-        crate::test_util::add_required_signer(&mut returned_tx, fordefi_pubkey);
+        add_required_signer(&mut returned_tx, fordefi_pubkey);
         let returned_message = returned_tx.message.serialize();
         let fee_payer_signature = fee_payer.sign_message(&returned_message);
         let fordefi_signature = fordefi_keypair.sign_message(&returned_message);
@@ -1665,7 +1649,7 @@ mod tests {
         let signer = create_native_test_signer("https://test.com", fordefi_pubkey);
 
         let mut tx = create_test_transaction(&keypair_pubkey(&fee_payer));
-        crate::test_util::add_required_signer(&mut tx, fordefi_pubkey);
+        add_required_signer(&mut tx, fordefi_pubkey);
 
         let result = signer.validate_native_auto_transaction(&tx);
         assert!(matches!(result.unwrap_err(), SignerError::SigningFailed(_)));
@@ -1684,8 +1668,7 @@ mod tests {
         let wire_bytes = build_mock_wire_transaction(&keypair, &message_data);
         let wire_b64 = STANDARD.encode(&wire_bytes);
 
-        let expected_idempotence_id =
-            crate::transaction_util::idempotency_key_from_message(&message_data);
+        let expected_idempotence_id = idempotency_key_from_message(&message_data);
         Mock::given(method("POST"))
             .and(path("/api/v1/transactions"))
             .and(header("Authorization", "Bearer test-token"))

--- a/rust/src/gcp_kms/mod.rs
+++ b/rust/src/gcp_kms/mod.rs
@@ -1,7 +1,7 @@
 //! Google Cloud KMS signer integration using EdDSA (Ed25519) signing
 
 use crate::error::SignerError;
-use crate::sdk_adapter::{Pubkey, Signature, Transaction};
+use crate::sdk_adapter::{Pubkey, Signature, VersionedTransaction};
 use crate::traits::{SignTransactionResult, SignedTransaction, SolanaSigner};
 use crate::transaction_util::TransactionUtil;
 use google_cloud_kms_v1::client::KeyManagementService;
@@ -140,9 +140,9 @@ impl GcpKmsSigner {
 
     async fn sign_and_serialize(
         &self,
-        transaction: &mut Transaction,
+        transaction: &mut VersionedTransaction,
     ) -> Result<SignedTransaction, SignerError> {
-        let signature = self.sign_bytes(&transaction.message_data()).await?;
+        let signature = self.sign_bytes(&transaction.message.serialize()).await?;
 
         TransactionUtil::add_signature_to_transaction(transaction, &self.public_key, signature)?;
 
@@ -185,7 +185,7 @@ impl SolanaSigner for GcpKmsSigner {
 
     async fn sign_transaction(
         &self,
-        tx: &mut Transaction,
+        tx: &mut VersionedTransaction,
     ) -> Result<SignTransactionResult, SignerError> {
         let signed_transaction = self.sign_and_serialize(tx).await?;
         Ok(TransactionUtil::classify_signed_transaction(
@@ -504,7 +504,7 @@ mod tests {
 
         // Create a dummy transaction
         let mut tx = create_test_transaction(&keypair.pubkey());
-        let signature = keypair.sign_message(&tx.message_data());
+        let signature = keypair.sign_message(&tx.message.serialize());
 
         // Mock AsymmetricSign
         Mock::given(method("POST"))

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -484,7 +484,7 @@ impl SolanaSigner for Signer {
 
     async fn sign_transaction(
         &self,
-        tx: &mut sdk_adapter::Transaction,
+        tx: &mut sdk_adapter::VersionedTransaction,
     ) -> Result<SignTransactionResult, SignerError> {
         match self {
             #[cfg(feature = "memory")]

--- a/rust/src/memory/mod.rs
+++ b/rust/src/memory/mod.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 
 use crate::sdk_adapter::{
-    keypair_pubkey, keypair_sign_message, Keypair, Pubkey, Signature, Transaction,
+    keypair_pubkey, keypair_sign_message, Keypair, Pubkey, Signature, VersionedTransaction,
 };
 use keypair_util::KeypairUtil;
 
@@ -82,9 +82,9 @@ impl SolanaSigner for MemorySigner {
 
     async fn sign_transaction(
         &self,
-        tx: &mut Transaction,
+        tx: &mut VersionedTransaction,
     ) -> Result<SignTransactionResult, SignerError> {
-        let signature = self.sign_bytes(&tx.message_data()).await?;
+        let signature = self.sign_bytes(&tx.message.serialize()).await?;
         TransactionUtil::add_signature_to_transaction(tx, &self.pubkey(), signature)?;
 
         let signed_transaction = (TransactionUtil::serialize_transaction(tx)?, signature);
@@ -195,5 +195,36 @@ mod tests {
         // Verify the transaction has the signature
         assert_eq!(tx.signatures.len(), 1);
         assert_eq!(tx.signatures[0], signature);
+    }
+
+    #[cfg(feature = "sdk-v4")]
+    #[cfg_attr(miri, ignore)]
+    #[tokio::test]
+    async fn test_sign_v1_transaction() {
+        use crate::test_util::create_test_v1_transaction;
+
+        let signer = create_test_signer();
+        let pubkey = keypair_pubkey(&signer.keypair);
+        let mut tx = create_test_v1_transaction(&pubkey);
+
+        // A verifying signature proves the 0x81 prefix was covered.
+        let message_bytes = tx.message.serialize();
+        assert_eq!(message_bytes[0], 0x81);
+
+        let result = signer
+            .sign_transaction(&mut tx)
+            .await
+            .expect("v1 transaction should sign");
+        let (serialized_tx, signature) = result.into_signed_transaction();
+
+        assert!(signature.verify(&pubkey.to_bytes(), &message_bytes));
+        assert_eq!(tx.signatures[0], signature);
+
+        use base64::Engine;
+        let wire = base64::engine::general_purpose::STANDARD
+            .decode(&serialized_tx)
+            .expect("serialized transaction should be base64");
+        assert_eq!(wire[..message_bytes.len()], message_bytes[..]);
+        assert_eq!(wire.len(), message_bytes.len() + 64);
     }
 }

--- a/rust/src/memory/mod.rs
+++ b/rust/src/memory/mod.rs
@@ -109,6 +109,8 @@ mod tests {
     use crate::test_util::create_test_transaction;
     #[cfg(feature = "sdk-v4")]
     use crate::test_util::create_test_v1_transaction;
+    #[cfg(feature = "sdk-v4")]
+    use base64::Engine;
 
     use super::*;
 
@@ -207,7 +209,6 @@ mod tests {
         let pubkey = keypair_pubkey(&signer.keypair);
         let mut tx = create_test_v1_transaction(&pubkey);
 
-        // A verifying signature proves the 0x81 prefix was covered.
         let message_bytes = tx.message.serialize();
         assert_eq!(message_bytes[0], 0x81);
 
@@ -220,7 +221,6 @@ mod tests {
         assert!(signature.verify(&pubkey.to_bytes(), &message_bytes));
         assert_eq!(tx.signatures[0], signature);
 
-        use base64::Engine;
         let wire = base64::engine::general_purpose::STANDARD
             .decode(&serialized_tx)
             .expect("serialized transaction should be base64");

--- a/rust/src/memory/mod.rs
+++ b/rust/src/memory/mod.rs
@@ -107,6 +107,8 @@ impl SolanaSigner for MemorySigner {
 #[cfg(test)]
 mod tests {
     use crate::test_util::create_test_transaction;
+    #[cfg(feature = "sdk-v4")]
+    use crate::test_util::create_test_v1_transaction;
 
     use super::*;
 
@@ -201,8 +203,6 @@ mod tests {
     #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_sign_v1_transaction() {
-        use crate::test_util::create_test_v1_transaction;
-
         let signer = create_test_signer();
         let pubkey = keypair_pubkey(&signer.keypair);
         let mut tx = create_test_v1_transaction(&pubkey);

--- a/rust/src/openfort/mod.rs
+++ b/rust/src/openfort/mod.rs
@@ -30,7 +30,7 @@
 
 mod types;
 
-use crate::sdk_adapter::{Pubkey, Signature, Transaction};
+use crate::sdk_adapter::{Pubkey, Signature, VersionedTransaction};
 use crate::signature_util::EXPECTED_SIGNATURE_LENGTH;
 use crate::traits::{SignTransactionResult, SignedTransaction};
 use crate::transaction_util::TransactionUtil;
@@ -456,10 +456,10 @@ impl OpenfortSigner {
 
     async fn sign_and_serialize(
         &self,
-        transaction: &mut Transaction,
+        transaction: &mut VersionedTransaction,
     ) -> Result<SignedTransaction, SignerError> {
         let public_key = self.initialized_pubkey()?;
-        let signature = self.sign_bytes(&transaction.message_data()).await?;
+        let signature = self.sign_bytes(&transaction.message.serialize()).await?;
         TransactionUtil::add_signature_to_transaction(transaction, &public_key, signature)?;
 
         Ok((
@@ -477,7 +477,7 @@ impl SolanaSigner for OpenfortSigner {
 
     async fn sign_transaction(
         &self,
-        tx: &mut Transaction,
+        tx: &mut VersionedTransaction,
     ) -> Result<SignTransactionResult, SignerError> {
         let signed_transaction = self.sign_and_serialize(tx).await?;
         Ok(TransactionUtil::classify_signed_transaction(
@@ -886,7 +886,7 @@ mod tests {
         let pubkey = keypair_pubkey(&keypair);
 
         let mut tx = create_test_transaction(&pubkey);
-        let signature = keypair_sign_message(&keypair, &tx.message_data());
+        let signature = keypair_sign_message(&keypair, &tx.message.serialize());
         let sig_hex = format!("0x{}", hex::encode(signature.as_ref()));
 
         let mut signer = create_test_signer(&mock_server.uri());

--- a/rust/src/para/mod.rs
+++ b/rust/src/para/mod.rs
@@ -2,7 +2,7 @@
 
 mod types;
 
-use crate::sdk_adapter::{Pubkey, Signature, Transaction};
+use crate::sdk_adapter::{Pubkey, Signature, VersionedTransaction};
 use crate::traits::{SignTransactionResult, SignedTransaction};
 use crate::transaction_util::TransactionUtil;
 use crate::{error::SignerError, http_client_config::HttpClientConfig, traits::SolanaSigner};
@@ -242,9 +242,9 @@ impl ParaSigner {
 
     async fn sign_and_serialize(
         &self,
-        transaction: &mut Transaction,
+        transaction: &mut VersionedTransaction,
     ) -> Result<SignedTransaction, SignerError> {
-        let signature = self.sign_bytes(&transaction.message_data()).await?;
+        let signature = self.sign_bytes(&transaction.message.serialize()).await?;
 
         TransactionUtil::add_signature_to_transaction(transaction, &self.pubkey(), signature)?;
 
@@ -300,7 +300,7 @@ impl SolanaSigner for ParaSigner {
 
     async fn sign_transaction(
         &self,
-        tx: &mut Transaction,
+        tx: &mut VersionedTransaction,
     ) -> Result<SignTransactionResult, SignerError> {
         let signed_transaction = self.sign_and_serialize(tx).await?;
         Ok(TransactionUtil::classify_signed_transaction(
@@ -594,7 +594,7 @@ mod tests {
         let keypair = create_test_keypair();
 
         let tx = create_test_transaction(&keypair_pubkey(&keypair));
-        let signature = keypair.sign_message(&tx.message_data());
+        let signature = keypair.sign_message(&tx.message.serialize());
         let sig_hex = hex::encode(signature);
 
         Mock::given(method("POST"))
@@ -611,7 +611,7 @@ mod tests {
             create_test_signer("test-api-key", "test-wallet-id", Some(mock_server.uri()));
         signer.public_key = keypair_pubkey(&keypair);
 
-        let result = signer.sign_message(&tx.message_data()).await;
+        let result = signer.sign_message(&tx.message.serialize()).await;
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), signature);
     }
@@ -622,7 +622,7 @@ mod tests {
         let keypair = create_test_keypair();
 
         let tx = create_test_transaction(&keypair_pubkey(&keypair));
-        let signature = keypair.sign_message(&tx.message_data());
+        let signature = keypair.sign_message(&tx.message.serialize());
         let sig_hex = format!("0x{}", hex::encode(signature));
 
         Mock::given(method("POST"))
@@ -638,7 +638,7 @@ mod tests {
             create_test_signer("test-api-key", "test-wallet-id", Some(mock_server.uri()));
         signer.public_key = keypair_pubkey(&keypair);
 
-        let result = signer.sign_message(&tx.message_data()).await;
+        let result = signer.sign_message(&tx.message.serialize()).await;
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), signature);
     }
@@ -649,7 +649,7 @@ mod tests {
         let keypair = create_test_keypair();
 
         let mut tx = create_test_transaction(&keypair_pubkey(&keypair));
-        let signature = keypair.sign_message(&tx.message_data());
+        let signature = keypair.sign_message(&tx.message.serialize());
         let sig_hex = hex::encode(signature);
 
         Mock::given(method("POST"))

--- a/rust/src/privy/mod.rs
+++ b/rust/src/privy/mod.rs
@@ -3,7 +3,7 @@
 mod authorization;
 mod types;
 
-use crate::sdk_adapter::{Pubkey, Signature, Transaction};
+use crate::sdk_adapter::{Pubkey, Signature, VersionedTransaction};
 use crate::traits::{SignTransactionResult, SignedTransaction};
 use crate::transaction_util::TransactionUtil;
 use crate::{error::SignerError, http_client_config::HttpClientConfig, traits::SolanaSigner};
@@ -278,13 +278,11 @@ impl PrivySigner {
     /// Policies must allow the `signTransaction` method.
     async fn sign_and_serialize(
         &self,
-        transaction: &mut Transaction,
+        transaction: &mut VersionedTransaction,
     ) -> Result<SignedTransaction, SignerError> {
         let public_key = self.initialized_pubkey()?;
 
-        let unsigned_wire = bincode::serialize(transaction).map_err(|e| {
-            SignerError::SerializationError(format!("Failed to serialize transaction: {e}"))
-        })?;
+        let unsigned_wire = crate::transaction_util::serialize_wire_transaction(transaction)?;
         let request = SignTransactionRequest {
             method: "signTransaction",
             chain_type: "solana",
@@ -304,11 +302,12 @@ impl PrivySigner {
                     "Failed to decode signed transaction returned by Privy".to_string(),
                 )
             })?;
-        let returned: Transaction = bincode::deserialize(&signed_wire).map_err(|e| {
-            SignerError::SerializationError(format!(
-                "Failed to deserialize signed transaction returned by Privy: {e}"
-            ))
-        })?;
+        let returned: VersionedTransaction =
+            crate::transaction_util::deserialize_wire_transaction(&signed_wire).map_err(|e| {
+                SignerError::SerializationError(format!(
+                    "Failed to deserialize signed transaction returned by Privy: {e}"
+                ))
+            })?;
 
         let position = TransactionUtil::get_signing_keypair_position(&returned, &public_key)?;
         let signature = returned.signatures.get(position).copied().ok_or_else(|| {
@@ -317,7 +316,7 @@ impl PrivySigner {
             )
         })?;
 
-        if !signature.verify(&public_key.to_bytes(), &transaction.message_data()) {
+        if !signature.verify(&public_key.to_bytes(), &transaction.message.serialize()) {
             return Err(SignerError::SigningFailed(
                 "Signature verification failed — the returned signature does not match the public key".to_string(),
             ));
@@ -340,7 +339,7 @@ impl SolanaSigner for PrivySigner {
 
     async fn sign_transaction(
         &self,
-        tx: &mut Transaction,
+        tx: &mut VersionedTransaction,
     ) -> Result<SignTransactionResult, SignerError> {
         let signed_transaction = self.sign_and_serialize(tx).await?;
         Ok(TransactionUtil::classify_signed_transaction(
@@ -437,7 +436,7 @@ mod tests {
 
         // Create a signed transaction
         let tx = create_test_transaction(&keypair_pubkey(&keypair));
-        let signature = keypair.sign_message(&tx.message_data());
+        let signature = keypair.sign_message(&tx.message.serialize());
 
         let mut signed_tx = tx.clone();
         signed_tx.signatures = vec![signature];
@@ -465,7 +464,7 @@ mod tests {
         signer.api_base_url = mock_server.uri();
         signer.public_key = Some(keypair.pubkey());
 
-        let result = signer.sign_message(&tx.message_data()).await;
+        let result = signer.sign_message(&tx.message.serialize()).await;
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), signature);
     }
@@ -588,7 +587,7 @@ mod tests {
         signer.api_base_url = mock_server.uri();
         signer.public_key = Some(keypair.pubkey());
 
-        let result = signer.sign_message(&tx.message_data()).await;
+        let result = signer.sign_message(&tx.message.serialize()).await;
         assert!(result.is_err());
         assert!(matches!(
             result.unwrap_err(),
@@ -617,7 +616,7 @@ mod tests {
         let mut tx = create_test_transaction(&keypair_pubkey(&keypair));
 
         // The signature that Privy API will return (signing the message_data)
-        let signature = keypair.sign_message(&tx.message_data());
+        let signature = keypair.sign_message(&tx.message.serialize());
 
         // Create a signed transaction to return from the mock
         let mut signed_tx = tx.clone();
@@ -665,7 +664,7 @@ mod tests {
 
         let mut tx = create_test_transaction(&keypair_pubkey(&keypair));
         let mut other_tx = create_test_transaction(&keypair_pubkey(&keypair));
-        other_tx.signatures = vec![keypair.sign_message(&other_tx.message_data())];
+        other_tx.signatures = vec![keypair.sign_message(&other_tx.message.serialize())];
 
         Mock::given(method("POST"))
             .and(path("/wallets/test-wallet-id/rpc"))

--- a/rust/src/privy/mod.rs
+++ b/rust/src/privy/mod.rs
@@ -5,7 +5,9 @@ mod types;
 
 use crate::sdk_adapter::{Pubkey, Signature, VersionedTransaction};
 use crate::traits::{SignTransactionResult, SignedTransaction};
-use crate::transaction_util::TransactionUtil;
+use crate::transaction_util::{
+    deserialize_wire_transaction, serialize_wire_transaction, TransactionUtil,
+};
 use crate::{error::SignerError, http_client_config::HttpClientConfig, traits::SolanaSigner};
 use authorization::prepare_privy_authorization_headers;
 pub use authorization::{
@@ -282,7 +284,7 @@ impl PrivySigner {
     ) -> Result<SignedTransaction, SignerError> {
         let public_key = self.initialized_pubkey()?;
 
-        let unsigned_wire = crate::transaction_util::serialize_wire_transaction(transaction)?;
+        let unsigned_wire = serialize_wire_transaction(transaction)?;
         let request = SignTransactionRequest {
             method: "signTransaction",
             chain_type: "solana",
@@ -303,7 +305,7 @@ impl PrivySigner {
                 )
             })?;
         let returned: VersionedTransaction =
-            crate::transaction_util::deserialize_wire_transaction(&signed_wire).map_err(|e| {
+            deserialize_wire_transaction(&signed_wire).map_err(|e| {
                 SignerError::SerializationError(format!(
                     "Failed to deserialize signed transaction returned by Privy: {e}"
                 ))

--- a/rust/src/sdk_adapter/v2.rs
+++ b/rust/src/sdk_adapter/v2.rs
@@ -6,11 +6,13 @@ pub use solana_sdk::hash::Hash;
 #[allow(unused_imports)]
 pub use solana_sdk::instruction::{AccountMeta, Instruction};
 #[allow(unused_imports)]
-pub use solana_sdk::message::Message;
+pub use solana_sdk::message::{Message, VersionedMessage};
 pub use solana_sdk::pubkey::Pubkey;
 pub use solana_sdk::signature::{Keypair, Signature};
 pub use solana_sdk::signer::Signer;
-pub use solana_sdk::transaction::{Transaction, VersionedTransaction};
+#[allow(unused_imports)]
+pub use solana_sdk::transaction::Transaction;
+pub use solana_sdk::transaction::VersionedTransaction;
 
 /// Parse a keypair from bytes (v2 adapter)
 pub fn keypair_from_bytes(bytes: &[u8]) -> Result<Keypair, String> {

--- a/rust/src/sdk_adapter/v3.rs
+++ b/rust/src/sdk_adapter/v3.rs
@@ -6,12 +6,14 @@ pub use solana_sdk_v3::hash::Hash;
 #[allow(unused_imports)]
 pub use solana_sdk_v3::instruction::{AccountMeta, Instruction};
 #[allow(unused_imports)]
-pub use solana_sdk_v3::message::Message;
+pub use solana_sdk_v3::message::{Message, VersionedMessage};
 pub use solana_sdk_v3::pubkey::Pubkey;
 pub use solana_sdk_v3::signature::{Keypair, Signature};
 #[allow(unused_imports)]
 pub use solana_sdk_v3::signer::Signer;
-pub use solana_sdk_v3::transaction::{Transaction, VersionedTransaction};
+#[allow(unused_imports)]
+pub use solana_sdk_v3::transaction::Transaction;
+pub use solana_sdk_v3::transaction::VersionedTransaction;
 
 /// Parse a keypair from bytes (v3 adapter)
 pub fn keypair_from_bytes(bytes: &[u8]) -> Result<Keypair, String> {

--- a/rust/src/sdk_adapter/v4.rs
+++ b/rust/src/sdk_adapter/v4.rs
@@ -6,12 +6,14 @@ pub use solana_sdk_v4::hash::Hash;
 #[allow(unused_imports)]
 pub use solana_sdk_v4::instruction::{AccountMeta, Instruction};
 #[allow(unused_imports)]
-pub use solana_sdk_v4::message::Message;
+pub use solana_sdk_v4::message::{Message, VersionedMessage};
 pub use solana_sdk_v4::pubkey::Pubkey;
 pub use solana_sdk_v4::signature::{Keypair, Signature};
 #[allow(unused_imports)]
 pub use solana_sdk_v4::signer::Signer;
-pub use solana_sdk_v4::transaction::{Transaction, VersionedTransaction};
+#[allow(unused_imports)]
+pub use solana_sdk_v4::transaction::Transaction;
+pub use solana_sdk_v4::transaction::VersionedTransaction;
 
 /// Parse a keypair from bytes (v4 adapter)
 pub fn keypair_from_bytes(bytes: &[u8]) -> Result<Keypair, String> {

--- a/rust/src/test_util.rs
+++ b/rust/src/test_util.rs
@@ -1,9 +1,13 @@
 use std::str::FromStr;
 
+#[cfg(feature = "sdk-v4")]
+use crate::sdk_adapter::Signature;
 use crate::sdk_adapter::{
     AccountMeta, Hash, Instruction, Message, Pubkey, Transaction, VersionedMessage,
     VersionedTransaction,
 };
+#[cfg(feature = "sdk-v4")]
+use solana_sdk_v4::message::v1::{Message as V1Message, TransactionConfig};
 
 fn create_transfer_instruction(from: &Pubkey, to: &Pubkey, lamports: u64) -> Instruction {
     Instruction {
@@ -43,8 +47,6 @@ pub fn add_required_signer(transaction: &mut VersionedTransaction, pubkey: Pubke
 /// an unset resource limit as zero rather than a default.
 #[cfg(feature = "sdk-v4")]
 pub fn create_test_v1_transaction(from: &Pubkey) -> VersionedTransaction {
-    use solana_sdk_v4::message::v1::{Message as V1Message, TransactionConfig};
-
     let to = Pubkey::new_unique();
     let instruction = create_transfer_instruction(from, &to, 1_000_000);
     let config = TransactionConfig::empty()
@@ -54,10 +56,7 @@ pub fn create_test_v1_transaction(from: &Pubkey) -> VersionedTransaction {
         .expect("v1 test message should compile");
 
     VersionedTransaction {
-        signatures: vec![
-            crate::sdk_adapter::Signature::default();
-            usize::from(message.header.num_required_signatures)
-        ],
+        signatures: vec![Signature::default(); usize::from(message.header.num_required_signatures)],
         message: VersionedMessage::V1(message),
     }
 }

--- a/rust/src/test_util.rs
+++ b/rust/src/test_util.rs
@@ -1,6 +1,9 @@
 use std::str::FromStr;
 
-use crate::sdk_adapter::{AccountMeta, Hash, Instruction, Message, Pubkey, Transaction};
+use crate::sdk_adapter::{
+    AccountMeta, Hash, Instruction, Message, Pubkey, Transaction, VersionedMessage,
+    VersionedTransaction,
+};
 
 fn create_transfer_instruction(from: &Pubkey, to: &Pubkey, lamports: u64) -> Instruction {
     Instruction {
@@ -14,15 +17,47 @@ fn create_transfer_instruction(from: &Pubkey, to: &Pubkey, lamports: u64) -> Ins
     }
 }
 
-pub fn create_test_transaction(from: &Pubkey) -> Transaction {
+pub fn create_test_transaction(from: &Pubkey) -> VersionedTransaction {
     let to = Pubkey::new_unique();
     create_test_transaction_with_recipient(from, &to)
 }
 
-pub fn create_test_transaction_with_recipient(from: &Pubkey, to: &Pubkey) -> Transaction {
+pub fn create_test_transaction_with_recipient(from: &Pubkey, to: &Pubkey) -> VersionedTransaction {
     let instruction = create_transfer_instruction(from, to, 1_000_000);
     let message = Message::new(&[instruction], Some(from));
     let mut tx = Transaction::new_unsigned(message);
     tx.message.recent_blockhash = Hash::default();
-    tx
+    tx.into()
+}
+
+/// Insert `pubkey` as a second required signer in a legacy test transaction.
+pub fn add_required_signer(transaction: &mut VersionedTransaction, pubkey: Pubkey) {
+    let VersionedMessage::Legacy(message) = &mut transaction.message else {
+        panic!("test helper only mutates legacy messages");
+    };
+    message.account_keys.insert(1, pubkey);
+    message.header.num_required_signatures = 2;
+}
+
+/// A v1 test transaction. v1 messages exist only in solana-sdk 4.x, and v1 treats
+/// an unset resource limit as zero rather than a default.
+#[cfg(feature = "sdk-v4")]
+pub fn create_test_v1_transaction(from: &Pubkey) -> VersionedTransaction {
+    use solana_sdk_v4::message::v1::{Message as V1Message, TransactionConfig};
+
+    let to = Pubkey::new_unique();
+    let instruction = create_transfer_instruction(from, &to, 1_000_000);
+    let config = TransactionConfig::empty()
+        .with_compute_unit_limit(30_000)
+        .with_loaded_accounts_data_size_limit(65_536);
+    let message = V1Message::try_compile_with_config(from, &[instruction], Hash::default(), config)
+        .expect("v1 test message should compile");
+
+    VersionedTransaction {
+        signatures: vec![
+            crate::sdk_adapter::Signature::default();
+            usize::from(message.header.num_required_signatures)
+        ],
+        message: VersionedMessage::V1(message),
+    }
 }

--- a/rust/src/test_util.rs
+++ b/rust/src/test_util.rs
@@ -43,8 +43,6 @@ pub fn add_required_signer(transaction: &mut VersionedTransaction, pubkey: Pubke
     message.header.num_required_signatures = 2;
 }
 
-/// A v1 test transaction. v1 messages exist only in solana-sdk 4.x, and v1 treats
-/// an unset resource limit as zero rather than a default.
 #[cfg(feature = "sdk-v4")]
 pub fn create_test_v1_transaction(from: &Pubkey) -> VersionedTransaction {
     let to = Pubkey::new_unique();

--- a/rust/src/tests/litesvm_util.rs
+++ b/rust/src/tests/litesvm_util.rs
@@ -1,4 +1,5 @@
-use crate::sdk_adapter::{Hash, Pubkey, Transaction};
+use crate::sdk_adapter::{Hash, Pubkey, VersionedTransaction};
+use crate::transaction_util::serialize_wire_transaction;
 use std::error::Error;
 
 #[cfg(feature = "sdk-v2")]
@@ -12,11 +13,11 @@ use litesvm_v4::LiteSVM;
 // solana-transaction 3.x, while solana-sdk 4.x uses solana-transaction 4.x.
 // The bincode wire format is identical across both, so v4 transactions are
 // round-tripped through the litesvm-compatible 3.x type. For v2/v3 the
-// adapter's own Transaction type already matches the bundled litesvm.
+// adapter's own transaction type already matches the bundled litesvm.
 #[cfg(not(feature = "sdk-v4"))]
-use crate::sdk_adapter::Transaction as LiteSvmTransaction;
+use crate::sdk_adapter::VersionedTransaction as LiteSvmTransaction;
 #[cfg(feature = "sdk-v4")]
-use solana_transaction_litesvm_v4::Transaction as LiteSvmTransaction;
+use solana_transaction_litesvm_v4::versioned::VersionedTransaction as LiteSvmTransaction;
 
 pub async fn start_litesvm(payer: &Pubkey) -> Result<LiteSVM, Box<dyn Error>> {
     let mut svm = LiteSVM::new()
@@ -35,9 +36,10 @@ pub async fn get_latest_blockhash(litesvm: &LiteSVM) -> Result<Hash, Box<dyn Err
 
 pub async fn simulate_transaction(
     litesvm: &LiteSVM,
-    transaction: &Transaction,
+    transaction: &VersionedTransaction,
 ) -> Result<(), Box<dyn Error>> {
-    let tx_bytes = bincode::serialize(transaction).expect("Failed to serialize transaction");
+    let tx_bytes =
+        serialize_wire_transaction(transaction).expect("Failed to serialize transaction");
 
     let tx_for_litesvm: LiteSvmTransaction =
         bincode::deserialize(&tx_bytes).expect("Failed to deserialize transaction");

--- a/rust/src/tests/test_aws_kms_integration.rs
+++ b/rust/src/tests/test_aws_kms_integration.rs
@@ -22,6 +22,7 @@ mod tests {
     use crate::aws_kms::AwsKmsSigner;
     use crate::test_util::create_test_transaction;
     use crate::traits::SolanaSigner;
+    use crate::transaction_util::deserialize_wire_transaction;
     use std::env;
 
     async fn get_signer() -> AwsKmsSigner {
@@ -44,7 +45,7 @@ mod tests {
         let signer = get_signer().await;
 
         let transaction = create_test_transaction(&signer.pubkey());
-        let message = transaction.message_data();
+        let message = transaction.message.serialize();
 
         let signature = signer
             .sign_message(&message)
@@ -69,11 +70,13 @@ mod tests {
             .expect("Failed to start LiteSVM");
 
         let mut transaction = create_test_transaction(&signer.pubkey());
-        transaction.message.recent_blockhash = get_latest_blockhash(&lite_svm)
-            .await
-            .expect("Failed to get latest blockhash");
+        transaction.message.set_recent_blockhash(
+            get_latest_blockhash(&lite_svm)
+                .await
+                .expect("Failed to get latest blockhash"),
+        );
 
-        let original_message = transaction.message_data();
+        let original_message = transaction.message.serialize();
 
         let (base64_txn, signature) = signer
             .sign_transaction(&mut transaction)
@@ -83,7 +86,10 @@ mod tests {
 
         assert_eq!(signature.as_ref().len(), 64, "Signature should be 64 bytes");
         assert!(
-            signature.verify(&signer.pubkey().to_bytes(), &transaction.message_data()),
+            signature.verify(
+                &signer.pubkey().to_bytes(),
+                &transaction.message.serialize()
+            ),
             "Signature should be valid"
         );
 
@@ -91,11 +97,11 @@ mod tests {
             .decode(&base64_txn)
             .expect("Failed to decode base64 transaction");
 
-        let decoded_transaction: crate::sdk_adapter::Transaction =
-            bincode::deserialize(&decoded_bytes).expect("Failed to deserialize transaction");
+        let decoded_transaction = deserialize_wire_transaction(&decoded_bytes)
+            .expect("Failed to deserialize transaction");
 
         assert_eq!(
-            decoded_transaction.message_data(),
+            decoded_transaction.message.serialize(),
             original_message,
             "Decoded transaction should have the same message"
         );

--- a/rust/src/tests/test_cdp_integration.rs
+++ b/rust/src/tests/test_cdp_integration.rs
@@ -24,6 +24,7 @@ mod tests {
     use crate::cdp::CdpSigner;
     use crate::test_util::create_test_transaction;
     use crate::traits::SolanaSigner;
+    use crate::transaction_util::deserialize_wire_transaction;
 
     async fn get_signer() -> CdpSigner {
         dotenv().ok();
@@ -70,11 +71,13 @@ mod tests {
             .expect("Failed to start LiteSVM");
 
         let mut transaction = create_test_transaction(&signer.pubkey());
-        transaction.message.recent_blockhash = get_latest_blockhash(&lite_svm)
-            .await
-            .expect("Failed to get latest blockhash");
+        transaction.message.set_recent_blockhash(
+            get_latest_blockhash(&lite_svm)
+                .await
+                .expect("Failed to get latest blockhash"),
+        );
 
-        let original_message = transaction.message_data();
+        let original_message = transaction.message.serialize();
 
         let (base64_txn, signature) = signer
             .sign_transaction(&mut transaction)
@@ -84,7 +87,10 @@ mod tests {
 
         assert_eq!(signature.as_ref().len(), 64, "Signature should be 64 bytes");
         assert!(
-            signature.verify(&signer.pubkey().to_bytes(), &transaction.message_data()),
+            signature.verify(
+                &signer.pubkey().to_bytes(),
+                &transaction.message.serialize()
+            ),
             "Signature should be valid"
         );
 
@@ -92,11 +98,11 @@ mod tests {
             .decode(&base64_txn)
             .expect("Failed to decode base64 transaction");
 
-        let decoded_transaction: crate::sdk_adapter::Transaction =
-            bincode::deserialize(&decoded_bytes).expect("Failed to deserialize transaction");
+        let decoded_transaction = deserialize_wire_transaction(&decoded_bytes)
+            .expect("Failed to deserialize transaction");
 
         assert_eq!(
-            decoded_transaction.message_data(),
+            decoded_transaction.message.serialize(),
             original_message,
             "Decoded transaction should have the same message"
         );

--- a/rust/src/tests/test_crossmint_integration.rs
+++ b/rust/src/tests/test_crossmint_integration.rs
@@ -12,7 +12,7 @@ mod tests {
 
     use super::*;
     use crate::crossmint::{CrossmintSigner, CrossmintSignerConfig};
-    use crate::sdk_adapter::{Message, Transaction};
+    use crate::sdk_adapter::{Message, Transaction, VersionedTransaction};
     use crate::tests::rpc_util::get_rpc_blockhash;
     use crate::traits::SolanaSigner;
 
@@ -77,9 +77,9 @@ mod tests {
 
         // Keep this integration test focused on remote signing behavior rather than
         // account balance/program execution checks by signing a minimal transaction.
-        let message = Message::new(&[], Some(&signer.pubkey()));
-        let mut transaction = Transaction::new_unsigned(message);
-        transaction.message.recent_blockhash = latest_blockhash;
+        let mut message = Message::new(&[], Some(&signer.pubkey()));
+        message.recent_blockhash = latest_blockhash;
+        let mut transaction: VersionedTransaction = Transaction::new_unsigned(message).into();
 
         let (base64_txn, signature) = signer
             .sign_transaction(&mut transaction)

--- a/rust/src/tests/test_dfns_integration.rs
+++ b/rust/src/tests/test_dfns_integration.rs
@@ -14,6 +14,7 @@ mod tests {
     use crate::dfns::{DfnsSigner, DfnsSignerConfig};
     use crate::test_util::create_test_transaction;
     use crate::traits::SolanaSigner;
+    use crate::transaction_util::deserialize_wire_transaction;
     use std::env;
 
     async fn get_signer() -> DfnsSigner {
@@ -48,7 +49,7 @@ mod tests {
         let signer = get_signer().await;
 
         let transaction = create_test_transaction(&signer.pubkey());
-        let message = transaction.message_data();
+        let message = transaction.message.serialize();
 
         let signature = signer
             .sign_message(&message)
@@ -73,11 +74,13 @@ mod tests {
             .expect("Failed to start LiteSVM");
 
         let mut transaction = create_test_transaction(&signer.pubkey());
-        transaction.message.recent_blockhash = get_latest_blockhash(&lite_svm)
-            .await
-            .expect("Failed to get latest blockhash");
+        transaction.message.set_recent_blockhash(
+            get_latest_blockhash(&lite_svm)
+                .await
+                .expect("Failed to get latest blockhash"),
+        );
 
-        let original_message = transaction.message_data();
+        let original_message = transaction.message.serialize();
 
         let (base64_txn, signature) = signer
             .sign_transaction(&mut transaction)
@@ -87,7 +90,10 @@ mod tests {
 
         assert_eq!(signature.as_ref().len(), 64, "Signature should be 64 bytes");
         assert!(
-            signature.verify(&signer.pubkey().to_bytes(), &transaction.message_data()),
+            signature.verify(
+                &signer.pubkey().to_bytes(),
+                &transaction.message.serialize()
+            ),
             "Signature should be valid"
         );
 
@@ -95,11 +101,11 @@ mod tests {
             .decode(&base64_txn)
             .expect("Failed to decode base64 transaction");
 
-        let decoded_transaction: crate::sdk_adapter::Transaction =
-            bincode::deserialize(&decoded_bytes).expect("Failed to deserialize transaction");
+        let decoded_transaction = deserialize_wire_transaction(&decoded_bytes)
+            .expect("Failed to deserialize transaction");
 
         assert_eq!(
-            decoded_transaction.message_data(),
+            decoded_transaction.message.serialize(),
             original_message,
             "Decoded transaction should have the same message"
         );

--- a/rust/src/tests/test_fireblocks_integration.rs
+++ b/rust/src/tests/test_fireblocks_integration.rs
@@ -64,7 +64,7 @@ mod tests {
         let signer = get_signer().await;
 
         let transaction = create_test_transaction(&signer.pubkey());
-        let message = transaction.message_data();
+        let message = transaction.message.serialize();
 
         let signature = signer
             .sign_message(&message)

--- a/rust/src/tests/test_fordefi_integration.rs
+++ b/rust/src/tests/test_fordefi_integration.rs
@@ -17,11 +17,18 @@ mod tests {
 
     use super::*;
     use crate::fordefi::{FordefiSigner, FordefiSignerConfig, SolanaChainUniqueId};
+    #[cfg(feature = "integration-tests")]
+    use crate::sdk_adapter::{AccountMeta, Instruction, Message, VersionedTransaction};
+    use crate::sdk_adapter::{Pubkey, Transaction};
     use crate::test_util::create_test_transaction;
     #[cfg(feature = "integration-tests")]
     use crate::tests::litesvm_util::{get_latest_blockhash, simulate_transaction, start_litesvm};
+    #[cfg(feature = "integration-tests")]
+    use crate::tests::rpc_util::{confirm_transaction, get_rpc_blockhash, send_raw_transaction};
     use crate::traits::SolanaSigner;
+    use crate::transaction_util::deserialize_wire_transaction;
     use std::env;
+    use std::str::FromStr;
 
     /// Build a `FordefiSigner` for the given vault, sharing the access token and
     /// request-signing key from the environment. `chain` selects black box mode
@@ -108,11 +115,13 @@ mod tests {
             .expect("Failed to start LiteSVM");
 
         let mut transaction = create_test_transaction(&signer.pubkey());
-        transaction.message.recent_blockhash = get_latest_blockhash(&lite_svm)
-            .await
-            .expect("Failed to get latest blockhash");
+        transaction.message.set_recent_blockhash(
+            get_latest_blockhash(&lite_svm)
+                .await
+                .expect("Failed to get latest blockhash"),
+        );
 
-        let original_message = transaction.message_data();
+        let original_message = transaction.message.serialize();
 
         let (base64_txn, signature) = signer
             .sign_transaction(&mut transaction)
@@ -122,7 +131,10 @@ mod tests {
 
         assert_eq!(signature.as_ref().len(), 64, "Signature should be 64 bytes");
         assert!(
-            signature.verify(&signer.pubkey().to_bytes(), &transaction.message_data()),
+            signature.verify(
+                &signer.pubkey().to_bytes(),
+                &transaction.message.serialize()
+            ),
             "Signature should be valid"
         );
 
@@ -130,11 +142,11 @@ mod tests {
             .decode(&base64_txn)
             .expect("Failed to decode base64 transaction");
 
-        let decoded_transaction: crate::sdk_adapter::Transaction =
-            bincode::deserialize(&decoded_bytes).expect("Failed to deserialize transaction");
+        let decoded_transaction = deserialize_wire_transaction(&decoded_bytes)
+            .expect("Failed to deserialize transaction");
 
         assert_eq!(
-            decoded_transaction.message_data(),
+            decoded_transaction.message.serialize(),
             original_message,
             "Decoded transaction should have the same message"
         );
@@ -155,12 +167,6 @@ mod tests {
     #[tokio::test]
     #[cfg(feature = "integration-tests")]
     async fn test_fordefi_devnet_transfer() {
-        use crate::sdk_adapter::{AccountMeta, Instruction, Message, Pubkey, Transaction};
-        use crate::tests::rpc_util::{
-            confirm_transaction, get_rpc_blockhash, send_raw_transaction,
-        };
-        use std::str::FromStr;
-
         let signer = get_signer().await;
         let from = signer.pubkey();
 
@@ -190,9 +196,9 @@ mod tests {
             .await
             .expect("Failed to get devnet blockhash");
 
-        let message = Message::new(&[transfer_ix], Some(&from));
-        let mut transaction = Transaction::new_unsigned(message);
-        transaction.message.recent_blockhash = blockhash;
+        let mut message = Message::new(&[transfer_ix], Some(&from));
+        message.recent_blockhash = blockhash;
+        let mut transaction: VersionedTransaction = Transaction::new_unsigned(message).into();
 
         let (base64_tx, signature) = signer
             .sign_transaction(&mut transaction)
@@ -202,7 +208,7 @@ mod tests {
 
         assert_eq!(signature.as_ref().len(), 64, "Signature should be 64 bytes");
         assert!(
-            signature.verify(&from.to_bytes(), &transaction.message_data()),
+            signature.verify(&from.to_bytes(), &transaction.message.serialize()),
             "Signature should verify locally"
         );
 
@@ -244,10 +250,6 @@ mod tests {
     #[tokio::test]
     #[cfg(feature = "integration-tests")]
     async fn test_fordefi_native_sign_transaction() {
-        use crate::sdk_adapter::{AccountMeta, Instruction, Message, Pubkey, Transaction};
-        use crate::tests::rpc_util::{confirm_transaction, get_rpc_blockhash};
-        use std::str::FromStr;
-
         let signer = get_native_signer().await;
         let from = signer.pubkey();
 
@@ -275,9 +277,9 @@ mod tests {
             .await
             .expect("Failed to get devnet blockhash");
 
-        let message = Message::new(&[transfer_ix], Some(&from));
-        let mut transaction = Transaction::new_unsigned(message);
-        transaction.message.recent_blockhash = blockhash;
+        let mut message = Message::new(&[transfer_ix], Some(&from));
+        message.recent_blockhash = blockhash;
+        let mut transaction: VersionedTransaction = Transaction::new_unsigned(message).into();
 
         let (serialized_tx, signature) = signer
             .sign_transaction(&mut transaction)

--- a/rust/src/tests/test_gcp_kms_integration.rs
+++ b/rust/src/tests/test_gcp_kms_integration.rs
@@ -26,6 +26,7 @@ mod tests {
     use crate::test_util::create_test_transaction;
     use crate::tests::litesvm_util::{get_latest_blockhash, simulate_transaction, start_litesvm};
     use crate::traits::SolanaSigner;
+    use crate::transaction_util::deserialize_wire_transaction;
     use std::env;
 
     async fn get_signer() -> GcpKmsSigner {
@@ -47,7 +48,7 @@ mod tests {
         let signer = get_signer().await;
 
         let transaction = create_test_transaction(&signer.pubkey());
-        let message = transaction.message_data();
+        let message = transaction.message.serialize();
 
         let signature = signer
             .sign_message(&message)
@@ -68,11 +69,13 @@ mod tests {
             .expect("Failed to start LiteSVM");
 
         let mut transaction = create_test_transaction(&signer.pubkey());
-        transaction.message.recent_blockhash = get_latest_blockhash(&lite_svm)
-            .await
-            .expect("Failed to get latest blockhash");
+        transaction.message.set_recent_blockhash(
+            get_latest_blockhash(&lite_svm)
+                .await
+                .expect("Failed to get latest blockhash"),
+        );
 
-        let original_message = transaction.message_data();
+        let original_message = transaction.message.serialize();
 
         let (base64_txn, signature) = signer
             .sign_transaction(&mut transaction)
@@ -82,7 +85,10 @@ mod tests {
 
         assert_eq!(signature.as_ref().len(), 64, "Signature should be 64 bytes");
         assert!(
-            signature.verify(&signer.pubkey().to_bytes(), &transaction.message_data()),
+            signature.verify(
+                &signer.pubkey().to_bytes(),
+                &transaction.message.serialize()
+            ),
             "Signature should be valid"
         );
 
@@ -90,11 +96,11 @@ mod tests {
             .decode(&base64_txn)
             .expect("Failed to decode base64 transaction");
 
-        let decoded_transaction: crate::sdk_adapter::Transaction =
-            bincode::deserialize(&decoded_bytes).expect("Failed to deserialize transaction");
+        let decoded_transaction = deserialize_wire_transaction(&decoded_bytes)
+            .expect("Failed to deserialize transaction");
 
         assert_eq!(
-            decoded_transaction.message_data(),
+            decoded_transaction.message.serialize(),
             original_message,
             "Decoded transaction should have the same message"
         );

--- a/rust/src/tests/test_openfort_integration.rs
+++ b/rust/src/tests/test_openfort_integration.rs
@@ -13,6 +13,7 @@ mod tests {
     use crate::openfort::{OpenfortSigner, OpenfortSignerConfig};
     use crate::test_util::create_test_transaction;
     use crate::traits::SolanaSigner;
+    use crate::transaction_util::deserialize_wire_transaction;
     use std::env;
 
     async fn get_signer() -> OpenfortSigner {
@@ -49,7 +50,7 @@ mod tests {
         let signer = get_signer().await;
 
         let transaction = create_test_transaction(&signer.pubkey());
-        let message = transaction.message_data();
+        let message = transaction.message.serialize();
 
         let signature = signer
             .sign_message(&message)
@@ -74,11 +75,13 @@ mod tests {
             .expect("Failed to start LiteSVM");
 
         let mut transaction = create_test_transaction(&signer.pubkey());
-        transaction.message.recent_blockhash = get_latest_blockhash(&lite_svm)
-            .await
-            .expect("Failed to get latest blockhash");
+        transaction.message.set_recent_blockhash(
+            get_latest_blockhash(&lite_svm)
+                .await
+                .expect("Failed to get latest blockhash"),
+        );
 
-        let original_message = transaction.message_data();
+        let original_message = transaction.message.serialize();
 
         let (base64_txn, signature) = signer
             .sign_transaction(&mut transaction)
@@ -88,7 +91,10 @@ mod tests {
 
         assert_eq!(signature.as_ref().len(), 64, "Signature should be 64 bytes");
         assert!(
-            signature.verify(&signer.pubkey().to_bytes(), &transaction.message_data()),
+            signature.verify(
+                &signer.pubkey().to_bytes(),
+                &transaction.message.serialize()
+            ),
             "Signature should be valid"
         );
 
@@ -96,11 +102,11 @@ mod tests {
             .decode(&base64_txn)
             .expect("Failed to decode base64 transaction");
 
-        let decoded_transaction: crate::sdk_adapter::Transaction =
-            bincode::deserialize(&decoded_bytes).expect("Failed to deserialize transaction");
+        let decoded_transaction = deserialize_wire_transaction(&decoded_bytes)
+            .expect("Failed to deserialize transaction");
 
         assert_eq!(
-            decoded_transaction.message_data(),
+            decoded_transaction.message.serialize(),
             original_message,
             "Decoded transaction should have the same message"
         );

--- a/rust/src/tests/test_para_integration.rs
+++ b/rust/src/tests/test_para_integration.rs
@@ -12,6 +12,7 @@ mod tests {
     use crate::para::ParaSigner;
     use crate::test_util::create_test_transaction;
     use crate::traits::SolanaSigner;
+    use crate::transaction_util::deserialize_wire_transaction;
     use std::env;
 
     async fn get_signer() -> ParaSigner {
@@ -41,7 +42,7 @@ mod tests {
         let signer = get_signer().await;
 
         let transaction = create_test_transaction(&signer.pubkey());
-        let message = transaction.message_data();
+        let message = transaction.message.serialize();
 
         let signature = signer
             .sign_message(&message)
@@ -65,11 +66,13 @@ mod tests {
             .expect("Failed to start LiteSVM");
 
         let mut transaction = create_test_transaction(&signer.pubkey());
-        transaction.message.recent_blockhash = get_latest_blockhash(&lite_svm)
-            .await
-            .expect("Failed to get latest blockhash");
+        transaction.message.set_recent_blockhash(
+            get_latest_blockhash(&lite_svm)
+                .await
+                .expect("Failed to get latest blockhash"),
+        );
 
-        let original_message = transaction.message_data();
+        let original_message = transaction.message.serialize();
 
         let (base64_txn, signature) = signer
             .sign_transaction(&mut transaction)
@@ -80,7 +83,10 @@ mod tests {
         // Validate the signature
         assert_eq!(signature.as_ref().len(), 64, "Signature should be 64 bytes");
         assert!(
-            signature.verify(&signer.pubkey().to_bytes(), &transaction.message_data()),
+            signature.verify(
+                &signer.pubkey().to_bytes(),
+                &transaction.message.serialize()
+            ),
             "Signature should be valid"
         );
 
@@ -89,11 +95,11 @@ mod tests {
             .decode(&base64_txn)
             .expect("Failed to decode base64 transaction");
 
-        let decoded_transaction: crate::sdk_adapter::Transaction =
-            bincode::deserialize(&decoded_bytes).expect("Failed to deserialize transaction");
+        let decoded_transaction = deserialize_wire_transaction(&decoded_bytes)
+            .expect("Failed to deserialize transaction");
 
         assert_eq!(
-            decoded_transaction.message_data(),
+            decoded_transaction.message.serialize(),
             original_message,
             "Decoded transaction should have the same message"
         );

--- a/rust/src/tests/test_privy_integration.rs
+++ b/rust/src/tests/test_privy_integration.rs
@@ -17,6 +17,7 @@ mod tests {
     };
     use crate::test_util::create_test_transaction;
     use crate::traits::SolanaSigner;
+    use crate::transaction_util::deserialize_wire_transaction;
     use std::env;
 
     async fn get_signer() -> PrivySigner {
@@ -63,7 +64,7 @@ mod tests {
         let signer = get_signer().await;
 
         let transaction = create_test_transaction(&signer.pubkey());
-        let message = transaction.message_data();
+        let message = transaction.message.serialize();
 
         let signature = signer
             .sign_message(&message)
@@ -87,11 +88,13 @@ mod tests {
             .expect("Failed to start LiteSVM");
 
         let mut transaction = create_test_transaction(&signer.pubkey());
-        transaction.message.recent_blockhash = get_latest_blockhash(&lite_svm)
-            .await
-            .expect("Failed to get latest blockhash");
+        transaction.message.set_recent_blockhash(
+            get_latest_blockhash(&lite_svm)
+                .await
+                .expect("Failed to get latest blockhash"),
+        );
 
-        let original_message = transaction.message_data();
+        let original_message = transaction.message.serialize();
 
         let (base64_txn, signature) = signer
             .sign_transaction(&mut transaction)
@@ -102,7 +105,10 @@ mod tests {
         // Validate the signature
         assert_eq!(signature.as_ref().len(), 64, "Signature should be 64 bytes");
         assert!(
-            signature.verify(&signer.pubkey().to_bytes(), &transaction.message_data()),
+            signature.verify(
+                &signer.pubkey().to_bytes(),
+                &transaction.message.serialize()
+            ),
             "Signature should be valid"
         );
 
@@ -111,11 +117,11 @@ mod tests {
             .decode(&base64_txn)
             .expect("Failed to decode base64 transaction");
 
-        let decoded_transaction: crate::sdk_adapter::Transaction =
-            bincode::deserialize(&decoded_bytes).expect("Failed to deserialize transaction");
+        let decoded_transaction = deserialize_wire_transaction(&decoded_bytes)
+            .expect("Failed to deserialize transaction");
 
         assert_eq!(
-            decoded_transaction.message_data(),
+            decoded_transaction.message.serialize(),
             original_message,
             "Decoded transaction should have the same message"
         );

--- a/rust/src/tests/test_turnkey_integration.rs
+++ b/rust/src/tests/test_turnkey_integration.rs
@@ -14,6 +14,7 @@ mod tests {
     use crate::sdk_adapter::Pubkey;
     use crate::test_util::create_test_transaction;
     use crate::traits::SolanaSigner;
+    use crate::transaction_util::deserialize_wire_transaction;
     use crate::turnkey::TurnkeySigner;
     use std::env;
 
@@ -51,7 +52,7 @@ mod tests {
         let signer = get_signer().await;
 
         let transaction = create_test_transaction(&signer.pubkey());
-        let message = transaction.message_data();
+        let message = transaction.message.serialize();
 
         let signature = signer
             .sign_message(&message)
@@ -76,11 +77,13 @@ mod tests {
             .expect("Failed to start LiteSVM");
 
         let mut transaction = create_test_transaction(&signer.pubkey());
-        transaction.message.recent_blockhash = get_latest_blockhash(&lite_svm)
-            .await
-            .expect("Failed to get latest blockhash");
+        transaction.message.set_recent_blockhash(
+            get_latest_blockhash(&lite_svm)
+                .await
+                .expect("Failed to get latest blockhash"),
+        );
 
-        let original_message = transaction.message_data();
+        let original_message = transaction.message.serialize();
 
         let (base64_txn, signature) = signer
             .sign_transaction(&mut transaction)
@@ -91,7 +94,10 @@ mod tests {
         // Validate the signature
         assert_eq!(signature.as_ref().len(), 64, "Signature should be 64 bytes");
         assert!(
-            signature.verify(&signer.pubkey().to_bytes(), &transaction.message_data()),
+            signature.verify(
+                &signer.pubkey().to_bytes(),
+                &transaction.message.serialize()
+            ),
             "Signature should be valid"
         );
 
@@ -100,11 +106,11 @@ mod tests {
             .decode(&base64_txn)
             .expect("Failed to decode base64 transaction");
 
-        let decoded_transaction: crate::sdk_adapter::Transaction =
-            bincode::deserialize(&decoded_bytes).expect("Failed to deserialize transaction");
+        let decoded_transaction = deserialize_wire_transaction(&decoded_bytes)
+            .expect("Failed to deserialize transaction");
 
         assert_eq!(
-            decoded_transaction.message_data(),
+            decoded_transaction.message.serialize(),
             original_message,
             "Decoded transaction should have the same message"
         );

--- a/rust/src/tests/test_utila_integration.rs
+++ b/rust/src/tests/test_utila_integration.rs
@@ -14,7 +14,7 @@ mod tests {
     use std::env;
 
     use super::*;
-    use crate::sdk_adapter::{Message, Transaction};
+    use crate::sdk_adapter::{Message, Transaction, VersionedTransaction};
     use crate::tests::rpc_util::get_rpc_blockhash;
     use crate::traits::SolanaSigner;
     use crate::utila::{UtilaSigner, UtilaSignerConfig};
@@ -74,9 +74,9 @@ mod tests {
             .await
             .expect("Failed to fetch latest RPC blockhash");
 
-        let message = Message::new(&[], Some(&signer.pubkey()));
-        let mut transaction = Transaction::new_unsigned(message);
-        transaction.message.recent_blockhash = latest_blockhash;
+        let mut message = Message::new(&[], Some(&signer.pubkey()));
+        message.recent_blockhash = latest_blockhash;
+        let mut transaction: VersionedTransaction = Transaction::new_unsigned(message).into();
 
         let (_base64_txn, signature) = signer
             .sign_transaction(&mut transaction)

--- a/rust/src/tests/test_vault_integration.rs
+++ b/rust/src/tests/test_vault_integration.rs
@@ -12,6 +12,7 @@ mod tests {
     use super::*;
     use crate::test_util::create_test_transaction;
     use crate::traits::SolanaSigner;
+    use crate::transaction_util::deserialize_wire_transaction;
     use crate::vault::VaultSigner;
     use std::env;
 
@@ -37,7 +38,7 @@ mod tests {
         let signer = get_signer().await;
 
         let transaction = create_test_transaction(&signer.pubkey());
-        let message = transaction.message_data();
+        let message = transaction.message.serialize();
 
         let signature = signer
             .sign_message(&message)
@@ -62,11 +63,13 @@ mod tests {
             .expect("Failed to start LiteSVM");
 
         let mut transaction = create_test_transaction(&signer.pubkey());
-        transaction.message.recent_blockhash = get_latest_blockhash(&lite_svm)
-            .await
-            .expect("Failed to get latest blockhash");
+        transaction.message.set_recent_blockhash(
+            get_latest_blockhash(&lite_svm)
+                .await
+                .expect("Failed to get latest blockhash"),
+        );
 
-        let original_message = transaction.message_data();
+        let original_message = transaction.message.serialize();
 
         let (base64_txn, signature) = signer
             .sign_transaction(&mut transaction)
@@ -77,7 +80,10 @@ mod tests {
         // Validate the signature
         assert_eq!(signature.as_ref().len(), 64, "Signature should be 64 bytes");
         assert!(
-            signature.verify(&signer.pubkey().to_bytes(), &transaction.message_data()),
+            signature.verify(
+                &signer.pubkey().to_bytes(),
+                &transaction.message.serialize()
+            ),
             "Signature should be valid"
         );
 
@@ -86,11 +92,11 @@ mod tests {
             .decode(&base64_txn)
             .expect("Failed to decode base64 transaction");
 
-        let decoded_transaction: crate::sdk_adapter::Transaction =
-            bincode::deserialize(&decoded_bytes).expect("Failed to deserialize transaction");
+        let decoded_transaction = deserialize_wire_transaction(&decoded_bytes)
+            .expect("Failed to deserialize transaction");
 
         assert_eq!(
-            decoded_transaction.message_data(),
+            decoded_transaction.message.serialize(),
             original_message,
             "Decoded transaction should have the same message"
         );

--- a/rust/src/traits.rs
+++ b/rust/src/traits.rs
@@ -3,7 +3,7 @@
 use async_trait::async_trait;
 
 use crate::error::SignerError;
-use crate::sdk_adapter::{Pubkey, Signature, Transaction};
+use crate::sdk_adapter::{Pubkey, Signature, VersionedTransaction};
 
 pub type SignedTransaction = (String, Signature);
 #[derive(Debug)]
@@ -38,14 +38,16 @@ pub trait SolanaSigner: Send + Sync {
     ///
     /// # Arguments
     ///
-    /// * `tx` - The transaction to sign (will be modified in place)
+    /// * `tx` - The transaction to sign (will be modified in place). Legacy, v0
+    ///   and v1 are accepted; convert a legacy `Transaction` with `.into()`.
+    ///   v1 requires `sdk-v4`.
     ///
     /// # Returns
     ///
     /// The encoded transaction/signature tuple, explicitly marked as complete or partial.
     async fn sign_transaction(
         &self,
-        tx: &mut Transaction,
+        tx: &mut VersionedTransaction,
     ) -> Result<SignTransactionResult, SignerError>;
 
     /// Sign an arbitrary message

--- a/rust/src/transaction_util.rs
+++ b/rust/src/transaction_util.rs
@@ -1,5 +1,5 @@
 use crate::error::SignerError;
-use crate::sdk_adapter::{Pubkey, Signature, Transaction};
+use crate::sdk_adapter::{Pubkey, Signature, VersionedTransaction};
 use crate::traits::{SignTransactionResult, SignedTransaction};
 use base64::{engine::general_purpose::STANDARD, Engine};
 
@@ -24,33 +24,72 @@ pub(crate) fn idempotency_key_from_message(message_bytes: &[u8]) -> String {
     )
 }
 
+/// Serialize a transaction to canonical wire bytes.
+///
+/// A v1 envelope appends its signatures with no length prefix, which serde cannot
+/// express, so `sdk-v4` uses wincode. The two codecs agree on legacy and v0.
+#[cfg(feature = "sdk-v4")]
+pub(crate) fn serialize_wire_transaction(
+    transaction: &VersionedTransaction,
+) -> Result<Vec<u8>, SignerError> {
+    wincode::serialize(transaction).map_err(|e| {
+        SignerError::SerializationError(format!("Failed to serialize transaction: {e}"))
+    })
+}
+
+#[cfg(not(feature = "sdk-v4"))]
+pub(crate) fn serialize_wire_transaction(
+    transaction: &VersionedTransaction,
+) -> Result<Vec<u8>, SignerError> {
+    bincode::serialize(transaction).map_err(|e| {
+        SignerError::SerializationError(format!("Failed to serialize transaction: {e}"))
+    })
+}
+
+/// Deserialize canonical wire bytes. See [`serialize_wire_transaction`] for the codec.
+#[cfg(feature = "sdk-v4")]
+pub(crate) fn deserialize_wire_transaction(
+    bytes: &[u8],
+) -> Result<VersionedTransaction, SignerError> {
+    wincode::deserialize(bytes).map_err(|e| {
+        SignerError::SerializationError(format!("Failed to deserialize transaction: {e}"))
+    })
+}
+
+#[cfg(not(feature = "sdk-v4"))]
+pub(crate) fn deserialize_wire_transaction(
+    bytes: &[u8],
+) -> Result<VersionedTransaction, SignerError> {
+    bincode::deserialize(bytes).map_err(|e| {
+        SignerError::SerializationError(format!("Failed to deserialize transaction: {e}"))
+    })
+}
+
 pub struct TransactionUtil;
 
 impl TransactionUtil {
     /// Encodes a Transaction to a base64 serialized String
-    pub fn serialize_transaction(transaction: &Transaction) -> Result<String, SignerError> {
-        Ok(
-            STANDARD.encode(bincode::serialize(transaction).map_err(|e| {
-                SignerError::SerializationError(format!("Failed to serialize transaction: {e}"))
-            })?),
-        )
+    pub fn serialize_transaction(
+        transaction: &VersionedTransaction,
+    ) -> Result<String, SignerError> {
+        Ok(STANDARD.encode(serialize_wire_transaction(transaction)?))
     }
 
     /// Get the position of a pubkey in the transaction's signing keypair positions.
     /// Returns the index where this signer's signature should be placed.
     pub fn get_signing_keypair_position(
-        transaction: &Transaction,
+        transaction: &VersionedTransaction,
         pubkey: &Pubkey,
     ) -> Result<usize, SignerError> {
-        let num_required_signatures = transaction.message.header.num_required_signatures as usize;
+        let num_required_signatures = transaction.message.header().num_required_signatures as usize;
 
-        if transaction.message.account_keys.len() < num_required_signatures {
+        if transaction.message.static_account_keys().len() < num_required_signatures {
             return Err(SignerError::SigningFailed(
                 "Invalid account index: not enough account keys".to_string(),
             ));
         }
 
-        let signed_keys = &transaction.message.account_keys[0..num_required_signatures];
+        let signed_keys = &transaction.message.static_account_keys()[0..num_required_signatures];
 
         signed_keys.iter().position(|x| x == pubkey).ok_or_else(|| {
             SignerError::SigningFailed(format!(
@@ -62,14 +101,14 @@ impl TransactionUtil {
 
     /// Add a signature to the transaction at the correct position.
     pub fn add_signature_to_transaction(
-        transaction: &mut Transaction,
+        transaction: &mut VersionedTransaction,
         pubkey: &Pubkey,
         signature: Signature,
     ) -> Result<(), SignerError> {
         let position = Self::get_signing_keypair_position(transaction, pubkey)?;
 
         // Ensure signatures vec is large enough
-        let num_required_signatures = transaction.message.header.num_required_signatures as usize;
+        let num_required_signatures = transaction.message.header().num_required_signatures as usize;
         if transaction.signatures.len() < num_required_signatures {
             transaction
                 .signatures
@@ -83,8 +122,8 @@ impl TransactionUtil {
     }
 
     /// Returns true when all required signature slots are populated with non-default values.
-    pub fn has_all_required_signatures(transaction: &Transaction) -> bool {
-        let num_required_signatures = transaction.message.header.num_required_signatures as usize;
+    pub fn has_all_required_signatures(transaction: &VersionedTransaction) -> bool {
+        let num_required_signatures = transaction.message.header().num_required_signatures as usize;
         if transaction.signatures.len() < num_required_signatures {
             return false;
         }
@@ -98,7 +137,7 @@ impl TransactionUtil {
 
     /// Classify a signed transaction result based on whether all required signatures are present.
     pub fn classify_signed_transaction(
-        transaction: &Transaction,
+        transaction: &VersionedTransaction,
         signed_transaction: SignedTransaction,
     ) -> SignTransactionResult {
         if Self::has_all_required_signatures(transaction) {
@@ -106,5 +145,56 @@ impl TransactionUtil {
         } else {
             SignTransactionResult::Partial(signed_transaction)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(feature = "sdk-v4")]
+    use super::*;
+    #[cfg(feature = "sdk-v4")]
+    use crate::test_util::create_test_transaction;
+
+    /// The wincode swap is only safe while the codecs agree on legacy, so every
+    /// already-signed transaction keeps its exact wire bytes.
+    #[cfg(feature = "sdk-v4")]
+    #[test]
+    fn wincode_matches_bincode_for_a_legacy_transaction() {
+        let transaction = create_test_transaction(&Pubkey::new_unique());
+
+        let wire = serialize_wire_transaction(&transaction).expect("serialize");
+        let bincode_wire = bincode::serialize(&transaction).expect("bincode serialize");
+
+        assert_eq!(wire, bincode_wire);
+    }
+
+    #[cfg(feature = "sdk-v4")]
+    #[test]
+    fn v1_envelope_places_the_message_first_and_signatures_last() {
+        use crate::test_util::create_test_v1_transaction;
+
+        let transaction = create_test_v1_transaction(&Pubkey::new_unique());
+        let message_bytes = transaction.message.serialize();
+
+        let wire = serialize_wire_transaction(&transaction).expect("serialize");
+
+        assert_eq!(message_bytes[0], 0x81);
+        assert_eq!(wire[..message_bytes.len()], message_bytes[..]);
+        assert_eq!(wire.len(), message_bytes.len() + 64);
+        assert_ne!(wire, bincode::serialize(&transaction).expect("bincode"));
+    }
+
+    #[cfg(feature = "sdk-v4")]
+    #[test]
+    fn v1_wire_transaction_round_trips() {
+        use crate::test_util::create_test_v1_transaction;
+
+        let transaction = create_test_v1_transaction(&Pubkey::new_unique());
+        let wire = serialize_wire_transaction(&transaction).expect("serialize");
+
+        let decoded = deserialize_wire_transaction(&wire).expect("deserialize");
+
+        assert_eq!(decoded.message.serialize(), transaction.message.serialize());
+        assert_eq!(decoded.signatures, transaction.signatures);
     }
 }

--- a/rust/src/transaction_util.rs
+++ b/rust/src/transaction_util.rs
@@ -25,9 +25,6 @@ pub(crate) fn idempotency_key_from_message(message_bytes: &[u8]) -> String {
 }
 
 /// Serialize a transaction to canonical wire bytes.
-///
-/// A v1 envelope appends its signatures with no length prefix, which serde cannot
-/// express, so `sdk-v4` uses wincode. The two codecs agree on legacy and v0.
 #[cfg(feature = "sdk-v4")]
 pub(crate) fn serialize_wire_transaction(
     transaction: &VersionedTransaction,
@@ -46,7 +43,7 @@ pub(crate) fn serialize_wire_transaction(
     })
 }
 
-/// Deserialize canonical wire bytes. See [`serialize_wire_transaction`] for the codec.
+/// Deserialize canonical wire bytes.
 #[cfg(feature = "sdk-v4")]
 pub(crate) fn deserialize_wire_transaction(
     bytes: &[u8],
@@ -153,10 +150,8 @@ mod tests {
     #[cfg(feature = "sdk-v4")]
     use super::*;
     #[cfg(feature = "sdk-v4")]
-    use crate::test_util::create_test_transaction;
+    use crate::test_util::{create_test_transaction, create_test_v1_transaction};
 
-    /// The wincode swap is only safe while the codecs agree on legacy, so every
-    /// already-signed transaction keeps its exact wire bytes.
     #[cfg(feature = "sdk-v4")]
     #[test]
     fn wincode_matches_bincode_for_a_legacy_transaction() {
@@ -171,8 +166,6 @@ mod tests {
     #[cfg(feature = "sdk-v4")]
     #[test]
     fn v1_envelope_places_the_message_first_and_signatures_last() {
-        use crate::test_util::create_test_v1_transaction;
-
         let transaction = create_test_v1_transaction(&Pubkey::new_unique());
         let message_bytes = transaction.message.serialize();
 
@@ -187,8 +180,6 @@ mod tests {
     #[cfg(feature = "sdk-v4")]
     #[test]
     fn v1_wire_transaction_round_trips() {
-        use crate::test_util::create_test_v1_transaction;
-
         let transaction = create_test_v1_transaction(&Pubkey::new_unique());
         let wire = serialize_wire_transaction(&transaction).expect("serialize");
 

--- a/rust/src/turnkey/mod.rs
+++ b/rust/src/turnkey/mod.rs
@@ -2,7 +2,7 @@
 
 mod types;
 
-use crate::sdk_adapter::{Pubkey, Signature, Transaction};
+use crate::sdk_adapter::{Pubkey, Signature, VersionedTransaction};
 use crate::traits::SignTransactionResult;
 pub use crate::traits::SignedTransaction;
 use crate::{
@@ -222,11 +222,9 @@ impl TurnkeySigner {
     /// conditions. Policies must allow `ACTIVITY_TYPE_SIGN_TRANSACTION_V2`.
     async fn sign_and_serialize(
         &self,
-        transaction: &mut Transaction,
+        transaction: &mut VersionedTransaction,
     ) -> Result<SignedTransaction, SignerError> {
-        let unsigned_wire = bincode::serialize(transaction).map_err(|e| {
-            SignerError::SerializationError(format!("Failed to serialize transaction: {e}"))
-        })?;
+        let unsigned_wire = crate::transaction_util::serialize_wire_transaction(transaction)?;
 
         let request = SignTransactionRequest {
             activity_type: "ACTIVITY_TYPE_SIGN_TRANSACTION_V2".to_string(),
@@ -257,11 +255,12 @@ impl TurnkeySigner {
                 "Failed to decode signed transaction returned by Turnkey: {e}"
             ))
         })?;
-        let returned: Transaction = bincode::deserialize(&signed_wire).map_err(|e| {
-            SignerError::SerializationError(format!(
-                "Failed to deserialize signed transaction returned by Turnkey: {e}"
-            ))
-        })?;
+        let returned: VersionedTransaction =
+            crate::transaction_util::deserialize_wire_transaction(&signed_wire).map_err(|e| {
+                SignerError::SerializationError(format!(
+                    "Failed to deserialize signed transaction returned by Turnkey: {e}"
+                ))
+            })?;
 
         let position = TransactionUtil::get_signing_keypair_position(&returned, &self.public_key)?;
         let signature = returned.signatures.get(position).copied().ok_or_else(|| {
@@ -270,7 +269,10 @@ impl TurnkeySigner {
             )
         })?;
 
-        if !signature.verify(&self.public_key.to_bytes(), &transaction.message_data()) {
+        if !signature.verify(
+            &self.public_key.to_bytes(),
+            &transaction.message.serialize(),
+        ) {
             return Err(SignerError::SigningFailed(
                 "Signature verification failed — the returned signature does not match the public key".to_string(),
             ));
@@ -353,7 +355,7 @@ impl SolanaSigner for TurnkeySigner {
 
     async fn sign_transaction(
         &self,
-        tx: &mut Transaction,
+        tx: &mut VersionedTransaction,
     ) -> Result<SignTransactionResult, SignerError> {
         let signed_transaction = self.sign_and_serialize(tx).await?;
         Ok(TransactionUtil::classify_signed_transaction(
@@ -557,7 +559,7 @@ mod tests {
 
         let mut tx = create_test_transaction(&keypair_pubkey(&keypair));
 
-        let signature = keypair.sign_message(&tx.message_data());
+        let signature = keypair.sign_message(&tx.message.serialize());
         let mut signed_tx = tx.clone();
         signed_tx.signatures = vec![signature];
         let signed_hex = hex::encode(bincode::serialize(&signed_tx).unwrap());
@@ -609,7 +611,7 @@ mod tests {
 
         let mut tx = create_test_transaction(&keypair_pubkey(&keypair));
         let mut other_tx = create_test_transaction(&keypair_pubkey(&keypair));
-        other_tx.signatures = vec![keypair.sign_message(&other_tx.message_data())];
+        other_tx.signatures = vec![keypair.sign_message(&other_tx.message.serialize())];
         let signed_hex = hex::encode(bincode::serialize(&other_tx).unwrap());
 
         Mock::given(method("POST"))

--- a/rust/src/turnkey/mod.rs
+++ b/rust/src/turnkey/mod.rs
@@ -5,10 +5,10 @@ mod types;
 use crate::sdk_adapter::{Pubkey, Signature, VersionedTransaction};
 use crate::traits::SignTransactionResult;
 pub use crate::traits::SignedTransaction;
-use crate::{
-    error::SignerError, http_client_config::HttpClientConfig, traits::SolanaSigner,
-    transaction_util::TransactionUtil,
+use crate::transaction_util::{
+    deserialize_wire_transaction, serialize_wire_transaction, TransactionUtil,
 };
+use crate::{error::SignerError, http_client_config::HttpClientConfig, traits::SolanaSigner};
 use base64::Engine;
 use p256::ecdsa::signature::Signer as P256Signer;
 use std::str::FromStr;
@@ -224,7 +224,7 @@ impl TurnkeySigner {
         &self,
         transaction: &mut VersionedTransaction,
     ) -> Result<SignedTransaction, SignerError> {
-        let unsigned_wire = crate::transaction_util::serialize_wire_transaction(transaction)?;
+        let unsigned_wire = serialize_wire_transaction(transaction)?;
 
         let request = SignTransactionRequest {
             activity_type: "ACTIVITY_TYPE_SIGN_TRANSACTION_V2".to_string(),
@@ -256,7 +256,7 @@ impl TurnkeySigner {
             ))
         })?;
         let returned: VersionedTransaction =
-            crate::transaction_util::deserialize_wire_transaction(&signed_wire).map_err(|e| {
+            deserialize_wire_transaction(&signed_wire).map_err(|e| {
                 SignerError::SerializationError(format!(
                     "Failed to deserialize signed transaction returned by Turnkey: {e}"
                 ))

--- a/rust/src/utila/mod.rs
+++ b/rust/src/utila/mod.rs
@@ -4,7 +4,9 @@ mod types;
 
 use crate::sdk_adapter::{Pubkey, Signature, VersionedTransaction};
 use crate::traits::{SignTransactionResult, SignedTransaction};
-use crate::transaction_util::TransactionUtil;
+use crate::transaction_util::{
+    deserialize_wire_transaction, serialize_wire_transaction, TransactionUtil,
+};
 use crate::{error::SignerError, http_client_config::HttpClientConfig, traits::SolanaSigner};
 use base64::{engine::general_purpose::STANDARD, Engine};
 use chrono::{Duration, Utc};
@@ -323,7 +325,7 @@ impl UtilaSigner {
         })?;
 
         let transaction: VersionedTransaction =
-            crate::transaction_util::deserialize_wire_transaction(&bytes).map_err(|_e| {
+            deserialize_wire_transaction(&bytes).map_err(|_e| {
                 SignerError::SerializationError(
                     "Failed to deserialize Utila rawTransaction".to_string(),
                 )
@@ -363,9 +365,7 @@ impl UtilaSigner {
     ) -> Result<SignedTransaction, SignerError> {
         let public_key = self.initialized_pubkey()?;
         let expected_message = transaction.message.serialize();
-        let raw_transaction = STANDARD.encode(crate::transaction_util::serialize_wire_transaction(
-            transaction,
-        )?);
+        let raw_transaction = STANDARD.encode(serialize_wire_transaction(transaction)?);
 
         let initiated = self.initiate_transaction(raw_transaction).await?;
         let signed = self.poll_signed_transaction(initiated).await?;

--- a/rust/src/utila/mod.rs
+++ b/rust/src/utila/mod.rs
@@ -2,7 +2,7 @@
 
 mod types;
 
-use crate::sdk_adapter::{Pubkey, Signature, Transaction, VersionedTransaction};
+use crate::sdk_adapter::{Pubkey, Signature, VersionedTransaction};
 use crate::traits::{SignTransactionResult, SignedTransaction};
 use crate::transaction_util::TransactionUtil;
 use crate::{error::SignerError, http_client_config::HttpClientConfig, traits::SolanaSigner};
@@ -322,75 +322,31 @@ impl UtilaSigner {
             )
         })?;
 
-        let signature = match bincode::deserialize::<VersionedTransaction>(&bytes) {
-            Ok(transaction) => {
-                let remote_message = transaction.message.serialize();
-                if remote_message != expected_message {
-                    return Err(SignerError::SigningFailed(
-                        "Utila returned a signed transaction with different message bytes"
-                            .to_string(),
-                    ));
-                }
+        let transaction: VersionedTransaction =
+            crate::transaction_util::deserialize_wire_transaction(&bytes).map_err(|_e| {
+                SignerError::SerializationError(
+                    "Failed to deserialize Utila rawTransaction".to_string(),
+                )
+            })?;
 
-                let required_signers =
-                    usize::from(transaction.message.header().num_required_signatures);
-                let signer_keys = transaction.message.static_account_keys();
-                if signer_keys.len() < required_signers {
-                    return Err(SignerError::SigningFailed(
-                        "Invalid account index: not enough account keys".to_string(),
-                    ));
-                }
+        let remote_message = transaction.message.serialize();
+        if remote_message != expected_message {
+            return Err(SignerError::SigningFailed(
+                "Utila returned a signed transaction with different message bytes".to_string(),
+            ));
+        }
 
-                let position = signer_keys
-                    .iter()
-                    .take(required_signers)
-                    .position(|key| key == &public_key)
-                    .ok_or_else(|| {
-                        SignerError::SigningFailed(
-                            "Failed to locate signer pubkey in Utila transaction".to_string(),
-                        )
-                    })?;
-
-                transaction
-                    .signatures
-                    .get(position)
-                    .copied()
-                    .filter(|sig| *sig != Signature::default())
-                    .ok_or_else(|| {
-                        SignerError::SigningFailed(
-                            "Utila rawTransaction did not contain a signer signature".to_string(),
-                        )
-                    })?
-            }
-            Err(_) => {
-                let transaction: Transaction = bincode::deserialize(&bytes).map_err(|_| {
-                    SignerError::SerializationError(
-                        "Failed to deserialize Utila rawTransaction".to_string(),
-                    )
-                })?;
-
-                let remote_message = transaction.message_data();
-                if remote_message != expected_message {
-                    return Err(SignerError::SigningFailed(
-                        "Utila returned a signed transaction with different message bytes"
-                            .to_string(),
-                    ));
-                }
-
-                let position =
-                    TransactionUtil::get_signing_keypair_position(&transaction, &public_key)?;
-                transaction
-                    .signatures
-                    .get(position)
-                    .copied()
-                    .filter(|sig| *sig != Signature::default())
-                    .ok_or_else(|| {
-                        SignerError::SigningFailed(
-                            "Utila rawTransaction did not contain a signer signature".to_string(),
-                        )
-                    })?
-            }
-        };
+        let position = TransactionUtil::get_signing_keypair_position(&transaction, &public_key)?;
+        let signature = transaction
+            .signatures
+            .get(position)
+            .copied()
+            .filter(|sig| *sig != Signature::default())
+            .ok_or_else(|| {
+                SignerError::SigningFailed(
+                    "Utila rawTransaction did not contain a signer signature".to_string(),
+                )
+            })?;
 
         if !signature.verify(&public_key.to_bytes(), expected_message) {
             return Err(SignerError::SigningFailed(
@@ -403,13 +359,13 @@ impl UtilaSigner {
 
     async fn sign_and_serialize(
         &self,
-        transaction: &mut Transaction,
+        transaction: &mut VersionedTransaction,
     ) -> Result<SignedTransaction, SignerError> {
         let public_key = self.initialized_pubkey()?;
-        let expected_message = transaction.message_data();
-        let raw_transaction = STANDARD.encode(bincode::serialize(transaction).map_err(|e| {
-            SignerError::SerializationError(format!("Failed to serialize transaction: {e}"))
-        })?);
+        let expected_message = transaction.message.serialize();
+        let raw_transaction = STANDARD.encode(crate::transaction_util::serialize_wire_transaction(
+            transaction,
+        )?);
 
         let initiated = self.initiate_transaction(raw_transaction).await?;
         let signed = self.poll_signed_transaction(initiated).await?;
@@ -446,7 +402,7 @@ impl SolanaSigner for UtilaSigner {
 
     async fn sign_transaction(
         &self,
-        tx: &mut Transaction,
+        tx: &mut VersionedTransaction,
     ) -> Result<SignTransactionResult, SignerError> {
         let signed_transaction = self.sign_and_serialize(tx).await?;
         Ok(TransactionUtil::classify_signed_transaction(
@@ -652,14 +608,14 @@ p6B5CCtpBPgD01Vm+bT/JQ==
         }))
     }
 
-    fn signed_transaction_payload() -> (Keypair, Transaction, String, String, Signature) {
+    fn signed_transaction_payload() -> (Keypair, VersionedTransaction, String, String, Signature) {
         let keypair = Keypair::new();
         let public_key = keypair_pubkey(&keypair);
         let unsigned = create_test_transaction(&public_key);
         let unsigned_raw = STANDARD.encode(bincode::serialize(&unsigned).unwrap());
 
         let mut signed = unsigned.clone();
-        let signature = keypair_sign_message(&keypair, &signed.message_data());
+        let signature = keypair_sign_message(&keypair, &signed.message.serialize());
         TransactionUtil::add_signature_to_transaction(&mut signed, &public_key, signature).unwrap();
         let signed_raw = STANDARD.encode(bincode::serialize(&signed).unwrap());
 
@@ -983,13 +939,19 @@ p6B5CCtpBPgD01Vm+bT/JQ==
 
     fn signed_transaction_payload_for_keypair(
         keypair: &Keypair,
-    ) -> (Transaction, Transaction, String, String, Signature) {
+    ) -> (
+        VersionedTransaction,
+        VersionedTransaction,
+        String,
+        String,
+        Signature,
+    ) {
         let public_key = keypair_pubkey(keypair);
         let unsigned = create_test_transaction(&public_key);
         let unsigned_raw = STANDARD.encode(bincode::serialize(&unsigned).unwrap());
 
         let mut signed = unsigned.clone();
-        let signature = keypair_sign_message(keypair, &signed.message_data());
+        let signature = keypair_sign_message(keypair, &signed.message.serialize());
         TransactionUtil::add_signature_to_transaction(&mut signed, &public_key, signature).unwrap();
         let signed_raw = STANDARD.encode(bincode::serialize(&signed).unwrap());
 

--- a/rust/src/vault/mod.rs
+++ b/rust/src/vault/mod.rs
@@ -7,7 +7,7 @@
 /// their own `Cargo.toml`.
 pub use reqwest;
 
-use crate::sdk_adapter::{Pubkey, Signature, Transaction};
+use crate::sdk_adapter::{Pubkey, Signature, VersionedTransaction};
 use crate::traits::{SignTransactionResult, SignedTransaction};
 use crate::{
     error::SignerError, http_client_config::HttpClientConfig, traits::SolanaSigner,
@@ -221,9 +221,9 @@ impl VaultSigner {
 
     async fn sign_and_serialize(
         &self,
-        transaction: &mut Transaction,
+        transaction: &mut VersionedTransaction,
     ) -> Result<SignedTransaction, SignerError> {
-        let signature = self.sign_bytes(&transaction.message_data()).await?;
+        let signature = self.sign_bytes(&transaction.message.serialize()).await?;
 
         TransactionUtil::add_signature_to_transaction(transaction, &self.pubkey, signature)?;
 
@@ -242,7 +242,7 @@ impl SolanaSigner for VaultSigner {
 
     async fn sign_transaction(
         &self,
-        tx: &mut Transaction,
+        tx: &mut VersionedTransaction,
     ) -> Result<SignTransactionResult, SignerError> {
         let signed_transaction = self.sign_and_serialize(tx).await?;
         Ok(TransactionUtil::classify_signed_transaction(
@@ -574,7 +574,7 @@ mod tests {
         let signer =
             create_test_signer_with_pubkey(&mock_server.uri(), keypair.pubkey().to_string());
         let mut tx = create_test_transaction(&keypair.pubkey());
-        let signature = keypair.sign_message(&tx.message_data());
+        let signature = keypair.sign_message(&tx.message.serialize());
         let signature_b64 = STANDARD.encode(signature.as_ref());
 
         Mock::given(method("POST"))


### PR DESCRIPTION
## Summary

Adds v1 transaction support ([SIMD-0385](https://github.com/solana-foundation/solana-improvement-documents/blob/main/proposals/0385-transaction-v1.md)) to the Rust crate.

`SolanaSigner::sign_transaction` was hardcoded to the legacy `Transaction`, so a v1 transaction could not be passed to a signer at all. It now takes a `VersionedTransaction`.

**No dependency bump was needed.** `VersionedMessage::V1` already exists in the solana-message 4.x line that `sdk-v4` resolves today. It is absent from the 2.x and 3.x lines, so v1 is gated to `sdk-v4` by the type system rather than any runtime check, and stays unrepresentable on the other SDK features. (My earlier read that this needed an unpublished solana-sdk 4.2.x was wrong.)

## The serializer had to change, and a test caught it

A v1 envelope leads with the **message** and appends its signatures as a fixed-length array with **no length prefix**. serde cannot express that, so `bincode::serialize` happily emits the legacy signatures-first layout for a v1 transaction:

```
bincode output for a v1 transaction:  [01] [64-byte sig] [0x81 message…]   ← invalid
correct v1 wire:                      [0x81 message…] [64-byte sig]
```

That would have shipped a signed transaction no validator accepts. The 4.x SDK encodes v1 with `wincode` (see `SchemaWrite for VersionedTransaction`), so `sdk-v4` now does too, behind `serialize_wire_transaction` / `deserialize_wire_transaction`.

The swap is safe because wincode and bincode agree byte-for-byte on legacy and v0 — the SDK asserts this in its own proptest, and there's now a test here pinning it directly, so no already-signed transaction changes its wire bytes. The earlier SDK features keep bincode, where it is correct and where v1 cannot occur.

This is why `wincode` appears as a new `sdk-v4`-only dependency. It was already in the lockfile transitively.

## Other changes

- Provider-response decoding routes through the same helpers, so Privy, Turnkey, CDP, Utila, Crossmint and Fordefi now **accept** a v1 envelope from a provider rather than failing to parse it.
- Utila's legacy fallback branch is deleted (net −60 lines there): decoding into `VersionedTransaction` already covers legacy, and the branch duplicated both the message-equality check and the signer-position walk. It now uses `TransactionUtil::get_signing_keypair_position` like every other backend.
- The signature-slot helpers needed only the accessor change from `message.header` / `message.account_keys` to `header()` / `static_account_keys()`.
- 14 backends dropped their now-unused legacy `Transaction` import.

## Tests

| Matrix | Result |
| --- | --- |
| `sdk-v2` | 332 passed, 0 clippy warnings |
| `sdk-v3` | 332 passed, 0 clippy warnings |
| `sdk-v4` | 336 passed, 0 clippy warnings |

The four extra tests on `sdk-v4` are the v1 ones; they're feature-gated because v1 cannot be constructed on the earlier SDKs. They assert a v1 message is signed over its `0x81` prefix, that a v1 envelope puts the message first with signatures at the tail **and that bincode disagrees there** (the regression guard for the bug above), that a v1 wire transaction round-trips, and that wincode still matches bincode on legacy.

That the existing 332 legacy and v0 tests pass unchanged under wincode on `sdk-v4` is the other half of the safety argument.

## Breaking change

`SolanaSigner::sign_transaction` takes `&mut VersionedTransaction` instead of `&mut Transaction`. Convert an existing legacy transaction with `.into()`. Signing a v1 transaction requires the `sdk-v4` feature.

## Test Plan

- `just rust-test` (all three SDK matrices)
- `just rust-fmt` (fmt + clippy, zero warnings on all three matrices)