### PR TITLE
chore(python): require solders>=0.29 for v1 transactions

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -11,7 +11,7 @@ license = "MIT"
 requires-python = ">=3.10"
 authors = [{ name = "Solana Foundation" }]
 keywords = ["solana", "signer", "keychain", "ed25519"]
-dependencies = ["httpx>=0.27", "solders>=0.26,<1"]
+dependencies = ["httpx>=0.27", "solders>=0.29,<1"]
 
 [project.urls]
 Repository = "https://github.com/solana-foundation/solana-keychain"


### PR DESCRIPTION
## What

Raise the `solders` floor in `python/pyproject.toml` from `>=0.26,<1` to `>=0.29,<1`.

## Why

The v1 transaction work in this stack depends on two things that first ship in solders 0.29.0:

- `solders.message.MessageV1` (SIMD-0385 message), and `VersionedMessage`/`VersionedTransaction` accepting it.
- `VersionedMessage`/`VersionedTransaction` serialized with wincode instead of bincode. Byte-identical for legacy and v0, and the only encoding that supports v1. This affects `bytes()`/`from_bytes`, `to_bytes_versioned`/`from_bytes_versioned`, and the base64 used in RPC requests.

`requirements.txt` already pins `solders==0.29.0`, so CI passes either way. The declared dependency range is what downstream installs resolve against: with the `>=0.26` floor, `pip install solana-keychain` can resolve to a solders that cannot parse or serialize a v1 transaction, and the failure surfaces at runtime rather than at resolve time.

## Testing

`just py-test` - 483 passed, 37 deselected.