### PR TITLE
fix(signers)!: report an unusable create response as an unconfirmed broadcast

### DIFF
--- a/go/core/errors.go
+++ b/go/core/errors.go
@@ -71,8 +71,14 @@ type SignerError struct {
 	// the transaction's outcome before retrying, and contains no secret
 	// material.
 	ProviderTxID string
-	detail       string
-	cause        error
+	// ProviderStatus is the provider's own HTTP status for
+	// CodeBroadcastUnconfirmed errors when that response was the failure, and 0
+	// when no response arrived or its body was the problem. Exported for the same
+	// reason as ProviderTxID: it is non-secret and the caller's only view of what
+	// the provider answered.
+	ProviderStatus int
+	detail         string
+	cause          error
 }
 
 // NewSignerError builds a SignerError with a (private) detail string.
@@ -126,7 +132,8 @@ func NewBroadcastUnconfirmedError(providerTxID, detail string) *SignerError {
 
 // UnconfirmedUnlessRejected reports a failed create as CodeBroadcastUnconfirmed
 // with no transaction id unless a 4xx rules the transaction out. status is 0 when
-// no response arrived.
+// no response arrived, and is reported back to the caller only when the response
+// itself was the failure.
 func UnconfirmedUnlessRejected(status int, err error) error {
 	if status >= 400 && status < 500 {
 		return err
@@ -136,7 +143,11 @@ func UnconfirmedUnlessRejected(status int, err error) error {
 	if errors.As(err, &se) {
 		detail = se.Detail()
 	}
-	return NewBroadcastUnconfirmedError("", detail)
+	out := NewBroadcastUnconfirmedError("", detail)
+	if status >= 400 {
+		out.ProviderStatus = status
+	}
+	return out
 }
 
 // CodeOf extracts the Code from an error if it is (or wraps) a *SignerError.

--- a/go/core/errors.go
+++ b/go/core/errors.go
@@ -117,9 +117,26 @@ func (e *SignerError) Detail() string { return e.detail }
 
 // NewBroadcastUnconfirmedError reports a failure after the provider has
 // accepted a transaction it broadcasts itself, carrying the provider-side
-// transaction id the caller must check before retrying.
+// transaction id the caller must check before retrying. providerTxID is "" when
+// the create itself failed without a usable response: nothing to check, and the
+// only safe recovery is replaying the identical bytes.
 func NewBroadcastUnconfirmedError(providerTxID, detail string) *SignerError {
 	return &SignerError{Code: CodeBroadcastUnconfirmed, ProviderTxID: providerTxID, detail: detail}
+}
+
+// UnconfirmedUnlessRejected reports a failed create as CodeBroadcastUnconfirmed
+// with no transaction id unless a 4xx rules the transaction out. status is 0 when
+// no response arrived.
+func UnconfirmedUnlessRejected(status int, err error) error {
+	if status >= 400 && status < 500 {
+		return err
+	}
+	detail := err.Error()
+	var se *SignerError
+	if errors.As(err, &se) {
+		detail = se.Detail()
+	}
+	return NewBroadcastUnconfirmedError("", detail)
 }
 
 // CodeOf extracts the Code from an error if it is (or wraps) a *SignerError.

--- a/go/core/errors.go
+++ b/go/core/errors.go
@@ -71,11 +71,8 @@ type SignerError struct {
 	// the transaction's outcome before retrying, and contains no secret
 	// material.
 	ProviderTxID string
-	// ProviderStatus is the provider's own HTTP status for
-	// CodeBroadcastUnconfirmed errors when that response was the failure, and 0
-	// when no response arrived or its body was the problem. Exported for the same
-	// reason as ProviderTxID: it is non-secret and the caller's only view of what
-	// the provider answered.
+	// ProviderStatus is the provider's HTTP status when its response was the
+	// failure, and 0 otherwise. Exported for the same reason as ProviderTxID.
 	ProviderStatus int
 	detail         string
 	cause          error
@@ -124,16 +121,14 @@ func (e *SignerError) Detail() string { return e.detail }
 // NewBroadcastUnconfirmedError reports a failure after the provider has
 // accepted a transaction it broadcasts itself, carrying the provider-side
 // transaction id the caller must check before retrying. providerTxID is "" when
-// the create itself failed without a usable response: nothing to check, and the
-// only safe recovery is replaying the identical bytes.
+// the create failed before an id was known.
 func NewBroadcastUnconfirmedError(providerTxID, detail string) *SignerError {
 	return &SignerError{Code: CodeBroadcastUnconfirmed, ProviderTxID: providerTxID, detail: detail}
 }
 
 // UnconfirmedUnlessRejected reports a failed create as CodeBroadcastUnconfirmed
 // with no transaction id unless a 4xx rules the transaction out. status is 0 when
-// no response arrived, and is reported back to the caller only when the response
-// itself was the failure.
+// no response arrived, and is passed on only when the response was the failure.
 func UnconfirmedUnlessRejected(status int, err error) error {
 	if status >= 400 && status < 500 {
 		return err

--- a/go/signers/crossmint/client.go
+++ b/go/signers/crossmint/client.go
@@ -106,9 +106,13 @@ func (s *Signer) createTransaction(ctx context.Context, transaction, idempotency
 	}}
 	status, body, err := s.doRequest(ctx, http.MethodPost, u, req, idempotencyKey)
 	if err != nil {
-		return transactionResponse{}, err
+		return transactionResponse{}, core.UnconfirmedUnlessRejected(status, err)
 	}
-	return parseResponseWithRequiredField[transactionResponse](status, body, "id", "create_transaction")
+	created, err := parseResponseWithRequiredField[transactionResponse](status, body, "id", "create_transaction")
+	if err != nil {
+		return transactionResponse{}, core.UnconfirmedUnlessRejected(status, err)
+	}
+	return created, nil
 }
 
 // getTransaction fetches the current state of a transaction.

--- a/go/signers/crossmint/signer.go
+++ b/go/signers/crossmint/signer.go
@@ -202,9 +202,12 @@ func (s *Signer) SignMessage(_ context.Context, _ []byte) (solana.Signature, err
 //
 // Not retry-safe: any failure after the create is accepted returns
 // CodeBroadcastUnconfirmed carrying the Crossmint transaction id; check that
-// transaction with Crossmint before retrying. Each create carries an
-// x-idempotency-key derived from the message bytes, so retrying the exact
-// same bytes cannot create a second transaction.
+// transaction with Crossmint before retrying. A create that fails without a
+// usable response returns CodeBroadcastUnconfirmed with no transaction id.
+//
+// Each create carries an x-idempotency-key derived from the message bytes, so
+// replaying these exact bytes cannot create a second transaction; a rebuilt
+// transaction derives a different key and executes as a new transfer.
 func (s *Signer) SignTransaction(ctx context.Context, tx *solana.Transaction) (core.SignedTransaction, error) {
 	if s.publicKey.IsZero() {
 		return core.SignedTransaction{}, core.NewSignerError(core.CodeConfigError, "signer not initialized")

--- a/go/signers/crossmint/signer_test.go
+++ b/go/signers/crossmint/signer_test.go
@@ -467,7 +467,6 @@ func assertUnconfirmedWithoutID(t *testing.T, err error, wantStatus int) {
 	}
 }
 
-// A 5xx can follow a create the provider already accepted, and only an identical-bytes replay dedupes.
 func TestCreateServerErrorIsUnconfirmedWithoutID(t *testing.T) {
 	s := createStatusSigner(t, http.StatusServiceUnavailable, `{"message":"unavailable"}`)
 	tx, err := testutils.CreateTestTransaction(s.Pubkey())
@@ -478,7 +477,6 @@ func TestCreateServerErrorIsUnconfirmedWithoutID(t *testing.T) {
 	assertUnconfirmedWithoutID(t, err, http.StatusServiceUnavailable)
 }
 
-// A 2xx means the transaction was accepted; an unusable body only hides the id.
 func TestCreateAcceptedWithoutIDIsUnconfirmed(t *testing.T) {
 	s := createStatusSigner(t, http.StatusCreated, `{"status":"pending"}`)
 	tx, err := testutils.CreateTestTransaction(s.Pubkey())
@@ -489,7 +487,6 @@ func TestCreateAcceptedWithoutIDIsUnconfirmed(t *testing.T) {
 	assertUnconfirmedWithoutID(t, err, 0)
 }
 
-// A 4xx rules the transaction out, so it stays a plain failure a caller can safely retry.
 func TestCreateRejectionStaysPlainFailure(t *testing.T) {
 	s := createStatusSigner(t, http.StatusBadRequest, `{"message":"invalid transaction"}`)
 	tx, err := testutils.CreateTestTransaction(s.Pubkey())

--- a/go/signers/crossmint/signer_test.go
+++ b/go/signers/crossmint/signer_test.go
@@ -439,6 +439,63 @@ func TestSignTransactionSuccess(t *testing.T) {
 	}
 }
 
+// createStatusSigner points a signer at a create endpoint answering status/body.
+func createStatusSigner(t *testing.T, status int, body string) *Signer {
+	t.Helper()
+	priv := testutils.TestPrivateKey()
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET "+testWalletPath, walletHandler(t, testAPIKey, pubkeyOf(priv).String()))
+	mux.HandleFunc("POST "+testWalletPath+"/transactions", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, status, body)
+	})
+	cfg := baseConfig(startServer(t, mux))
+	cfg.MaxPollAttempts = 1
+	return newTestSigner(t, cfg)
+}
+
+// assertUnconfirmedWithoutID checks for an unconfirmed broadcast with no id.
+func assertUnconfirmedWithoutID(t *testing.T, err error) {
+	t.Helper()
+	assertCode(t, err, core.CodeBroadcastUnconfirmed)
+	var se *core.SignerError
+	if !errors.As(err, &se) || se.ProviderTxID != "" {
+		t.Errorf("error must carry no provider transaction id, got %v", err)
+	}
+}
+
+// A 5xx can follow a create the provider already accepted, and only an identical-bytes replay dedupes.
+func TestCreateServerErrorIsUnconfirmedWithoutID(t *testing.T) {
+	s := createStatusSigner(t, http.StatusServiceUnavailable, `{"message":"unavailable"}`)
+	tx, err := testutils.CreateTestTransaction(s.Pubkey())
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = s.SignTransaction(context.Background(), tx)
+	assertUnconfirmedWithoutID(t, err)
+}
+
+// A 2xx means the transaction was accepted; an unusable body only hides the id.
+func TestCreateAcceptedWithoutIDIsUnconfirmed(t *testing.T) {
+	s := createStatusSigner(t, http.StatusCreated, `{"status":"pending"}`)
+	tx, err := testutils.CreateTestTransaction(s.Pubkey())
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = s.SignTransaction(context.Background(), tx)
+	assertUnconfirmedWithoutID(t, err)
+}
+
+// A 4xx rules the transaction out, so it stays a plain failure a caller can safely retry.
+func TestCreateRejectionStaysPlainFailure(t *testing.T) {
+	s := createStatusSigner(t, http.StatusBadRequest, `{"message":"invalid transaction"}`)
+	tx, err := testutils.CreateTestTransaction(s.Pubkey())
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = s.SignTransaction(context.Background(), tx)
+	assertCode(t, err, core.CodeRemoteAPIError)
+}
+
 // TestSignTransactionRejectsApprovalSignaturesForLocalTransactionBytes:
 // approval signatures (over Crossmint's internal payload) must never be used
 // as the transaction signature.

--- a/go/signers/crossmint/signer_test.go
+++ b/go/signers/crossmint/signer_test.go
@@ -453,13 +453,17 @@ func createStatusSigner(t *testing.T, status int, body string) *Signer {
 	return newTestSigner(t, cfg)
 }
 
-// assertUnconfirmedWithoutID checks for an unconfirmed broadcast with no id.
-func assertUnconfirmedWithoutID(t *testing.T, err error) {
+// assertUnconfirmedWithoutID checks for an unconfirmed broadcast with no id,
+// carrying wantStatus (0 when the provider sent no failing status).
+func assertUnconfirmedWithoutID(t *testing.T, err error, wantStatus int) {
 	t.Helper()
 	assertCode(t, err, core.CodeBroadcastUnconfirmed)
 	var se *core.SignerError
 	if !errors.As(err, &se) || se.ProviderTxID != "" {
 		t.Errorf("error must carry no provider transaction id, got %v", err)
+	}
+	if se != nil && se.ProviderStatus != wantStatus {
+		t.Errorf("provider status = %d, want %d", se.ProviderStatus, wantStatus)
 	}
 }
 
@@ -471,7 +475,7 @@ func TestCreateServerErrorIsUnconfirmedWithoutID(t *testing.T) {
 		t.Fatal(err)
 	}
 	_, err = s.SignTransaction(context.Background(), tx)
-	assertUnconfirmedWithoutID(t, err)
+	assertUnconfirmedWithoutID(t, err, http.StatusServiceUnavailable)
 }
 
 // A 2xx means the transaction was accepted; an unusable body only hides the id.
@@ -482,7 +486,7 @@ func TestCreateAcceptedWithoutIDIsUnconfirmed(t *testing.T) {
 		t.Fatal(err)
 	}
 	_, err = s.SignTransaction(context.Background(), tx)
-	assertUnconfirmedWithoutID(t, err)
+	assertUnconfirmedWithoutID(t, err, 0)
 }
 
 // A 4xx rules the transaction out, so it stays a plain failure a caller can safely retry.

--- a/go/signers/fordefi/client.go
+++ b/go/signers/fordefi/client.go
@@ -146,7 +146,17 @@ func (s *Signer) signRequest(ctx context.Context, path string, timestamp int64, 
 
 // submitTransaction POSTs a signing request to /api/v1/transactions with
 // request-level P-256 signing and returns the Fordefi transaction ID.
-func (s *Signer) submitTransaction(ctx context.Context, request transactionRequest, idempotenceID string) (string, error) {
+//
+// broadcastManaged marks a submit whose acceptance means Fordefi is already
+// broadcasting, so an unresolved failure is reported as unconfirmed.
+func (s *Signer) submitTransaction(ctx context.Context, request transactionRequest, idempotenceID string, broadcastManaged bool) (string, error) {
+	classify := func(status int, err error) error {
+		if !broadcastManaged {
+			return err
+		}
+		return core.UnconfirmedUnlessRejected(status, err)
+	}
+
 	body, err := json.Marshal(request)
 	if err != nil {
 		return "", core.WrapSignerError(core.CodeSerializationError, "failed to serialize fordefi request", err)
@@ -171,15 +181,15 @@ func (s *Signer) submitTransaction(ctx context.Context, request transactionReque
 
 	status, respBody, err := s.send(req)
 	if err != nil {
-		return "", err
+		return "", classify(status, err)
 	}
 	if !is2xx(status) {
-		return "", core.NewSignerError(core.CodeRemoteAPIError, fmt.Sprintf("API error %d", status))
+		return "", classify(status, core.NewSignerError(core.CodeRemoteAPIError, fmt.Sprintf("API error %d", status)))
 	}
 
 	var created createTransactionResponse
 	if err := json.Unmarshal(respBody, &created); err != nil || created.ID == "" {
-		return "", core.NewSignerError(core.CodeSerializationError, "failed to parse response")
+		return "", classify(status, core.NewSignerError(core.CodeSerializationError, "failed to parse response"))
 	}
 	return created.ID, nil
 }

--- a/go/signers/fordefi/signer.go
+++ b/go/signers/fordefi/signer.go
@@ -207,9 +207,13 @@ func (s *Signer) SignMessage(ctx context.Context, message []byte) (solana.Signat
 //
 // Native mode is not retry-safe: any failure after Fordefi accepts the
 // submission returns CodeBroadcastUnconfirmed carrying the Fordefi transaction
-// id; check that transaction with Fordefi before retrying. Each native create
-// carries an x-idempotence-id derived from the message bytes, so retrying the
-// exact same bytes cannot create a second Fordefi transaction.
+// id; check that transaction with Fordefi before retrying. A submission that
+// fails without a usable response returns CodeBroadcastUnconfirmed with no
+// transaction id.
+//
+// Each native create carries an x-idempotence-id derived from the message bytes,
+// so replaying these exact bytes cannot create a second Fordefi transaction; a
+// rebuilt transaction derives a different id and is broadcast again.
 func (s *Signer) SignTransaction(ctx context.Context, tx *solana.Transaction) (core.SignedTransaction, error) {
 	if s.chain != "" {
 		return s.signTransactionNative(ctx, tx)
@@ -260,7 +264,7 @@ func (s *Signer) signBlackBox(ctx context.Context, data []byte) (solana.Signatur
 			Format:     "hash_binary",
 			HashBinary: base64.StdEncoding.EncodeToString(data),
 		},
-	}, "")
+	}, "", false)
 	if err != nil {
 		return solana.Signature{}, err
 	}
@@ -283,7 +287,7 @@ func (s *Signer) signSolanaMessage(ctx context.Context, message []byte) (solana.
 			Chain:   s.chain,
 			RawData: base64.StdEncoding.EncodeToString(message),
 		},
-	}, "")
+	}, "", false)
 	if err != nil {
 		return solana.Signature{}, err
 	}
@@ -330,7 +334,7 @@ func (s *Signer) signTransactionNative(ctx context.Context, tx *solana.Transacti
 			PushMode: "auto",
 			Fee:      s.fee,
 		},
-	}, core.IdempotencyKeyFromMessage(messageBytes))
+	}, core.IdempotencyKeyFromMessage(messageBytes), true)
 	if err != nil {
 		return core.SignedTransaction{}, err
 	}

--- a/go/signers/fordefi/signer_test.go
+++ b/go/signers/fordefi/signer_test.go
@@ -689,6 +689,96 @@ func assertBroadcastUnconfirmed(t *testing.T, err error, wantTxID string) {
 	}
 }
 
+// A 5xx can follow a create the provider already accepted, and only an identical-bytes replay dedupes.
+func TestSignTransactionNativeSubmitServerErrorIsUnconfirmedWithoutID(t *testing.T) {
+	pub := testutils.TestPublicKey()
+	s := newTestSigner(t, nativeConfig(t), pub.String(), func(mux *http.ServeMux) {
+		mux.HandleFunc(transactionsPath, func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusBadGateway)
+		})
+	})
+
+	tx, err := testutils.CreateTestTransaction(pub)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = s.SignTransaction(context.Background(), tx)
+	if err == nil {
+		t.Fatal("expected a failed submit to be reported")
+	}
+	assertBroadcastUnconfirmedWithoutID(t, err)
+}
+
+// A 2xx means the transaction was accepted; an unusable body only hides the id.
+func TestSignTransactionNativeSubmitWithoutIDIsUnconfirmed(t *testing.T) {
+	pub := testutils.TestPublicKey()
+	s := newTestSigner(t, nativeConfig(t), pub.String(), func(mux *http.ServeMux) {
+		mux.HandleFunc(transactionsPath, func(w http.ResponseWriter, _ *http.Request) {
+			writeJSON(w, map[string]any{"state": "pending"})
+		})
+	})
+
+	tx, err := testutils.CreateTestTransaction(pub)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = s.SignTransaction(context.Background(), tx)
+	if err == nil {
+		t.Fatal("expected an accepted submit without an id to be reported")
+	}
+	assertBroadcastUnconfirmedWithoutID(t, err)
+}
+
+// A 4xx rules the transaction out, so it stays a plain failure a caller can safely retry.
+func TestSignTransactionNativeSubmitRejectionStaysPlainFailure(t *testing.T) {
+	pub := testutils.TestPublicKey()
+	s := newTestSigner(t, nativeConfig(t), pub.String(), func(mux *http.ServeMux) {
+		mux.HandleFunc(transactionsPath, func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+		})
+	})
+
+	tx, err := testutils.CreateTestTransaction(pub)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = s.SignTransaction(context.Background(), tx)
+	if code, _ := core.CodeOf(err); code != core.CodeRemoteAPIError {
+		t.Errorf("got %s, want REMOTE_API_ERROR", code)
+	}
+}
+
+// Black-box mode only signs, so a failed submit has no on-chain outcome to be unconfirmed about.
+func TestSignTransactionBlackBoxSubmitServerErrorIsNotUnconfirmed(t *testing.T) {
+	pub := testutils.TestPublicKey()
+	s := newTestSigner(t, baseConfig(t), pub.String(), func(mux *http.ServeMux) {
+		mux.HandleFunc(transactionsPath, func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusBadGateway)
+		})
+	})
+
+	tx, err := testutils.CreateTestTransaction(pub)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = s.SignTransaction(context.Background(), tx)
+	if code, _ := core.CodeOf(err); code != core.CodeRemoteAPIError {
+		t.Errorf("got %s, want REMOTE_API_ERROR", code)
+	}
+}
+
+// assertBroadcastUnconfirmedWithoutID checks for an unconfirmed broadcast with no id.
+func assertBroadcastUnconfirmedWithoutID(t *testing.T, err error) {
+	t.Helper()
+	if code, _ := core.CodeOf(err); code != core.CodeBroadcastUnconfirmed {
+		t.Errorf("got %s, want BROADCAST_UNCONFIRMED", code)
+	}
+	var se *core.SignerError
+	if !errors.As(err, &se) || se.ProviderTxID != "" {
+		t.Errorf("error must carry no provider transaction id, got %v", err)
+	}
+}
+
 func TestSignTransactionNativeRejectsMultiSigner(t *testing.T) {
 	pub := testutils.TestPublicKey()
 	var requests atomic.Int64

--- a/go/signers/fordefi/signer_test.go
+++ b/go/signers/fordefi/signer_test.go
@@ -689,7 +689,6 @@ func assertBroadcastUnconfirmed(t *testing.T, err error, wantTxID string) {
 	}
 }
 
-// A 5xx can follow a create the provider already accepted, and only an identical-bytes replay dedupes.
 func TestSignTransactionNativeSubmitServerErrorIsUnconfirmedWithoutID(t *testing.T) {
 	pub := testutils.TestPublicKey()
 	s := newTestSigner(t, nativeConfig(t), pub.String(), func(mux *http.ServeMux) {
@@ -709,7 +708,6 @@ func TestSignTransactionNativeSubmitServerErrorIsUnconfirmedWithoutID(t *testing
 	assertBroadcastUnconfirmedWithoutID(t, err, http.StatusBadGateway)
 }
 
-// A 2xx means the transaction was accepted; an unusable body only hides the id.
 func TestSignTransactionNativeSubmitWithoutIDIsUnconfirmed(t *testing.T) {
 	pub := testutils.TestPublicKey()
 	s := newTestSigner(t, nativeConfig(t), pub.String(), func(mux *http.ServeMux) {
@@ -729,7 +727,6 @@ func TestSignTransactionNativeSubmitWithoutIDIsUnconfirmed(t *testing.T) {
 	assertBroadcastUnconfirmedWithoutID(t, err, 0)
 }
 
-// A 4xx rules the transaction out, so it stays a plain failure a caller can safely retry.
 func TestSignTransactionNativeSubmitRejectionStaysPlainFailure(t *testing.T) {
 	pub := testutils.TestPublicKey()
 	s := newTestSigner(t, nativeConfig(t), pub.String(), func(mux *http.ServeMux) {

--- a/go/signers/fordefi/signer_test.go
+++ b/go/signers/fordefi/signer_test.go
@@ -706,7 +706,7 @@ func TestSignTransactionNativeSubmitServerErrorIsUnconfirmedWithoutID(t *testing
 	if err == nil {
 		t.Fatal("expected a failed submit to be reported")
 	}
-	assertBroadcastUnconfirmedWithoutID(t, err)
+	assertBroadcastUnconfirmedWithoutID(t, err, http.StatusBadGateway)
 }
 
 // A 2xx means the transaction was accepted; an unusable body only hides the id.
@@ -726,7 +726,7 @@ func TestSignTransactionNativeSubmitWithoutIDIsUnconfirmed(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected an accepted submit without an id to be reported")
 	}
-	assertBroadcastUnconfirmedWithoutID(t, err)
+	assertBroadcastUnconfirmedWithoutID(t, err, 0)
 }
 
 // A 4xx rules the transaction out, so it stays a plain failure a caller can safely retry.
@@ -767,8 +767,9 @@ func TestSignTransactionBlackBoxSubmitServerErrorIsNotUnconfirmed(t *testing.T) 
 	}
 }
 
-// assertBroadcastUnconfirmedWithoutID checks for an unconfirmed broadcast with no id.
-func assertBroadcastUnconfirmedWithoutID(t *testing.T, err error) {
+// assertBroadcastUnconfirmedWithoutID checks for an unconfirmed broadcast with no
+// id, carrying wantStatus (0 when the provider sent no failing status).
+func assertBroadcastUnconfirmedWithoutID(t *testing.T, err error, wantStatus int) {
 	t.Helper()
 	if code, _ := core.CodeOf(err); code != core.CodeBroadcastUnconfirmed {
 		t.Errorf("got %s, want BROADCAST_UNCONFIRMED", code)
@@ -776,6 +777,9 @@ func assertBroadcastUnconfirmedWithoutID(t *testing.T, err error) {
 	var se *core.SignerError
 	if !errors.As(err, &se) || se.ProviderTxID != "" {
 		t.Errorf("error must carry no provider transaction id, got %v", err)
+	}
+	if se != nil && se.ProviderStatus != wantStatus {
+		t.Errorf("provider status = %d, want %d", se.ProviderStatus, wantStatus)
 	}
 }
 

--- a/python/src/solana_keychain/core/errors.py
+++ b/python/src/solana_keychain/core/errors.py
@@ -49,6 +49,9 @@ class SignerError(Exception):
     Security: ``str()``, ``repr()``, and ``args`` only ever expose the fixed generic
     message for the code. The per-error ``detail`` is kept private so key material and
     raw remote-API responses cannot leak through formatted output or logs.
+
+    ``status_code`` is the remote HTTP status when the failure came from a response,
+    and ``None`` otherwise.
     """
 
     def __init__(
@@ -57,6 +60,7 @@ class SignerError(Exception):
         detail: str = "",
         *,
         provider_transaction_id: str | None = None,
+        status_code: int | None = None,
     ) -> None:
         message = _GENERIC_MESSAGES[code]
         if provider_transaction_id is not None:
@@ -65,6 +69,7 @@ class SignerError(Exception):
         self.code = code
         self._detail = detail
         self.provider_transaction_id = provider_transaction_id
+        self.status_code = status_code
 
     def __repr__(self) -> str:
         return f"SignerError({self.code.value})"

--- a/python/src/solana_keychain/core/http.py
+++ b/python/src/solana_keychain/core/http.py
@@ -66,6 +66,13 @@ def sanitize_remote_error_response(
     return f"{normalized[:max_length]} [truncated]"
 
 
+def provider_may_have_accepted(status_code: int | None) -> bool:
+    """A 4xx is the only create outcome that rules out a transaction; anything else
+    (no response, timeout, 5xx, unusable success body) may already be executing.
+    """
+    return status_code is None or not 400 <= status_code < 500
+
+
 async def fetch_signer_json(
     *,
     url: str,
@@ -154,6 +161,7 @@ async def _request_json(
             SignerErrorCode.REMOTE_API_ERROR,
             f"{provider_name} API error: {response.status_code}: "
             f"{sanitize_remote_error_response(response.text)}",
+            status_code=response.status_code,
         )
     try:
         return response.json()

--- a/python/src/solana_keychain/crossmint/signer.py
+++ b/python/src/solana_keychain/crossmint/signer.py
@@ -258,6 +258,16 @@ class CrossmintSigner(SolanaSigner):
                 json_body={"params": params},
                 extra_headers={"x-idempotency-key": idempotency_key},
             )
+        except asyncio.CancelledError as error:
+            # The re-raise must stay a CancelledError for asyncio, so the warning
+            # goes to the log.
+            _logger.warning(
+                "Crossmint may have created a cancelled transaction with no id "
+                "returned; check before retrying"
+            )
+            raise asyncio.CancelledError(
+                "Crossmint may have created the transaction, but no transaction id was returned"
+            ) from error
         except SignerError as error:
             if not provider_may_have_accepted(error.status_code):
                 raise

--- a/python/src/solana_keychain/crossmint/signer.py
+++ b/python/src/solana_keychain/crossmint/signer.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import json
+import logging
 from dataclasses import dataclass, field
 from typing import Any
 from urllib.parse import quote
@@ -15,7 +16,12 @@ from solders.signature import Signature
 from solders.transaction import VersionedTransaction
 
 from solana_keychain.core.errors import SignerError, SignerErrorCode
-from solana_keychain.core.http import assert_https_url, fetch_signer_json, normalize_base_url
+from solana_keychain.core.http import (
+    assert_https_url,
+    fetch_signer_json,
+    normalize_base_url,
+    provider_may_have_accepted,
+)
 from solana_keychain.core.signer import SignedTransaction, SolanaSigner
 from solana_keychain.core.transaction_util import (
     ED25519_SIGNATURE_LENGTH,
@@ -26,6 +32,8 @@ from solana_keychain.core.transaction_util import (
     signed_message_bytes,
 )
 from solana_keychain.crossmint.derive import derive_signing_key
+
+_logger = logging.getLogger("solana_keychain")
 
 DEFAULT_API_BASE_URL = "https://www.crossmint.com/api"
 API_VERSION_PATH = "2025-06-09"
@@ -241,14 +249,20 @@ class CrossmintSigner(SolanaSigner):
         params: dict[str, Any] = {"transaction": transaction_b58}
         if self._signer is not None:
             params["signer"] = self._signer
-        return await self._request_with_required_field(
-            method="POST",
-            url=self._wallets_url("transactions"),
-            required_field="id",
-            context="create_transaction",
-            json_body={"params": params},
-            extra_headers={"x-idempotency-key": idempotency_key},
-        )
+        try:
+            return await self._request_with_required_field(
+                method="POST",
+                url=self._wallets_url("transactions"),
+                required_field="id",
+                context="create_transaction",
+                json_body={"params": params},
+                extra_headers={"x-idempotency-key": idempotency_key},
+            )
+        except SignerError as error:
+            if not provider_may_have_accepted(error.status_code):
+                raise
+            # Crossmint may be executing a transaction whose id never reached us.
+            raise SignerError(SignerErrorCode.BROADCAST_UNCONFIRMED, error._detail) from None
 
     async def _get_transaction(self, transaction_id: str) -> dict[str, Any]:
         return await self._request_with_required_field(
@@ -555,9 +569,14 @@ class CrossmintSigner(SolanaSigner):
 
         Not retry-safe: any failure after the create is accepted raises
         ``BROADCAST_UNCONFIRMED`` carrying ``provider_transaction_id``; check
-        that transaction with Crossmint before retrying. Each create carries an
-        ``x-idempotency-key`` derived from the message bytes, so retrying the
-        exact same bytes cannot create a second transaction.
+        that transaction with Crossmint before retrying. A create that fails
+        without a usable response raises ``BROADCAST_UNCONFIRMED`` with no
+        ``provider_transaction_id``.
+
+        Each create carries an ``x-idempotency-key`` derived from the message
+        bytes, so replaying these exact bytes cannot create a second
+        transaction; a rebuilt transaction derives a different key and executes
+        as a new transfer.
         """
         public_key = self._initialized_pubkey()
         expected_message = signed_message_bytes(transaction.message)
@@ -573,6 +592,17 @@ class CrossmintSigner(SolanaSigner):
             return await self._finish_managed_transaction(
                 create_response, transaction, expected_message, public_key
             )
+        except asyncio.CancelledError as error:
+            # Awaiting a cancelled task strips the raised instance, so the id is
+            # also logged; the re-raise must stay a CancelledError for asyncio.
+            _logger.warning(
+                "Crossmint may have executed cancelled transaction %s; check it before retrying",
+                provider_transaction_id,
+            )
+            raise asyncio.CancelledError(
+                "Crossmint may have executed the transaction, but the outcome could "
+                f"not be confirmed (provider transaction id: {provider_transaction_id})"
+            ) from error
         except SignerError as error:
             raise SignerError(
                 SignerErrorCode.BROADCAST_UNCONFIRMED,

--- a/python/src/solana_keychain/crossmint/signer.py
+++ b/python/src/solana_keychain/crossmint/signer.py
@@ -262,7 +262,11 @@ class CrossmintSigner(SolanaSigner):
             if not provider_may_have_accepted(error.status_code):
                 raise
             # Crossmint may be executing a transaction whose id never reached us.
-            raise SignerError(SignerErrorCode.BROADCAST_UNCONFIRMED, error._detail) from None
+            raise SignerError(
+                SignerErrorCode.BROADCAST_UNCONFIRMED,
+                error._detail,
+                status_code=error.status_code,
+            ) from None
 
     async def _get_transaction(self, transaction_id: str) -> dict[str, Any]:
         return await self._request_with_required_field(

--- a/python/src/solana_keychain/fordefi/signer.py
+++ b/python/src/solana_keychain/fordefi/signer.py
@@ -394,6 +394,16 @@ class FordefiSigner(SolanaSigner):
                 self._solana_transaction_request(message_data),
                 idempotence_id=idempotency_key_from_message(message_data),
             )
+        except asyncio.CancelledError as error:
+            # The re-raise must stay a CancelledError for asyncio, so the warning
+            # goes to the log.
+            _logger.warning(
+                "Fordefi may have accepted a cancelled transaction with no id "
+                "returned; check before retrying"
+            )
+            raise asyncio.CancelledError(
+                "Fordefi may have accepted the transaction, but no transaction id was returned"
+            ) from error
         except SignerError as error:
             if not provider_may_have_accepted(error.status_code):
                 raise

--- a/python/src/solana_keychain/fordefi/signer.py
+++ b/python/src/solana_keychain/fordefi/signer.py
@@ -25,6 +25,7 @@ from solana_keychain.core.http import (
     assert_https_url,
     fetch_signer_json,
     normalize_base_url,
+    provider_may_have_accepted,
 )
 from solana_keychain.core.signer import SignedTransaction, SolanaSigner
 from solana_keychain.core.transaction_util import (
@@ -354,9 +355,13 @@ class FordefiSigner(SolanaSigner):
         Native mode is not retry-safe: any failure after Fordefi accepts the
         submission raises ``BROADCAST_UNCONFIRMED`` carrying
         ``provider_transaction_id``; check that transaction with Fordefi
-        before retrying. Each native create carries an ``x-idempotence-id``
-        derived from the message bytes, so retrying the exact same bytes
-        cannot create a second transaction.
+        before retrying. A submission that fails without a usable response
+        raises ``BROADCAST_UNCONFIRMED`` with no ``provider_transaction_id``.
+
+        Each native create carries an ``x-idempotence-id`` derived from the
+        message bytes, so replaying these exact bytes cannot create a second
+        transaction; a rebuilt transaction derives a different id and is
+        broadcast again.
         """
         if self._chain is not None:
             return await self._sign_transaction_native(transaction)
@@ -384,10 +389,16 @@ class FordefiSigner(SolanaSigner):
     ) -> SignedTransaction:
         self._require_sole_required_signer(transaction)
         message_data = signed_message_bytes(transaction.message)
-        transaction_id = await self._post_transaction(
-            self._solana_transaction_request(message_data),
-            idempotence_id=idempotency_key_from_message(message_data),
-        )
+        try:
+            transaction_id = await self._post_transaction(
+                self._solana_transaction_request(message_data),
+                idempotence_id=idempotency_key_from_message(message_data),
+            )
+        except SignerError as error:
+            if not provider_may_have_accepted(error.status_code):
+                raise
+            # Fordefi may be broadcasting a transaction whose id never reached us.
+            raise SignerError(SignerErrorCode.BROADCAST_UNCONFIRMED, error._detail) from None
         try:
             return await self._finish_native_broadcast(transaction_id)
         except asyncio.CancelledError as error:

--- a/python/src/solana_keychain/fordefi/signer.py
+++ b/python/src/solana_keychain/fordefi/signer.py
@@ -398,7 +398,11 @@ class FordefiSigner(SolanaSigner):
             if not provider_may_have_accepted(error.status_code):
                 raise
             # Fordefi may be broadcasting a transaction whose id never reached us.
-            raise SignerError(SignerErrorCode.BROADCAST_UNCONFIRMED, error._detail) from None
+            raise SignerError(
+                SignerErrorCode.BROADCAST_UNCONFIRMED,
+                error._detail,
+                status_code=error.status_code,
+            ) from None
         try:
             return await self._finish_native_broadcast(transaction_id)
         except asyncio.CancelledError as error:

--- a/python/tests/test_crossmint_signer.py
+++ b/python/tests/test_crossmint_signer.py
@@ -280,8 +280,6 @@ async def test_sign_transaction_polling_timeout() -> None:
 
 @respx.mock
 async def test_create_server_error_is_unconfirmed_without_a_transaction_id() -> None:
-    """A 5xx can follow a create the provider already accepted, and only an
-    identical-bytes replay dedupes."""
     keypair = Keypair()
     signer = await initialized_signer(keypair)
     respx.post(TRANSACTIONS_URL).mock(
@@ -296,7 +294,6 @@ async def test_create_server_error_is_unconfirmed_without_a_transaction_id() -> 
 
 @respx.mock
 async def test_create_accepted_without_an_id_is_unconfirmed() -> None:
-    """A 2xx means the transaction was accepted; an unusable body only hides the id."""
     keypair = Keypair()
     signer = await initialized_signer(keypair)
     respx.post(TRANSACTIONS_URL).mock(return_value=httpx.Response(200, json={"status": "pending"}))
@@ -309,7 +306,6 @@ async def test_create_accepted_without_an_id_is_unconfirmed() -> None:
 
 @respx.mock
 async def test_create_rejected_by_crossmint_stays_a_plain_failure() -> None:
-    """A 4xx rules the transaction out, so it stays a plain failure a caller can safely retry."""
     keypair = Keypair()
     signer = await initialized_signer(keypair)
     respx.post(TRANSACTIONS_URL).mock(
@@ -318,6 +314,40 @@ async def test_create_rejected_by_crossmint_stays_a_plain_failure() -> None:
     with pytest.raises(SignerError) as excinfo:
         await signer.sign_transaction(create_test_transaction(keypair.pubkey()))
     assert excinfo.value.code == SignerErrorCode.REMOTE_API_ERROR
+
+
+@respx.mock
+async def test_cancellation_during_create_warns_without_a_transaction_id(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """No id exists yet, so the warning is all the caller gets."""
+    keypair = Keypair()
+    signer = await initialized_signer(keypair)
+    creating = asyncio.Event()
+    observed: list[str] = []
+
+    async def hang(_request: httpx.Request) -> httpx.Response:
+        creating.set()
+        await asyncio.Event().wait()
+        raise AssertionError("unreachable")
+
+    respx.post(TRANSACTIONS_URL).mock(side_effect=hang)
+
+    async def run() -> None:
+        try:
+            await signer.sign_transaction(create_test_transaction(keypair.pubkey()))
+        except asyncio.CancelledError as error:
+            observed.append(str(error))
+            raise
+
+    task = asyncio.create_task(run())
+    await creating.wait()
+    task.cancel()
+    with caplog.at_level(logging.WARNING, logger="solana_keychain"):
+        with pytest.raises(asyncio.CancelledError):
+            await task
+    assert observed and "may have created the transaction" in observed[0]
+    assert "check before retrying" in caplog.text
 
 
 @respx.mock

--- a/python/tests/test_crossmint_signer.py
+++ b/python/tests/test_crossmint_signer.py
@@ -291,6 +291,7 @@ async def test_create_server_error_is_unconfirmed_without_a_transaction_id() -> 
         await signer.sign_transaction(create_test_transaction(keypair.pubkey()))
     assert excinfo.value.code == SignerErrorCode.BROADCAST_UNCONFIRMED
     assert excinfo.value.provider_transaction_id is None
+    assert excinfo.value.status_code == 503
 
 
 @respx.mock
@@ -303,6 +304,7 @@ async def test_create_accepted_without_an_id_is_unconfirmed() -> None:
         await signer.sign_transaction(create_test_transaction(keypair.pubkey()))
     assert excinfo.value.code == SignerErrorCode.BROADCAST_UNCONFIRMED
     assert excinfo.value.provider_transaction_id is None
+    assert excinfo.value.status_code is None
 
 
 @respx.mock

--- a/python/tests/test_crossmint_signer.py
+++ b/python/tests/test_crossmint_signer.py
@@ -1,5 +1,7 @@
+import asyncio
 import hashlib
 import json
+import logging
 import uuid
 from typing import Any
 
@@ -274,6 +276,83 @@ async def test_sign_transaction_polling_timeout() -> None:
         await signer.sign_transaction(create_test_transaction(keypair.pubkey()))
     assert excinfo.value.code == SignerErrorCode.BROADCAST_UNCONFIRMED
     assert excinfo.value.provider_transaction_id == "tx-1"
+
+
+@respx.mock
+async def test_create_server_error_is_unconfirmed_without_a_transaction_id() -> None:
+    """A 5xx can follow a create the provider already accepted, and only an
+    identical-bytes replay dedupes."""
+    keypair = Keypair()
+    signer = await initialized_signer(keypair)
+    respx.post(TRANSACTIONS_URL).mock(
+        return_value=httpx.Response(503, json={"error": "service unavailable"})
+    )
+    with pytest.raises(SignerError) as excinfo:
+        await signer.sign_transaction(create_test_transaction(keypair.pubkey()))
+    assert excinfo.value.code == SignerErrorCode.BROADCAST_UNCONFIRMED
+    assert excinfo.value.provider_transaction_id is None
+
+
+@respx.mock
+async def test_create_accepted_without_an_id_is_unconfirmed() -> None:
+    """A 2xx means the transaction was accepted; an unusable body only hides the id."""
+    keypair = Keypair()
+    signer = await initialized_signer(keypair)
+    respx.post(TRANSACTIONS_URL).mock(return_value=httpx.Response(200, json={"status": "pending"}))
+    with pytest.raises(SignerError) as excinfo:
+        await signer.sign_transaction(create_test_transaction(keypair.pubkey()))
+    assert excinfo.value.code == SignerErrorCode.BROADCAST_UNCONFIRMED
+    assert excinfo.value.provider_transaction_id is None
+
+
+@respx.mock
+async def test_create_rejected_by_crossmint_stays_a_plain_failure() -> None:
+    """A 4xx rules the transaction out, so it stays a plain failure a caller can safely retry."""
+    keypair = Keypair()
+    signer = await initialized_signer(keypair)
+    respx.post(TRANSACTIONS_URL).mock(
+        return_value=httpx.Response(400, json={"error": "invalid transaction"})
+    )
+    with pytest.raises(SignerError) as excinfo:
+        await signer.sign_transaction(create_test_transaction(keypair.pubkey()))
+    assert excinfo.value.code == SignerErrorCode.REMOTE_API_ERROR
+
+
+@respx.mock
+async def test_cancellation_after_create_carries_the_transaction_id(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The re-raised CancelledError must carry the provider transaction id, and the
+    id must also be logged: awaiting the cancelled task yields a fresh
+    CancelledError from the task machinery, without the message."""
+    keypair = Keypair()
+    signer = await initialized_signer(keypair)
+    polling = asyncio.Event()
+    observed: list[str] = []
+
+    async def hang(_request: httpx.Request) -> httpx.Response:
+        polling.set()
+        await asyncio.Event().wait()
+        raise AssertionError("unreachable")
+
+    respx.post(TRANSACTIONS_URL).mock(return_value=httpx.Response(200, json=tx_response("pending")))
+    respx.get(f"{TRANSACTIONS_URL}/tx-1").mock(side_effect=hang)
+
+    async def run() -> None:
+        try:
+            await signer.sign_transaction(create_test_transaction(keypair.pubkey()))
+        except asyncio.CancelledError as error:
+            observed.append(str(error))
+            raise
+
+    task = asyncio.create_task(run())
+    await polling.wait()
+    task.cancel()
+    with caplog.at_level(logging.WARNING, logger="solana_keychain"):
+        with pytest.raises(asyncio.CancelledError):
+            await task
+    assert observed and "tx-1" in observed[0]
+    assert "tx-1" in caplog.text
 
 
 @respx.mock

--- a/python/tests/test_fordefi_signer.py
+++ b/python/tests/test_fordefi_signer.py
@@ -366,8 +366,6 @@ async def test_sign_transaction_native_polling_timeout_is_broadcast_unconfirmed(
 
 @respx.mock
 async def test_native_submit_server_error_is_unconfirmed_without_a_transaction_id() -> None:
-    """A 5xx can follow a create the provider already accepted, and only an
-    identical-bytes replay dedupes."""
     keypair = Keypair()
     signer = make_signer(keypair, chain="solana_devnet")
     respx.post(TRANSACTIONS_URL).mock(
@@ -382,7 +380,6 @@ async def test_native_submit_server_error_is_unconfirmed_without_a_transaction_i
 
 @respx.mock
 async def test_native_submit_accepted_without_an_id_is_unconfirmed() -> None:
-    """A 2xx means the transaction was accepted; an unusable body only hides the id."""
     keypair = Keypair()
     signer = make_signer(keypair, chain="solana_devnet")
     respx.post(TRANSACTIONS_URL).mock(return_value=httpx.Response(200, json={"state": "pending"}))
@@ -395,7 +392,6 @@ async def test_native_submit_accepted_without_an_id_is_unconfirmed() -> None:
 
 @respx.mock
 async def test_native_submit_rejected_by_fordefi_stays_a_plain_failure() -> None:
-    """A 4xx rules the transaction out, so it stays a plain failure a caller can safely retry."""
     keypair = Keypair()
     signer = make_signer(keypair, chain="solana_devnet")
     respx.post(TRANSACTIONS_URL).mock(
@@ -418,6 +414,40 @@ async def test_black_box_submit_server_error_is_not_reported_as_unconfirmed() ->
     with pytest.raises(SignerError) as excinfo:
         await signer.sign_transaction(create_test_transaction(keypair.pubkey()))
     assert excinfo.value.code == SignerErrorCode.REMOTE_API_ERROR
+
+
+@respx.mock
+async def test_cancellation_during_native_submit_warns_without_a_transaction_id(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """No id exists yet, so the warning is all the caller gets."""
+    keypair = Keypair()
+    signer = make_signer(keypair, chain="solana_devnet")
+    submitting = asyncio.Event()
+    observed: list[str] = []
+
+    async def hang(_request: httpx.Request) -> httpx.Response:
+        submitting.set()
+        await asyncio.Event().wait()
+        raise AssertionError("unreachable")
+
+    respx.post(TRANSACTIONS_URL).mock(side_effect=hang)
+
+    async def run() -> None:
+        try:
+            await signer.sign_transaction(create_test_transaction(keypair.pubkey()))
+        except asyncio.CancelledError as error:
+            observed.append(str(error))
+            raise
+
+    task = asyncio.create_task(run())
+    await submitting.wait()
+    task.cancel()
+    with caplog.at_level(logging.WARNING, logger="solana_keychain"):
+        with pytest.raises(asyncio.CancelledError):
+            await task
+    assert observed and "may have accepted the transaction" in observed[0]
+    assert "check before retrying" in caplog.text
 
 
 @respx.mock

--- a/python/tests/test_fordefi_signer.py
+++ b/python/tests/test_fordefi_signer.py
@@ -365,6 +365,60 @@ async def test_sign_transaction_native_polling_timeout_is_broadcast_unconfirmed(
 
 
 @respx.mock
+async def test_native_submit_server_error_is_unconfirmed_without_a_transaction_id() -> None:
+    """A 5xx can follow a create the provider already accepted, and only an
+    identical-bytes replay dedupes."""
+    keypair = Keypair()
+    signer = make_signer(keypair, chain="solana_devnet")
+    respx.post(TRANSACTIONS_URL).mock(
+        return_value=httpx.Response(502, json={"error": "bad gateway"})
+    )
+    with pytest.raises(SignerError) as excinfo:
+        await signer.sign_transaction(create_test_transaction(keypair.pubkey()))
+    assert excinfo.value.code == SignerErrorCode.BROADCAST_UNCONFIRMED
+    assert excinfo.value.provider_transaction_id is None
+
+
+@respx.mock
+async def test_native_submit_accepted_without_an_id_is_unconfirmed() -> None:
+    """A 2xx means the transaction was accepted; an unusable body only hides the id."""
+    keypair = Keypair()
+    signer = make_signer(keypair, chain="solana_devnet")
+    respx.post(TRANSACTIONS_URL).mock(return_value=httpx.Response(200, json={"state": "pending"}))
+    with pytest.raises(SignerError) as excinfo:
+        await signer.sign_transaction(create_test_transaction(keypair.pubkey()))
+    assert excinfo.value.code == SignerErrorCode.BROADCAST_UNCONFIRMED
+    assert excinfo.value.provider_transaction_id is None
+
+
+@respx.mock
+async def test_native_submit_rejected_by_fordefi_stays_a_plain_failure() -> None:
+    """A 4xx rules the transaction out, so it stays a plain failure a caller can safely retry."""
+    keypair = Keypair()
+    signer = make_signer(keypair, chain="solana_devnet")
+    respx.post(TRANSACTIONS_URL).mock(
+        return_value=httpx.Response(401, json={"error": "unauthorized"})
+    )
+    with pytest.raises(SignerError) as excinfo:
+        await signer.sign_transaction(create_test_transaction(keypair.pubkey()))
+    assert excinfo.value.code == SignerErrorCode.REMOTE_API_ERROR
+
+
+@respx.mock
+async def test_black_box_submit_server_error_is_not_reported_as_unconfirmed() -> None:
+    """Black-box mode only signs, so a failed submit has no on-chain outcome to be
+    unconfirmed about."""
+    keypair = Keypair()
+    signer = make_signer(keypair)
+    respx.post(TRANSACTIONS_URL).mock(
+        return_value=httpx.Response(502, json={"error": "bad gateway"})
+    )
+    with pytest.raises(SignerError) as excinfo:
+        await signer.sign_transaction(create_test_transaction(keypair.pubkey()))
+    assert excinfo.value.code == SignerErrorCode.REMOTE_API_ERROR
+
+
+@respx.mock
 async def test_sign_transaction_native_cancellation_carries_the_transaction_id(
     caplog: pytest.LogCaptureFixture,
 ) -> None:

--- a/python/tests/test_fordefi_signer.py
+++ b/python/tests/test_fordefi_signer.py
@@ -377,6 +377,7 @@ async def test_native_submit_server_error_is_unconfirmed_without_a_transaction_i
         await signer.sign_transaction(create_test_transaction(keypair.pubkey()))
     assert excinfo.value.code == SignerErrorCode.BROADCAST_UNCONFIRMED
     assert excinfo.value.provider_transaction_id is None
+    assert excinfo.value.status_code == 502
 
 
 @respx.mock
@@ -389,6 +390,7 @@ async def test_native_submit_accepted_without_an_id_is_unconfirmed() -> None:
         await signer.sign_transaction(create_test_transaction(keypair.pubkey()))
     assert excinfo.value.code == SignerErrorCode.BROADCAST_UNCONFIRMED
     assert excinfo.value.provider_transaction_id is None
+    assert excinfo.value.status_code is None
 
 
 @respx.mock

--- a/rust/src/crossmint/mod.rs
+++ b/rust/src/crossmint/mod.rs
@@ -1495,7 +1495,6 @@ mod tests {
         }
     }
 
-    /// A 5xx can follow a create the provider already accepted, and only an identical-bytes replay dedupes.
     #[tokio::test]
     async fn test_create_server_error_is_unconfirmed_without_a_transaction_id() {
         let server = MockServer::start().await;
@@ -1532,7 +1531,6 @@ mod tests {
         }
     }
 
-    /// A 2xx means the transaction was accepted; an unusable body only hides the id.
     #[tokio::test]
     async fn test_create_accepted_without_an_id_is_unconfirmed() {
         let server = MockServer::start().await;
@@ -1570,7 +1568,6 @@ mod tests {
         }
     }
 
-    /// A 4xx rules the transaction out, so it stays a plain failure a caller can safely retry.
     #[tokio::test]
     async fn test_create_rejected_by_crossmint_stays_a_plain_failure() {
         let server = MockServer::start().await;

--- a/rust/src/crossmint/mod.rs
+++ b/rust/src/crossmint/mod.rs
@@ -805,6 +805,7 @@ impl CrossmintSigner {
             .await
             .map_err(|error| SignerError::BroadcastUnconfirmed {
                 provider_tx_id: Some(provider_tx_id),
+                provider_status: None,
                 detail: error.detail_string(),
             })?;
 
@@ -1482,6 +1483,7 @@ mod tests {
             SignerError::BroadcastUnconfirmed {
                 provider_tx_id,
                 detail,
+                ..
             } => {
                 assert_eq!(provider_tx_id.as_deref(), Some("tx-approval"));
                 assert!(
@@ -1518,8 +1520,13 @@ mod tests {
         let mut tx = create_test_transaction(&signer.pubkey());
 
         match signer.sign_transaction(&mut tx).await.unwrap_err() {
-            SignerError::BroadcastUnconfirmed { provider_tx_id, .. } => {
+            SignerError::BroadcastUnconfirmed {
+                provider_tx_id,
+                provider_status,
+                ..
+            } => {
                 assert_eq!(provider_tx_id, None);
+                assert_eq!(provider_status, Some(503));
             }
             other => panic!("Expected BroadcastUnconfirmed error, got: {:?}", other),
         }
@@ -1551,8 +1558,13 @@ mod tests {
         let mut tx = create_test_transaction(&signer.pubkey());
 
         match signer.sign_transaction(&mut tx).await.unwrap_err() {
-            SignerError::BroadcastUnconfirmed { provider_tx_id, .. } => {
+            SignerError::BroadcastUnconfirmed {
+                provider_tx_id,
+                provider_status,
+                ..
+            } => {
                 assert_eq!(provider_tx_id, None);
+                assert_eq!(provider_status, None);
             }
             other => panic!("Expected BroadcastUnconfirmed error, got: {:?}", other),
         }

--- a/rust/src/crossmint/mod.rs
+++ b/rust/src/crossmint/mod.rs
@@ -6,7 +6,7 @@ use crate::sdk_adapter::{Pubkey, Signature, VersionedTransaction};
 use crate::traits::SignTransactionResult;
 use crate::transaction_util::{
     deserialize_wire_transaction, idempotency_key_from_message, serialize_wire_transaction,
-    TransactionUtil,
+    unconfirmed_unless_rejected, TransactionUtil,
 };
 use crate::{error::SignerError, http_client_config::HttpClientConfig, traits::SolanaSigner};
 use std::str::FromStr;
@@ -244,9 +244,13 @@ impl CrossmintSigner {
             .header("x-idempotency-key", idempotency_key)
             .json(&request)
             .send()
-            .await?;
+            .await
+            .map_err(|error| unconfirmed_unless_rejected(None, error.into()))?;
 
-        Self::parse_response_with_required_field(response, "id", "create_transaction").await
+        let status = response.status().as_u16();
+        Self::parse_response_with_required_field(response, "id", "create_transaction")
+            .await
+            .map_err(|error| unconfirmed_unless_rejected(Some(status), error))
     }
 
     async fn get_transaction(
@@ -768,9 +772,13 @@ impl CrossmintSigner {
     ///
     /// Not retry-safe: any failure after the create is accepted returns
     /// [`SignerError::BroadcastUnconfirmed`] carrying the Crossmint transaction id;
-    /// check that transaction with Crossmint before retrying. Each create carries
-    /// an `x-idempotency-key` derived from the message bytes, so retrying the
-    /// exact same bytes cannot create a second transaction.
+    /// check that transaction with Crossmint before retrying. A create that fails
+    /// without a usable response returns `BroadcastUnconfirmed` with no id.
+    ///
+    /// Each create carries an `x-idempotency-key` derived from the message bytes,
+    /// so replaying these exact bytes cannot create a second transaction; a
+    /// rebuilt transaction derives a different key and executes as a new
+    /// transfer.
     async fn sign_and_serialize(
         &self,
         transaction: &mut VersionedTransaction,
@@ -796,7 +804,7 @@ impl CrossmintSigner {
             .finish_managed_transaction(create_response, &expected_message)
             .await
             .map_err(|error| SignerError::BroadcastUnconfirmed {
-                provider_tx_id,
+                provider_tx_id: Some(provider_tx_id),
                 detail: error.detail_string(),
             })?;
 
@@ -1475,13 +1483,108 @@ mod tests {
                 provider_tx_id,
                 detail,
             } => {
-                assert_eq!(provider_tx_id, "tx-approval");
+                assert_eq!(provider_tx_id.as_deref(), Some("tx-approval"));
                 assert!(
                     detail.contains("Unable to extract signature"),
                     "Unexpected error detail: {detail}"
                 );
             }
             other => panic!("Expected BroadcastUnconfirmed error, got: {:?}", other),
+        }
+    }
+
+    /// A 5xx can follow a create the provider already accepted, and only an identical-bytes replay dedupes.
+    #[tokio::test]
+    async fn test_create_server_error_is_unconfirmed_without_a_transaction_id() {
+        let server = MockServer::start().await;
+        let wallet_keypair = Keypair::new();
+        let signer_address = keypair_pubkey(&wallet_keypair).to_string();
+
+        Mock::given(method("GET"))
+            .and(path("/2025-06-09/wallets/test-wallet"))
+            .respond_with(wallet_response(&signer_address))
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/2025-06-09/wallets/test-wallet/transactions"))
+            .respond_with(ResponseTemplate::new(503).set_body_json(serde_json::json!({
+                "error": "service unavailable"
+            })))
+            .mount(&server)
+            .await;
+
+        let mut signer = create_test_signer(&server.uri(), 1, 1);
+        signer.init().await.unwrap();
+        let mut tx = create_test_transaction(&signer.pubkey());
+
+        match signer.sign_transaction(&mut tx).await.unwrap_err() {
+            SignerError::BroadcastUnconfirmed { provider_tx_id, .. } => {
+                assert_eq!(provider_tx_id, None);
+            }
+            other => panic!("Expected BroadcastUnconfirmed error, got: {:?}", other),
+        }
+    }
+
+    /// A 2xx means the transaction was accepted; an unusable body only hides the id.
+    #[tokio::test]
+    async fn test_create_accepted_without_an_id_is_unconfirmed() {
+        let server = MockServer::start().await;
+        let wallet_keypair = Keypair::new();
+        let signer_address = keypair_pubkey(&wallet_keypair).to_string();
+
+        Mock::given(method("GET"))
+            .and(path("/2025-06-09/wallets/test-wallet"))
+            .respond_with(wallet_response(&signer_address))
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/2025-06-09/wallets/test-wallet/transactions"))
+            .respond_with(
+                ResponseTemplate::new(201)
+                    .set_body_json(serde_json::json!({ "status": "pending" })),
+            )
+            .mount(&server)
+            .await;
+
+        let mut signer = create_test_signer(&server.uri(), 1, 1);
+        signer.init().await.unwrap();
+        let mut tx = create_test_transaction(&signer.pubkey());
+
+        match signer.sign_transaction(&mut tx).await.unwrap_err() {
+            SignerError::BroadcastUnconfirmed { provider_tx_id, .. } => {
+                assert_eq!(provider_tx_id, None);
+            }
+            other => panic!("Expected BroadcastUnconfirmed error, got: {:?}", other),
+        }
+    }
+
+    /// A 4xx rules the transaction out, so it stays a plain failure a caller can safely retry.
+    #[tokio::test]
+    async fn test_create_rejected_by_crossmint_stays_a_plain_failure() {
+        let server = MockServer::start().await;
+        let wallet_keypair = Keypair::new();
+        let signer_address = keypair_pubkey(&wallet_keypair).to_string();
+
+        Mock::given(method("GET"))
+            .and(path("/2025-06-09/wallets/test-wallet"))
+            .respond_with(wallet_response(&signer_address))
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/2025-06-09/wallets/test-wallet/transactions"))
+            .respond_with(ResponseTemplate::new(400).set_body_json(serde_json::json!({
+                "message": "invalid transaction"
+            })))
+            .mount(&server)
+            .await;
+
+        let mut signer = create_test_signer(&server.uri(), 1, 1);
+        signer.init().await.unwrap();
+        let mut tx = create_test_transaction(&signer.pubkey());
+
+        match signer.sign_transaction(&mut tx).await.unwrap_err() {
+            SignerError::RemoteApiError(_) => {}
+            other => panic!("Expected RemoteApiError, got: {:?}", other),
         }
     }
 

--- a/rust/src/error.rs
+++ b/rust/src/error.rs
@@ -48,11 +48,9 @@ pub enum SignerError {
     /// transaction. Retrying blindly risks a duplicate spend; check the provider
     /// transaction id first.
     ///
-    /// `provider_tx_id` is `None` when the create itself failed without a usable
-    /// response: nothing to check, and the only safe recovery is replaying the
-    /// identical bytes. `provider_status` is the provider's own HTTP status when
-    /// that response was the failure, and `None` when no response arrived or its
-    /// body was the problem.
+    /// Both fields are `None` when the create failed without a usable response:
+    /// nothing to check, and the only safe recovery is replaying the identical
+    /// bytes.
     #[error("Broadcast unconfirmed; the provider may have executed the transaction (provider transaction id: {})", provider_tx_id.as_deref().unwrap_or("unknown"))]
     BroadcastUnconfirmed {
         provider_tx_id: Option<String>,

--- a/rust/src/error.rs
+++ b/rust/src/error.rs
@@ -50,10 +50,13 @@ pub enum SignerError {
     ///
     /// `provider_tx_id` is `None` when the create itself failed without a usable
     /// response: nothing to check, and the only safe recovery is replaying the
-    /// identical bytes.
+    /// identical bytes. `provider_status` is the provider's own HTTP status when
+    /// that response was the failure, and `None` when no response arrived or its
+    /// body was the problem.
     #[error("Broadcast unconfirmed; the provider may have executed the transaction (provider transaction id: {})", provider_tx_id.as_deref().unwrap_or("unknown"))]
     BroadcastUnconfirmed {
         provider_tx_id: Option<String>,
+        provider_status: Option<u16>,
         detail: String,
     },
 
@@ -164,6 +167,7 @@ mod tests {
             SignerError::Other(secret.to_string()),
             SignerError::BroadcastUnconfirmed {
                 provider_tx_id: Some("tx-id".to_string()),
+                provider_status: None,
                 detail: secret.to_string(),
             },
         ];
@@ -225,6 +229,7 @@ mod tests {
     fn test_broadcast_unconfirmed_surfaces_tx_id_but_not_detail() {
         let err = SignerError::BroadcastUnconfirmed {
             provider_tx_id: Some("provider-tx-123".to_string()),
+            provider_status: None,
             detail: "sensitive-detail".to_string(),
         };
         let display = format!("{err}");

--- a/rust/src/error.rs
+++ b/rust/src/error.rs
@@ -47,9 +47,13 @@ pub enum SignerError {
     /// Crossmint) for any failure after the provider has accepted the
     /// transaction. Retrying blindly risks a duplicate spend; check the provider
     /// transaction id first.
-    #[error("Broadcast unconfirmed; the provider may have executed the transaction (provider transaction id: {provider_tx_id})")]
+    ///
+    /// `provider_tx_id` is `None` when the create itself failed without a usable
+    /// response: nothing to check, and the only safe recovery is replaying the
+    /// identical bytes.
+    #[error("Broadcast unconfirmed; the provider may have executed the transaction (provider transaction id: {})", provider_tx_id.as_deref().unwrap_or("unknown"))]
     BroadcastUnconfirmed {
-        provider_tx_id: String,
+        provider_tx_id: Option<String>,
         detail: String,
     },
 
@@ -131,7 +135,8 @@ impl fmt::Debug for SignerError {
             SignerError::BroadcastUnconfirmed { provider_tx_id, .. } => {
                 write!(
                     f,
-                    "SignerError::BroadcastUnconfirmed(provider_tx_id: {provider_tx_id}, [REDACTED])"
+                    "SignerError::BroadcastUnconfirmed(provider_tx_id: {}, [REDACTED])",
+                    provider_tx_id.as_deref().unwrap_or("unknown")
                 )
             }
             SignerError::Other(_) => write!(f, "SignerError::Other([REDACTED])"),
@@ -158,7 +163,7 @@ mod tests {
             SignerError::IoError(secret.to_string()),
             SignerError::Other(secret.to_string()),
             SignerError::BroadcastUnconfirmed {
-                provider_tx_id: "tx-id".to_string(),
+                provider_tx_id: Some("tx-id".to_string()),
                 detail: secret.to_string(),
             },
         ];
@@ -219,7 +224,7 @@ mod tests {
     #[test]
     fn test_broadcast_unconfirmed_surfaces_tx_id_but_not_detail() {
         let err = SignerError::BroadcastUnconfirmed {
-            provider_tx_id: "provider-tx-123".to_string(),
+            provider_tx_id: Some("provider-tx-123".to_string()),
             detail: "sensitive-detail".to_string(),
         };
         let display = format!("{err}");

--- a/rust/src/fordefi/mod.rs
+++ b/rust/src/fordefi/mod.rs
@@ -1788,7 +1788,6 @@ mod tests {
         }
     }
 
-    /// A 5xx can follow a create the provider already accepted, and only an identical-bytes replay dedupes.
     #[tokio::test]
     async fn test_native_submit_server_error_is_unconfirmed_without_a_transaction_id() {
         let mock_server = MockServer::start().await;
@@ -1815,7 +1814,6 @@ mod tests {
         }
     }
 
-    /// A 2xx means the transaction was accepted; an unusable body only hides the id.
     #[tokio::test]
     async fn test_native_submit_accepted_without_an_id_is_unconfirmed() {
         let mock_server = MockServer::start().await;
@@ -1839,7 +1837,6 @@ mod tests {
         }
     }
 
-    /// A 4xx rules the transaction out, so it stays a plain failure a caller can safely retry.
     #[tokio::test]
     async fn test_native_submit_rejected_by_fordefi_stays_a_plain_failure() {
         let mock_server = MockServer::start().await;

--- a/rust/src/fordefi/mod.rs
+++ b/rust/src/fordefi/mod.rs
@@ -17,7 +17,8 @@ use crate::http_client_config::HttpClientConfig;
 use crate::sdk_adapter::{Pubkey, Signature, VersionedTransaction};
 use crate::traits::{SignTransactionResult, SignedTransaction, SolanaSigner};
 use crate::transaction_util::{
-    deserialize_wire_transaction, idempotency_key_from_message, TransactionUtil,
+    deserialize_wire_transaction, idempotency_key_from_message, unconfirmed_unless_rejected,
+    TransactionUtil,
 };
 pub use request_signer::{FordefiRequestSigner, PemRequestSigner};
 use types::{
@@ -237,10 +238,13 @@ impl FordefiSigner {
 
     /// POST a serialized request body to `/api/v1/transactions` with P-256
     /// request signing. Returns the Fordefi transaction ID.
+    /// `broadcast_managed` marks a submit whose acceptance means Fordefi is already
+    /// broadcasting, so an unresolved failure is reported as unconfirmed.
     async fn submit_request<T: serde::Serialize>(
         &self,
         request: &T,
         idempotence_id: Option<&str>,
+        broadcast_managed: bool,
     ) -> Result<String, SignerError> {
         let path = "/api/v1/transactions";
         let body = serde_json::to_string(request)?;
@@ -261,13 +265,30 @@ impl FordefiSigner {
         if let Some(id) = idempotence_id {
             builder = builder.header("x-idempotence-id", id);
         }
-        let response = builder.body(body).send().await?;
+        let classify = |status: Option<u16>, error: SignerError| {
+            if broadcast_managed {
+                unconfirmed_unless_rejected(status, error)
+            } else {
+                error
+            }
+        };
 
+        let response = builder
+            .body(body)
+            .send()
+            .await
+            .map_err(|error| classify(None, error.into()))?;
+
+        let status = response.status().as_u16();
         if !response.status().is_success() {
-            return Err(Self::extract_api_error(response, "submit_request").await);
+            let error = Self::extract_api_error(response, "submit_request").await;
+            return Err(classify(Some(status), error));
         }
 
-        let create_response: CreateTransactionResponse = response.json().await?;
+        let create_response: CreateTransactionResponse = response
+            .json()
+            .await
+            .map_err(|error| classify(Some(status), error.into()))?;
         Ok(create_response.id)
     }
 
@@ -286,7 +307,7 @@ impl FordefiSigner {
             },
         };
 
-        self.submit_request(&request, None).await
+        self.submit_request(&request, None, false).await
     }
 
     /// Submit a native Solana transaction request.
@@ -310,8 +331,12 @@ impl FordefiSigner {
             },
         };
 
-        self.submit_request(&request, Some(&idempotency_key_from_message(data_bytes)))
-            .await
+        self.submit_request(
+            &request,
+            Some(&idempotency_key_from_message(data_bytes)),
+            true,
+        )
+        .await
     }
 
     /// Submit a native Solana message request.
@@ -333,7 +358,7 @@ impl FordefiSigner {
             },
         };
 
-        self.submit_request(&request, None).await
+        self.submit_request(&request, None, false).await
     }
 
     // -----------------------------------------------------------------------
@@ -488,8 +513,12 @@ impl FordefiSigner {
     /// empty — only the signature, usable with RPC transaction lookups, is
     /// returned.
     ///
+    /// A submit that fails without a usable response returns
+    /// [`SignerError::BroadcastUnconfirmed`] with no transaction id.
+    ///
     /// Each native create carries an `x-idempotence-id` derived from the message
-    /// bytes, so retrying the exact same bytes cannot create a second transaction.
+    /// bytes, so replaying these exact bytes cannot create a second transaction; a
+    /// rebuilt transaction derives a different id and is broadcast again.
     async fn sign_and_serialize_native(
         &self,
         transaction: &mut VersionedTransaction,
@@ -504,7 +533,7 @@ impl FordefiSigner {
         // caller might blindly retry into a duplicate spend.
         self.finish_native_broadcast(&tx_id).await.map_err(|error| {
             SignerError::BroadcastUnconfirmed {
-                provider_tx_id: tx_id,
+                provider_tx_id: Some(tx_id),
                 detail: error.detail_string(),
             }
         })
@@ -1752,9 +1781,95 @@ mod tests {
         let result = signer.sign_transaction(&mut tx).await;
         match result.unwrap_err() {
             SignerError::BroadcastUnconfirmed { provider_tx_id, .. } => {
-                assert_eq!(provider_tx_id, "native-tx-no-raw");
+                assert_eq!(provider_tx_id.as_deref(), Some("native-tx-no-raw"));
             }
             other => panic!("Expected BroadcastUnconfirmed, got: {other:?}"),
+        }
+    }
+
+    /// A 5xx can follow a create the provider already accepted, and only an identical-bytes replay dedupes.
+    #[tokio::test]
+    async fn test_native_submit_server_error_is_unconfirmed_without_a_transaction_id() {
+        let mock_server = MockServer::start().await;
+        let pubkey = keypair_pubkey(&create_test_keypair());
+        let signer = create_native_test_signer(&mock_server.uri(), pubkey);
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/transactions"))
+            .respond_with(ResponseTemplate::new(502))
+            .mount(&mock_server)
+            .await;
+
+        let mut tx = create_test_transaction(&pubkey);
+        match signer.sign_transaction(&mut tx).await.unwrap_err() {
+            SignerError::BroadcastUnconfirmed { provider_tx_id, .. } => {
+                assert_eq!(provider_tx_id, None);
+            }
+            other => panic!("Expected BroadcastUnconfirmed, got: {other:?}"),
+        }
+    }
+
+    /// A 2xx means the transaction was accepted; an unusable body only hides the id.
+    #[tokio::test]
+    async fn test_native_submit_accepted_without_an_id_is_unconfirmed() {
+        let mock_server = MockServer::start().await;
+        let pubkey = keypair_pubkey(&create_test_keypair());
+        let signer = create_native_test_signer(&mock_server.uri(), pubkey);
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/transactions"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(serde_json::json!({ "state": "pending" })),
+            )
+            .mount(&mock_server)
+            .await;
+
+        let mut tx = create_test_transaction(&pubkey);
+        match signer.sign_transaction(&mut tx).await.unwrap_err() {
+            SignerError::BroadcastUnconfirmed { provider_tx_id, .. } => {
+                assert_eq!(provider_tx_id, None);
+            }
+            other => panic!("Expected BroadcastUnconfirmed, got: {other:?}"),
+        }
+    }
+
+    /// A 4xx rules the transaction out, so it stays a plain failure a caller can safely retry.
+    #[tokio::test]
+    async fn test_native_submit_rejected_by_fordefi_stays_a_plain_failure() {
+        let mock_server = MockServer::start().await;
+        let pubkey = keypair_pubkey(&create_test_keypair());
+        let signer = create_native_test_signer(&mock_server.uri(), pubkey);
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/transactions"))
+            .respond_with(ResponseTemplate::new(401))
+            .mount(&mock_server)
+            .await;
+
+        let mut tx = create_test_transaction(&pubkey);
+        match signer.sign_transaction(&mut tx).await.unwrap_err() {
+            SignerError::RemoteApiError(_) => {}
+            other => panic!("Expected RemoteApiError, got: {other:?}"),
+        }
+    }
+
+    /// Black-box mode only signs, so a failed submit has no on-chain outcome to be unconfirmed about.
+    #[tokio::test]
+    async fn test_black_box_submit_server_error_is_not_reported_as_unconfirmed() {
+        let mock_server = MockServer::start().await;
+        let pubkey = keypair_pubkey(&create_test_keypair());
+        let signer = create_test_signer(&mock_server.uri(), pubkey);
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/transactions"))
+            .respond_with(ResponseTemplate::new(502))
+            .mount(&mock_server)
+            .await;
+
+        let mut tx = create_test_transaction(&pubkey);
+        match signer.sign_transaction(&mut tx).await.unwrap_err() {
+            SignerError::RemoteApiError(_) => {}
+            other => panic!("Expected RemoteApiError, got: {other:?}"),
         }
     }
 
@@ -1790,7 +1905,7 @@ mod tests {
                 provider_tx_id,
                 detail,
             } => {
-                assert_eq!(provider_tx_id, "native-tx-fail");
+                assert_eq!(provider_tx_id.as_deref(), Some("native-tx-fail"));
                 assert!(
                     detail.contains("aborted"),
                     "detail must carry the state, got: {detail}"
@@ -1904,7 +2019,7 @@ mod tests {
                 provider_tx_id,
                 detail,
             } => {
-                assert_eq!(provider_tx_id, "native-tx-pending");
+                assert_eq!(provider_tx_id.as_deref(), Some("native-tx-pending"));
                 assert!(
                     detail.contains("timeout"),
                     "detail must carry the cause, got: {detail}"
@@ -1949,7 +2064,7 @@ mod tests {
         let result = signer.sign_transaction(&mut tx).await;
         match result.unwrap_err() {
             SignerError::BroadcastUnconfirmed { provider_tx_id, .. } => {
-                assert_eq!(provider_tx_id, "native-tx-malformed");
+                assert_eq!(provider_tx_id.as_deref(), Some("native-tx-malformed"));
             }
             other => panic!("Expected BroadcastUnconfirmed, got: {other:?}"),
         }

--- a/rust/src/fordefi/mod.rs
+++ b/rust/src/fordefi/mod.rs
@@ -534,6 +534,7 @@ impl FordefiSigner {
         self.finish_native_broadcast(&tx_id).await.map_err(|error| {
             SignerError::BroadcastUnconfirmed {
                 provider_tx_id: Some(tx_id),
+                provider_status: None,
                 detail: error.detail_string(),
             }
         })
@@ -1802,8 +1803,13 @@ mod tests {
 
         let mut tx = create_test_transaction(&pubkey);
         match signer.sign_transaction(&mut tx).await.unwrap_err() {
-            SignerError::BroadcastUnconfirmed { provider_tx_id, .. } => {
+            SignerError::BroadcastUnconfirmed {
+                provider_tx_id,
+                provider_status,
+                ..
+            } => {
                 assert_eq!(provider_tx_id, None);
+                assert_eq!(provider_status, Some(502));
             }
             other => panic!("Expected BroadcastUnconfirmed, got: {other:?}"),
         }
@@ -1904,6 +1910,7 @@ mod tests {
             SignerError::BroadcastUnconfirmed {
                 provider_tx_id,
                 detail,
+                ..
             } => {
                 assert_eq!(provider_tx_id.as_deref(), Some("native-tx-fail"));
                 assert!(
@@ -2018,6 +2025,7 @@ mod tests {
             SignerError::BroadcastUnconfirmed {
                 provider_tx_id,
                 detail,
+                ..
             } => {
                 assert_eq!(provider_tx_id.as_deref(), Some("native-tx-pending"));
                 assert!(

--- a/rust/src/transaction_util.rs
+++ b/rust/src/transaction_util.rs
@@ -26,7 +26,8 @@ pub(crate) fn idempotency_key_from_message(message_bytes: &[u8]) -> String {
 
 /// A 4xx is the only create outcome that rules out a transaction; anything else
 /// (no response, timeout, 5xx, unusable success body) may already be executing.
-/// `status` is `None` when no response arrived.
+/// `status` is `None` when no response arrived, and is reported back to the caller
+/// only when the response itself was the failure.
 #[cfg(any(feature = "crossmint", feature = "fordefi"))]
 pub(crate) fn unconfirmed_unless_rejected(status: Option<u16>, error: SignerError) -> SignerError {
     if matches!(status, Some(status) if (400..500).contains(&status)) {
@@ -34,6 +35,7 @@ pub(crate) fn unconfirmed_unless_rejected(status: Option<u16>, error: SignerErro
     }
     SignerError::BroadcastUnconfirmed {
         provider_tx_id: None,
+        provider_status: status.filter(|status| *status >= 400),
         detail: error.detail_string(),
     }
 }

--- a/rust/src/transaction_util.rs
+++ b/rust/src/transaction_util.rs
@@ -26,8 +26,8 @@ pub(crate) fn idempotency_key_from_message(message_bytes: &[u8]) -> String {
 
 /// A 4xx is the only create outcome that rules out a transaction; anything else
 /// (no response, timeout, 5xx, unusable success body) may already be executing.
-/// `status` is `None` when no response arrived, and is reported back to the caller
-/// only when the response itself was the failure.
+/// `status` is `None` when no response arrived, and is passed on only when the
+/// response was the failure.
 #[cfg(any(feature = "crossmint", feature = "fordefi"))]
 pub(crate) fn unconfirmed_unless_rejected(status: Option<u16>, error: SignerError) -> SignerError {
     if matches!(status, Some(status) if (400..500).contains(&status)) {

--- a/rust/src/transaction_util.rs
+++ b/rust/src/transaction_util.rs
@@ -24,6 +24,20 @@ pub(crate) fn idempotency_key_from_message(message_bytes: &[u8]) -> String {
     )
 }
 
+/// A 4xx is the only create outcome that rules out a transaction; anything else
+/// (no response, timeout, 5xx, unusable success body) may already be executing.
+/// `status` is `None` when no response arrived.
+#[cfg(any(feature = "crossmint", feature = "fordefi"))]
+pub(crate) fn unconfirmed_unless_rejected(status: Option<u16>, error: SignerError) -> SignerError {
+    if matches!(status, Some(status) if (400..500).contains(&status)) {
+        return error;
+    }
+    SignerError::BroadcastUnconfirmed {
+        provider_tx_id: None,
+        detail: error.detail_string(),
+    }
+}
+
 /// Serialize a transaction to canonical wire bytes.
 #[cfg(feature = "sdk-v4")]
 pub(crate) fn serialize_wire_transaction(

--- a/typescript/packages/core/src/errors.ts
+++ b/typescript/packages/core/src/errors.ts
@@ -6,7 +6,8 @@ export const SignerErrorCode = {
      * The provider may have executed the transaction, but the outcome could not
      * be confirmed. Raised by broadcast-managed signers for any failure after
      * the provider has accepted the transaction; `context.providerTransactionId`
-     * carries the provider-side id to check before retrying.
+     * carries the provider-side id to check before retrying, and `context.status`
+     * the provider's HTTP status when its response was the failure.
      */
     BROADCAST_UNCONFIRMED: 'SIGNER_BROADCAST_UNCONFIRMED',
     CONFIG_ERROR: 'SIGNER_CONFIG_ERROR',

--- a/typescript/packages/core/src/http.ts
+++ b/typescript/packages/core/src/http.ts
@@ -18,12 +18,21 @@ export interface FetchSignerJsonOptions {
 }
 
 /**
+ * The provider's own HTTP status when its response was the failure, and
+ * `undefined` when no response arrived or its body was the problem.
+ */
+export function providerStatus(error: unknown): number | undefined {
+    const status = error instanceof SignerError ? error.context?.status : undefined;
+    return typeof status === 'number' ? status : undefined;
+}
+
+/**
  * A 4xx is the only create outcome that rules out a transaction; anything else
  * (no response, timeout, 5xx, unusable success body) may already be executing.
  */
 export function providerMayHaveAccepted(error: unknown): boolean {
-    const status = error instanceof SignerError ? error.context?.status : undefined;
-    return typeof status !== 'number' || status < 400 || status >= 500;
+    const status = providerStatus(error);
+    return status === undefined || status < 400 || status >= 500;
 }
 
 /**

--- a/typescript/packages/core/src/http.ts
+++ b/typescript/packages/core/src/http.ts
@@ -17,10 +17,7 @@ export interface FetchSignerJsonOptions {
     url: string;
 }
 
-/**
- * The provider's own HTTP status when its response was the failure, and
- * `undefined` when no response arrived or its body was the problem.
- */
+/** The provider's HTTP status when its response was the failure. */
 export function providerStatus(error: unknown): number | undefined {
     const status = error instanceof SignerError ? error.context?.status : undefined;
     return typeof status === 'number' ? status : undefined;

--- a/typescript/packages/core/src/http.ts
+++ b/typescript/packages/core/src/http.ts
@@ -1,4 +1,4 @@
-import { sanitizeRemoteErrorResponse, SignerErrorCode, throwSignerError } from './errors.js';
+import { sanitizeRemoteErrorResponse, SignerError, SignerErrorCode, throwSignerError } from './errors.js';
 
 /** Default timeout applied to remote signer API requests. */
 export const DEFAULT_FETCH_TIMEOUT_MS = 60_000;
@@ -15,6 +15,15 @@ export interface FetchSignerJsonOptions {
     timeoutMs?: number;
     /** Fully-qualified request URL. */
     url: string;
+}
+
+/**
+ * A 4xx is the only create outcome that rules out a transaction; anything else
+ * (no response, timeout, 5xx, unusable success body) may already be executing.
+ */
+export function providerMayHaveAccepted(error: unknown): boolean {
+    const status = error instanceof SignerError ? error.context?.status : undefined;
+    return typeof status !== 'number' || status < 400 || status >= 500;
 }
 
 /**

--- a/typescript/packages/crossmint/src/__tests__/crossmint-signer.test.ts
+++ b/typescript/packages/crossmint/src/__tests__/crossmint-signer.test.ts
@@ -883,7 +883,6 @@ describe('CrossmintSigner', () => {
             });
         });
 
-        // A 4xx rules the transaction out, so it stays a plain failure a caller can safely retry.
         it('keeps a 4xx during transaction creation a plain failure', async () => {
             vi.mocked(fetch)
                 .mockResolvedValueOnce(mockWalletResponse()) // create()
@@ -905,7 +904,6 @@ describe('CrossmintSigner', () => {
             });
         });
 
-        // A request with no response may still have been read and acted on.
         it('reports a network error during transaction creation as unconfirmed with no transaction id', async () => {
             vi.mocked(fetch)
                 .mockResolvedValueOnce(mockWalletResponse()) // create()
@@ -952,7 +950,6 @@ describe('CrossmintSigner', () => {
             expect(error.context?.status).toBe(503);
         });
 
-        // A 2xx means the transaction was accepted; an unusable body only hides the id.
         it('reports an accepted create with no id as unconfirmed', async () => {
             vi.mocked(fetch)
                 .mockResolvedValueOnce(mockWalletResponse()) // create()

--- a/typescript/packages/crossmint/src/__tests__/crossmint-signer.test.ts
+++ b/typescript/packages/crossmint/src/__tests__/crossmint-signer.test.ts
@@ -926,6 +926,7 @@ describe('CrossmintSigner', () => {
             expect(error.code).toBe('SIGNER_BROADCAST_UNCONFIRMED');
             expect(error.context?.cause).toMatchObject({ code: 'SIGNER_HTTP_ERROR' });
             expect(error.context?.providerTransactionId).toBeUndefined();
+            expect(error.context?.status).toBeUndefined();
         });
 
         it('reports a 5xx during transaction creation as unconfirmed with no transaction id', async () => {
@@ -948,6 +949,7 @@ describe('CrossmintSigner', () => {
             expect(error.code).toBe('SIGNER_BROADCAST_UNCONFIRMED');
             expect(error.context?.cause).toMatchObject({ code: 'SIGNER_REMOTE_API_ERROR' });
             expect(error.context?.providerTransactionId).toBeUndefined();
+            expect(error.context?.status).toBe(503);
         });
 
         // A 2xx means the transaction was accepted; an unusable body only hides the id.

--- a/typescript/packages/crossmint/src/__tests__/crossmint-signer.test.ts
+++ b/typescript/packages/crossmint/src/__tests__/crossmint-signer.test.ts
@@ -24,7 +24,7 @@ vi.mock('@solana/transactions', async importOriginal => {
     };
 });
 
-import { assertSignatureValid, isSolanaSendingSigner, isSolanaSigner } from '@solana/keychain-core';
+import { assertSignatureValid, isSolanaSendingSigner, isSolanaSigner, type SignerError } from '@solana/keychain-core';
 import { isMessagePartialSigner, isTransactionPartialSigner, isTransactionSendingSigner } from '@solana/signers';
 import { getTransactionDecoder } from '@solana/transactions';
 import { createCrossmintSigner } from '../crossmint-signer.js';
@@ -306,7 +306,7 @@ describe('CrossmintSigner', () => {
                     createMockTransaction(),
                     createMockTransaction(),
                 ]),
-            ).rejects.toMatchObject({ code: 'SIGNER_REMOTE_API_ERROR' });
+            ).rejects.toMatchObject({ code: 'SIGNER_BROADCAST_UNCONFIRMED' });
 
             // wallet create + tx0 create + tx1 create = 3 fetches; tx2 must not be created.
             expect(vi.mocked(fetch)).toHaveBeenCalledTimes(3);
@@ -883,7 +883,8 @@ describe('CrossmintSigner', () => {
             });
         });
 
-        it('throws on HTTP error during transaction creation', async () => {
+        // A 4xx rules the transaction out, so it stays a plain failure a caller can safely retry.
+        it('keeps a 4xx during transaction creation a plain failure', async () => {
             vi.mocked(fetch)
                 .mockResolvedValueOnce(mockWalletResponse()) // create()
                 .mockResolvedValueOnce(new Response(JSON.stringify({ message: 'Unauthorized' }), { status: 401 }));
@@ -904,7 +905,8 @@ describe('CrossmintSigner', () => {
             });
         });
 
-        it('throws on network error during transaction creation', async () => {
+        // A request with no response may still have been read and acted on.
+        it('reports a network error during transaction creation as unconfirmed with no transaction id', async () => {
             vi.mocked(fetch)
                 .mockResolvedValueOnce(mockWalletResponse()) // create()
                 .mockRejectedValueOnce(new Error('network down'));
@@ -915,9 +917,59 @@ describe('CrossmintSigner', () => {
                 pollIntervalMs: 1,
             });
 
-            await expect(signer.signAndSendTransactions([createMockTransaction()])).rejects.toMatchObject({
-                code: 'SIGNER_HTTP_ERROR',
+            const error = await signer.signAndSendTransactions([createMockTransaction()]).then(
+                () => {
+                    throw new Error('expected the create failure to be reported');
+                },
+                (thrown: SignerError) => thrown,
+            );
+            expect(error.code).toBe('SIGNER_BROADCAST_UNCONFIRMED');
+            expect(error.context?.cause).toMatchObject({ code: 'SIGNER_HTTP_ERROR' });
+            expect(error.context?.providerTransactionId).toBeUndefined();
+        });
+
+        it('reports a 5xx during transaction creation as unconfirmed with no transaction id', async () => {
+            vi.mocked(fetch)
+                .mockResolvedValueOnce(mockWalletResponse()) // create()
+                .mockResolvedValueOnce(new Response(JSON.stringify({ message: 'unavailable' }), { status: 503 }));
+
+            const signer = await createCrossmintSigner({
+                ...mockConfig,
+                maxPollAttempts: 1,
+                pollIntervalMs: 1,
             });
+
+            const error = await signer.signAndSendTransactions([createMockTransaction()]).then(
+                () => {
+                    throw new Error('expected the create failure to be reported');
+                },
+                (thrown: SignerError) => thrown,
+            );
+            expect(error.code).toBe('SIGNER_BROADCAST_UNCONFIRMED');
+            expect(error.context?.cause).toMatchObject({ code: 'SIGNER_REMOTE_API_ERROR' });
+            expect(error.context?.providerTransactionId).toBeUndefined();
+        });
+
+        // A 2xx means the transaction was accepted; an unusable body only hides the id.
+        it('reports an accepted create with no id as unconfirmed', async () => {
+            vi.mocked(fetch)
+                .mockResolvedValueOnce(mockWalletResponse()) // create()
+                .mockResolvedValueOnce(new Response(JSON.stringify({ status: 'pending' }), { status: 201 }));
+
+            const signer = await createCrossmintSigner({
+                ...mockConfig,
+                maxPollAttempts: 1,
+                pollIntervalMs: 1,
+            });
+
+            const error = await signer.signAndSendTransactions([createMockTransaction()]).then(
+                () => {
+                    throw new Error('expected the create failure to be reported');
+                },
+                (thrown: SignerError) => thrown,
+            );
+            expect(error.code).toBe('SIGNER_BROADCAST_UNCONFIRMED');
+            expect(error.context?.providerTransactionId).toBeUndefined();
         });
 
         it('uses the final polled response when maxPollAttempts is 1', async () => {

--- a/typescript/packages/crossmint/src/crossmint-signer.ts
+++ b/typescript/packages/crossmint/src/crossmint-signer.ts
@@ -8,6 +8,7 @@ import {
     fetchSignerJson,
     idempotencyKeyFromMessage,
     normalizeBaseUrl,
+    providerMayHaveAccepted,
     sanitizeRemoteErrorResponse,
     SignerError,
     SignerErrorCode,
@@ -71,9 +72,13 @@ let base64Encoder: ReturnType<typeof getBase64Encoder> | undefined;
  *
  * Not retry-safe: any failure after the create is accepted rejects with
  * `BROADCAST_UNCONFIRMED` carrying `context.providerTransactionId`; check that
- * transaction with Crossmint before retrying. Each create carries an
- * `x-idempotency-key` derived from the message bytes, so retrying the exact
- * same bytes cannot create a second transaction.
+ * transaction with Crossmint before retrying. A create that fails without a
+ * usable response rejects with `BROADCAST_UNCONFIRMED` and no
+ * `providerTransactionId`.
+ *
+ * Each create carries an `x-idempotency-key` derived from the message bytes, so
+ * replaying these exact bytes cannot create a second transaction; a rebuilt
+ * transaction derives a different key and executes as a new transfer.
  */
 class CrossmintSigner<TAddress extends string = string> implements CrossmintSendingSigner<TAddress> {
     // No signTransactions/signMessages: Kit classifies signers by duck-typed
@@ -255,7 +260,19 @@ class CrossmintSigner<TAddress extends string = string> implements CrossmintSend
      * has already accepted, so an aborted transaction may still land server-side.
      */
     private async signTransactionManaged(transaction: Transaction, abortSignal?: AbortSignal): Promise<SignatureBytes> {
-        const created = await this.createTransaction(transaction, abortSignal);
+        let created: CrossmintTransactionResponse;
+        try {
+            created = await this.createTransaction(transaction, abortSignal);
+        } catch (error) {
+            if (!providerMayHaveAccepted(error)) {
+                throw error;
+            }
+            // Crossmint may be executing a transaction whose id never reached us.
+            return throwSignerError(SignerErrorCode.BROADCAST_UNCONFIRMED, {
+                cause: error,
+                message: 'Crossmint may have created the transaction, but no transaction id was returned',
+            });
+        }
         // Post-create failures leave an outcome Crossmint may still execute, so
         // they surface as BROADCAST_UNCONFIRMED with the transaction id.
         try {

--- a/typescript/packages/crossmint/src/crossmint-signer.ts
+++ b/typescript/packages/crossmint/src/crossmint-signer.ts
@@ -9,6 +9,7 @@ import {
     idempotencyKeyFromMessage,
     normalizeBaseUrl,
     providerMayHaveAccepted,
+    providerStatus,
     sanitizeRemoteErrorResponse,
     SignerError,
     SignerErrorCode,
@@ -268,9 +269,11 @@ class CrossmintSigner<TAddress extends string = string> implements CrossmintSend
                 throw error;
             }
             // Crossmint may be executing a transaction whose id never reached us.
+            const status = providerStatus(error);
             return throwSignerError(SignerErrorCode.BROADCAST_UNCONFIRMED, {
                 cause: error,
                 message: 'Crossmint may have created the transaction, but no transaction id was returned',
+                ...(status === undefined ? {} : { status }),
             });
         }
         // Post-create failures leave an outcome Crossmint may still execute, so

--- a/typescript/packages/fordefi/src/__tests__/fordefi-signer.test.ts
+++ b/typescript/packages/fordefi/src/__tests__/fordefi-signer.test.ts
@@ -366,6 +366,22 @@ describe('FordefiSigner', () => {
             await expect(signer.signTransactions([mockTx])).rejects.toThrow();
         });
 
+        // Black-box mode only signs, so a failed submit has no on-chain outcome to be unconfirmed about.
+        it('does not report a 5xx on a black-box submit as unconfirmed', async () => {
+            setupCreateVaultMock();
+            const signer = await FordefiSigner.create(mockConfig);
+            vi.mocked(fetch).mockResolvedValueOnce(new Response(JSON.stringify({ message: 'boom' }), { status: 502 }));
+
+            const mockTx = { messageBytes: new Uint8Array(32) } as never;
+            const error = await signer.signTransactions([mockTx]).then(
+                () => {
+                    throw new Error('expected the submit failure to be reported');
+                },
+                (thrown: SignerError) => thrown,
+            );
+            expect(error.code).toBe('SIGNER_REMOTE_API_ERROR');
+        });
+
         it('should handle completed state without signatures', async () => {
             setupCreateVaultMock();
             const signer = await FordefiSigner.create(mockConfig);
@@ -624,6 +640,67 @@ describe('FordefiSigner', () => {
             const cause = error.context?.cause as SignerError;
             expect(cause.code).toBe('SIGNER_SIGNING_FAILED');
             expect(cause.context?.message).toContain('no fee-payer signature');
+        });
+
+        // A 5xx can follow a create the provider already accepted, and only an identical-bytes replay dedupes.
+        it('reports a 5xx on submit as unconfirmed with no transaction id', async () => {
+            setupCreateVaultMock();
+            const signer = await FordefiSigner.create(nativeConfig);
+            vi.mocked(fetch).mockResolvedValueOnce(new Response(JSON.stringify({ message: 'boom' }), { status: 502 }));
+
+            const mockTx = {
+                messageBytes: new Uint8Array(32),
+                signatures: { [MOCK_ADDRESS]: null },
+            } as never;
+            const error = await signer.signAndSendTransactions([mockTx]).then(
+                () => {
+                    throw new Error('expected the submit failure to be reported');
+                },
+                (thrown: SignerError) => thrown,
+            );
+            expect(error.code).toBe('SIGNER_BROADCAST_UNCONFIRMED');
+            expect(error.context?.providerTransactionId).toBeUndefined();
+        });
+
+        // A 2xx means the transaction was accepted; an unusable body only hides the id.
+        it('reports an accepted submit with no id as unconfirmed', async () => {
+            setupCreateVaultMock();
+            const signer = await FordefiSigner.create(nativeConfig);
+            vi.mocked(fetch).mockResolvedValueOnce(new Response(JSON.stringify({ state: 'pending' }), { status: 200 }));
+
+            const mockTx = {
+                messageBytes: new Uint8Array(32),
+                signatures: { [MOCK_ADDRESS]: null },
+            } as never;
+            const error = await signer.signAndSendTransactions([mockTx]).then(
+                () => {
+                    throw new Error('expected the submit failure to be reported');
+                },
+                (thrown: SignerError) => thrown,
+            );
+            expect(error.code).toBe('SIGNER_BROADCAST_UNCONFIRMED');
+            expect(error.context?.providerTransactionId).toBeUndefined();
+        });
+
+        // A 4xx rules the transaction out, so it stays a plain failure a caller can safely retry.
+        it('keeps a 4xx on submit a plain failure', async () => {
+            setupCreateVaultMock();
+            const signer = await FordefiSigner.create(nativeConfig);
+            vi.mocked(fetch).mockResolvedValueOnce(
+                new Response(JSON.stringify({ message: 'Unauthorized' }), { status: 401 }),
+            );
+
+            const mockTx = {
+                messageBytes: new Uint8Array(32),
+                signatures: { [MOCK_ADDRESS]: null },
+            } as never;
+            const error = await signer.signAndSendTransactions([mockTx]).then(
+                () => {
+                    throw new Error('expected the submit failure to be reported');
+                },
+                (thrown: SignerError) => thrown,
+            );
+            expect(error.code).toBe('SIGNER_REMOTE_API_ERROR');
         });
 
         it('should throw when raw_transaction is missing from response', async () => {

--- a/typescript/packages/fordefi/src/__tests__/fordefi-signer.test.ts
+++ b/typescript/packages/fordefi/src/__tests__/fordefi-signer.test.ts
@@ -660,6 +660,7 @@ describe('FordefiSigner', () => {
             );
             expect(error.code).toBe('SIGNER_BROADCAST_UNCONFIRMED');
             expect(error.context?.providerTransactionId).toBeUndefined();
+            expect(error.context?.status).toBe(502);
         });
 
         // A 2xx means the transaction was accepted; an unusable body only hides the id.
@@ -680,6 +681,7 @@ describe('FordefiSigner', () => {
             );
             expect(error.code).toBe('SIGNER_BROADCAST_UNCONFIRMED');
             expect(error.context?.providerTransactionId).toBeUndefined();
+            expect(error.context?.status).toBeUndefined();
         });
 
         // A 4xx rules the transaction out, so it stays a plain failure a caller can safely retry.

--- a/typescript/packages/fordefi/src/__tests__/fordefi-signer.test.ts
+++ b/typescript/packages/fordefi/src/__tests__/fordefi-signer.test.ts
@@ -642,7 +642,6 @@ describe('FordefiSigner', () => {
             expect(cause.context?.message).toContain('no fee-payer signature');
         });
 
-        // A 5xx can follow a create the provider already accepted, and only an identical-bytes replay dedupes.
         it('reports a 5xx on submit as unconfirmed with no transaction id', async () => {
             setupCreateVaultMock();
             const signer = await FordefiSigner.create(nativeConfig);
@@ -663,7 +662,6 @@ describe('FordefiSigner', () => {
             expect(error.context?.status).toBe(502);
         });
 
-        // A 2xx means the transaction was accepted; an unusable body only hides the id.
         it('reports an accepted submit with no id as unconfirmed', async () => {
             setupCreateVaultMock();
             const signer = await FordefiSigner.create(nativeConfig);
@@ -684,7 +682,6 @@ describe('FordefiSigner', () => {
             expect(error.context?.status).toBeUndefined();
         });
 
-        // A 4xx rules the transaction out, so it stays a plain failure a caller can safely retry.
         it('keeps a 4xx on submit a plain failure', async () => {
             setupCreateVaultMock();
             const signer = await FordefiSigner.create(nativeConfig);

--- a/typescript/packages/fordefi/src/fordefi-signer.ts
+++ b/typescript/packages/fordefi/src/fordefi-signer.ts
@@ -9,6 +9,7 @@ import {
     fetchSignerJson,
     idempotencyKeyFromMessage,
     normalizeBaseUrl,
+    providerMayHaveAccepted,
     signBatchStaggered,
     SignerErrorCode,
     SolanaSendingSigner,
@@ -152,9 +153,12 @@ export interface FordefiSignerConfig {
  * Native mode is not retry-safe: any failure after Fordefi accepts the
  * submission rejects with `BROADCAST_UNCONFIRMED` carrying
  * `context.providerTransactionId`; check that transaction with Fordefi before
- * retrying. Each native create carries an `x-idempotence-id` derived from the
- * message bytes, so retrying the exact same bytes cannot create a second
- * transaction.
+ * retrying. A submission that fails without a usable response rejects with
+ * `BROADCAST_UNCONFIRMED` and no `providerTransactionId`.
+ *
+ * Each native create carries an `x-idempotence-id` derived from the message
+ * bytes, so replaying these exact bytes cannot create a second transaction; a
+ * rebuilt transaction derives a different id and is broadcast again.
  */
 export interface FordefiNativeSigner<TAddress extends string = string>
     extends SolanaSendingSigner<TAddress>, MessagePartialSigner<TAddress> {}
@@ -514,7 +518,19 @@ export class FordefiSigner<TAddress extends string = string> implements MessageP
                 this.assertNativeAutoTransactionSupported(transaction);
 
                 const base64Data = Buffer.from(transaction.messageBytes).toString('base64');
-                const txId = await this.submitSolanaTransaction(base64Data);
+                let txId: string;
+                try {
+                    txId = await this.submitSolanaTransaction(base64Data);
+                } catch (error) {
+                    if (!providerMayHaveAccepted(error)) {
+                        throw error;
+                    }
+                    // Fordefi may be broadcasting a transaction whose id never reached us.
+                    return throwSignerError(SignerErrorCode.BROADCAST_UNCONFIRMED, {
+                        cause: error,
+                        message: 'Fordefi may have accepted the transaction, but no transaction id was returned',
+                    });
+                }
                 // Once the submit is accepted Fordefi is already broadcasting
                 // (push_mode 'auto'), so any later failure leaves an on-chain
                 // outcome this client cannot rule out. Report those as

--- a/typescript/packages/fordefi/src/fordefi-signer.ts
+++ b/typescript/packages/fordefi/src/fordefi-signer.ts
@@ -10,6 +10,7 @@ import {
     idempotencyKeyFromMessage,
     normalizeBaseUrl,
     providerMayHaveAccepted,
+    providerStatus,
     signBatchStaggered,
     SignerErrorCode,
     SolanaSendingSigner,
@@ -526,9 +527,11 @@ export class FordefiSigner<TAddress extends string = string> implements MessageP
                         throw error;
                     }
                     // Fordefi may be broadcasting a transaction whose id never reached us.
+                    const status = providerStatus(error);
                     return throwSignerError(SignerErrorCode.BROADCAST_UNCONFIRMED, {
                         cause: error,
                         message: 'Fordefi may have accepted the transaction, but no transaction id was returned',
+                        ...(status === undefined ? {} : { status }),
                     });
                 }
                 // Once the submit is accepted Fordefi is already broadcasting


### PR DESCRIPTION
Stacked on #264 (and through it on the v1 stack). Crossmint + Fordefi, all four languages.

## Problem

Crossmint and native-mode Fordefi (`push_mode: auto`) broadcast server-side, so an accepted create means the transaction may execute. #241/#254 covered every failure *after* a fully parsed create response, mapping it to `BROADCAST_UNCONFIRMED` with the provider transaction id. The create call itself was not covered:

- the response never arrives (connection reset, timeout)
- the provider answers 5xx after having accepted the work
- a 2xx body is unparseable, or carries no `id`

All four create helpers returned a plain `HTTP_ERROR` / `REMOTE_API_ERROR` / `SERIALIZATION_ERROR` before the provider-id wrapper ran. A caller cannot distinguish that from "never created". An exact-bytes retry is deduplicated by the `x-idempotency-key` / `x-idempotence-id` we send, but the natural recovery is to rebuild with a fresh blockhash, which derives a different key: the provider executes a second transfer while the first may also land.

A 2xx with no `id` is the sharpest case: the provider accepted the transaction and we reported a parse error.

## Fix

A failed create is reported as `BROADCAST_UNCONFIRMED` with **no** provider transaction id, unless the provider rejected it with a **4xx**.

A 4xx is the one outcome that rules a create out: the provider read the request, validated it, and refused it, so it stays a plain failure a caller can safely retry. Everything else - no response, a timeout, a 5xx, or a success whose body could not be used - leaves work the provider may already be executing. The error then says: there is nothing to look up, and the only safe recovery is replaying the identical bytes.

- **Rust**: `unconfirmed_unless_rejected(status, error)` in `transaction_util`, applied in the Crossmint create and the Fordefi submit (native only, via a `broadcast_managed` flag on the shared `submit_request`).
- **TypeScript**: `providerMayHaveAccepted(error)` in `@solana/keychain-core`, applied at both create call sites.
- **Python**: `provider_may_have_accepted(status_code)` in `core.http`; `SignerError` now carries `status_code` for remote-API failures so the create path can tell 4xx from everything else.
- **Go**: `core.UnconfirmedUnlessRejected(status, err)`, applied in the Crossmint create and (native only) the Fordefi submit.

Black-box Fordefi submits are untouched: that mode only signs, so a failed submit has no on-chain outcome to be unconfirmed about. Covered by a test in each language.

### Python cancellation

The Crossmint signer's post-create guard was `except SignerError`, which never catches `CancelledError`, and the poll loop sleeps - so cancelling a sign mid-poll discarded the transaction id. It now logs and re-raises a `CancelledError` carrying the id, matching what the Fordefi signer already does.

## Breaking

`SignerError::BroadcastUnconfirmed::provider_tx_id` is now `Option<String>` in Rust; `None` means the create failed before an id was known. Display/Debug render `unknown` in that case. Go keeps its documented `""` convention, Python `None`, TypeScript an absent `context.providerTransactionId`.

## Deliberately not fixed

A caller that rebuilds the transaction before retrying still creates a second one. A signer handed finished transaction bytes cannot know that two different-blockhash transactions are the same intent, and a config-level static idempotency key would collapse every transfer into the first. Deduplicating at intent level needs a caller-supplied key, which is an API change outside this fix. The docstrings now state the constraint explicitly: replay the identical bytes, never a rebuilt transaction.

Crossmint documents `x-idempotency-key` only as "Unique key to prevent duplicate transaction creation" and specifies neither replay nor conflict semantics, so this PR does not build recovery on top of a replay returning the original transaction. Worth a live probe separately - if a replayed key does return the original, a single same-key retry could turn "unknown" back into a usable transaction id.

## Testing

Each language gets the same four cases per signer: 5xx create, accepted create with no id, 4xx create stays a plain failure, and a black-box submit failure that must not be reported as unconfirmed. Python adds a cancellation test asserting the id reaches both the raised error and the log.

- `just rust-test` - 339 (sdk-v2), 339 (sdk-v3), 343 (sdk-v4), all passing
- `just py-test` - 491 passed
- `just ts-test` - all packages passing (crossmint 43, fordefi 67)
- `just go-test` - 15 modules ok
- `just rust-fmt`, `just ts-fmt`, `just py-fmt` (ruff + mypy strict), `just go-fmt` clean
- `just ts-treeshake` - all 15 factories tree-shake cleanly

One pre-existing TypeScript test asserted the old behaviour (a network error during create surfacing as `HTTP_ERROR`); it now asserts the unconfirmed report, and the 4xx create test was renamed to state why it stays a plain failure.