### PR TITLE
fix(crossmint): keep scanning submitted approvals past an incomplete entry

### DIFF
--- a/rust/src/crossmint/mod.rs
+++ b/rust/src/crossmint/mod.rs
@@ -676,8 +676,12 @@ impl CrossmintSigner {
         let executed_message = transaction.message.serialize();
         let candidates = self.verification_candidates();
         for entry in submitted {
-            let address = entry.signer.as_ref()?.address.as_deref()?;
-            let encoded = entry.signature.as_deref()?;
+            let Some(address) = entry.signer.as_ref().and_then(|s| s.address.as_deref()) else {
+                continue;
+            };
+            let Some(encoded) = entry.signature.as_deref() else {
+                continue;
+            };
             let Ok(approver) = Pubkey::from_str(address) else {
                 continue;
             };
@@ -1437,6 +1441,70 @@ mod tests {
             .signatures
             .iter()
             .all(|s| *s == Signature::default()));
+    }
+
+    /// A quorum entry carrying neither a top-level address nor signature must not
+    /// end the scan: the wallet's approval can follow it.
+    #[tokio::test]
+    async fn test_sign_transaction_skips_submitted_approvals_without_an_address() {
+        let server = MockServer::start().await;
+        let wallet_keypair = Keypair::new();
+        let wallet_pubkey = keypair_pubkey(&wallet_keypair);
+        let sponsor_keypair = Keypair::new();
+        let sponsor_pubkey = keypair_pubkey(&sponsor_keypair);
+
+        Mock::given(method("GET"))
+            .and(path("/2025-06-09/wallets/test-wallet"))
+            .respond_with(wallet_response(&wallet_pubkey.to_string()))
+            .mount(&server)
+            .await;
+
+        let mut executed_tx = create_test_transaction(&sponsor_pubkey);
+        let sponsor_signature =
+            keypair_sign_message(&sponsor_keypair, &executed_tx.message.serialize());
+        TransactionUtil::add_signature_to_transaction(
+            &mut executed_tx,
+            &sponsor_pubkey,
+            sponsor_signature,
+        )
+        .unwrap();
+        let approval_signature =
+            keypair_sign_message(&wallet_keypair, &executed_tx.message.serialize());
+
+        Mock::given(method("POST"))
+            .and(path("/2025-06-09/wallets/test-wallet/transactions"))
+            .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
+                "id": "tx-quorum-first",
+                "status": "success",
+                "approvals": {
+                    "submitted": [
+                        { "signer": { "locator": format!("server:{wallet_pubkey}") } },
+                        {
+                            "signature": bs58::encode(approval_signature.as_ref()).into_string(),
+                            "signer": { "address": wallet_pubkey.to_string() }
+                        }
+                    ]
+                },
+                "onChain": {
+                    "transaction": bs58::encode(bincode::serialize(&executed_tx).unwrap())
+                        .into_string()
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let mut signer = create_test_signer(&server.uri(), 1, 1);
+        signer.init().await.unwrap();
+
+        let mut local_tx = create_test_transaction(&wallet_pubkey);
+        let (serialized, signature) = signer
+            .sign_transaction(&mut local_tx)
+            .await
+            .unwrap()
+            .into_signed_transaction();
+
+        assert_eq!(signature, sponsor_signature);
+        assert!(serialized.is_empty());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- `signature_from_approvals` in `rust/src/crossmint/mod.rs` used `?` on the per-entry `signer.address` and `signature` options, which returns from the whole function rather than skipping the entry. A submitted approvals list whose first entry lacks a top-level address (a quorum entry, permitted by the checked-in schema, both fields are `Option`) hid every approval after it.
- With the approval hidden, a sponsored transaction Crossmint had already broadcast fell through to the error path and surfaced as `BroadcastUnconfirmed` instead of the fee-payer transaction id, so the caller had to reconcile a transaction that in fact succeeded.
- Skips incomplete entries and keeps scanning, which is what the TypeScript (`crossmint-signer.ts`), Python (`signer.py`), and Go (`signer.go`) parsers already do. Rust was the outlier.

## Test Plan
- New `test_sign_transaction_skips_submitted_approvals_without_an_address`: submitted list is a locator-only quorum entry followed by a valid wallet approval; asserts the sponsor fee-payer signature comes back. Verified it fails on the parent branch (`BroadcastUnconfirmed`) and passes with the fix.
- `just rust-test` green across the sdk-v2 / sdk-v3 / sdk-v4 matrices (340/340/344), `just rust-fmt` clean.

## Notes
- Unrelated parity gap left alone: TypeScript also falls back to a `server:<address>` locator when `address` is absent; Rust, Python, and Go do not.

Stacked on #265.