### PR TITLE
refactor(python)!: package-wide cleanup with shared helpers and contract normalization

### DIFF
--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -12,3 +12,4 @@
 
 - verify versioned-message signatures against `0x80`-prefixed bytes, which `solders` omits from `bytes(message)` (#222)
 - scope the integration require-run guard to the requested flow so a configured backend cannot mask a skipped one (#222)
+- Fireblocks no longer waits one extra poll interval before reporting a polling timeout

--- a/python/README.md
+++ b/python/README.md
@@ -97,10 +97,10 @@ from solana_keychain import VaultSignerConfig, create_vault_signer
 
 signer = await create_vault_signer(
     VaultSignerConfig(
-        vault_addr="https://vault.example.com",
+        api_base_url="https://vault.example.com",
         token=os.environ["VAULT_TOKEN"],
         key_name="my-solana-key",
-        pubkey="4BuiY9QUUfPoAGNJBja3JapAuVWMc9c7in6UCgyC2zPR",
+        public_key="4BuiY9QUUfPoAGNJBja3JapAuVWMc9c7in6UCgyC2zPR",
     )
 )
 ```

--- a/python/src/solana_keychain/aws_kms/signer.py
+++ b/python/src/solana_keychain/aws_kms/signer.py
@@ -17,6 +17,7 @@ from solders.signature import Signature
 from solders.transaction import VersionedTransaction
 
 from solana_keychain.core.errors import SignerError, SignerErrorCode
+from solana_keychain.core.signature_util import verify_returned_signature
 from solana_keychain.core.signer import SignedTransaction, SolanaSigner
 from solana_keychain.core.transaction_util import (
     ED25519_SIGNATURE_LENGTH,
@@ -100,13 +101,7 @@ class AwsKmsSigner(SolanaSigner):
                 f"got {len(signature_bytes)}",
             )
         signature = Signature.from_bytes(signature_bytes)
-        if not signature.verify(self._pubkey, message):
-            raise SignerError(
-                SignerErrorCode.SIGNING_FAILED,
-                "Signature verification failed — the returned signature does not match "
-                "the public key",
-            )
-        return signature
+        return verify_returned_signature(signature, self._pubkey, message)
 
     async def sign_transaction(self, transaction: VersionedTransaction) -> SignedTransaction:
         signature = await self._sign_bytes(signed_message_bytes(transaction.message))

--- a/python/src/solana_keychain/cdp/jwt.py
+++ b/python/src/solana_keychain/cdp/jwt.py
@@ -2,18 +2,17 @@
 ES256 wallet token for write endpoints."""
 
 import base64
-import hashlib
-import json
 import time
 import uuid
 from typing import Any
-from urllib.parse import urlsplit
 
 try:
     import jwt as pyjwt
     from cryptography.hazmat.primitives.asymmetric import ec
     from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
     from cryptography.hazmat.primitives.serialization import load_der_private_key
+
+    from solana_keychain.core.wallet_jwt import create_es256_wallet_jwt
 except ImportError as error:  # pragma: no cover
     raise ImportError(
         "solana_keychain.cdp requires the cdp extra: pip install 'solana-keychain[cdp]'"
@@ -30,30 +29,6 @@ ED25519_KEYPAIR_LENGTH = 64
 
 def jwt_uri(host: str, method: str, path: str) -> str:
     return f"{method} {host}{path}"
-
-
-def extract_host(base_url: str) -> str:
-    """Extract the request host (including port if present) from a base URL."""
-    try:
-        parsed = urlsplit(base_url)
-        hostname = parsed.hostname
-        port = parsed.port
-    except ValueError:
-        raise SignerError(
-            SignerErrorCode.CONFIG_ERROR, f"Invalid CDP base URL: {base_url}"
-        ) from None
-    if not hostname:
-        raise SignerError(SignerErrorCode.CONFIG_ERROR, f"Missing host in CDP base URL: {base_url}")
-    return f"{hostname}:{port}" if port is not None else hostname
-
-
-def compute_req_hash(body: Any | None) -> str | None:
-    """SHA-256 hex of the request body serialized with recursively sorted keys and
-    compact separators; ``None`` for absent, null, or empty-object bodies."""
-    if body is None or body == {}:
-        return None
-    serialized = json.dumps(body, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
-    return hashlib.sha256(serialized.encode()).hexdigest()
 
 
 def _parse_ed25519_signing_key(api_key_secret: str) -> Ed25519PrivateKey:
@@ -136,21 +111,4 @@ def create_wallet_jwt(
             SignerErrorCode.INVALID_PRIVATE_KEY,
             "Failed to parse walletSecret as EC private key",
         )
-
-    now = int(time.time())
-    claims: dict[str, Any] = {
-        "uris": [jwt_uri(host, method, path)],
-        "iat": now,
-        "nbf": now,
-        "exp": now + JWT_TTL_SECONDS,
-        "jti": str(uuid.uuid4()),
-    }
-    req_hash = compute_req_hash(request_body)
-    if req_hash is not None:
-        claims["reqHash"] = req_hash
-    try:
-        return pyjwt.encode(claims, signing_key, algorithm="ES256", headers={"typ": "JWT"})
-    except Exception:
-        raise SignerError(
-            SignerErrorCode.SIGNING_FAILED, "Failed to create CDP wallet JWT"
-        ) from None
+    return create_es256_wallet_jwt(signing_key, host, method, path, request_body, "CDP")

--- a/python/src/solana_keychain/cdp/signer.py
+++ b/python/src/solana_keychain/cdp/signer.py
@@ -16,7 +16,7 @@ from solders.pubkey import Pubkey
 from solders.signature import Signature
 from solders.transaction import VersionedTransaction
 
-from solana_keychain.cdp.jwt import create_auth_jwt, create_wallet_jwt, extract_host
+from solana_keychain.cdp.jwt import create_auth_jwt, create_wallet_jwt
 from solana_keychain.core.errors import SignerError, SignerErrorCode
 from solana_keychain.core.http import assert_https_url, fetch_signer_json, normalize_base_url
 from solana_keychain.core.signature_util import verify_returned_signature
@@ -29,6 +29,7 @@ from solana_keychain.core.transaction_util import (
     serialize_transaction,
     signed_message_bytes,
 )
+from solana_keychain.core.wallet_jwt import extract_host
 
 DEFAULT_API_BASE_URL = "https://api.cdp.coinbase.com"
 BASE_PATH = "/platform/v2/solana/accounts"
@@ -77,7 +78,7 @@ class CdpSigner(SolanaSigner):
         api_base_url = normalize_base_url(config.api_base_url)
         assert_https_url(api_base_url, "api_base_url")
         self._api_base_url = api_base_url
-        self._api_host = extract_host(api_base_url)
+        self._api_host = extract_host(api_base_url, "CDP")
         self._api_key_id = config.api_key_id
         self._api_key_secret = config.api_key_secret
         self._wallet_secret = config.wallet_secret

--- a/python/src/solana_keychain/cdp/signer.py
+++ b/python/src/solana_keychain/cdp/signer.py
@@ -18,7 +18,12 @@ from solders.transaction import VersionedTransaction
 
 from solana_keychain.cdp.jwt import create_auth_jwt, create_wallet_jwt
 from solana_keychain.core.errors import SignerError, SignerErrorCode
-from solana_keychain.core.http import assert_https_url, fetch_signer_json, normalize_base_url
+from solana_keychain.core.http import (
+    assert_https_url,
+    fetch_signer_json,
+    normalize_base_url,
+    probe_availability,
+)
 from solana_keychain.core.signature_util import verify_returned_signature
 from solana_keychain.core.signer import SignedTransaction, SolanaSigner
 from solana_keychain.core.transaction_util import (
@@ -184,7 +189,8 @@ class CdpSigner(SolanaSigner):
 
     async def is_available(self) -> bool:
         path = f"{BASE_PATH}/{self._pubkey}"
-        try:
+
+        async def probe() -> bool:
             auth_token = create_auth_jwt(
                 self._api_key_id, self._api_key_secret, self._api_host, "GET", path
             )
@@ -194,9 +200,9 @@ class CdpSigner(SolanaSigner):
                 headers={"Authorization": f"Bearer {auth_token}"},
                 client=self._http_client,
             )
-        except SignerError:
-            return False
-        return True
+            return True
+
+        return await probe_availability(probe)
 
 
 async def create_cdp_signer(config: CdpSignerConfig) -> CdpSigner:

--- a/python/src/solana_keychain/cdp/signer.py
+++ b/python/src/solana_keychain/cdp/signer.py
@@ -19,6 +19,7 @@ from solders.transaction import VersionedTransaction
 from solana_keychain.cdp.jwt import create_auth_jwt, create_wallet_jwt, extract_host
 from solana_keychain.core.errors import SignerError, SignerErrorCode
 from solana_keychain.core.http import assert_https_url, fetch_signer_json, normalize_base_url
+from solana_keychain.core.signature_util import verify_returned_signature
 from solana_keychain.core.signer import SignedTransaction, SolanaSigner
 from solana_keychain.core.transaction_util import (
     ED25519_SIGNATURE_LENGTH,
@@ -135,13 +136,7 @@ class CdpSigner(SolanaSigner):
                 f"Invalid signature length from CDP (expected {ED25519_SIGNATURE_LENGTH} bytes)",
             )
         signature = Signature.from_bytes(signature_bytes)
-        if not signature.verify(self._pubkey, message):
-            raise SignerError(
-                SignerErrorCode.SIGNING_FAILED,
-                "Signature verification failed — the returned signature does not match "
-                "the public key",
-            )
-        return signature
+        return verify_returned_signature(signature, self._pubkey, message)
 
     async def sign_transaction(self, transaction: VersionedTransaction) -> SignedTransaction:
         message_data = signed_message_bytes(transaction.message)
@@ -179,12 +174,7 @@ class CdpSigner(SolanaSigner):
                 "Signature not found at expected position in CDP response",
             )
         signature = signatures[position]
-        if not signature.verify(self._pubkey, message_data):
-            raise SignerError(
-                SignerErrorCode.SIGNING_FAILED,
-                "Signature verification failed — the returned signature does not match "
-                "the public key",
-            )
+        verify_returned_signature(signature, self._pubkey, message_data)
 
         add_signature_to_transaction(transaction, self._pubkey, signature)
         return classify_signed_transaction(

--- a/python/src/solana_keychain/core/__init__.py
+++ b/python/src/solana_keychain/core/__init__.py
@@ -7,7 +7,7 @@ from solana_keychain.core.http import (
     sanitize_remote_error_response,
 )
 from solana_keychain.core.signature_util import verify_returned_signature
-from solana_keychain.core.signer import SignedTransaction, SolanaSigner
+from solana_keychain.core.signer import SignedTransaction, SolanaSigner, require_initialized
 from solana_keychain.core.transaction_util import (
     ED25519_SIGNATURE_LENGTH,
     add_signature_to_transaction,
@@ -32,6 +32,7 @@ __all__ = [
     "get_signing_keypair_position",
     "has_all_required_signatures",
     "normalize_base_url",
+    "require_initialized",
     "sanitize_remote_error_response",
     "serialize_transaction",
     "signed_message_bytes",

--- a/python/src/solana_keychain/core/__init__.py
+++ b/python/src/solana_keychain/core/__init__.py
@@ -6,6 +6,7 @@ from solana_keychain.core.http import (
     normalize_base_url,
     sanitize_remote_error_response,
 )
+from solana_keychain.core.signature_util import verify_returned_signature
 from solana_keychain.core.signer import SignedTransaction, SolanaSigner
 from solana_keychain.core.transaction_util import (
     ED25519_SIGNATURE_LENGTH,
@@ -34,4 +35,5 @@ __all__ = [
     "sanitize_remote_error_response",
     "serialize_transaction",
     "signed_message_bytes",
+    "verify_returned_signature",
 ]

--- a/python/src/solana_keychain/core/http.py
+++ b/python/src/solana_keychain/core/http.py
@@ -1,7 +1,9 @@
 """HTTPS-enforcing HTTP pipeline for remote signer backends."""
 
+import asyncio
 import os
 import re
+from collections.abc import Awaitable, Callable
 from typing import Any
 from urllib.parse import urlsplit
 
@@ -10,6 +12,7 @@ import httpx
 from solana_keychain.core.errors import SignerError, SignerErrorCode
 
 DEFAULT_REQUEST_TIMEOUT_SECONDS = 60.0
+AVAILABILITY_TIMEOUT_SECONDS = 5.0
 DEFAULT_REMOTE_ERROR_RESPONSE_MAX_LENGTH = 256
 
 _LOOPBACK_HOSTNAMES = frozenset({"localhost", "127.0.0.1", "::1"})
@@ -64,6 +67,19 @@ def sanitize_remote_error_response(
     if len(normalized) <= max_length:
         return normalized
     return f"{normalized[:max_length]} [truncated]"
+
+
+async def probe_availability(probe: Callable[[], Awaitable[bool]]) -> bool:
+    """Run a backend health probe under the shared availability timeout.
+
+    Any failure means unavailable: a signer error, a timeout, or an exception from
+    caller-supplied credential machinery all report ``False`` rather than raising,
+    since the contract returns a bool. Cancellation still propagates.
+    """
+    try:
+        return await asyncio.wait_for(probe(), AVAILABILITY_TIMEOUT_SECONDS)
+    except Exception:
+        return False
 
 
 def provider_may_have_accepted(status_code: int | None) -> bool:

--- a/python/src/solana_keychain/core/poll.py
+++ b/python/src/solana_keychain/core/poll.py
@@ -1,0 +1,14 @@
+"""Attempt pacing for backends that poll a provider until a transaction settles."""
+
+import asyncio
+from collections.abc import AsyncIterator
+
+
+async def poll_attempts(max_attempts: int, interval_ms: int) -> AsyncIterator[int]:
+    """Yield attempt indices ``0..max_attempts-1``, sleeping ``interval_ms`` before
+    every attempt but the first, so a caller that exhausts the loop reports its
+    timeout without waiting out one more interval."""
+    for attempt in range(max_attempts):
+        if attempt:
+            await asyncio.sleep(interval_ms / 1000)
+        yield attempt

--- a/python/src/solana_keychain/core/signature_util.py
+++ b/python/src/solana_keychain/core/signature_util.py
@@ -1,0 +1,20 @@
+"""Signature verification shared by every backend that receives signatures from a
+remote service."""
+
+from solders.pubkey import Pubkey
+from solders.signature import Signature
+
+from solana_keychain.core.errors import SignerError, SignerErrorCode
+
+
+def verify_returned_signature(
+    signature: Signature, public_key: Pubkey, message: bytes
+) -> Signature:
+    """Verify a signature returned by a signing backend against the expected public
+    key and message, raising ``SIGNING_FAILED`` on mismatch."""
+    if not signature.verify(public_key, message):
+        raise SignerError(
+            SignerErrorCode.SIGNING_FAILED,
+            "Signature verification failed: the returned signature does not match the public key",
+        )
+    return signature

--- a/python/src/solana_keychain/core/signer.py
+++ b/python/src/solana_keychain/core/signer.py
@@ -2,10 +2,26 @@
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
+from typing import TypeVar
 
 from solders.pubkey import Pubkey
 from solders.signature import Signature
 from solders.transaction import VersionedTransaction
+
+from solana_keychain.core.errors import SignerError, SignerErrorCode
+
+_T = TypeVar("_T")
+
+
+def require_initialized(value: _T | None, signer_name: str) -> _T:
+    """Return state resolved by ``init()``, raising ``NOT_INITIALIZED`` when the
+    signer has not been initialized yet."""
+    if value is None:
+        raise SignerError(
+            SignerErrorCode.NOT_INITIALIZED,
+            f"{signer_name} is not initialized; call init() before signing",
+        )
+    return value
 
 
 @dataclass(frozen=True)

--- a/python/src/solana_keychain/core/wallet_jwt.py
+++ b/python/src/solana_keychain/core/wallet_jwt.py
@@ -1,0 +1,75 @@
+"""ES256 wallet-auth JWT building for backends that stamp write requests with a
+hash of the exact request body.
+
+Requires ``pyjwt`` and ``cryptography``; import it from a backend module whose
+extra provides them.
+"""
+
+import hashlib
+import json
+import time
+import uuid
+from typing import Any
+from urllib.parse import urlsplit
+
+import jwt as pyjwt
+from cryptography.hazmat.primitives.asymmetric import ec
+
+from solana_keychain.core.errors import SignerError, SignerErrorCode
+
+WALLET_JWT_TTL_SECONDS = 120
+
+
+def extract_host(base_url: str, provider_name: str) -> str:
+    """Extract the request host (including port if present) from a base URL."""
+    try:
+        parsed = urlsplit(base_url)
+        hostname = parsed.hostname
+        port = parsed.port
+    except ValueError:
+        raise SignerError(
+            SignerErrorCode.CONFIG_ERROR, f"Invalid {provider_name} base URL: {base_url}"
+        ) from None
+    if not hostname:
+        raise SignerError(
+            SignerErrorCode.CONFIG_ERROR, f"Missing host in {provider_name} base URL: {base_url}"
+        )
+    return f"{hostname}:{port}" if port is not None else hostname
+
+
+def compute_req_hash(body: Any | None) -> str | None:
+    """SHA-256 hex of the request body serialized with recursively sorted keys and
+    compact separators; ``None`` for absent, null, or empty-object bodies."""
+    if body is None or body == {}:
+        return None
+    serialized = json.dumps(body, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return hashlib.sha256(serialized.encode()).hexdigest()
+
+
+def create_es256_wallet_jwt(
+    signing_key: ec.EllipticCurvePrivateKey,
+    host: str,
+    method: str,
+    path: str,
+    request_body: Any | None,
+    provider_name: str,
+) -> str:
+    """Build an ES256 wallet-auth JWT scoped to a single request URI, carrying
+    ``reqHash`` over the sorted request body when one is present."""
+    now = int(time.time())
+    claims: dict[str, Any] = {
+        "uris": [f"{method} {host}{path}"],
+        "iat": now,
+        "nbf": now,
+        "exp": now + WALLET_JWT_TTL_SECONDS,
+        "jti": str(uuid.uuid4()),
+    }
+    req_hash = compute_req_hash(request_body)
+    if req_hash is not None:
+        claims["reqHash"] = req_hash
+    try:
+        return pyjwt.encode(claims, signing_key, algorithm="ES256", headers={"typ": "JWT"})
+    except Exception:
+        raise SignerError(
+            SignerErrorCode.SIGNING_FAILED, f"Failed to create {provider_name} wallet JWT"
+        ) from None

--- a/python/src/solana_keychain/crossmint/signer.py
+++ b/python/src/solana_keychain/crossmint/signer.py
@@ -22,7 +22,11 @@ from solana_keychain.core.http import (
     normalize_base_url,
     provider_may_have_accepted,
 )
-from solana_keychain.core.signer import SignedTransaction, SolanaSigner
+from solana_keychain.core.signer import (
+    SignedTransaction,
+    SolanaSigner,
+    require_initialized,
+)
 from solana_keychain.core.transaction_util import (
     ED25519_SIGNATURE_LENGTH,
     add_signature_to_transaction,
@@ -228,12 +232,7 @@ class CrossmintSigner(SolanaSigner):
             ) from None
 
     def _initialized_pubkey(self) -> Pubkey:
-        if self._public_key is None:
-            raise SignerError(
-                SignerErrorCode.NOT_INITIALIZED,
-                "CrossmintSigner is not initialized; call init() before signing",
-            )
-        return self._public_key
+        return require_initialized(self._public_key, "CrossmintSigner")
 
     @property
     def pubkey(self) -> Pubkey:

--- a/python/src/solana_keychain/crossmint/signer.py
+++ b/python/src/solana_keychain/crossmint/signer.py
@@ -20,6 +20,7 @@ from solana_keychain.core.http import (
     assert_https_url,
     fetch_signer_json,
     normalize_base_url,
+    probe_availability,
     provider_may_have_accepted,
 )
 from solana_keychain.core.signer import (
@@ -43,7 +44,6 @@ DEFAULT_API_BASE_URL = "https://www.crossmint.com/api"
 API_VERSION_PATH = "2025-06-09"
 DEFAULT_POLL_INTERVAL_MS = 1000
 DEFAULT_MAX_POLL_ATTEMPTS = 60
-AVAILABILITY_TIMEOUT_SECONDS = 5.0
 
 
 _AWAITING_APPROVAL_ERROR = (
@@ -654,11 +654,11 @@ class CrossmintSigner(SolanaSigner):
         )
 
     async def is_available(self) -> bool:
-        try:
-            await asyncio.wait_for(self._fetch_wallet(), AVAILABILITY_TIMEOUT_SECONDS)
-        except (SignerError, asyncio.TimeoutError):
-            return False
-        return True
+        async def probe() -> bool:
+            await self._fetch_wallet()
+            return True
+
+        return await probe_availability(probe)
 
 
 async def create_crossmint_signer(config: CrossmintSignerConfig) -> CrossmintSigner:

--- a/python/src/solana_keychain/crossmint/signer.py
+++ b/python/src/solana_keychain/crossmint/signer.py
@@ -290,18 +290,24 @@ class CrossmintSigner(SolanaSigner):
         error = response.get("error")
         return json.dumps(error) if error is not None else "unknown error"
 
+    def _settled_or_none(self, response: dict[str, Any]) -> dict[str, Any] | None:
+        status = response.get("status")
+        if status == "success":
+            return response
+        if status == "failed":
+            raise SignerError(
+                SignerErrorCode.SIGNING_FAILED,
+                f"Crossmint transaction failed: {self._failure_detail(response)}",
+            )
+        return None
+
     async def _poll_transaction(self, response: dict[str, Any]) -> dict[str, Any]:
         approval_submitted = False
         for _ in range(self._max_poll_attempts):
-            status = response.get("status")
-            if status == "success":
-                return response
-            if status == "failed":
-                raise SignerError(
-                    SignerErrorCode.SIGNING_FAILED,
-                    f"Crossmint transaction failed: {self._failure_detail(response)}",
-                )
-            if status == "awaiting-approval" and not approval_submitted:
+            settled = self._settled_or_none(response)
+            if settled is not None:
+                return settled
+            if response.get("status") == "awaiting-approval" and not approval_submitted:
                 # Approve at most once; the approval may register asynchronously,
                 # so afterwards awaiting-approval re-polls like any other
                 # in-flight status.
@@ -311,15 +317,10 @@ class CrossmintSigner(SolanaSigner):
             await asyncio.sleep(self._poll_interval_ms / 1000)
             response = await self._get_transaction(str(response.get("id")))
 
-        status = response.get("status")
-        if status == "success":
-            return response
-        if status == "failed":
-            raise SignerError(
-                SignerErrorCode.SIGNING_FAILED,
-                f"Crossmint transaction failed: {self._failure_detail(response)}",
-            )
-        if status == "awaiting-approval" and not approval_submitted:
+        settled = self._settled_or_none(response)
+        if settled is not None:
+            return settled
+        if response.get("status") == "awaiting-approval" and not approval_submitted:
             raise SignerError(SignerErrorCode.SIGNING_FAILED, _AWAITING_APPROVAL_ERROR)
         raise SignerError(
             SignerErrorCode.REMOTE_API_ERROR,

--- a/python/src/solana_keychain/dfns/signer.py
+++ b/python/src/solana_keychain/dfns/signer.py
@@ -11,6 +11,7 @@ from solders.transaction import VersionedTransaction
 
 from solana_keychain.core.errors import SignerError, SignerErrorCode
 from solana_keychain.core.http import assert_https_url, fetch_signer_json, normalize_base_url
+from solana_keychain.core.signature_util import verify_returned_signature
 from solana_keychain.core.signer import SignedTransaction, SolanaSigner
 from solana_keychain.core.transaction_util import (
     ED25519_SIGNATURE_LENGTH,
@@ -213,13 +214,7 @@ class DfnsSigner(SolanaSigner):
         signature = await self._send_signature_request(
             {"kind": "Message", "message": f"0x{message.hex()}"}
         )
-        if not signature.verify(public_key, message):
-            raise SignerError(
-                SignerErrorCode.SIGNING_FAILED,
-                "Signature verification failed — the returned signature does not match "
-                "the public key",
-            )
-        return signature
+        return verify_returned_signature(signature, public_key, message)
 
     async def sign_transaction(self, transaction: VersionedTransaction) -> SignedTransaction:
         public_key, _ = self._initialized()
@@ -230,12 +225,7 @@ class DfnsSigner(SolanaSigner):
                 "blockchainKind": "Solana",
             }
         )
-        if not signature.verify(public_key, signed_message_bytes(transaction.message)):
-            raise SignerError(
-                SignerErrorCode.SIGNING_FAILED,
-                "Signature verification failed — the returned signature does not match "
-                "the public key",
-            )
+        verify_returned_signature(signature, public_key, signed_message_bytes(transaction.message))
         add_signature_to_transaction(transaction, public_key, signature)
         return classify_signed_transaction(
             transaction, serialize_transaction(transaction), signature

--- a/python/src/solana_keychain/dfns/signer.py
+++ b/python/src/solana_keychain/dfns/signer.py
@@ -12,7 +12,11 @@ from solders.transaction import VersionedTransaction
 from solana_keychain.core.errors import SignerError, SignerErrorCode
 from solana_keychain.core.http import assert_https_url, fetch_signer_json, normalize_base_url
 from solana_keychain.core.signature_util import verify_returned_signature
-from solana_keychain.core.signer import SignedTransaction, SolanaSigner
+from solana_keychain.core.signer import (
+    SignedTransaction,
+    SolanaSigner,
+    require_initialized,
+)
 from solana_keychain.core.transaction_util import (
     ED25519_SIGNATURE_LENGTH,
     add_signature_to_transaction,
@@ -125,12 +129,10 @@ class DfnsSigner(SolanaSigner):
         self._key_id = key_id
 
     def _initialized(self) -> tuple[Pubkey, str]:
-        if self._public_key is None or self._key_id is None:
-            raise SignerError(
-                SignerErrorCode.NOT_INITIALIZED,
-                "DfnsSigner is not initialized; call init() before signing",
-            )
-        return self._public_key, self._key_id
+        return (
+            require_initialized(self._public_key, "DfnsSigner"),
+            require_initialized(self._key_id, "DfnsSigner"),
+        )
 
     @property
     def pubkey(self) -> Pubkey:

--- a/python/src/solana_keychain/dfns/signer.py
+++ b/python/src/solana_keychain/dfns/signer.py
@@ -10,7 +10,12 @@ from solders.signature import Signature
 from solders.transaction import VersionedTransaction
 
 from solana_keychain.core.errors import SignerError, SignerErrorCode
-from solana_keychain.core.http import assert_https_url, fetch_signer_json, normalize_base_url
+from solana_keychain.core.http import (
+    assert_https_url,
+    fetch_signer_json,
+    normalize_base_url,
+    probe_availability,
+)
 from solana_keychain.core.signature_util import verify_returned_signature
 from solana_keychain.core.signer import (
     SignedTransaction,
@@ -234,14 +239,16 @@ class DfnsSigner(SolanaSigner):
         )
 
     async def is_available(self) -> bool:
-        try:
+        async def probe() -> bool:
             wallet = await self._get_wallet()
             _, scheme, curve, _ = self._signing_key_fields(wallet)
-        except SignerError:
-            return False
-        return (
-            str(wallet.get("status", "")) == "Active" and scheme == "EdDSA" and curve == "ed25519"
-        )
+            return (
+                str(wallet.get("status", "")) == "Active"
+                and scheme == "EdDSA"
+                and curve == "ed25519"
+            )
+
+        return await probe_availability(probe)
 
 
 async def create_dfns_signer(config: DfnsSignerConfig) -> DfnsSigner:

--- a/python/src/solana_keychain/fireblocks/signer.py
+++ b/python/src/solana_keychain/fireblocks/signer.py
@@ -15,7 +15,11 @@ from solders.transaction import VersionedTransaction
 from solana_keychain.core.errors import SignerError, SignerErrorCode
 from solana_keychain.core.http import assert_https_url, fetch_signer_json, normalize_base_url
 from solana_keychain.core.signature_util import verify_returned_signature
-from solana_keychain.core.signer import SignedTransaction, SolanaSigner
+from solana_keychain.core.signer import (
+    SignedTransaction,
+    SolanaSigner,
+    require_initialized,
+)
 from solana_keychain.core.transaction_util import (
     ED25519_SIGNATURE_LENGTH,
     add_signature_to_transaction,
@@ -102,12 +106,7 @@ class FireblocksSigner(SolanaSigner):
         self._public_key = await self._fetch_public_key()
 
     def _initialized_pubkey(self) -> Pubkey:
-        if self._public_key is None:
-            raise SignerError(
-                SignerErrorCode.NOT_INITIALIZED,
-                "FireblocksSigner is not initialized; call init() before signing",
-            )
-        return self._public_key
+        return require_initialized(self._public_key, "FireblocksSigner")
 
     @property
     def pubkey(self) -> Pubkey:

--- a/python/src/solana_keychain/fireblocks/signer.py
+++ b/python/src/solana_keychain/fireblocks/signer.py
@@ -12,7 +12,12 @@ from solders.signature import Signature
 from solders.transaction import VersionedTransaction
 
 from solana_keychain.core.errors import SignerError, SignerErrorCode
-from solana_keychain.core.http import assert_https_url, fetch_signer_json, normalize_base_url
+from solana_keychain.core.http import (
+    assert_https_url,
+    fetch_signer_json,
+    normalize_base_url,
+    probe_availability,
+)
 from solana_keychain.core.poll import poll_attempts
 from solana_keychain.core.signature_util import verify_returned_signature
 from solana_keychain.core.signer import (
@@ -323,11 +328,12 @@ class FireblocksSigner(SolanaSigner):
     async def is_available(self) -> bool:
         if self._public_key is None:
             return False
-        try:
+
+        async def probe() -> bool:
             await self._get_json(f"/v1/vault/accounts/{quote(self._vault_account_id, safe='')}")
-        except SignerError:
-            return False
-        return True
+            return True
+
+        return await probe_availability(probe)
 
 
 async def create_fireblocks_signer(config: FireblocksSignerConfig) -> FireblocksSigner:

--- a/python/src/solana_keychain/fireblocks/signer.py
+++ b/python/src/solana_keychain/fireblocks/signer.py
@@ -1,6 +1,5 @@
 """Fireblocks API signer integration."""
 
-import asyncio
 import json
 from dataclasses import dataclass, field
 from typing import Any
@@ -14,6 +13,7 @@ from solders.transaction import VersionedTransaction
 
 from solana_keychain.core.errors import SignerError, SignerErrorCode
 from solana_keychain.core.http import assert_https_url, fetch_signer_json, normalize_base_url
+from solana_keychain.core.poll import poll_attempts
 from solana_keychain.core.signature_util import verify_returned_signature
 from solana_keychain.core.signer import (
     SignedTransaction,
@@ -194,7 +194,7 @@ class FireblocksSigner(SolanaSigner):
     async def _poll_for_signature(
         self, transaction_id: str, *, program_call: bool = False
     ) -> dict[str, Any]:
-        for _ in range(self._max_poll_attempts):
+        async for _ in poll_attempts(self._max_poll_attempts, self._poll_interval_ms):
             response = await self._get_json(f"/v1/transactions/{quote(transaction_id, safe='')}")
             if not isinstance(response, dict):
                 raise SignerError(SignerErrorCode.SERIALIZATION_ERROR, "Failed to parse response")
@@ -215,7 +215,6 @@ class FireblocksSigner(SolanaSigner):
                 raise SignerError(
                     SignerErrorCode.SIGNING_FAILED, f"Transaction {status}: {transaction_id}"
                 )
-            await asyncio.sleep(self._poll_interval_ms / 1000)
         raise SignerError(
             SignerErrorCode.REMOTE_API_ERROR,
             f"Transaction polling timeout after {self._max_poll_attempts} attempts - "

--- a/python/src/solana_keychain/fireblocks/signer.py
+++ b/python/src/solana_keychain/fireblocks/signer.py
@@ -14,6 +14,7 @@ from solders.transaction import VersionedTransaction
 
 from solana_keychain.core.errors import SignerError, SignerErrorCode
 from solana_keychain.core.http import assert_https_url, fetch_signer_json, normalize_base_url
+from solana_keychain.core.signature_util import verify_returned_signature
 from solana_keychain.core.signer import SignedTransaction, SolanaSigner
 from solana_keychain.core.transaction_util import (
     ED25519_SIGNATURE_LENGTH,
@@ -270,7 +271,7 @@ class FireblocksSigner(SolanaSigner):
         )
         response = await self._poll_for_signature(transaction_id)
         signature = self._extract_signature(response)
-        self._assert_signature_matches(signature, public_key, message)
+        verify_returned_signature(signature, public_key, message)
         return signature
 
     async def _sign_program_call(
@@ -303,17 +304,8 @@ class FireblocksSigner(SolanaSigner):
         )
         response = await self._poll_for_signature(transaction_id, program_call=True)
         signature = self._extract_signature(response, allow_tx_hash_carrier=True)
-        self._assert_signature_matches(signature, public_key, message)
+        verify_returned_signature(signature, public_key, message)
         return signature
-
-    @staticmethod
-    def _assert_signature_matches(signature: Signature, public_key: Pubkey, message: bytes) -> None:
-        if not signature.verify(public_key, message):
-            raise SignerError(
-                SignerErrorCode.SIGNING_FAILED,
-                "Signature verification failed — the returned signature does not match "
-                "the public key",
-            )
 
     async def sign_transaction(self, transaction: VersionedTransaction) -> SignedTransaction:
         message = signed_message_bytes(transaction.message)

--- a/python/src/solana_keychain/fordefi/signer.py
+++ b/python/src/solana_keychain/fordefi/signer.py
@@ -27,6 +27,7 @@ from solana_keychain.core.http import (
     normalize_base_url,
     provider_may_have_accepted,
 )
+from solana_keychain.core.poll import poll_attempts
 from solana_keychain.core.signature_util import verify_returned_signature
 from solana_keychain.core.signer import SignedTransaction, SolanaSigner
 from solana_keychain.core.transaction_util import (
@@ -280,7 +281,7 @@ class FordefiSigner(SolanaSigner):
 
     async def _poll_for_result(self, transaction_id: str, *, pushable: bool) -> dict[str, Any]:
         success_states = _PUSHABLE_SUCCESS_STATES if pushable else _NON_PUSHABLE_SUCCESS_STATES
-        for attempt in range(self._max_poll_attempts):
+        async for _ in poll_attempts(self._max_poll_attempts, self._poll_interval_ms):
             response = await self._get_json(
                 f"/api/v1/transactions/{quote(transaction_id, safe='')}"
             )
@@ -294,8 +295,6 @@ class FordefiSigner(SolanaSigner):
                     SignerErrorCode.SIGNING_FAILED,
                     f"Transaction {transaction_id} reached terminal state: {state}",
                 )
-            if attempt + 1 < self._max_poll_attempts:
-                await asyncio.sleep(self._poll_interval_ms / 1000)
         raise SignerError(
             SignerErrorCode.REMOTE_API_ERROR,
             f"Polling timeout after {self._max_poll_attempts} attempts",

--- a/python/src/solana_keychain/fordefi/signer.py
+++ b/python/src/solana_keychain/fordefi/signer.py
@@ -27,6 +27,7 @@ from solana_keychain.core.http import (
     normalize_base_url,
     provider_may_have_accepted,
 )
+from solana_keychain.core.signature_util import verify_returned_signature
 from solana_keychain.core.signer import SignedTransaction, SolanaSigner
 from solana_keychain.core.transaction_util import (
     ED25519_SIGNATURE_LENGTH,
@@ -329,14 +330,6 @@ class FordefiSigner(SolanaSigner):
         result = await self._poll_for_result(transaction_id, pushable=False)
         return self._extract_signature(result)
 
-    def _verify_signature(self, signature: Signature, message: bytes) -> None:
-        if not signature.verify(self._public_key, message):
-            raise SignerError(
-                SignerErrorCode.SIGNING_FAILED,
-                "Signature verification failed — the returned signature does not match "
-                "the public key",
-            )
-
     async def sign_transaction(self, transaction: VersionedTransaction) -> SignedTransaction:
         """Sign ``transaction`` via Fordefi MPC.
 
@@ -367,7 +360,7 @@ class FordefiSigner(SolanaSigner):
             return await self._sign_transaction_native(transaction)
         message_data = signed_message_bytes(transaction.message)
         signature = await self._sign_black_box(message_data)
-        self._verify_signature(signature, message_data)
+        verify_returned_signature(signature, self._public_key, message_data)
         add_signature_to_transaction(transaction, self._public_key, signature)
         return classify_signed_transaction(
             transaction, serialize_transaction(transaction), signature
@@ -462,7 +455,9 @@ class FordefiSigner(SolanaSigner):
                 "Fordefi signature slot missing from returned transaction",
             )
         signature = signatures[position]
-        self._verify_signature(signature, signed_message_bytes(returned.message))
+        verify_returned_signature(
+            signature, self._public_key, signed_message_bytes(returned.message)
+        )
         return classify_signed_transaction(returned, "", signature)
 
     async def sign_message(self, message: bytes) -> Signature:
@@ -472,7 +467,7 @@ class FordefiSigner(SolanaSigner):
             signature = self._extract_signature(result)
         else:
             signature = await self._sign_black_box(message)
-        self._verify_signature(signature, message)
+        verify_returned_signature(signature, self._public_key, message)
         return signature
 
     async def _fetch_vault(self, timeout_seconds: float) -> dict[str, Any]:

--- a/python/src/solana_keychain/fordefi/signer.py
+++ b/python/src/solana_keychain/fordefi/signer.py
@@ -21,10 +21,12 @@ from solders.transaction import VersionedTransaction
 
 from solana_keychain.core.errors import SignerError, SignerErrorCode
 from solana_keychain.core.http import (
+    AVAILABILITY_TIMEOUT_SECONDS,
     DEFAULT_REQUEST_TIMEOUT_SECONDS,
     assert_https_url,
     fetch_signer_json,
     normalize_base_url,
+    probe_availability,
     provider_may_have_accepted,
 )
 from solana_keychain.core.poll import poll_attempts
@@ -48,7 +50,6 @@ DEFAULT_POLL_INTERVAL_MS = 2000
 DEFAULT_MAX_POLL_ATTEMPTS = 50
 SUPPORTED_CHAINS = ("solana_devnet", "solana_mainnet")
 
-_AVAILABILITY_TIMEOUT_SECONDS = 5.0
 _VAULT_VERIFICATION_TIMEOUT_SECONDS = 10.0
 
 _PUSHABLE_SUCCESS_STATES = frozenset({"completed"})
@@ -518,15 +519,12 @@ class FordefiSigner(SolanaSigner):
         """Readiness probe: the vault is reachable with the bearer token and the
         request signer can produce an ``x-signature`` value."""
 
-        async def probe() -> None:
-            await self._fetch_vault(_AVAILABILITY_TIMEOUT_SECONDS)
+        async def probe() -> bool:
+            await self._fetch_vault(AVAILABILITY_TIMEOUT_SECONDS)
             await self._sign_request("/api/v1/vaults", _timestamp_ms(), "")
+            return True
 
-        try:
-            await asyncio.wait_for(probe(), timeout=_AVAILABILITY_TIMEOUT_SECONDS)
-        except Exception:
-            return False
-        return True
+        return await probe_availability(probe)
 
 
 async def create_fordefi_signer(config: FordefiSignerConfig) -> FordefiSigner:

--- a/python/src/solana_keychain/gcp_kms/signer.py
+++ b/python/src/solana_keychain/gcp_kms/signer.py
@@ -17,6 +17,7 @@ from solders.signature import Signature
 from solders.transaction import VersionedTransaction
 
 from solana_keychain.core.errors import SignerError, SignerErrorCode
+from solana_keychain.core.signature_util import verify_returned_signature
 from solana_keychain.core.signer import SignedTransaction, SolanaSigner
 from solana_keychain.core.transaction_util import (
     ED25519_SIGNATURE_LENGTH,
@@ -90,13 +91,7 @@ class GcpKmsSigner(SolanaSigner):
                 f"got {len(signature_bytes)}",
             )
         signature = Signature.from_bytes(signature_bytes)
-        if not signature.verify(self._pubkey, message):
-            raise SignerError(
-                SignerErrorCode.SIGNING_FAILED,
-                "Signature verification failed — the returned signature does not match "
-                "the public key",
-            )
-        return signature
+        return verify_returned_signature(signature, self._pubkey, message)
 
     async def sign_transaction(self, transaction: VersionedTransaction) -> SignedTransaction:
         signature = await self._sign_bytes(signed_message_bytes(transaction.message))

--- a/python/src/solana_keychain/openfort/jwt.py
+++ b/python/src/solana_keychain/openfort/jwt.py
@@ -1,17 +1,13 @@
 """Openfort wallet-auth JWT: an ES256 token signed by the project's wallet secret,
 carrying a hash of the exact request body."""
 
-import hashlib
-import json
-import time
-import uuid
 from typing import Any
-from urllib.parse import urlsplit
 
 try:
-    import jwt as pyjwt
     from cryptography.hazmat.primitives.asymmetric import ec
     from cryptography.hazmat.primitives.serialization import load_pem_private_key
+
+    from solana_keychain.core.wallet_jwt import create_es256_wallet_jwt
 except ImportError as error:  # pragma: no cover
     raise ImportError(
         "solana_keychain.openfort requires the openfort extra: "
@@ -19,32 +15,6 @@ except ImportError as error:  # pragma: no cover
     ) from error
 
 from solana_keychain.core.errors import SignerError, SignerErrorCode
-
-JWT_LIFETIME_SECONDS = 120
-
-
-def extract_host(base_url: str) -> str:
-    """Extract the request host (including port if present) from a base URL."""
-    try:
-        parsed = urlsplit(base_url)
-        hostname = parsed.hostname
-        port = parsed.port
-    except ValueError:
-        raise SignerError(
-            SignerErrorCode.CONFIG_ERROR, f"Invalid Openfort base URL: {base_url}"
-        ) from None
-    if not hostname:
-        raise SignerError(
-            SignerErrorCode.CONFIG_ERROR, f"Missing host in Openfort base URL: {base_url}"
-        )
-    return f"{hostname}:{port}" if port is not None else hostname
-
-
-def compute_req_hash(body: Any) -> str:
-    """SHA-256 hex of the request body serialized with recursively sorted keys and
-    compact separators."""
-    serialized = json.dumps(body, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
-    return hashlib.sha256(serialized.encode()).hexdigest()
 
 
 def _wallet_secret_to_pem(wallet_secret: str) -> str:
@@ -76,19 +46,4 @@ def create_wallet_jwt(
             "Failed to parse Openfort wallet secret as EC P-256 private key "
             "(expected base64 PKCS#8 DER or PEM)",
         )
-
-    now = int(time.time())
-    claims = {
-        "uris": [f"{method} {host}{path}"],
-        "iat": now,
-        "nbf": now,
-        "exp": now + JWT_LIFETIME_SECONDS,
-        "jti": str(uuid.uuid4()),
-        "reqHash": compute_req_hash(request_body),
-    }
-    try:
-        return pyjwt.encode(claims, signing_key, algorithm="ES256", headers={"typ": "JWT"})
-    except Exception:
-        raise SignerError(
-            SignerErrorCode.SIGNING_FAILED, "Failed to create Openfort wallet JWT"
-        ) from None
+    return create_es256_wallet_jwt(signing_key, host, method, path, request_body, "Openfort")

--- a/python/src/solana_keychain/openfort/signer.py
+++ b/python/src/solana_keychain/openfort/signer.py
@@ -25,7 +25,8 @@ from solana_keychain.core.transaction_util import (
     serialize_transaction,
     signed_message_bytes,
 )
-from solana_keychain.openfort.jwt import create_wallet_jwt, extract_host
+from solana_keychain.core.wallet_jwt import extract_host
+from solana_keychain.openfort.jwt import create_wallet_jwt
 
 DEFAULT_API_BASE_URL = "https://api.openfort.io"
 ACCOUNTS_PATH = "/v2/accounts"
@@ -67,7 +68,7 @@ class OpenfortSigner(SolanaSigner):
         api_base_url = normalize_base_url(config.api_base_url)
         assert_https_url(api_base_url, "api_base_url")
         self._api_base_url = api_base_url
-        self._api_host = extract_host(api_base_url)
+        self._api_host = extract_host(api_base_url, "Openfort")
         self._secret_key = config.secret_key
         self._account_id = config.account_id
         self._wallet_secret = config.wallet_secret

--- a/python/src/solana_keychain/openfort/signer.py
+++ b/python/src/solana_keychain/openfort/signer.py
@@ -12,6 +12,7 @@ from solders.transaction import VersionedTransaction
 
 from solana_keychain.core.errors import SignerError, SignerErrorCode
 from solana_keychain.core.http import assert_https_url, fetch_signer_json, normalize_base_url
+from solana_keychain.core.signature_util import verify_returned_signature
 from solana_keychain.core.signer import SignedTransaction, SolanaSigner
 from solana_keychain.core.transaction_util import (
     ED25519_SIGNATURE_LENGTH,
@@ -153,13 +154,7 @@ class OpenfortSigner(SolanaSigner):
                 f"(expected {ED25519_SIGNATURE_LENGTH} bytes)",
             )
         signature = Signature.from_bytes(signature_bytes)
-        if not signature.verify(public_key, message):
-            raise SignerError(
-                SignerErrorCode.SIGNING_FAILED,
-                "Signature verification failed — the returned signature does not match "
-                "the public key",
-            )
-        return signature
+        return verify_returned_signature(signature, public_key, message)
 
     async def sign_transaction(self, transaction: VersionedTransaction) -> SignedTransaction:
         signature = await self._sign_bytes(signed_message_bytes(transaction.message))

--- a/python/src/solana_keychain/openfort/signer.py
+++ b/python/src/solana_keychain/openfort/signer.py
@@ -13,7 +13,11 @@ from solders.transaction import VersionedTransaction
 from solana_keychain.core.errors import SignerError, SignerErrorCode
 from solana_keychain.core.http import assert_https_url, fetch_signer_json, normalize_base_url
 from solana_keychain.core.signature_util import verify_returned_signature
-from solana_keychain.core.signer import SignedTransaction, SolanaSigner
+from solana_keychain.core.signer import (
+    SignedTransaction,
+    SolanaSigner,
+    require_initialized,
+)
 from solana_keychain.core.transaction_util import (
     ED25519_SIGNATURE_LENGTH,
     add_signature_to_transaction,
@@ -108,12 +112,7 @@ class OpenfortSigner(SolanaSigner):
         self._public_key = await self._fetch_public_key()
 
     def _initialized_pubkey(self) -> Pubkey:
-        if self._public_key is None:
-            raise SignerError(
-                SignerErrorCode.NOT_INITIALIZED,
-                "OpenfortSigner is not initialized; call init() before signing",
-            )
-        return self._public_key
+        return require_initialized(self._public_key, "OpenfortSigner")
 
     @property
     def pubkey(self) -> Pubkey:

--- a/python/src/solana_keychain/openfort/signer.py
+++ b/python/src/solana_keychain/openfort/signer.py
@@ -11,7 +11,12 @@ from solders.signature import Signature
 from solders.transaction import VersionedTransaction
 
 from solana_keychain.core.errors import SignerError, SignerErrorCode
-from solana_keychain.core.http import assert_https_url, fetch_signer_json, normalize_base_url
+from solana_keychain.core.http import (
+    assert_https_url,
+    fetch_signer_json,
+    normalize_base_url,
+    probe_availability,
+)
 from solana_keychain.core.signature_util import verify_returned_signature
 from solana_keychain.core.signer import (
     SignedTransaction,
@@ -169,10 +174,11 @@ class OpenfortSigner(SolanaSigner):
     async def is_available(self) -> bool:
         if self._public_key is None:
             return False
-        try:
+
+        async def probe() -> bool:
             return await self._fetch_public_key() == self._public_key
-        except SignerError:
-            return False
+
+        return await probe_availability(probe)
 
 
 async def create_openfort_signer(config: OpenfortSignerConfig) -> OpenfortSigner:

--- a/python/src/solana_keychain/para/signer.py
+++ b/python/src/solana_keychain/para/signer.py
@@ -14,7 +14,11 @@ from solders.transaction import VersionedTransaction
 from solana_keychain.core.errors import SignerError, SignerErrorCode
 from solana_keychain.core.http import assert_https_url, fetch_signer_json, normalize_base_url
 from solana_keychain.core.signature_util import verify_returned_signature
-from solana_keychain.core.signer import SignedTransaction, SolanaSigner
+from solana_keychain.core.signer import (
+    SignedTransaction,
+    SolanaSigner,
+    require_initialized,
+)
 from solana_keychain.core.transaction_util import (
     add_signature_to_transaction,
     classify_signed_transaction,
@@ -111,12 +115,7 @@ class ParaSigner(SolanaSigner):
             ) from None
 
     def _initialized_pubkey(self) -> Pubkey:
-        if self._public_key is None:
-            raise SignerError(
-                SignerErrorCode.NOT_INITIALIZED,
-                "ParaSigner is not initialized; call init() before signing",
-            )
-        return self._public_key
+        return require_initialized(self._public_key, "ParaSigner")
 
     @property
     def pubkey(self) -> Pubkey:

--- a/python/src/solana_keychain/para/signer.py
+++ b/python/src/solana_keychain/para/signer.py
@@ -1,6 +1,5 @@
 """Para API signer integration."""
 
-import asyncio
 import logging
 import re
 from dataclasses import dataclass, field
@@ -12,7 +11,12 @@ from solders.signature import Signature
 from solders.transaction import VersionedTransaction
 
 from solana_keychain.core.errors import SignerError, SignerErrorCode
-from solana_keychain.core.http import assert_https_url, fetch_signer_json, normalize_base_url
+from solana_keychain.core.http import (
+    assert_https_url,
+    fetch_signer_json,
+    normalize_base_url,
+    probe_availability,
+)
 from solana_keychain.core.signature_util import verify_returned_signature
 from solana_keychain.core.signer import (
     SignedTransaction,
@@ -28,7 +32,6 @@ from solana_keychain.core.transaction_util import (
 
 DEFAULT_API_BASE_URL = "https://api.getpara.com"
 REQUEST_TIMEOUT_SECONDS = 30.0
-AVAILABILITY_TIMEOUT_SECONDS = 5.0
 
 SIGNATURE_HEX_LENGTH = 128
 
@@ -184,15 +187,14 @@ class ParaSigner(SolanaSigner):
     async def is_available(self) -> bool:
         """Availability makes a network call bounded to 5 seconds; cache the result
         if frequent checks are needed."""
-        try:
-            wallet = await asyncio.wait_for(self._fetch_wallet(), AVAILABILITY_TIMEOUT_SECONDS)
-        except (SignerError, asyncio.TimeoutError):
-            # asyncio.TimeoutError: on 3.10 wait_for raises this distinct class;
-            # from 3.11 it aliases the builtin, so one except covers both.
-            return False
-        wallet_type = str(wallet.get("type", ""))
-        status = str(wallet.get("status", ""))
-        return wallet_type.upper() == "SOLANA" and status.upper() in ("ACTIVE", "READY")
+
+        async def probe() -> bool:
+            wallet = await self._fetch_wallet()
+            wallet_type = str(wallet.get("type", ""))
+            status = str(wallet.get("status", ""))
+            return wallet_type.upper() == "SOLANA" and status.upper() in ("ACTIVE", "READY")
+
+        return await probe_availability(probe)
 
 
 async def create_para_signer(config: ParaSignerConfig) -> ParaSigner:

--- a/python/src/solana_keychain/para/signer.py
+++ b/python/src/solana_keychain/para/signer.py
@@ -149,7 +149,7 @@ class ParaSigner(SolanaSigner):
             signature_bytes = bytes.fromhex(stripped)
         except ValueError:
             raise SignerError(
-                SignerErrorCode.SIGNING_FAILED, "Failed to decode hex signature"
+                SignerErrorCode.SERIALIZATION_ERROR, "Failed to decode hex signature"
             ) from None
         try:
             return Signature.from_bytes(signature_bytes)

--- a/python/src/solana_keychain/para/signer.py
+++ b/python/src/solana_keychain/para/signer.py
@@ -13,6 +13,7 @@ from solders.transaction import VersionedTransaction
 
 from solana_keychain.core.errors import SignerError, SignerErrorCode
 from solana_keychain.core.http import assert_https_url, fetch_signer_json, normalize_base_url
+from solana_keychain.core.signature_util import verify_returned_signature
 from solana_keychain.core.signer import SignedTransaction, SolanaSigner
 from solana_keychain.core.transaction_util import (
     add_signature_to_transaction,
@@ -169,13 +170,7 @@ class ParaSigner(SolanaSigner):
         if not isinstance(hex_signature, str):
             raise SignerError(SignerErrorCode.SIGNING_FAILED, "Missing signature in response")
         signature = self._decode_hex_signature(hex_signature)
-        if not signature.verify(public_key, data):
-            raise SignerError(
-                SignerErrorCode.SIGNING_FAILED,
-                "Signature verification failed — the returned signature does not match "
-                "the public key",
-            )
-        return signature
+        return verify_returned_signature(signature, public_key, data)
 
     async def sign_transaction(self, transaction: VersionedTransaction) -> SignedTransaction:
         signature = await self._sign_bytes(signed_message_bytes(transaction.message))

--- a/python/src/solana_keychain/privy/signer.py
+++ b/python/src/solana_keychain/privy/signer.py
@@ -12,6 +12,7 @@ from solders.transaction import VersionedTransaction
 
 from solana_keychain.core.errors import SignerError, SignerErrorCode
 from solana_keychain.core.http import assert_https_url, fetch_signer_json, normalize_base_url
+from solana_keychain.core.signature_util import verify_returned_signature
 from solana_keychain.core.signer import SignedTransaction, SolanaSigner
 from solana_keychain.core.transaction_util import (
     add_signature_to_transaction,
@@ -163,13 +164,7 @@ class PrivySigner(SolanaSigner):
             signature = Signature.from_bytes(signature_bytes)
         except Exception:
             raise SignerError(SignerErrorCode.SIGNING_FAILED, "Failed to parse signature") from None
-        if not signature.verify(public_key, message):
-            raise SignerError(
-                SignerErrorCode.SIGNING_FAILED,
-                "Signature verification failed — the returned signature does not match "
-                "the public key",
-            )
-        return signature
+        return verify_returned_signature(signature, public_key, message)
 
     async def sign_transaction(self, transaction: VersionedTransaction) -> SignedTransaction:
         """Sign via Privy's ``signTransaction`` RPC, submitting the full wire
@@ -208,12 +203,7 @@ class PrivySigner(SolanaSigner):
                 "Privy signature slot missing from returned transaction",
             )
         signature = signatures[position]
-        if not signature.verify(public_key, signed_message_bytes(transaction.message)):
-            raise SignerError(
-                SignerErrorCode.SIGNING_FAILED,
-                "Signature verification failed — the returned signature does not match "
-                "the public key",
-            )
+        verify_returned_signature(signature, public_key, signed_message_bytes(transaction.message))
         add_signature_to_transaction(transaction, public_key, signature)
         return classify_signed_transaction(
             transaction, serialize_transaction(transaction), signature

--- a/python/src/solana_keychain/privy/signer.py
+++ b/python/src/solana_keychain/privy/signer.py
@@ -11,7 +11,12 @@ from solders.signature import Signature
 from solders.transaction import VersionedTransaction
 
 from solana_keychain.core.errors import SignerError, SignerErrorCode
-from solana_keychain.core.http import assert_https_url, fetch_signer_json, normalize_base_url
+from solana_keychain.core.http import (
+    assert_https_url,
+    fetch_signer_json,
+    normalize_base_url,
+    probe_availability,
+)
 from solana_keychain.core.signature_util import verify_returned_signature
 from solana_keychain.core.signer import (
     SignedTransaction,
@@ -214,10 +219,11 @@ class PrivySigner(SolanaSigner):
     async def is_available(self) -> bool:
         if self._public_key is None:
             return False
-        try:
+
+        async def probe() -> bool:
             return await self._fetch_public_key() == self._public_key
-        except SignerError:
-            return False
+
+        return await probe_availability(probe)
 
 
 async def create_privy_signer(config: PrivySignerConfig) -> PrivySigner:

--- a/python/src/solana_keychain/privy/signer.py
+++ b/python/src/solana_keychain/privy/signer.py
@@ -13,7 +13,11 @@ from solders.transaction import VersionedTransaction
 from solana_keychain.core.errors import SignerError, SignerErrorCode
 from solana_keychain.core.http import assert_https_url, fetch_signer_json, normalize_base_url
 from solana_keychain.core.signature_util import verify_returned_signature
-from solana_keychain.core.signer import SignedTransaction, SolanaSigner
+from solana_keychain.core.signer import (
+    SignedTransaction,
+    SolanaSigner,
+    require_initialized,
+)
 from solana_keychain.core.transaction_util import (
     add_signature_to_transaction,
     classify_signed_transaction,
@@ -74,12 +78,7 @@ class PrivySigner(SolanaSigner):
         self._public_key = await self._fetch_public_key()
 
     def _initialized_pubkey(self) -> Pubkey:
-        if self._public_key is None:
-            raise SignerError(
-                SignerErrorCode.NOT_INITIALIZED,
-                "PrivySigner is not initialized; call init() before signing",
-            )
-        return self._public_key
+        return require_initialized(self._public_key, "PrivySigner")
 
     @property
     def pubkey(self) -> Pubkey:

--- a/python/src/solana_keychain/turnkey/signer.py
+++ b/python/src/solana_keychain/turnkey/signer.py
@@ -21,6 +21,7 @@ from solders.transaction import VersionedTransaction
 
 from solana_keychain.core.errors import SignerError, SignerErrorCode
 from solana_keychain.core.http import assert_https_url, fetch_signer_json, normalize_base_url
+from solana_keychain.core.signature_util import verify_returned_signature
 from solana_keychain.core.signer import SignedTransaction, SolanaSigner
 from solana_keychain.core.transaction_util import (
     add_signature_to_transaction,
@@ -188,13 +189,7 @@ class TurnkeySigner(SolanaSigner):
         signature = Signature.from_bytes(
             self._assemble_signature(sign_result["r"], sign_result["s"])
         )
-        if not signature.verify(self._pubkey, message):
-            raise SignerError(
-                SignerErrorCode.SIGNING_FAILED,
-                "Signature verification failed — the returned signature does not match "
-                "the public key",
-            )
-        return signature
+        return verify_returned_signature(signature, self._pubkey, message)
 
     @staticmethod
     def _completed_activity_result(response: Any) -> Any:
@@ -244,12 +239,9 @@ class TurnkeySigner(SolanaSigner):
                 "Turnkey signature slot missing from returned transaction",
             )
         signature = signatures[position]
-        if not signature.verify(self._pubkey, signed_message_bytes(transaction.message)):
-            raise SignerError(
-                SignerErrorCode.SIGNING_FAILED,
-                "Signature verification failed — the returned signature does not match "
-                "the public key",
-            )
+        verify_returned_signature(
+            signature, self._pubkey, signed_message_bytes(transaction.message)
+        )
         add_signature_to_transaction(transaction, self._pubkey, signature)
         return classify_signed_transaction(
             transaction, serialize_transaction(transaction), signature

--- a/python/src/solana_keychain/turnkey/signer.py
+++ b/python/src/solana_keychain/turnkey/signer.py
@@ -20,7 +20,12 @@ from solders.signature import Signature
 from solders.transaction import VersionedTransaction
 
 from solana_keychain.core.errors import SignerError, SignerErrorCode
-from solana_keychain.core.http import assert_https_url, fetch_signer_json, normalize_base_url
+from solana_keychain.core.http import (
+    assert_https_url,
+    fetch_signer_json,
+    normalize_base_url,
+    probe_availability,
+)
 from solana_keychain.core.signature_util import verify_returned_signature
 from solana_keychain.core.signer import SignedTransaction, SolanaSigner
 from solana_keychain.core.transaction_util import (
@@ -251,13 +256,13 @@ class TurnkeySigner(SolanaSigner):
         return await self._sign_bytes(message)
 
     async def is_available(self) -> bool:
-        try:
+        async def probe() -> bool:
             await self._post_stamped(
                 "/public/v1/query/whoami", {"organizationId": self._organization_id}
             )
-        except SignerError:
-            return False
-        return True
+            return True
+
+        return await probe_availability(probe)
 
 
 async def create_turnkey_signer(config: TurnkeySignerConfig) -> TurnkeySigner:

--- a/python/src/solana_keychain/utila/signer.py
+++ b/python/src/solana_keychain/utila/signer.py
@@ -24,6 +24,7 @@ from solders.transaction import VersionedTransaction
 
 from solana_keychain.core.errors import SignerError, SignerErrorCode
 from solana_keychain.core.http import assert_https_url, fetch_signer_json, normalize_base_url
+from solana_keychain.core.signature_util import verify_returned_signature
 from solana_keychain.core.signer import SignedTransaction, SolanaSigner
 from solana_keychain.core.transaction_util import (
     add_signature_to_transaction,
@@ -345,12 +346,7 @@ class UtilaSigner(SolanaSigner):
                 "Utila rawTransaction did not contain a signer signature",
             )
         signature = signatures[position]
-        if not signature.verify(public_key, expected_message):
-            raise SignerError(
-                SignerErrorCode.SIGNING_FAILED,
-                "Signature verification failed for Utila rawTransaction",
-            )
-        return signature
+        return verify_returned_signature(signature, public_key, expected_message)
 
     async def sign_transaction(self, transaction: VersionedTransaction) -> SignedTransaction:
         public_key = self._initialized_pubkey()

--- a/python/src/solana_keychain/utila/signer.py
+++ b/python/src/solana_keychain/utila/signer.py
@@ -24,6 +24,7 @@ from solders.transaction import VersionedTransaction
 
 from solana_keychain.core.errors import SignerError, SignerErrorCode
 from solana_keychain.core.http import assert_https_url, fetch_signer_json, normalize_base_url
+from solana_keychain.core.poll import poll_attempts
 from solana_keychain.core.signature_util import verify_returned_signature
 from solana_keychain.core.signer import (
     SignedTransaction,
@@ -267,7 +268,10 @@ class UtilaSigner(SolanaSigner):
         return transaction_id
 
     async def _poll_signed_transaction(self, transaction: dict[str, Any]) -> dict[str, Any]:
-        for _ in range(self._max_poll_attempts):
+        async for attempt in poll_attempts(self._max_poll_attempts, self._poll_interval_ms):
+            if attempt:
+                transaction_id = self._extract_transaction_id(str(transaction.get("name", "")))
+                transaction = await self._get_transaction(transaction_id)
             state = transaction.get("state")
             if state == "SIGNED":
                 return transaction
@@ -276,18 +280,6 @@ class UtilaSigner(SolanaSigner):
                     SignerErrorCode.SIGNING_FAILED,
                     f"Utila transaction reached terminal state {state}",
                 )
-            await asyncio.sleep(self._poll_interval_ms / 1000)
-            transaction_id = self._extract_transaction_id(str(transaction.get("name", "")))
-            transaction = await self._get_transaction(transaction_id)
-
-        state = transaction.get("state")
-        if state == "SIGNED":
-            return transaction
-        if state in _TERMINAL_FAILURE_STATES:
-            raise SignerError(
-                SignerErrorCode.SIGNING_FAILED,
-                f"Utila transaction reached terminal state {state}",
-            )
         raise SignerError(
             SignerErrorCode.REMOTE_API_ERROR,
             f"Utila transaction polling timed out after {self._max_poll_attempts} attempts",

--- a/python/src/solana_keychain/utila/signer.py
+++ b/python/src/solana_keychain/utila/signer.py
@@ -25,7 +25,11 @@ from solders.transaction import VersionedTransaction
 from solana_keychain.core.errors import SignerError, SignerErrorCode
 from solana_keychain.core.http import assert_https_url, fetch_signer_json, normalize_base_url
 from solana_keychain.core.signature_util import verify_returned_signature
-from solana_keychain.core.signer import SignedTransaction, SolanaSigner
+from solana_keychain.core.signer import (
+    SignedTransaction,
+    SolanaSigner,
+    require_initialized,
+)
 from solana_keychain.core.transaction_util import (
     add_signature_to_transaction,
     classify_signed_transaction,
@@ -211,12 +215,7 @@ class UtilaSigner(SolanaSigner):
             ) from None
 
     def _initialized_pubkey(self) -> Pubkey:
-        if self._public_key is None:
-            raise SignerError(
-                SignerErrorCode.NOT_INITIALIZED,
-                "UtilaSigner is not initialized; call init() before signing",
-            )
-        return self._public_key
+        return require_initialized(self._public_key, "UtilaSigner")
 
     @property
     def pubkey(self) -> Pubkey:

--- a/python/src/solana_keychain/utila/signer.py
+++ b/python/src/solana_keychain/utila/signer.py
@@ -1,6 +1,5 @@
 """Utila API signer integration."""
 
-import asyncio
 import base64
 import time
 from dataclasses import dataclass, field
@@ -23,7 +22,12 @@ from solders.signature import Signature
 from solders.transaction import VersionedTransaction
 
 from solana_keychain.core.errors import SignerError, SignerErrorCode
-from solana_keychain.core.http import assert_https_url, fetch_signer_json, normalize_base_url
+from solana_keychain.core.http import (
+    assert_https_url,
+    fetch_signer_json,
+    normalize_base_url,
+    probe_availability,
+)
 from solana_keychain.core.poll import poll_attempts
 from solana_keychain.core.signature_util import verify_returned_signature
 from solana_keychain.core.signer import (
@@ -43,7 +47,6 @@ API_AUDIENCE = "https://api.utila.io/"
 TOKEN_TTL_SECONDS = 55 * 60
 DEFAULT_POLL_INTERVAL_MS = 1000
 DEFAULT_MAX_POLL_ATTEMPTS = 60
-AVAILABILITY_TIMEOUT_SECONDS = 5.0
 
 _TERMINAL_FAILURE_STATES = frozenset(
     {
@@ -372,11 +375,11 @@ class UtilaSigner(SolanaSigner):
         )
 
     async def is_available(self) -> bool:
-        try:
-            await asyncio.wait_for(self._fetch_wallet(), AVAILABILITY_TIMEOUT_SECONDS)
-        except (SignerError, asyncio.TimeoutError):
-            return False
-        return True
+        async def probe() -> bool:
+            await self._fetch_wallet()
+            return True
+
+        return await probe_availability(probe)
 
 
 async def create_utila_signer(config: UtilaSignerConfig) -> UtilaSigner:

--- a/python/src/solana_keychain/vault/signer.py
+++ b/python/src/solana_keychain/vault/signer.py
@@ -10,7 +10,12 @@ from solders.signature import Signature
 from solders.transaction import VersionedTransaction
 
 from solana_keychain.core.errors import SignerError, SignerErrorCode
-from solana_keychain.core.http import assert_https_url, fetch_signer_json, normalize_base_url
+from solana_keychain.core.http import (
+    assert_https_url,
+    fetch_signer_json,
+    normalize_base_url,
+    probe_availability,
+)
 from solana_keychain.core.signature_util import verify_returned_signature
 from solana_keychain.core.signer import SignedTransaction, SolanaSigner
 from solana_keychain.core.transaction_util import (
@@ -111,7 +116,8 @@ class VaultSigner(SolanaSigner):
 
     async def is_available(self) -> bool:
         url = f"{self._vault_addr}/v1/transit/keys/{quote(self._key_name, safe='')}"
-        try:
+
+        async def probe() -> bool:
             result = await fetch_signer_json(
                 url=url,
                 provider_name="Vault",
@@ -119,12 +125,12 @@ class VaultSigner(SolanaSigner):
                 headers={"X-Vault-Token": self._token},
                 client=self._http_client,
             )
-        except SignerError:
-            return False
-        data = result.get("data") if isinstance(result, dict) else None
-        if not isinstance(data, dict):
-            return False
-        return data.get("supports_signing") is True and data.get("type") == "ed25519"
+            data = result.get("data") if isinstance(result, dict) else None
+            if not isinstance(data, dict):
+                return False
+            return data.get("supports_signing") is True and data.get("type") == "ed25519"
+
+        return await probe_availability(probe)
 
 
 async def create_vault_signer(config: VaultSignerConfig) -> VaultSigner:

--- a/python/src/solana_keychain/vault/signer.py
+++ b/python/src/solana_keychain/vault/signer.py
@@ -11,6 +11,7 @@ from solders.transaction import VersionedTransaction
 
 from solana_keychain.core.errors import SignerError, SignerErrorCode
 from solana_keychain.core.http import assert_https_url, fetch_signer_json, normalize_base_url
+from solana_keychain.core.signature_util import verify_returned_signature
 from solana_keychain.core.signer import SignedTransaction, SolanaSigner
 from solana_keychain.core.transaction_util import (
     add_signature_to_transaction,
@@ -96,13 +97,7 @@ class VaultSigner(SolanaSigner):
             signature = Signature.from_bytes(signature_bytes)
         except Exception:
             raise SignerError(SignerErrorCode.SIGNING_FAILED, "Invalid signature format") from None
-        if not signature.verify(self._pubkey, payload):
-            raise SignerError(
-                SignerErrorCode.SIGNING_FAILED,
-                "Signature verification failed — the returned signature does not match "
-                "the public key",
-            )
-        return signature
+        return verify_returned_signature(signature, self._pubkey, payload)
 
     async def sign_transaction(self, transaction: VersionedTransaction) -> SignedTransaction:
         signature = await self._sign_bytes(signed_message_bytes(transaction.message))

--- a/python/src/solana_keychain/vault/signer.py
+++ b/python/src/solana_keychain/vault/signer.py
@@ -31,14 +31,14 @@ class VaultSignerConfig:
     """Configuration for a Vault transit-engine signer.
 
     The Vault key must be an ed25519 key created in the transit engine, e.g.
-    ``vault write transit/keys/my-key type=ed25519``. ``pubkey`` is the base58
+    ``vault write transit/keys/my-key type=ed25519``. ``public_key`` is the base58
     Solana public key corresponding to that transit key.
     """
 
-    vault_addr: str
+    api_base_url: str
     token: str = field(repr=False)
     key_name: str
-    pubkey: str
+    public_key: str
     http_client: httpx.AsyncClient | None = field(default=None, repr=False)
 
 
@@ -57,14 +57,14 @@ class VaultSigner(SolanaSigner):
 
     def __init__(self, config: VaultSignerConfig) -> None:
         try:
-            self._pubkey = Pubkey.from_string(config.pubkey)
+            self._pubkey = Pubkey.from_string(config.public_key)
         except Exception:
             raise SignerError(
                 SignerErrorCode.INVALID_PUBLIC_KEY, "Failed to decode base58 public key"
             ) from None
-        vault_addr = normalize_base_url(config.vault_addr)
-        assert_https_url(vault_addr, "vault_addr", allow_http_loopback_in_tests=True)
-        self._vault_addr = vault_addr
+        api_base_url = normalize_base_url(config.api_base_url)
+        assert_https_url(api_base_url, "api_base_url", allow_http_loopback_in_tests=True)
+        self._api_base_url = api_base_url
         self._token = config.token
         self._key_name = config.key_name
         self._http_client = config.http_client
@@ -77,7 +77,7 @@ class VaultSigner(SolanaSigner):
         return self._pubkey
 
     async def _sign_bytes(self, payload: bytes) -> Signature:
-        url = f"{self._vault_addr}/v1/transit/sign/{quote(self._key_name, safe='')}"
+        url = f"{self._api_base_url}/v1/transit/sign/{quote(self._key_name, safe='')}"
         result = await fetch_signer_json(
             url=url,
             provider_name="Vault",
@@ -115,7 +115,7 @@ class VaultSigner(SolanaSigner):
         return await self._sign_bytes(message)
 
     async def is_available(self) -> bool:
-        url = f"{self._vault_addr}/v1/transit/keys/{quote(self._key_name, safe='')}"
+        url = f"{self._api_base_url}/v1/transit/keys/{quote(self._key_name, safe='')}"
 
         async def probe() -> bool:
             result = await fetch_signer_json(

--- a/python/tests/integration/test_vault_integration.py
+++ b/python/tests/integration/test_vault_integration.py
@@ -17,10 +17,10 @@ async def make_signer() -> VaultSigner:
     env = require_env("VAULT_ADDR", "VAULT_TOKEN", "VAULT_KEY_NAME", "VAULT_SIGNER_PUBKEY")
     return await create_vault_signer(
         VaultSignerConfig(
-            vault_addr=env["VAULT_ADDR"],
+            api_base_url=env["VAULT_ADDR"],
             token=env["VAULT_TOKEN"],
             key_name=env["VAULT_KEY_NAME"],
-            pubkey=env["VAULT_SIGNER_PUBKEY"],
+            public_key=env["VAULT_SIGNER_PUBKEY"],
         )
     )
 

--- a/python/tests/test_cdp_signer.py
+++ b/python/tests/test_cdp_signer.py
@@ -17,13 +17,9 @@ from solders.transaction import VersionedTransaction
 
 from solana_keychain import SignerError, SignerErrorCode
 from solana_keychain.cdp import CdpSigner, CdpSignerConfig, create_cdp_signer
-from solana_keychain.cdp.jwt import (
-    compute_req_hash,
-    create_auth_jwt,
-    create_wallet_jwt,
-    extract_host,
-)
+from solana_keychain.cdp.jwt import create_auth_jwt, create_wallet_jwt
 from solana_keychain.core import signed_message_bytes
+from solana_keychain.core.wallet_jwt import compute_req_hash
 from tests.util import create_test_transaction, create_test_v1_transaction
 
 API_BASE_URL = "https://cdp.example.com"
@@ -66,23 +62,6 @@ def decode_auth_claims(request: httpx.Request) -> tuple[dict[str, Any], dict[str
 def decode_wallet_claims(request: httpx.Request) -> dict[str, Any]:
     token = request.headers["X-Wallet-Auth"]
     return pyjwt.decode(token, _WALLET_EC_KEY.public_key(), algorithms=["ES256"])
-
-
-def test_extract_host() -> None:
-    assert extract_host("https://api.cdp.coinbase.com") == "api.cdp.coinbase.com"
-    assert extract_host("https://cdp.example.com:8443/base") == "cdp.example.com:8443"
-    with pytest.raises(SignerError) as excinfo:
-        extract_host("not a url")
-    assert excinfo.value.code == SignerErrorCode.CONFIG_ERROR
-
-
-def test_compute_req_hash_rules() -> None:
-    assert compute_req_hash(None) is None
-    assert compute_req_hash({}) is None
-    ordered = compute_req_hash({"a": 1, "b": {"c": 2, "d": 3}})
-    reordered = compute_req_hash({"b": {"d": 3, "c": 2}, "a": 1})
-    assert ordered == reordered
-    assert ordered is not None
 
 
 def test_create_auth_jwt_shape() -> None:

--- a/python/tests/test_http.py
+++ b/python/tests/test_http.py
@@ -1,3 +1,5 @@
+import asyncio
+
 import httpx
 import pytest
 import respx
@@ -9,6 +11,7 @@ from solana_keychain.core import (
     normalize_base_url,
     sanitize_remote_error_response,
 )
+from solana_keychain.core.http import probe_availability
 
 
 def test_normalize_base_url_strips_whitespace_and_trailing_slashes() -> None:
@@ -109,3 +112,35 @@ async def test_caller_supplied_client_is_used_and_not_closed() -> None:
             url=URL, provider_name="Test", method="POST", json_body={"a": 1}, client=client
         ) == {"ok": 1}
         assert not client.is_closed
+
+
+async def test_probe_availability_returns_the_probe_result() -> None:
+    async def healthy() -> bool:
+        return True
+
+    async def unhealthy() -> bool:
+        return False
+
+    assert await probe_availability(healthy)
+    assert not await probe_availability(unhealthy)
+
+
+async def test_probe_availability_reports_unavailable_on_any_failure() -> None:
+    async def signer_error() -> bool:
+        raise SignerError(SignerErrorCode.HTTP_ERROR, "unreachable")
+
+    async def credential_error() -> bool:
+        raise RuntimeError("kms unavailable")
+
+    assert not await probe_availability(signer_error)
+    assert not await probe_availability(credential_error)
+
+
+async def test_probe_availability_bounds_a_slow_probe(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("solana_keychain.core.http.AVAILABILITY_TIMEOUT_SECONDS", 0.01)
+
+    async def slow() -> bool:
+        await asyncio.sleep(5)
+        return True
+
+    assert not await probe_availability(slow)

--- a/python/tests/test_openfort_signer.py
+++ b/python/tests/test_openfort_signer.py
@@ -17,12 +17,13 @@ from solders.keypair import Keypair
 
 from solana_keychain import SignerError, SignerErrorCode
 from solana_keychain.core import signed_message_bytes
+from solana_keychain.core.wallet_jwt import compute_req_hash
 from solana_keychain.openfort import (
     OpenfortSigner,
     OpenfortSignerConfig,
     create_openfort_signer,
 )
-from solana_keychain.openfort.jwt import compute_req_hash, create_wallet_jwt, extract_host
+from solana_keychain.openfort.jwt import create_wallet_jwt
 from tests.util import create_test_transaction
 
 API_BASE_URL = "https://openfort.example.com"
@@ -73,14 +74,6 @@ async def initialized_signer(keypair: Keypair, **overrides: Any) -> OpenfortSign
     signer = make_signer(**overrides)
     await signer.init()
     return signer
-
-
-def test_extract_host() -> None:
-    assert extract_host("https://api.openfort.io") == "api.openfort.io"
-    assert extract_host("https://openfort.example.com:8443") == "openfort.example.com:8443"
-    with pytest.raises(SignerError) as excinfo:
-        extract_host("not a url")
-    assert excinfo.value.code == SignerErrorCode.CONFIG_ERROR
 
 
 @pytest.mark.parametrize(

--- a/python/tests/test_para_signer.py
+++ b/python/tests/test_para_signer.py
@@ -204,7 +204,7 @@ async def test_sign_message_undecodable_signature() -> None:
     mock_sign_response("zz" * 64)
     with pytest.raises(SignerError) as excinfo:
         await signer.sign_message(b"hello")
-    assert excinfo.value.code == SignerErrorCode.SIGNING_FAILED
+    assert excinfo.value.code == SignerErrorCode.SERIALIZATION_ERROR
 
 
 @respx.mock

--- a/python/tests/test_para_signer.py
+++ b/python/tests/test_para_signer.py
@@ -276,7 +276,7 @@ async def test_is_available_false_on_api_error() -> None:
 async def test_is_available_false_on_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
     keypair = Keypair()
     signer = await initialized_signer(keypair)
-    monkeypatch.setattr("solana_keychain.para.signer.AVAILABILITY_TIMEOUT_SECONDS", 0.05)
+    monkeypatch.setattr("solana_keychain.core.http.AVAILABILITY_TIMEOUT_SECONDS", 0.05)
 
     async def slow_response(_request: httpx.Request) -> httpx.Response:
         await asyncio.sleep(0.5)

--- a/python/tests/test_poll.py
+++ b/python/tests/test_poll.py
@@ -1,0 +1,26 @@
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+from solana_keychain.core.poll import poll_attempts
+
+
+async def test_yields_every_attempt_and_sleeps_only_between_them() -> None:
+    with patch("solana_keychain.core.poll.asyncio.sleep", new=AsyncMock()) as sleep:
+        attempts = [attempt async for attempt in poll_attempts(3, 250)]
+    assert attempts == [0, 1, 2]
+    assert sleep.await_count == 2
+    assert sleep.await_args_list[0].args == (0.25,)
+
+
+async def test_caller_breaking_early_does_not_sleep_again() -> None:
+    with patch("solana_keychain.core.poll.asyncio.sleep", new=AsyncMock()) as sleep:
+        async for _ in poll_attempts(10, 1000):
+            break
+    assert sleep.await_count == 0
+
+
+async def test_single_attempt_never_sleeps() -> None:
+    calls: list[Any] = []
+    with patch("solana_keychain.core.poll.asyncio.sleep", new=AsyncMock(side_effect=calls.append)):
+        assert [attempt async for attempt in poll_attempts(1, 5000)] == [0]
+    assert calls == []

--- a/python/tests/test_signature_util.py
+++ b/python/tests/test_signature_util.py
@@ -1,0 +1,19 @@
+import pytest
+from solders.keypair import Keypair
+
+from solana_keychain.core import SignerError, SignerErrorCode, verify_returned_signature
+
+
+def test_returns_signature_when_it_verifies() -> None:
+    keypair = Keypair()
+    message = b"payload"
+    signature = keypair.sign_message(message)
+    assert verify_returned_signature(signature, keypair.pubkey(), message) == signature
+
+
+def test_raises_signing_failed_on_mismatch() -> None:
+    keypair = Keypair()
+    signature = keypair.sign_message(b"payload")
+    with pytest.raises(SignerError) as excinfo:
+        verify_returned_signature(signature, Keypair().pubkey(), b"payload")
+    assert excinfo.value.code == SignerErrorCode.SIGNING_FAILED

--- a/python/tests/test_vault_signer.py
+++ b/python/tests/test_vault_signer.py
@@ -25,10 +25,10 @@ SIGN_URL = f"{VAULT_ADDR}/v1/transit/sign/{KEY_NAME}"
 KEYS_URL = f"{VAULT_ADDR}/v1/transit/keys/{KEY_NAME}"
 
 
-def make_signer(pubkey: str = TEST_PUBKEY) -> VaultSigner:
+def make_signer(public_key: str = TEST_PUBKEY) -> VaultSigner:
     return VaultSigner(
         VaultSignerConfig(
-            vault_addr=VAULT_ADDR, token=VAULT_TOKEN, key_name=KEY_NAME, pubkey=pubkey
+            api_base_url=VAULT_ADDR, token=VAULT_TOKEN, key_name=KEY_NAME, public_key=public_key
         )
     )
 
@@ -42,7 +42,7 @@ def mock_sign_response(signature_b64: str, prefix: str = "vault:v1:") -> None:
 async def test_create_vault_signer_factory() -> None:
     signer = await create_vault_signer(
         VaultSignerConfig(
-            vault_addr=VAULT_ADDR, token=VAULT_TOKEN, key_name=KEY_NAME, pubkey=TEST_PUBKEY
+            api_base_url=VAULT_ADDR, token=VAULT_TOKEN, key_name=KEY_NAME, public_key=TEST_PUBKEY
         )
     )
     assert str(signer.pubkey) == TEST_PUBKEY
@@ -50,18 +50,18 @@ async def test_create_vault_signer_factory() -> None:
 
 def test_invalid_pubkey_rejected() -> None:
     with pytest.raises(SignerError) as excinfo:
-        make_signer(pubkey="invalid-pubkey")
+        make_signer(public_key="invalid-pubkey")
     assert excinfo.value.code == SignerErrorCode.INVALID_PUBLIC_KEY
 
 
-def test_non_https_vault_addr_rejected() -> None:
+def test_non_https_api_base_url_rejected() -> None:
     with pytest.raises(SignerError) as excinfo:
         VaultSigner(
             VaultSignerConfig(
-                vault_addr="http://vault.example.com",
+                api_base_url="http://vault.example.com",
                 token=VAULT_TOKEN,
                 key_name=KEY_NAME,
-                pubkey=TEST_PUBKEY,
+                public_key=TEST_PUBKEY,
             )
         )
     assert excinfo.value.code == SignerErrorCode.CONFIG_ERROR
@@ -75,7 +75,7 @@ def test_repr_shows_pubkey_and_never_token() -> None:
 
 def test_config_repr_never_contains_token() -> None:
     config = VaultSignerConfig(
-        vault_addr=VAULT_ADDR, token=VAULT_TOKEN, key_name=KEY_NAME, pubkey=TEST_PUBKEY
+        api_base_url=VAULT_ADDR, token=VAULT_TOKEN, key_name=KEY_NAME, public_key=TEST_PUBKEY
     )
     assert VAULT_TOKEN not in repr(config)
 
@@ -101,7 +101,7 @@ async def test_sign_message_success() -> None:
     signature = keypair.sign_message(message)
     mock_sign_response(base64.b64encode(bytes(signature)).decode("ascii"))
 
-    signer = make_signer(pubkey=str(keypair.pubkey()))
+    signer = make_signer(public_key=str(keypair.pubkey()))
     result = await signer.sign_message(message)
 
     assert result == signature
@@ -118,7 +118,7 @@ async def test_sign_message_signature_verification_failure() -> None:
     signature = signing_keypair.sign_message(message)
     mock_sign_response(base64.b64encode(bytes(signature)).decode("ascii"))
 
-    signer = make_signer(pubkey=str(other_keypair.pubkey()))
+    signer = make_signer(public_key=str(other_keypair.pubkey()))
     with pytest.raises(SignerError) as excinfo:
         await signer.sign_message(message)
     assert excinfo.value.code == SignerErrorCode.SIGNING_FAILED
@@ -157,7 +157,7 @@ async def test_sign_transaction_success() -> None:
     signature = keypair.sign_message(signed_message_bytes(transaction.message))
     mock_sign_response(base64.b64encode(bytes(signature)).decode("ascii"), prefix="vault:v2:")
 
-    signer = make_signer(pubkey=str(keypair.pubkey()))
+    signer = make_signer(public_key=str(keypair.pubkey()))
     result = await signer.sign_transaction(transaction)
 
     assert result.is_complete

--- a/python/tests/test_wallet_jwt.py
+++ b/python/tests/test_wallet_jwt.py
@@ -1,0 +1,26 @@
+import pytest
+
+from solana_keychain import SignerError, SignerErrorCode
+from solana_keychain.core.wallet_jwt import compute_req_hash, extract_host
+
+
+def test_extract_host_keeps_port_and_drops_path() -> None:
+    assert extract_host("https://api.example.com", "Example") == "api.example.com"
+    assert extract_host("https://api.example.com:8443/base", "Example") == "api.example.com:8443"
+
+
+def test_extract_host_rejects_unparseable_url() -> None:
+    with pytest.raises(SignerError) as excinfo:
+        extract_host("not a url", "Example")
+    assert excinfo.value.code == SignerErrorCode.CONFIG_ERROR
+
+
+def test_compute_req_hash_is_none_for_absent_and_empty_bodies() -> None:
+    assert compute_req_hash(None) is None
+    assert compute_req_hash({}) is None
+
+
+def test_compute_req_hash_is_key_order_independent() -> None:
+    ordered = compute_req_hash({"a": 1, "b": {"c": 2, "d": 3}})
+    assert ordered is not None
+    assert ordered == compute_req_hash({"b": {"d": 3, "c": 2}, "a": 1})


### PR DESCRIPTION
## Summary
- Introduce shared helpers and delete their per-backend copies: `core/signature_util.py` (returned-signature verification, 12 sites), `require_initialized()` in `core/signer.py` (7 identical init-state guards), `core/wallet_jwt.py` (CDP/Openfort host extraction, request-body hashing, ES256 claim set) and `core/poll.py` (poll pacing for Fireblocks/Fordefi/Utila, with Crossmint's repeated settled-state arms collapsed in place)
- Normalize the backend contract: every remote `is_available()` now runs under one shared five-second timeout via `probe_availability()`, Para's decode-failure error code matches the other twelve backends, and `VaultSignerConfig` uses the same field names as every other config
- Behavior fixes that fell out of the dedup: Fireblocks no longer sleeps one extra interval before reporting a polling timeout, and Utila no longer re-classifies one state past its attempt budget

Python already had `core/http.py`, so this is a smaller sweep than the Rust equivalent: one commit per cleanup theme, the three breaking ones flagged with `!`.

## Test Plan
- `just py-test`: 506 passed (was 499; +7 for the new helper suites)
- `just py-fmt`: ruff format, ruff check and mypy strict all clean
- `pytest python/tests/integration --collect-only -m integration`: 37 tests still collect

## Breaking Changes
- `is_available()` on CDP, Dfns, Fireblocks, Openfort, Privy, Turnkey and Vault returns `False` after five seconds instead of waiting on the provider up to the 60s request timeout. The per-backend `AVAILABILITY_TIMEOUT_SECONDS` constants are gone; use `solana_keychain.core.http.AVAILABILITY_TIMEOUT_SECONDS`.
- `VaultSignerConfig.vault_addr` is now `api_base_url`; `VaultSignerConfig.pubkey` is now `public_key`. The `VAULT_ADDR` environment variable read by the integration suite is unchanged.
- A Para response whose signature is not valid hex raises `SignerErrorCode.SERIALIZATION_ERROR` instead of `SIGNING_FAILED`.
- Openfort omits `reqHash` for an empty request body instead of hashing `{}`, matching CDP. The signer always sends a non-empty body, so no live request changes.

Migration: rename the two Vault config fields, import the availability constant from `core.http`, and treat Para hex-decode failures as `SERIALIZATION_ERROR`.