### PR TITLE
feat(signers): sign-and-send parity for Rust, Python and Go

### DIFF
--- a/go/README.md
+++ b/go/README.md
@@ -194,10 +194,10 @@ present.
 
 ### Sign and Send
 
-`core.SignAndSendTransaction` gets a transaction on chain with one call whichever
-shape the signer has. Managed-broadcast signers (Crossmint, Fordefi native mode)
-broadcast through their provider and ignore the send function; every other signer
-signs and the injected function broadcasts the result:
+`core.SignAndSendTransaction` gets a transaction on chain with one call.
+Managed-broadcast signers (Crossmint, Fordefi native mode) broadcast through their
+provider and ignore the send function; every other signer signs and the send
+function broadcasts the base64-encoded result:
 
 ```go
 sig, err := core.SignAndSendTransaction(ctx, signer, tx,

--- a/go/README.md
+++ b/go/README.md
@@ -192,6 +192,22 @@ type Signer interface {
 Completeness }`; use `IsComplete()` to check whether every required signature is
 present.
 
+### Signer capabilities
+
+Backends differ in whether the provider broadcasts the transaction and in whether
+they can sign arbitrary bytes. Managed-broadcast signers implement
+`core.TransactionBroadcaster`, whose `BroadcastsTransactions()` reports the first
+at runtime; the second is fixed per backend:
+
+| Backend | `BroadcastsTransactions()` | `SignTransaction` | `SignMessage` |
+|---------|----------------------------|-------------------|---------------|
+| memory, vault, privy, turnkey, awskms, fireblocks, gcpkms, dfns, para, openfort | not implemented | yes | yes |
+| cdp | not implemented | yes | UTF-8 payloads only, otherwise `CodeSerializationError` |
+| crossmint | `true` | provider broadcasts | `CodeSigningFailed` |
+| utila | not implemented | yes | `CodeSigningFailed` |
+| fordefi (black-box mode) | `false` | yes | yes |
+| fordefi (native mode) | `true` | provider broadcasts | yes |
+
 ### Sign and Send
 
 `core.SignAndSendTransaction` gets a transaction on chain with one call.

--- a/go/README.md
+++ b/go/README.md
@@ -199,14 +199,18 @@ they can sign arbitrary bytes. Managed-broadcast signers implement
 `core.TransactionBroadcaster`, whose `BroadcastsTransactions()` reports the first
 at runtime; the second is fixed per backend:
 
-| Backend | `BroadcastsTransactions()` | `SignTransaction` | `SignMessage` |
-|---------|----------------------------|-------------------|---------------|
-| memory, vault, privy, turnkey, awskms, fireblocks, gcpkms, dfns, para, openfort | not implemented | yes | yes |
-| cdp | not implemented | yes | UTF-8 payloads only, otherwise `CodeSerializationError` |
-| crossmint | `true` | provider broadcasts | `CodeSigningFailed` |
-| utila | not implemented | yes | `CodeSigningFailed` |
-| fordefi (black-box mode) | `false` | yes | yes |
-| fordefi (native mode) | `true` | provider broadcasts | yes |
+| Backend | `BroadcastsTransactions()` | `SignTransaction` | `SignAndSendTransaction` | `SignMessage` |
+|---------|----------------------------|-------------------|--------------------------|---------------|
+| memory, vault, privy, turnkey, awskms, fireblocks, gcpkms, dfns, para, openfort | not implemented | yes | not implemented | yes |
+| cdp | not implemented | yes | not implemented | UTF-8 payloads only, otherwise `CodeSerializationError` |
+| crossmint | `true` | yes | yes | `CodeSigningFailed` |
+| utila | not implemented | yes | not implemented | `CodeSigningFailed` |
+| fordefi (black-box mode) | `false` | yes | `CodeSigningFailed` | yes |
+| fordefi (native mode) | `true` | `CodeSigningFailed` | yes | yes |
+
+Crossmint supports both: it decides per request whether to rewrite and broadcast
+the transaction or to sign the caller's exact bytes, and `SignTransaction`
+exposes that distinction through an empty `EncodedTransaction`.
 
 ### Sign and Send
 

--- a/go/README.md
+++ b/go/README.md
@@ -192,6 +192,20 @@ type Signer interface {
 Completeness }`; use `IsComplete()` to check whether every required signature is
 present.
 
+### Sign and Send
+
+`core.SignAndSendTransaction` gets a transaction on chain with one call whichever
+shape the signer has. Managed-broadcast signers (Crossmint, Fordefi native mode)
+broadcast through their provider and ignore the send function; every other signer
+signs and the injected function broadcasts the result:
+
+```go
+sig, err := core.SignAndSendTransaction(ctx, signer, tx,
+	func(ctx context.Context, encoded string) (solana.Signature, error) {
+		return rpcClient.SendEncodedTransaction(ctx, encoded)
+	})
+```
+
 ## Packages
 
 | Package | Description |

--- a/go/core/batch_test.go
+++ b/go/core/batch_test.go
@@ -43,6 +43,11 @@ type broadcastingSigner struct {
 
 func (b *broadcastingSigner) BroadcastsTransactions() bool { return b.broadcasts }
 
+func (b *broadcastingSigner) SignAndSendTransaction(context.Context, *solana.Transaction) (solana.Signature, error) {
+	b.calls.Add(1)
+	return solana.Signature{}, nil
+}
+
 func (b *broadcastingSigner) SignTransaction(context.Context, *solana.Transaction) (SignedTransaction, error) {
 	b.calls.Add(1)
 	return SignedTransaction{}, nil

--- a/go/core/remote.go
+++ b/go/core/remote.go
@@ -72,6 +72,22 @@ func SleepContext(ctx context.Context, d time.Duration) error {
 	}
 }
 
+// SleepContextUnconfirmed is SleepContext for a poll loop the provider may already
+// be executing: cancellation cannot rule the broadcast out, so it reports
+// CodeBroadcastUnconfirmed with providerTxID rather than a plain failure the
+// caller would be free to retry.
+func SleepContextUnconfirmed(ctx context.Context, d time.Duration, providerTxID string) error {
+	if err := SleepContext(ctx, d); err == nil {
+		return nil
+	}
+	return &SignerError{
+		Code:         CodeBroadcastUnconfirmed,
+		ProviderTxID: providerTxID,
+		detail:       "transaction polling cancelled after the provider accepted the transaction",
+		cause:        ctx.Err(),
+	}
+}
+
 // ResolvePollBounds validates a backend's poll configuration, substituting the
 // backend defaults for zero values and rejecting negative ones.
 func ResolvePollBounds(interval, defaultInterval time.Duration, attempts, defaultAttempts int) (time.Duration, int, error) {

--- a/go/core/remote.go
+++ b/go/core/remote.go
@@ -72,10 +72,9 @@ func SleepContext(ctx context.Context, d time.Duration) error {
 	}
 }
 
-// SleepContextUnconfirmed is SleepContext for a poll loop the provider may already
-// be executing: cancellation cannot rule the broadcast out, so it reports
-// CodeBroadcastUnconfirmed with providerTxID rather than a plain failure the
-// caller would be free to retry.
+// SleepContextUnconfirmed is SleepContext for a poll loop whose transaction the
+// provider may already be executing: cancellation cannot rule the broadcast out, so
+// it reports CodeBroadcastUnconfirmed rather than a failure the caller may retry.
 func SleepContextUnconfirmed(ctx context.Context, d time.Duration, providerTxID string) error {
 	if err := SleepContext(ctx, d); err == nil {
 		return nil

--- a/go/core/remote_test.go
+++ b/go/core/remote_test.go
@@ -1,0 +1,47 @@
+package core
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestSleepContextReportsCancellationAsAFailedRequest(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := SleepContext(ctx, time.Minute)
+	if code, ok := CodeOf(err); !ok || code != CodeHTTPError {
+		t.Errorf("got code %q (ok=%v), want CodeHTTPError", code, ok)
+	}
+}
+
+// Cancelling a poll the provider may already be executing must not look like a
+// plain failure: the caller would retry a transaction that is already on chain.
+func TestSleepContextUnconfirmedReportsCancellationAsUnconfirmed(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := SleepContextUnconfirmed(ctx, time.Minute, "provider-tx-1")
+
+	var se *SignerError
+	if !errors.As(err, &se) {
+		t.Fatalf("got %v, want a *SignerError", err)
+	}
+	if se.Code != CodeBroadcastUnconfirmed {
+		t.Errorf("got code %q, want CodeBroadcastUnconfirmed", se.Code)
+	}
+	if se.ProviderTxID != "provider-tx-1" {
+		t.Errorf("got provider transaction id %q, want provider-tx-1", se.ProviderTxID)
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Error("the cancellation cause is not reachable via errors.Is")
+	}
+}
+
+func TestSleepContextUnconfirmedReturnsNilWhenTheWaitCompletes(t *testing.T) {
+	if err := SleepContextUnconfirmed(context.Background(), time.Millisecond, "provider-tx-1"); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/go/core/remote_test.go
+++ b/go/core/remote_test.go
@@ -17,8 +17,7 @@ func TestSleepContextReportsCancellationAsAFailedRequest(t *testing.T) {
 	}
 }
 
-// Cancelling a poll the provider may already be executing must not look like a
-// plain failure: the caller would retry a transaction that is already on chain.
+// A plain failure here would invite a retry of a transaction already on chain.
 func TestSleepContextUnconfirmedReportsCancellationAsUnconfirmed(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()

--- a/go/core/send_test.go
+++ b/go/core/send_test.go
@@ -83,6 +83,20 @@ func TestSignAndSendTransactionRequiresASenderBeforeSigning(t *testing.T) {
 	}
 }
 
+// The signature a broadcasting provider returns is the only handle on the
+// transaction it just put on chain, so an empty one cannot be passed off as one.
+func TestSignAndSendTransactionRejectsABroadcastWithoutASignature(t *testing.T) {
+	s := &sendingSigner{
+		broadcasts: true,
+		signed:     SignedTransaction{EncodedTransaction: "encoded", Completeness: Complete},
+	}
+
+	_, err := SignAndSendTransaction(context.Background(), s, &solana.Transaction{}, nil)
+	if code, ok := CodeOf(err); !ok || code != CodeSigningFailed {
+		t.Errorf("got code %q (ok=%v), want CodeSigningFailed", code, ok)
+	}
+}
+
 // A partially signed transaction cannot land, so it must not reach the sender.
 func TestSignAndSendTransactionRejectsPartialSignatures(t *testing.T) {
 	s := &sendingSigner{signed: SignedTransaction{EncodedTransaction: "encoded", Completeness: Partial}}

--- a/go/core/send_test.go
+++ b/go/core/send_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/gagliardetto/solana-go"
 )
 
-// sendingSigner is a minimal in-package Signer stub for SignAndSendTransaction
-// tests: it records that it signed and returns a configurable result.
+// sendingSigner is a minimal in-package Signer stub: it records that it signed
+// and returns a configurable result.
 type sendingSigner struct {
 	broadcasts bool
 	signed     SignedTransaction
@@ -36,8 +36,8 @@ func completeSignature(first byte) SignedTransaction {
 	return SignedTransaction{EncodedTransaction: "encoded", Signature: sig, Completeness: Complete}
 }
 
-// A managed-broadcast signer needs no send function: its SignTransaction already
-// put the transaction on chain, so its own signature identifies it.
+// A managed-broadcast signer needs no send function: SignTransaction already put
+// the transaction on chain.
 func TestSignAndSendTransactionUsesTheProviderBroadcast(t *testing.T) {
 	s := &sendingSigner{broadcasts: true, signed: completeSignature(7)}
 
@@ -70,8 +70,7 @@ func TestSignAndSendTransactionBroadcastsWithTheInjectedSender(t *testing.T) {
 	}
 }
 
-// A sign-only signer with no sender must fail before signing: a signature the
-// caller cannot broadcast is a wasted remote signing request.
+// A signature the caller cannot broadcast is a wasted remote signing request.
 func TestSignAndSendTransactionRequiresASenderBeforeSigning(t *testing.T) {
 	s := &sendingSigner{signed: completeSignature(1)}
 

--- a/go/core/send_test.go
+++ b/go/core/send_test.go
@@ -1,0 +1,103 @@
+package core
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gagliardetto/solana-go"
+)
+
+// sendingSigner is a minimal in-package Signer stub for SignAndSendTransaction
+// tests: it records that it signed and returns a configurable result.
+type sendingSigner struct {
+	broadcasts bool
+	signed     SignedTransaction
+	signCalls  int
+}
+
+func (s *sendingSigner) Pubkey() solana.PublicKey { return solana.PublicKey{} }
+
+func (s *sendingSigner) SignMessage(context.Context, []byte) (solana.Signature, error) {
+	return solana.Signature{}, NewSignerError(CodeSigningFailed, "not used in this test")
+}
+
+func (s *sendingSigner) SignTransaction(context.Context, *solana.Transaction) (SignedTransaction, error) {
+	s.signCalls++
+	return s.signed, nil
+}
+
+func (s *sendingSigner) IsAvailable(context.Context) bool { return true }
+
+func (s *sendingSigner) BroadcastsTransactions() bool { return s.broadcasts }
+
+func completeSignature(first byte) SignedTransaction {
+	var sig solana.Signature
+	sig[0] = first
+	return SignedTransaction{EncodedTransaction: "encoded", Signature: sig, Completeness: Complete}
+}
+
+// A managed-broadcast signer needs no send function: its SignTransaction already
+// put the transaction on chain, so its own signature identifies it.
+func TestSignAndSendTransactionUsesTheProviderBroadcast(t *testing.T) {
+	s := &sendingSigner{broadcasts: true, signed: completeSignature(7)}
+
+	sig, err := SignAndSendTransaction(context.Background(), s, &solana.Transaction{}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sig != s.signed.Signature {
+		t.Errorf("got signature %v, want the one the provider broadcast %v", sig, s.signed.Signature)
+	}
+}
+
+func TestSignAndSendTransactionBroadcastsWithTheInjectedSender(t *testing.T) {
+	s := &sendingSigner{signed: completeSignature(9)}
+	var sent string
+	send := func(_ context.Context, encoded string) (solana.Signature, error) {
+		sent = encoded
+		return s.signed.Signature, nil
+	}
+
+	sig, err := SignAndSendTransaction(context.Background(), s, &solana.Transaction{}, send)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sent != "encoded" {
+		t.Errorf("sender received %q, want the encoded signed transaction", sent)
+	}
+	if sig != s.signed.Signature {
+		t.Errorf("got signature %v, want %v", sig, s.signed.Signature)
+	}
+}
+
+// A sign-only signer with no sender must fail before signing: a signature the
+// caller cannot broadcast is a wasted remote signing request.
+func TestSignAndSendTransactionRequiresASenderBeforeSigning(t *testing.T) {
+	s := &sendingSigner{signed: completeSignature(1)}
+
+	_, err := SignAndSendTransaction(context.Background(), s, &solana.Transaction{}, nil)
+	if code, ok := CodeOf(err); !ok || code != CodeConfigError {
+		t.Errorf("got code %q (ok=%v), want CodeConfigError", code, ok)
+	}
+	if s.signCalls != 0 {
+		t.Errorf("signer called %d times, want 0", s.signCalls)
+	}
+}
+
+// A partially signed transaction cannot land, so it must not reach the sender.
+func TestSignAndSendTransactionRejectsPartialSignatures(t *testing.T) {
+	s := &sendingSigner{signed: SignedTransaction{EncodedTransaction: "encoded", Completeness: Partial}}
+	sendCalled := false
+	send := func(context.Context, string) (solana.Signature, error) {
+		sendCalled = true
+		return solana.Signature{}, nil
+	}
+
+	_, err := SignAndSendTransaction(context.Background(), s, &solana.Transaction{}, send)
+	if code, ok := CodeOf(err); !ok || code != CodeSigningFailed {
+		t.Errorf("got code %q (ok=%v), want CodeSigningFailed", code, ok)
+	}
+	if sendCalled {
+		t.Error("sender was called with a partially signed transaction")
+	}
+}

--- a/go/core/send_test.go
+++ b/go/core/send_test.go
@@ -30,6 +30,14 @@ func (s *sendingSigner) IsAvailable(context.Context) bool { return true }
 
 func (s *sendingSigner) BroadcastsTransactions() bool { return s.broadcasts }
 
+func (s *sendingSigner) SignAndSendTransaction(ctx context.Context, tx *solana.Transaction) (solana.Signature, error) {
+	signed, err := s.SignTransaction(ctx, tx)
+	if err != nil {
+		return solana.Signature{}, err
+	}
+	return signed.Signature, nil
+}
+
 func completeSignature(first byte) SignedTransaction {
 	var sig solana.Signature
 	sig[0] = first

--- a/go/core/sign.go
+++ b/go/core/sign.go
@@ -49,8 +49,19 @@ type SendTransactionFn func(ctx context.Context, encodedTransaction string) (sol
 // send is checked before signing so a missing one cannot waste a signature.
 func SignAndSendTransaction(ctx context.Context, s Signer, tx *solana.Transaction, send SendTransactionFn) (solana.Signature, error) {
 	broadcaster, ok := s.(TransactionBroadcaster)
-	broadcasts := ok && broadcaster.BroadcastsTransactions()
-	if !broadcasts && send == nil {
+	if ok && broadcaster.BroadcastsTransactions() {
+		signed, err := s.SignTransaction(ctx, tx)
+		if err != nil {
+			return solana.Signature{}, err
+		}
+		if signed.Signature == (solana.Signature{}) {
+			return solana.Signature{}, NewSignerError(CodeSigningFailed,
+				"signer returned no signature for the transaction it broadcast")
+		}
+		return signed.Signature, nil
+	}
+
+	if send == nil {
 		return solana.Signature{}, NewSignerError(CodeConfigError,
 			"this signer cannot broadcast transactions; supply a SendTransactionFn to broadcast the signed one")
 	}
@@ -58,9 +69,6 @@ func SignAndSendTransaction(ctx context.Context, s Signer, tx *solana.Transactio
 	signed, err := s.SignTransaction(ctx, tx)
 	if err != nil {
 		return solana.Signature{}, err
-	}
-	if broadcasts {
-		return signed.Signature, nil
 	}
 	if !signed.IsComplete() {
 		return solana.Signature{}, NewSignerError(CodeSigningFailed,

--- a/go/core/sign.go
+++ b/go/core/sign.go
@@ -38,19 +38,15 @@ func AttachSignature(tx *solana.Transaction, pubkey solana.PublicKey, sig solana
 	return Classify(tx, encoded, sig), nil
 }
 
-// SendTransactionFn broadcasts a base64-encoded wire transaction and returns the
-// signature identifying it. Core has no RPC dependency, so the network hop is
-// always injected: implement it with whatever transport the caller already has,
-// an rpc.Client.SendEncodedTransaction call or a relayer endpoint.
+// SendTransactionFn broadcasts a base64-encoded wire transaction and returns its
+// signature. Core has no RPC dependency, so the network hop is always caller-supplied.
 type SendTransactionFn func(ctx context.Context, encodedTransaction string) (solana.Signature, error)
 
-// SignAndSendTransaction gets tx on chain with one call, whichever shape the
-// signer has. A TransactionBroadcaster signs and broadcasts through its provider,
-// so its own signature identifies the transaction; any other signer signs and send
-// broadcasts the result.
+// SignAndSendTransaction gets tx on chain with one call. A TransactionBroadcaster
+// broadcasts through its provider, so its own signature identifies the transaction
+// and send is ignored; any other signer signs and send broadcasts the result.
 //
-// send is required for signers that do not broadcast and ignored by the ones that
-// do. It is checked before signing so a missing one cannot waste a signature.
+// send is checked before signing so a missing one cannot waste a signature.
 func SignAndSendTransaction(ctx context.Context, s Signer, tx *solana.Transaction, send SendTransactionFn) (solana.Signature, error) {
 	broadcaster, ok := s.(TransactionBroadcaster)
 	broadcasts := ok && broadcaster.BroadcastsTransactions()

--- a/go/core/sign.go
+++ b/go/core/sign.go
@@ -38,6 +38,41 @@ func AttachSignature(tx *solana.Transaction, pubkey solana.PublicKey, sig solana
 	return Classify(tx, encoded, sig), nil
 }
 
+// SendTransactionFn broadcasts a base64-encoded wire transaction and returns the
+// signature identifying it. Core has no RPC dependency, so the network hop is
+// always injected: implement it with whatever transport the caller already has,
+// an rpc.Client.SendEncodedTransaction call or a relayer endpoint.
+type SendTransactionFn func(ctx context.Context, encodedTransaction string) (solana.Signature, error)
+
+// SignAndSendTransaction gets tx on chain with one call, whichever shape the
+// signer has. A TransactionBroadcaster signs and broadcasts through its provider,
+// so its own signature identifies the transaction; any other signer signs and send
+// broadcasts the result.
+//
+// send is required for signers that do not broadcast and ignored by the ones that
+// do. It is checked before signing so a missing one cannot waste a signature.
+func SignAndSendTransaction(ctx context.Context, s Signer, tx *solana.Transaction, send SendTransactionFn) (solana.Signature, error) {
+	broadcaster, ok := s.(TransactionBroadcaster)
+	broadcasts := ok && broadcaster.BroadcastsTransactions()
+	if !broadcasts && send == nil {
+		return solana.Signature{}, NewSignerError(CodeConfigError,
+			"this signer cannot broadcast transactions; supply a SendTransactionFn to broadcast the signed one")
+	}
+
+	signed, err := s.SignTransaction(ctx, tx)
+	if err != nil {
+		return solana.Signature{}, err
+	}
+	if broadcasts {
+		return signed.Signature, nil
+	}
+	if !signed.IsComplete() {
+		return solana.Signature{}, NewSignerError(CodeSigningFailed,
+			"transaction is still missing signatures after signing and cannot be broadcast")
+	}
+	return send(ctx, signed.EncodedTransaction)
+}
+
 // SignTransactionWith signs tx's message with signFn and attaches the resulting
 // signature at pubkey's position. Backends whose remote API signs the message
 // bytes directly implement SignTransaction through this helper.

--- a/go/core/sign.go
+++ b/go/core/sign.go
@@ -50,15 +50,15 @@ type SendTransactionFn func(ctx context.Context, encodedTransaction string) (sol
 func SignAndSendTransaction(ctx context.Context, s Signer, tx *solana.Transaction, send SendTransactionFn) (solana.Signature, error) {
 	broadcaster, ok := s.(TransactionBroadcaster)
 	if ok && broadcaster.BroadcastsTransactions() {
-		signed, err := s.SignTransaction(ctx, tx)
+		sig, err := broadcaster.SignAndSendTransaction(ctx, tx)
 		if err != nil {
 			return solana.Signature{}, err
 		}
-		if signed.Signature == (solana.Signature{}) {
+		if sig == (solana.Signature{}) {
 			return solana.Signature{}, NewSignerError(CodeSigningFailed,
 				"signer returned no signature for the transaction it broadcast")
 		}
-		return signed.Signature, nil
+		return sig, nil
 	}
 
 	if send == nil {

--- a/go/core/types.go
+++ b/go/core/types.go
@@ -62,14 +62,19 @@ type Signer interface {
 	IsAvailable(ctx context.Context) bool
 }
 
-// TransactionBroadcaster marks signers whose SignTransaction broadcasts
+// TransactionBroadcaster marks signers whose provider executes the transaction
 // server-side, where a failure does not mean nothing happened; callers must
 // reconcile by provider transaction id before retrying, and SignTransactions
 // rejects them.
 type TransactionBroadcaster interface {
-	// BroadcastsTransactions reports whether SignTransaction broadcasts in
-	// this signer's current configuration.
+	// BroadcastsTransactions reports whether this signer broadcasts in its
+	// current configuration.
 	BroadcastsTransactions() bool
+
+	// SignAndSendTransaction signs tx and broadcasts it through the provider.
+	// The provider may rewrite tx, in which case tx is left untouched and the
+	// returned signature identifies the transaction that actually landed.
+	SignAndSendTransaction(ctx context.Context, tx *solana.Transaction) (solana.Signature, error)
 }
 
 // SignatureDictionary maps a signer address to its signature, a convenience for

--- a/go/signers/crossmint/signer.go
+++ b/go/signers/crossmint/signer.go
@@ -274,7 +274,7 @@ func (s *Signer) pollTransaction(ctx context.Context, response transactionRespon
 			response = next
 			approvalSubmitted = true
 		default:
-			if err := core.SleepContext(ctx, s.pollInterval); err != nil {
+			if err := core.SleepContextUnconfirmed(ctx, s.pollInterval, response.ID); err != nil {
 				return transactionResponse{}, err
 			}
 			next, err := s.getTransaction(ctx, response.ID)

--- a/go/signers/crossmint/signer.go
+++ b/go/signers/crossmint/signer.go
@@ -242,10 +242,7 @@ func (s *Signer) finishManagedTransaction(ctx context.Context, tx *solana.Transa
 	return core.AttachSignature(tx, s.publicKey, sig)
 }
 
-// SignAndSendTransaction signs tx and lets Crossmint execute it. Crossmint
-// decides per request whether to rewrite and broadcast the transaction or to
-// sign the caller's exact bytes; SignTransaction exposes that distinction
-// through an empty EncodedTransaction.
+// SignAndSendTransaction signs tx and lets Crossmint execute it.
 func (s *Signer) SignAndSendTransaction(ctx context.Context, tx *solana.Transaction) (solana.Signature, error) {
 	signed, err := s.SignTransaction(ctx, tx)
 	if err != nil {

--- a/go/signers/crossmint/signer.go
+++ b/go/signers/crossmint/signer.go
@@ -190,6 +190,10 @@ func (s *Signer) SignMessage(_ context.Context, _ []byte) (solana.Signature, err
 // replaying these exact bytes cannot create a second transaction; a rebuilt
 // transaction derives a different key and executes as a new transfer.
 func (s *Signer) SignTransaction(ctx context.Context, tx *solana.Transaction) (core.SignedTransaction, error) {
+	return s.executeManagedTransaction(ctx, tx)
+}
+
+func (s *Signer) executeManagedTransaction(ctx context.Context, tx *solana.Transaction) (core.SignedTransaction, error) {
 	if s.publicKey.IsZero() {
 		return core.SignedTransaction{}, core.NewNotInitializedError("crossmint")
 	}
@@ -244,7 +248,7 @@ func (s *Signer) finishManagedTransaction(ctx context.Context, tx *solana.Transa
 
 // SignAndSendTransaction signs tx and lets Crossmint execute it.
 func (s *Signer) SignAndSendTransaction(ctx context.Context, tx *solana.Transaction) (solana.Signature, error) {
-	signed, err := s.SignTransaction(ctx, tx)
+	signed, err := s.executeManagedTransaction(ctx, tx)
 	if err != nil {
 		return solana.Signature{}, err
 	}

--- a/go/signers/crossmint/signer.go
+++ b/go/signers/crossmint/signer.go
@@ -242,6 +242,18 @@ func (s *Signer) finishManagedTransaction(ctx context.Context, tx *solana.Transa
 	return core.AttachSignature(tx, s.publicKey, sig)
 }
 
+// SignAndSendTransaction signs tx and lets Crossmint execute it. Crossmint
+// decides per request whether to rewrite and broadcast the transaction or to
+// sign the caller's exact bytes; SignTransaction exposes that distinction
+// through an empty EncodedTransaction.
+func (s *Signer) SignAndSendTransaction(ctx context.Context, tx *solana.Transaction) (solana.Signature, error) {
+	signed, err := s.SignTransaction(ctx, tx)
+	if err != nil {
+		return solana.Signature{}, err
+	}
+	return signed.Signature, nil
+}
+
 // IsAvailable reports whether the Crossmint wallet can be fetched within the
 // availability timeout. Errors are swallowed.
 func (s *Signer) IsAvailable(ctx context.Context) bool {

--- a/go/signers/fordefi/client.go
+++ b/go/signers/fordefi/client.go
@@ -197,7 +197,8 @@ func (s *Signer) getTransaction(ctx context.Context, txID string) (transactionSt
 // attempt budget is exhausted. When pushable is true (native Solana
 // transactions, auto-broadcast) the only success state is "completed"; when
 // false (black box / messages) "signed" succeeds, with "completed" accepted
-// defensively. Cancellation of ctx aborts the wait.
+// defensively. Cancellation of ctx aborts the wait, reported as
+// CodeBroadcastUnconfirmed when pushable because Fordefi may already have executed it.
 func (s *Signer) pollForResult(ctx context.Context, txID string, pushable bool) (transactionStatusResponse, error) {
 	for attempt := 0; attempt < s.maxPollAttempts; attempt++ {
 		response, err := s.getTransaction(ctx, txID)
@@ -215,7 +216,13 @@ func (s *Signer) pollForResult(ctx context.Context, txID string, pushable bool) 
 		}
 
 		if attempt+1 < s.maxPollAttempts {
-			if err := core.SleepContext(ctx, s.pollInterval); err != nil {
+			var err error
+			if pushable {
+				err = core.SleepContextUnconfirmed(ctx, s.pollInterval, txID)
+			} else {
+				err = core.SleepContext(ctx, s.pollInterval)
+			}
+			if err != nil {
 				return transactionStatusResponse{}, err
 			}
 		}

--- a/go/signers/fordefi/signer.go
+++ b/go/signers/fordefi/signer.go
@@ -24,9 +24,10 @@ const (
 // Two signing modes are supported, selected by Config.Chain:
 //   - Black box (default, Chain empty): signs the caller's exact message bytes
 //     via black_box_signature; the caller broadcasts the signed transaction.
+//     See SignTransaction.
 //   - Native Solana (Chain set): submits solana_transaction requests with
-//     push_mode "auto" — Fordefi may replace the blockhash and fees, signs,
-//     and broadcasts the transaction itself. See SignTransaction.
+//     push_mode "auto"; Fordefi may replace the blockhash and fees, signs,
+//     and broadcasts the transaction itself. See SignAndSendTransaction.
 type Signer struct {
 	accessToken     string
 	vaultID         string

--- a/go/signers/fordefi/signer.go
+++ b/go/signers/fordefi/signer.go
@@ -203,7 +203,8 @@ func (s *Signer) SignMessage(ctx context.Context, message []byte) (solana.Signat
 // rebuilt transaction derives a different id and is broadcast again.
 func (s *Signer) SignTransaction(ctx context.Context, tx *solana.Transaction) (core.SignedTransaction, error) {
 	if s.chain != "" {
-		return s.signTransactionNative(ctx, tx)
+		return core.SignedTransaction{}, core.NewSignerError(core.CodeSigningFailed,
+			"Fordefi native mode broadcasts through its own API; call SignAndSendTransaction instead")
 	}
 	messageBytes, err := tx.Message.MarshalBinary()
 	if err != nil {
@@ -217,6 +218,22 @@ func (s *Signer) SignTransaction(ctx context.Context, tx *solana.Transaction) (c
 		return core.SignedTransaction{}, err
 	}
 	return core.AttachSignature(tx, s.pubkey, signature)
+}
+
+// SignAndSendTransaction signs tx and lets Fordefi broadcast it, which only
+// native mode does. Fordefi replaces the blockhash (and optionally fees) and
+// signs its own bytes, so tx is left untouched and the returned signature
+// identifies the transaction that landed.
+func (s *Signer) SignAndSendTransaction(ctx context.Context, tx *solana.Transaction) (solana.Signature, error) {
+	if s.chain == "" {
+		return solana.Signature{}, core.NewSignerError(core.CodeSigningFailed,
+			"Fordefi black-box mode only signs; sign the transaction and broadcast the result")
+	}
+	signed, err := s.signTransactionNative(ctx, tx)
+	if err != nil {
+		return solana.Signature{}, err
+	}
+	return signed.Signature, nil
 }
 
 // IsAvailable reports whether the vault is reachable with the bearer token and

--- a/go/signers/fordefi/signer_test.go
+++ b/go/signers/fordefi/signer_test.go
@@ -630,18 +630,12 @@ func TestSignTransactionNativeSuccess(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	res, err := s.SignTransaction(context.Background(), tx)
+	res, err := s.SignAndSendTransaction(context.Background(), tx)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if res.EncodedTransaction != "" {
-		t.Error("native mode auto-broadcasts; EncodedTransaction must be empty")
-	}
-	if res.Signature != signature {
-		t.Errorf("signature = %s, want %s", res.Signature, signature)
-	}
-	if !res.IsComplete() {
-		t.Error("returned transaction is fully signed, want Complete")
+	if res != signature {
+		t.Errorf("signature = %s, want %s", res, signature)
 	}
 	for _, sig := range tx.Signatures {
 		if !sig.IsZero() {
@@ -661,7 +655,7 @@ func TestSignTransactionNativeWaitsForCompleted(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = s.SignTransaction(context.Background(), tx)
+	_, err = s.SignAndSendTransaction(context.Background(), tx)
 	if err == nil {
 		t.Fatal("expected polling timeout when a pushable transaction never completes")
 	}
@@ -696,7 +690,7 @@ func TestSignTransactionNativeSubmitServerErrorIsUnconfirmedWithoutID(t *testing
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = s.SignTransaction(context.Background(), tx)
+	_, err = s.SignAndSendTransaction(context.Background(), tx)
 	if err == nil {
 		t.Fatal("expected a failed submit to be reported")
 	}
@@ -715,7 +709,7 @@ func TestSignTransactionNativeSubmitWithoutIDIsUnconfirmed(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = s.SignTransaction(context.Background(), tx)
+	_, err = s.SignAndSendTransaction(context.Background(), tx)
 	if err == nil {
 		t.Fatal("expected an accepted submit without an id to be reported")
 	}
@@ -734,7 +728,7 @@ func TestSignTransactionNativeSubmitRejectionStaysPlainFailure(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = s.SignTransaction(context.Background(), tx)
+	_, err = s.SignAndSendTransaction(context.Background(), tx)
 	if code, _ := core.CodeOf(err); code != core.CodeRemoteAPIError {
 		t.Errorf("got %s, want REMOTE_API_ERROR", code)
 	}
@@ -790,7 +784,7 @@ func TestSignTransactionNativeRejectsMultiSigner(t *testing.T) {
 		t.Fatal(err)
 	}
 	tx.Message.Header.NumRequiredSignatures = 2
-	_, err = s.SignTransaction(context.Background(), tx)
+	_, err = s.SignAndSendTransaction(context.Background(), tx)
 	if err == nil {
 		t.Fatal("expected multi-signer transaction to be rejected")
 	}
@@ -811,7 +805,7 @@ func TestSignTransactionNativeMissingRawTransaction(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = s.SignTransaction(context.Background(), tx)
+	_, err = s.SignAndSendTransaction(context.Background(), tx)
 	if err == nil {
 		t.Fatal("expected error when raw_transaction is missing")
 	}
@@ -836,7 +830,7 @@ func TestSignTransactionNativeUndecodableRawTransaction(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = s.SignTransaction(context.Background(), tx)
+	_, err = s.SignAndSendTransaction(context.Background(), tx)
 	if err == nil {
 		t.Fatal("expected error for an undecodable wire transaction")
 	}

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -7,6 +7,7 @@
 - thirteen-backend parity: Memory, Vault, Privy, Turnkey, AWS KMS, Fireblocks, GCP KMS, Dfns, Para, CDP, Crossmint, Openfort, Utila (#210, #211, #213–#221)
 - `create_keychain_signer()` umbrella factory with lazy per-backend imports, plus the env-gated live integration suite (#222)
 - Fordefi backend: black-box raw signing and native Solana auto-broadcast mode, pluggable P-256 request signer, vault ownership verification (#227)
+- `sign_and_send_transaction()`: one call to get a transaction on chain, using the provider's broadcast when the signer has one and a caller-injected send function otherwise
 
 ### Bug Fixes
 

--- a/python/README.md
+++ b/python/README.md
@@ -135,6 +135,22 @@ Errors are always `SignerError` with a stable `code`
 (`SIGNER_INVALID_PRIVATE_KEY`, `SIGNER_SIGNING_FAILED`, …).
 `str()`/`repr()` of a `SignerError` never include key material or raw remote responses.
 
+### Sign and Send
+
+`sign_and_send_transaction` gets a transaction on chain with one call whichever
+shape the signer has. Signers whose `broadcasts_transactions` is True (Crossmint,
+Fordefi native mode) broadcast through their provider and the send function is
+never called; every other signer signs and the injected function broadcasts the
+result:
+
+```python
+from solana_keychain import sign_and_send_transaction
+
+signature = await sign_and_send_transaction(
+    signer, transaction, lambda encoded: rpc_send(encoded)
+)
+```
+
 ## Development
 
 From the repo root (recipes bootstrap `python/.venv` automatically):

--- a/python/README.md
+++ b/python/README.md
@@ -137,18 +137,15 @@ Errors are always `SignerError` with a stable `code`
 
 ### Sign and Send
 
-`sign_and_send_transaction` gets a transaction on chain with one call whichever
-shape the signer has. Signers whose `broadcasts_transactions` is True (Crossmint,
-Fordefi native mode) broadcast through their provider and the send function is
-never called; every other signer signs and the injected function broadcasts the
-result:
+`sign_and_send_transaction` gets a transaction on chain with one call. Signers
+whose `broadcasts_transactions` is True (Crossmint, Fordefi native mode) broadcast
+through their provider and the send function is never called; every other signer
+signs and the send function broadcasts the base64-encoded result:
 
 ```python
 from solana_keychain import sign_and_send_transaction
 
-signature = await sign_and_send_transaction(
-    signer, transaction, lambda encoded: rpc_send(encoded)
-)
+signature = await sign_and_send_transaction(signer, transaction, rpc_send)
 ```
 
 ## Development

--- a/python/README.md
+++ b/python/README.md
@@ -135,6 +135,21 @@ Errors are always `SignerError` with a stable `code`
 (`SIGNER_INVALID_PRIVATE_KEY`, `SIGNER_SIGNING_FAILED`, …).
 `str()`/`repr()` of a `SignerError` never include key material or raw remote responses.
 
+### Signer capabilities
+
+Backends differ in whether the provider broadcasts the transaction and in whether
+they can sign arbitrary bytes. `broadcasts_transactions` reports the first at
+runtime; the second is fixed per backend:
+
+| Backend | `broadcasts_transactions` | `sign_transaction` | `sign_message` |
+|---------|---------------------------|--------------------|----------------|
+| memory, vault, privy, turnkey, aws-kms, fireblocks, gcp-kms, dfns, para, openfort | False | yes | yes |
+| cdp | False | yes | UTF-8 payloads only, otherwise `SERIALIZATION_ERROR` |
+| crossmint | True | provider broadcasts | `SIGNING_FAILED` |
+| utila | False | yes | `SIGNING_FAILED` |
+| fordefi (black-box mode) | False | yes | yes |
+| fordefi (native mode) | True | provider broadcasts | yes |
+
 ### Sign and Send
 
 `sign_and_send_transaction` gets a transaction on chain with one call. Signers

--- a/python/README.md
+++ b/python/README.md
@@ -141,14 +141,18 @@ Backends differ in whether the provider broadcasts the transaction and in whethe
 they can sign arbitrary bytes. `broadcasts_transactions` reports the first at
 runtime; the second is fixed per backend:
 
-| Backend | `broadcasts_transactions` | `sign_transaction` | `sign_message` |
-|---------|---------------------------|--------------------|----------------|
-| memory, vault, privy, turnkey, aws-kms, fireblocks, gcp-kms, dfns, para, openfort | False | yes | yes |
-| cdp | False | yes | UTF-8 payloads only, otherwise `SERIALIZATION_ERROR` |
-| crossmint | True | provider broadcasts | `SIGNING_FAILED` |
-| utila | False | yes | `SIGNING_FAILED` |
-| fordefi (black-box mode) | False | yes | yes |
-| fordefi (native mode) | True | provider broadcasts | yes |
+| Backend | `broadcasts_transactions` | `sign_transaction` | `sign_and_send_transaction` | `sign_message` |
+|---------|---------------------------|--------------------|-----------------------------|----------------|
+| memory, vault, privy, turnkey, aws-kms, fireblocks, gcp-kms, dfns, para, openfort | False | yes | `SIGNING_FAILED` | yes |
+| cdp | False | yes | `SIGNING_FAILED` | UTF-8 payloads only, otherwise `SERIALIZATION_ERROR` |
+| crossmint | True | yes | yes | `SIGNING_FAILED` |
+| utila | False | yes | `SIGNING_FAILED` | `SIGNING_FAILED` |
+| fordefi (black-box mode) | False | yes | `SIGNING_FAILED` | yes |
+| fordefi (native mode) | True | `SIGNING_FAILED` | yes | yes |
+
+Crossmint supports both: it decides per request whether to rewrite and broadcast
+the transaction or to sign the caller's exact bytes, and `sign_transaction`
+exposes that distinction through an empty ``encoded_transaction``.
 
 ### Sign and Send
 

--- a/python/src/solana_keychain/__init__.py
+++ b/python/src/solana_keychain/__init__.py
@@ -1,8 +1,10 @@
 from solana_keychain.core import (
+    SendTransactionFn,
     SignedTransaction,
     SignerError,
     SignerErrorCode,
     SolanaSigner,
+    sign_and_send_transaction,
 )
 from solana_keychain.keychain import SUPPORTED_BACKENDS, create_keychain_signer
 from solana_keychain.memory import MemorySigner, MemorySignerConfig, create_memory_signer
@@ -15,6 +17,7 @@ __all__ = [
     "MemorySignerConfig",
     "ParaSigner",
     "ParaSignerConfig",
+    "SendTransactionFn",
     "SignedTransaction",
     "SignerError",
     "SignerErrorCode",
@@ -25,4 +28,5 @@ __all__ = [
     "create_memory_signer",
     "create_para_signer",
     "create_vault_signer",
+    "sign_and_send_transaction",
 ]

--- a/python/src/solana_keychain/core/__init__.py
+++ b/python/src/solana_keychain/core/__init__.py
@@ -6,6 +6,7 @@ from solana_keychain.core.http import (
     normalize_base_url,
     sanitize_remote_error_response,
 )
+from solana_keychain.core.send import SendTransactionFn, sign_and_send_transaction
 from solana_keychain.core.signature_util import verify_returned_signature
 from solana_keychain.core.signer import SignedTransaction, SolanaSigner, require_initialized
 from solana_keychain.core.transaction_util import (
@@ -21,6 +22,7 @@ from solana_keychain.core.transaction_util import (
 __all__ = [
     "DEFAULT_REQUEST_TIMEOUT_SECONDS",
     "ED25519_SIGNATURE_LENGTH",
+    "SendTransactionFn",
     "SignedTransaction",
     "SignerError",
     "SignerErrorCode",
@@ -35,6 +37,7 @@ __all__ = [
     "require_initialized",
     "sanitize_remote_error_response",
     "serialize_transaction",
+    "sign_and_send_transaction",
     "signed_message_bytes",
     "verify_returned_signature",
 ]

--- a/python/src/solana_keychain/core/send.py
+++ b/python/src/solana_keychain/core/send.py
@@ -1,0 +1,51 @@
+"""Getting a signed transaction on chain, whichever shape the signer has."""
+
+from collections.abc import Awaitable, Callable
+
+from solders.signature import Signature
+from solders.transaction import VersionedTransaction
+
+from solana_keychain.core.errors import SignerError, SignerErrorCode
+from solana_keychain.core.signer import SolanaSigner
+
+SendTransactionFn = Callable[[str], Awaitable[Signature]]
+"""Broadcasts a base64-encoded wire transaction and returns the signature
+identifying it. The package has no RPC client, so the network hop is always
+injected: implement it with whatever transport the caller already has, an RPC
+client call or a relayer endpoint."""
+
+
+async def sign_and_send_transaction(
+    signer: SolanaSigner,
+    transaction: VersionedTransaction,
+    send_transaction: SendTransactionFn | None = None,
+) -> Signature:
+    """Sign ``transaction`` and get it on chain with one call.
+
+    A signer whose ``broadcasts_transactions`` is True has already broadcast the
+    transaction through its provider, so its own signature identifies it and
+    ``send_transaction`` is never called. Any other signer signs, and
+    ``send_transaction`` broadcasts the encoded result.
+
+    Raises ``CONFIG_ERROR`` when a signer that cannot broadcast is given no
+    ``send_transaction``, checked before signing so a missing one cannot waste a
+    remote signing request, and ``SIGNING_FAILED`` when the signed transaction is
+    still missing signatures and therefore cannot land.
+    """
+    if not signer.broadcasts_transactions:
+        if send_transaction is None:
+            raise SignerError(
+                SignerErrorCode.CONFIG_ERROR,
+                "this signer cannot broadcast transactions; supply send_transaction to "
+                "broadcast the signed one",
+            )
+        signed = await signer.sign_transaction(transaction)
+        if not signed.is_complete:
+            raise SignerError(
+                SignerErrorCode.SIGNING_FAILED,
+                "transaction is still missing signatures after signing and cannot be broadcast",
+            )
+        return await send_transaction(signed.encoded_transaction)
+
+    signed = await signer.sign_transaction(transaction)
+    return signed.signature

--- a/python/src/solana_keychain/core/send.py
+++ b/python/src/solana_keychain/core/send.py
@@ -9,10 +9,8 @@ from solana_keychain.core.errors import SignerError, SignerErrorCode
 from solana_keychain.core.signer import SolanaSigner
 
 SendTransactionFn = Callable[[str], Awaitable[Signature]]
-"""Broadcasts a base64-encoded wire transaction and returns the signature
-identifying it. The package has no RPC client, so the network hop is always
-injected: implement it with whatever transport the caller already has, an RPC
-client call or a relayer endpoint."""
+"""Broadcasts a base64-encoded wire transaction and returns its signature. The
+package has no RPC client, so the network hop is always caller-supplied."""
 
 
 async def sign_and_send_transaction(
@@ -22,15 +20,13 @@ async def sign_and_send_transaction(
 ) -> Signature:
     """Sign ``transaction`` and get it on chain with one call.
 
-    A signer whose ``broadcasts_transactions`` is True has already broadcast the
-    transaction through its provider, so its own signature identifies it and
-    ``send_transaction`` is never called. Any other signer signs, and
+    A signer whose ``broadcasts_transactions`` is True broadcasts through its
+    provider and ``send_transaction`` is never called; any other signer signs and
     ``send_transaction`` broadcasts the encoded result.
 
     Raises ``CONFIG_ERROR`` when a signer that cannot broadcast is given no
-    ``send_transaction``, checked before signing so a missing one cannot waste a
-    remote signing request, and ``SIGNING_FAILED`` when the signed transaction is
-    still missing signatures and therefore cannot land.
+    ``send_transaction``, and ``SIGNING_FAILED`` when the signed transaction is
+    still missing signatures.
     """
     if not signer.broadcasts_transactions:
         if send_transaction is None:

--- a/python/src/solana_keychain/core/send.py
+++ b/python/src/solana_keychain/core/send.py
@@ -29,13 +29,13 @@ async def sign_and_send_transaction(
     returns no signature or the signed transaction is still missing signatures.
     """
     if signer.broadcasts_transactions:
-        signed = await signer.sign_transaction(transaction)
-        if signed.signature == Signature.default():
+        signature = await signer.sign_and_send_transaction(transaction)
+        if signature == Signature.default():
             raise SignerError(
                 SignerErrorCode.SIGNING_FAILED,
                 "signer returned no signature for the transaction it broadcast",
             )
-        return signed.signature
+        return signature
 
     if send_transaction is None:
         raise SignerError(

--- a/python/src/solana_keychain/core/send.py
+++ b/python/src/solana_keychain/core/send.py
@@ -25,23 +25,28 @@ async def sign_and_send_transaction(
     ``send_transaction`` broadcasts the encoded result.
 
     Raises ``CONFIG_ERROR`` when a signer that cannot broadcast is given no
-    ``send_transaction``, and ``SIGNING_FAILED`` when the signed transaction is
-    still missing signatures.
+    ``send_transaction``, and ``SIGNING_FAILED`` when the broadcasting signer
+    returns no signature or the signed transaction is still missing signatures.
     """
-    if not signer.broadcasts_transactions:
-        if send_transaction is None:
-            raise SignerError(
-                SignerErrorCode.CONFIG_ERROR,
-                "this signer cannot broadcast transactions; supply send_transaction to "
-                "broadcast the signed one",
-            )
+    if signer.broadcasts_transactions:
         signed = await signer.sign_transaction(transaction)
-        if not signed.is_complete:
+        if signed.signature == Signature.default():
             raise SignerError(
                 SignerErrorCode.SIGNING_FAILED,
-                "transaction is still missing signatures after signing and cannot be broadcast",
+                "signer returned no signature for the transaction it broadcast",
             )
-        return await send_transaction(signed.encoded_transaction)
+        return signed.signature
 
+    if send_transaction is None:
+        raise SignerError(
+            SignerErrorCode.CONFIG_ERROR,
+            "this signer cannot broadcast transactions; supply send_transaction to "
+            "broadcast the signed one",
+        )
     signed = await signer.sign_transaction(transaction)
-    return signed.signature
+    if not signed.is_complete:
+        raise SignerError(
+            SignerErrorCode.SIGNING_FAILED,
+            "transaction is still missing signatures after signing and cannot be broadcast",
+        )
+    return await send_transaction(signed.encoded_transaction)

--- a/python/src/solana_keychain/core/signer.py
+++ b/python/src/solana_keychain/core/signer.py
@@ -58,6 +58,22 @@ class SolanaSigner(ABC):
 
         Accepts legacy, v0 and v1."""
 
+    async def sign_and_send_transaction(self, transaction: VersionedTransaction) -> Signature:
+        """Sign ``transaction`` and broadcast it through the provider.
+
+        Implemented only by signers whose provider executes the transaction
+        server-side; ``broadcasts_transactions`` reports which shape a signer has
+        in its current configuration. The provider may rewrite the transaction, in
+        which case ``transaction`` is left untouched and the returned signature
+        identifies the transaction that actually landed.
+
+        Raises ``SIGNING_FAILED`` when this signer cannot broadcast.
+        """
+        raise SignerError(
+            SignerErrorCode.SIGNING_FAILED,
+            "this signer cannot broadcast transactions; sign it and broadcast the result",
+        )
+
     @abstractmethod
     async def sign_message(self, message: bytes) -> Signature:
         """Sign arbitrary message bytes."""

--- a/python/src/solana_keychain/crossmint/signer.py
+++ b/python/src/solana_keychain/crossmint/signer.py
@@ -648,12 +648,7 @@ class CrossmintSigner(SolanaSigner):
         )
 
     async def sign_and_send_transaction(self, transaction: VersionedTransaction) -> Signature:
-        """Sign ``transaction`` and let Crossmint execute it.
-
-        Crossmint decides per request whether to rewrite and broadcast the
-        transaction or to sign the caller's exact bytes; ``sign_transaction``
-        exposes that distinction through an empty ``encoded_transaction``.
-        """
+        """Sign ``transaction`` and let Crossmint execute it."""
         signed = await self.sign_transaction(transaction)
         return signed.signature
 

--- a/python/src/solana_keychain/crossmint/signer.py
+++ b/python/src/solana_keychain/crossmint/signer.py
@@ -647,6 +647,16 @@ class CrossmintSigner(SolanaSigner):
             transaction, serialize_transaction(transaction), signature
         )
 
+    async def sign_and_send_transaction(self, transaction: VersionedTransaction) -> Signature:
+        """Sign ``transaction`` and let Crossmint execute it.
+
+        Crossmint decides per request whether to rewrite and broadcast the
+        transaction or to sign the caller's exact bytes; ``sign_transaction``
+        exposes that distinction through an empty ``encoded_transaction``.
+        """
+        signed = await self.sign_transaction(transaction)
+        return signed.signature
+
     async def sign_message(self, message: bytes) -> Signature:
         raise SignerError(
             SignerErrorCode.SIGNING_FAILED,

--- a/python/src/solana_keychain/crossmint/signer.py
+++ b/python/src/solana_keychain/crossmint/signer.py
@@ -592,6 +592,11 @@ class CrossmintSigner(SolanaSigner):
         transaction; a rebuilt transaction derives a different key and executes
         as a new transfer.
         """
+        return await self._execute_managed_transaction(transaction)
+
+    async def _execute_managed_transaction(
+        self, transaction: VersionedTransaction
+    ) -> SignedTransaction:
         public_key = self._initialized_pubkey()
         expected_message = signed_message_bytes(transaction.message)
         transaction_b58 = base58.b58encode(bytes(transaction)).decode("ascii")
@@ -649,7 +654,7 @@ class CrossmintSigner(SolanaSigner):
 
     async def sign_and_send_transaction(self, transaction: VersionedTransaction) -> Signature:
         """Sign ``transaction`` and let Crossmint execute it."""
-        signed = await self.sign_transaction(transaction)
+        signed = await self._execute_managed_transaction(transaction)
         return signed.signature
 
     async def sign_message(self, message: bytes) -> Signature:

--- a/python/src/solana_keychain/fordefi/signer.py
+++ b/python/src/solana_keychain/fordefi/signer.py
@@ -111,7 +111,8 @@ class FordefiSigner(SolanaSigner):
 
     Black-box mode (default) signs the caller's exact message bytes and the
     caller broadcasts. Native mode (``chain`` set) lets Fordefi replace the
-    blockhash and fees, sign, and auto-broadcast; see ``sign_transaction``.
+    blockhash and fees, sign, and auto-broadcast; see
+    ``sign_and_send_transaction``.
     """
 
     def __init__(self, config: FordefiSignerConfig) -> None:
@@ -337,27 +338,15 @@ class FordefiSigner(SolanaSigner):
         ``transaction`` in place, and returns the encoded transaction for the
         caller to broadcast.
 
-        Native mode (``chain`` set) submits the message for signing with
-        ``push_mode: auto``: Fordefi replaces the blockhash (and optionally
-        fees), signs, and broadcasts the transaction itself. The returned
-        ``encoded_transaction`` is therefore empty and ``transaction`` is left
-        unmodified — the returned signature identifies the on-chain
-        transaction. Only legacy transactions whose sole required signer is
-        the configured vault are supported.
-
-        Native mode is not retry-safe: any failure after Fordefi accepts the
-        submission raises ``BROADCAST_UNCONFIRMED`` carrying
-        ``provider_transaction_id``; check that transaction with Fordefi
-        before retrying. A submission that fails without a usable response
-        raises ``BROADCAST_UNCONFIRMED`` with no ``provider_transaction_id``.
-
-        Each native create carries an ``x-idempotence-id`` derived from the
-        message bytes, so replaying these exact bytes cannot create a second
-        transaction; a rebuilt transaction derives a different id and is
-        broadcast again.
+        Native mode (``chain`` set) broadcasts through Fordefi, so it raises
+        ``SIGNING_FAILED`` here; call ``sign_and_send_transaction`` instead.
         """
         if self._chain is not None:
-            return await self._sign_transaction_native(transaction)
+            raise SignerError(
+                SignerErrorCode.SIGNING_FAILED,
+                "Fordefi native mode broadcasts through its own API; call "
+                "sign_and_send_transaction instead",
+            )
         message_data = signed_message_bytes(transaction.message)
         signature = await self._sign_black_box(message_data)
         verify_returned_signature(signature, self._public_key, message_data)
@@ -365,6 +354,35 @@ class FordefiSigner(SolanaSigner):
         return classify_signed_transaction(
             transaction, serialize_transaction(transaction), signature
         )
+
+    async def sign_and_send_transaction(self, transaction: VersionedTransaction) -> Signature:
+        """Sign ``transaction`` and let Fordefi broadcast it (native mode only).
+
+        Submits the message for signing with ``push_mode: auto``: Fordefi
+        replaces the blockhash (and optionally fees), signs, and broadcasts the
+        transaction itself, so ``transaction`` is left unmodified and the
+        returned signature identifies the on-chain transaction. Only legacy
+        transactions whose sole required signer is the configured vault are
+        supported.
+
+        Not retry-safe: any failure after Fordefi accepts the submission raises
+        ``BROADCAST_UNCONFIRMED`` carrying ``provider_transaction_id``; check
+        that transaction with Fordefi before retrying. A submission that fails
+        without a usable response raises ``BROADCAST_UNCONFIRMED`` with no
+        ``provider_transaction_id``.
+
+        Each create carries an ``x-idempotence-id`` derived from the message
+        bytes, so replaying these exact bytes cannot create a second
+        transaction; a rebuilt transaction derives a different id and is
+        broadcast again.
+        """
+        if self._chain is None:
+            raise SignerError(
+                SignerErrorCode.SIGNING_FAILED,
+                "Fordefi black-box mode only signs; sign the transaction and broadcast the result",
+            )
+        signed = await self._sign_transaction_native(transaction)
+        return signed.signature
 
     def _require_sole_required_signer(self, transaction: VersionedTransaction) -> None:
         account_keys = transaction.message.account_keys

--- a/python/tests/test_fordefi_signer.py
+++ b/python/tests/test_fordefi_signer.py
@@ -359,7 +359,7 @@ async def test_sign_transaction_native_polling_timeout_is_broadcast_unconfirmed(
         return_value=status_response("waiting_for_signing_trigger")
     )
     with pytest.raises(SignerError) as excinfo:
-        await signer.sign_transaction(create_test_transaction(keypair.pubkey()))
+        await signer.sign_and_send_transaction(create_test_transaction(keypair.pubkey()))
     assert excinfo.value.code == SignerErrorCode.BROADCAST_UNCONFIRMED
     assert excinfo.value.provider_transaction_id == "tx-1"
 
@@ -372,7 +372,7 @@ async def test_native_submit_server_error_is_unconfirmed_without_a_transaction_i
         return_value=httpx.Response(502, json={"error": "bad gateway"})
     )
     with pytest.raises(SignerError) as excinfo:
-        await signer.sign_transaction(create_test_transaction(keypair.pubkey()))
+        await signer.sign_and_send_transaction(create_test_transaction(keypair.pubkey()))
     assert excinfo.value.code == SignerErrorCode.BROADCAST_UNCONFIRMED
     assert excinfo.value.provider_transaction_id is None
     assert excinfo.value.status_code == 502
@@ -384,7 +384,7 @@ async def test_native_submit_accepted_without_an_id_is_unconfirmed() -> None:
     signer = make_signer(keypair, chain="solana_devnet")
     respx.post(TRANSACTIONS_URL).mock(return_value=httpx.Response(200, json={"state": "pending"}))
     with pytest.raises(SignerError) as excinfo:
-        await signer.sign_transaction(create_test_transaction(keypair.pubkey()))
+        await signer.sign_and_send_transaction(create_test_transaction(keypair.pubkey()))
     assert excinfo.value.code == SignerErrorCode.BROADCAST_UNCONFIRMED
     assert excinfo.value.provider_transaction_id is None
     assert excinfo.value.status_code is None
@@ -398,7 +398,7 @@ async def test_native_submit_rejected_by_fordefi_stays_a_plain_failure() -> None
         return_value=httpx.Response(401, json={"error": "unauthorized"})
     )
     with pytest.raises(SignerError) as excinfo:
-        await signer.sign_transaction(create_test_transaction(keypair.pubkey()))
+        await signer.sign_and_send_transaction(create_test_transaction(keypair.pubkey()))
     assert excinfo.value.code == SignerErrorCode.REMOTE_API_ERROR
 
 
@@ -435,7 +435,7 @@ async def test_cancellation_during_native_submit_warns_without_a_transaction_id(
 
     async def run() -> None:
         try:
-            await signer.sign_transaction(create_test_transaction(keypair.pubkey()))
+            await signer.sign_and_send_transaction(create_test_transaction(keypair.pubkey()))
         except asyncio.CancelledError as error:
             observed.append(str(error))
             raise
@@ -472,7 +472,7 @@ async def test_sign_transaction_native_cancellation_carries_the_transaction_id(
 
     async def run() -> None:
         try:
-            await signer.sign_transaction(create_test_transaction(keypair.pubkey()))
+            await signer.sign_and_send_transaction(create_test_transaction(keypair.pubkey()))
         except asyncio.CancelledError as error:
             observed.append(str(error))
             raise
@@ -543,11 +543,9 @@ async def test_sign_transaction_native_success() -> None:
     )
     transaction = create_test_transaction(keypair.pubkey())
 
-    result = await signer.sign_transaction(transaction)
+    result = await signer.sign_and_send_transaction(transaction)
 
-    assert result.signature == signature
-    assert result.encoded_transaction == ""
-    assert result.is_complete
+    assert result == signature
     assert all(sig == Signature.default() for sig in transaction.signatures), (
         "the caller's transaction must be left untouched by provider-chosen bytes"
     )
@@ -572,7 +570,7 @@ async def test_sign_transaction_native_missing_raw_transaction() -> None:
     signer = make_signer(keypair, chain="solana_devnet")
     mock_sign_flow(status_response("completed"))
     with pytest.raises(SignerError) as excinfo:
-        await signer.sign_transaction(create_test_transaction(keypair.pubkey()))
+        await signer.sign_and_send_transaction(create_test_transaction(keypair.pubkey()))
     assert excinfo.value.code == SignerErrorCode.BROADCAST_UNCONFIRMED
     assert excinfo.value.provider_transaction_id == "tx-1"
 
@@ -587,7 +585,7 @@ async def test_sign_transaction_native_verifies_against_returned_message() -> No
     raw_transaction = base64.b64encode(bytes(returned)).decode("ascii")
     mock_sign_flow(status_response("completed", raw_transaction=raw_transaction))
     with pytest.raises(SignerError) as excinfo:
-        await signer.sign_transaction(transaction)
+        await signer.sign_and_send_transaction(transaction)
     assert excinfo.value.code == SignerErrorCode.BROADCAST_UNCONFIRMED
     assert excinfo.value.provider_transaction_id == "tx-1"
 
@@ -598,7 +596,7 @@ async def test_sign_transaction_native_rejects_multi_signer_before_submitting() 
     signer = make_signer(keypair, chain="solana_devnet")
     transaction = create_two_signer_transaction(keypair.pubkey(), Keypair().pubkey())
     with pytest.raises(SignerError) as excinfo:
-        await signer.sign_transaction(transaction)
+        await signer.sign_and_send_transaction(transaction)
     assert excinfo.value.code == SignerErrorCode.SIGNING_FAILED
     assert not respx.calls
 

--- a/python/tests/test_send.py
+++ b/python/tests/test_send.py
@@ -1,0 +1,96 @@
+import pytest
+from solders.keypair import Keypair
+from solders.pubkey import Pubkey
+from solders.signature import Signature
+from solders.transaction import VersionedTransaction
+
+from solana_keychain.core import (
+    SignedTransaction,
+    SignerError,
+    SignerErrorCode,
+    SolanaSigner,
+    sign_and_send_transaction,
+)
+from tests.util import create_test_transaction
+
+ENCODED = "encoded-transaction"
+SIGNATURE = Signature.default()
+
+
+class StubSigner(SolanaSigner):
+    def __init__(self, *, broadcasts: bool, is_complete: bool) -> None:
+        self._broadcasts = broadcasts
+        self._is_complete = is_complete
+        self._pubkey = Keypair().pubkey()
+
+    @property
+    def pubkey(self) -> Pubkey:
+        return self._pubkey
+
+    @property
+    def broadcasts_transactions(self) -> bool:
+        return self._broadcasts
+
+    async def sign_transaction(self, transaction: VersionedTransaction) -> SignedTransaction:
+        return SignedTransaction(
+            encoded_transaction=ENCODED,
+            signature=SIGNATURE,
+            is_complete=self._is_complete,
+        )
+
+    async def sign_message(self, message: bytes) -> Signature:
+        return SIGNATURE
+
+    async def is_available(self) -> bool:
+        return True
+
+
+async def test_broadcasting_signer_skips_the_injected_sender() -> None:
+    """A provider that broadcasts server-side has already put the transaction on
+    chain, so its own signature identifies it."""
+    signer = StubSigner(broadcasts=True, is_complete=True)
+
+    async def send(encoded: str) -> Signature:
+        raise AssertionError("send must not run for a signer that broadcasts")
+
+    signature = await sign_and_send_transaction(
+        signer, create_test_transaction(signer.pubkey), send
+    )
+    assert signature == SIGNATURE
+
+
+async def test_sign_only_signer_broadcasts_the_encoded_transaction() -> None:
+    signer = StubSigner(broadcasts=False, is_complete=True)
+    sent: list[str] = []
+    broadcast_signature = Signature.from_bytes(bytes([1] * 64))
+
+    async def send(encoded: str) -> Signature:
+        sent.append(encoded)
+        return broadcast_signature
+
+    signature = await sign_and_send_transaction(
+        signer, create_test_transaction(signer.pubkey), send
+    )
+    assert sent == [ENCODED]
+    assert signature == broadcast_signature
+
+
+async def test_missing_sender_is_rejected_before_signing() -> None:
+    """A signature the caller cannot broadcast is a wasted remote signing request."""
+    signer = StubSigner(broadcasts=False, is_complete=True)
+
+    with pytest.raises(SignerError) as excinfo:
+        await sign_and_send_transaction(signer, create_test_transaction(signer.pubkey))
+    assert excinfo.value.code == SignerErrorCode.CONFIG_ERROR
+
+
+async def test_partial_signature_is_rejected_before_broadcast() -> None:
+    """A partially signed transaction cannot land, so it must never be broadcast."""
+    signer = StubSigner(broadcasts=False, is_complete=False)
+
+    async def send(encoded: str) -> Signature:
+        raise AssertionError("send must not run for a partially signed transaction")
+
+    with pytest.raises(SignerError) as excinfo:
+        await sign_and_send_transaction(signer, create_test_transaction(signer.pubkey), send)
+    assert excinfo.value.code == SignerErrorCode.SIGNING_FAILED

--- a/python/tests/test_send.py
+++ b/python/tests/test_send.py
@@ -41,6 +41,9 @@ class StubSigner(SolanaSigner):
             is_complete=self._is_complete,
         )
 
+    async def sign_and_send_transaction(self, transaction: VersionedTransaction) -> Signature:
+        return self._signature
+
     async def sign_message(self, message: bytes) -> Signature:
         return self._signature
 

--- a/python/tests/test_send.py
+++ b/python/tests/test_send.py
@@ -46,8 +46,7 @@ class StubSigner(SolanaSigner):
 
 
 async def test_broadcasting_signer_skips_the_injected_sender() -> None:
-    """A provider that broadcasts server-side has already put the transaction on
-    chain, so its own signature identifies it."""
+    """A provider that broadcasts server-side already put the transaction on chain."""
     signer = StubSigner(broadcasts=True, is_complete=True)
 
     async def send(encoded: str) -> Signature:

--- a/python/tests/test_send.py
+++ b/python/tests/test_send.py
@@ -14,13 +14,16 @@ from solana_keychain.core import (
 from tests.util import create_test_transaction
 
 ENCODED = "encoded-transaction"
-SIGNATURE = Signature.default()
+SIGNATURE = Signature.from_bytes(bytes([7] * 64))
 
 
 class StubSigner(SolanaSigner):
-    def __init__(self, *, broadcasts: bool, is_complete: bool) -> None:
+    def __init__(
+        self, *, broadcasts: bool, is_complete: bool, signature: Signature = SIGNATURE
+    ) -> None:
         self._broadcasts = broadcasts
         self._is_complete = is_complete
+        self._signature = signature
         self._pubkey = Keypair().pubkey()
 
     @property
@@ -34,12 +37,12 @@ class StubSigner(SolanaSigner):
     async def sign_transaction(self, transaction: VersionedTransaction) -> SignedTransaction:
         return SignedTransaction(
             encoded_transaction=ENCODED,
-            signature=SIGNATURE,
+            signature=self._signature,
             is_complete=self._is_complete,
         )
 
     async def sign_message(self, message: bytes) -> Signature:
-        return SIGNATURE
+        return self._signature
 
     async def is_available(self) -> bool:
         return True
@@ -81,6 +84,19 @@ async def test_missing_sender_is_rejected_before_signing() -> None:
     with pytest.raises(SignerError) as excinfo:
         await sign_and_send_transaction(signer, create_test_transaction(signer.pubkey))
     assert excinfo.value.code == SignerErrorCode.CONFIG_ERROR
+
+
+async def test_broadcasting_signer_without_a_signature_is_rejected() -> None:
+    """The signature a broadcasting provider returns is the only handle on the
+    transaction it just put on chain, so an empty one cannot be passed off as one."""
+    signer = StubSigner(broadcasts=True, is_complete=True, signature=Signature.default())
+
+    async def send(encoded: str) -> Signature:
+        raise AssertionError("send must not run for a signer that broadcasts")
+
+    with pytest.raises(SignerError) as excinfo:
+        await sign_and_send_transaction(signer, create_test_transaction(signer.pubkey), send)
+    assert excinfo.value.code == SignerErrorCode.SIGNING_FAILED
 
 
 async def test_partial_signature_is_rejected_before_broadcast() -> None:

--- a/rust/README.md
+++ b/rust/README.md
@@ -321,6 +321,22 @@ pub trait SolanaSigner: Send + Sync {
 }
 ```
 
+### Sign and Send
+
+`sign_and_send` gets a transaction on chain with one call whichever shape the
+signer has. Signers that report `broadcasts_transactions()` (Crossmint, Fordefi
+native mode) broadcast through their provider and the send closure is never
+called; every other signer signs and the closure broadcasts the result:
+
+```rust
+use solana_keychain::sign_and_send;
+
+let signature = sign_and_send(&signer, &mut tx, |encoded| async move {
+    rpc_send(encoded).await
+})
+.await?;
+```
+
 ### Fordefi Signer
 
 Fordefi supports two signing modes, which differ in whether Fordefi broadcasts the transaction and in what `sign_transaction` returns:

--- a/rust/README.md
+++ b/rust/README.md
@@ -321,6 +321,21 @@ pub trait SolanaSigner: Send + Sync {
 }
 ```
 
+### Signer capabilities
+
+Backends differ in whether the provider broadcasts the transaction and in whether
+they can sign arbitrary bytes. `broadcasts_transactions()` reports the first at
+runtime; the second is fixed per backend:
+
+| Backend | `broadcasts_transactions()` | `sign_transaction` | `sign_message` |
+|---------|-----------------------------|--------------------|----------------|
+| memory, vault, privy, turnkey, aws-kms, fireblocks, gcp-kms, dfns, para, openfort | `false` | yes | yes |
+| cdp | `false` | yes | UTF-8 payloads only, otherwise `SerializationError` |
+| crossmint | `true` | provider broadcasts | `SigningFailed` |
+| utila | `false` | yes | `SigningFailed` |
+| fordefi (black-box mode) | `false` | yes | yes |
+| fordefi (native mode) | `true` | provider broadcasts | yes |
+
 ### Sign and Send
 
 `sign_and_send` gets a transaction on chain with one call. Signers that report

--- a/rust/README.md
+++ b/rust/README.md
@@ -323,10 +323,10 @@ pub trait SolanaSigner: Send + Sync {
 
 ### Sign and Send
 
-`sign_and_send` gets a transaction on chain with one call whichever shape the
-signer has. Signers that report `broadcasts_transactions()` (Crossmint, Fordefi
-native mode) broadcast through their provider and the send closure is never
-called; every other signer signs and the closure broadcasts the result:
+`sign_and_send` gets a transaction on chain with one call. Signers that report
+`broadcasts_transactions()` (Crossmint, Fordefi native mode) broadcast through
+their provider and the send closure is never called; every other signer signs and
+the closure broadcasts the base64-encoded result:
 
 ```rust
 use solana_keychain::sign_and_send;

--- a/rust/README.md
+++ b/rust/README.md
@@ -327,14 +327,18 @@ Backends differ in whether the provider broadcasts the transaction and in whethe
 they can sign arbitrary bytes. `broadcasts_transactions()` reports the first at
 runtime; the second is fixed per backend:
 
-| Backend | `broadcasts_transactions()` | `sign_transaction` | `sign_message` |
-|---------|-----------------------------|--------------------|----------------|
-| memory, vault, privy, turnkey, aws-kms, fireblocks, gcp-kms, dfns, para, openfort | `false` | yes | yes |
-| cdp | `false` | yes | UTF-8 payloads only, otherwise `SerializationError` |
-| crossmint | `true` | provider broadcasts | `SigningFailed` |
-| utila | `false` | yes | `SigningFailed` |
-| fordefi (black-box mode) | `false` | yes | yes |
-| fordefi (native mode) | `true` | provider broadcasts | yes |
+| Backend | `broadcasts_transactions()` | `sign_transaction` | `sign_and_send_transaction` | `sign_message` |
+|---------|-----------------------------|--------------------|-----------------------------|----------------|
+| memory, vault, privy, turnkey, aws-kms, fireblocks, gcp-kms, dfns, para, openfort | `false` | yes | `SigningFailed` | yes |
+| cdp | `false` | yes | `SigningFailed` | UTF-8 payloads only, otherwise `SerializationError` |
+| crossmint | `true` | yes | yes | `SigningFailed` |
+| utila | `false` | yes | `SigningFailed` | `SigningFailed` |
+| fordefi (black-box mode) | `false` | yes | `SigningFailed` | yes |
+| fordefi (native mode) | `true` | `SigningFailed` | yes | yes |
+
+Crossmint supports both: it decides per request whether to rewrite and broadcast
+the transaction or to sign the caller's exact bytes, and `sign_transaction`
+exposes that distinction through an empty encoded transaction.
 
 ### Sign and Send
 

--- a/rust/README.md
+++ b/rust/README.md
@@ -358,10 +358,10 @@ let signature = sign_and_send(&signer, &mut tx, |encoded| async move {
 
 ### Fordefi Signer
 
-Fordefi supports two signing modes, which differ in whether Fordefi broadcasts the transaction and in what `sign_transaction` returns:
+Fordefi supports two signing modes, which differ in whether Fordefi broadcasts the transaction and in which entry point is available:
 
-- **Black box mode** : Signs raw bytes via EdDSA; the wire transaction is assembled locally. Fordefi does **not** broadcast — `sign_transaction` returns the signed serialized transaction, and **you** submit it to an RPC. Use with a Fordefi black box vault.
-- **Native Solana mode** (recommended): Uses Solana-specific API types. Fordefi modifies the transaction (at minimum updating the blockhash, and optionally adding priority fees) and **auto-broadcasts** it on-chain (`push_mode: "auto"`). Because the transaction is already submitted, `sign_transaction` returns an **empty** serialized transaction (only the signature is meaningful) and updates your `&mut VersionedTransaction` to the Fordefi-signed one — do not re-send it. The current auto-broadcast request supports only transactions whose sole required signer is the configured Fordefi vault; additional required signers are rejected before submission. Use with a regular Fordefi Solana vault.
+- **Black box mode** : Signs raw bytes via EdDSA; the wire transaction is assembled locally. Fordefi does **not** broadcast: `sign_transaction` returns the signed serialized transaction, and **you** submit it to an RPC. `sign_and_send_transaction` is rejected in this mode. Use with a Fordefi black box vault.
+- **Native Solana mode** (recommended): Uses Solana-specific API types. Fordefi modifies the transaction (at minimum updating the blockhash, and optionally adding priority fees) and **auto-broadcasts** it on-chain (`push_mode: "auto"`). Call `sign_and_send_transaction`, which returns the signature, the on-chain identifier; do not re-send the transaction. `sign_transaction` is rejected in this mode. The current auto-broadcast request supports only transactions whose sole required signer is the configured Fordefi vault; additional required signers are rejected before submission. Use with a regular Fordefi Solana vault.
 
 Construction is async because it fetches the Fordefi vault and verifies that its
 authoritative address matches the configured `public_key` before returning.

--- a/rust/src/crossmint/mod.rs
+++ b/rust/src/crossmint/mod.rs
@@ -846,11 +846,22 @@ impl SolanaSigner for CrossmintSigner {
         true
     }
 
+    /// Crossmint decides per request whether to rewrite and broadcast the
+    /// transaction or to sign the caller's exact bytes, so both shapes stay
+    /// reachable: an empty encoded transaction means Crossmint broadcast it.
     async fn sign_transaction(
         &self,
         tx: &mut VersionedTransaction,
     ) -> Result<SignTransactionResult, SignerError> {
         self.sign_and_serialize(tx).await
+    }
+
+    async fn sign_and_send_transaction(
+        &self,
+        tx: &mut VersionedTransaction,
+    ) -> Result<Signature, SignerError> {
+        let (_, signature) = self.sign_and_serialize(tx).await?.into_signed_transaction();
+        Ok(signature)
     }
 
     async fn sign_message(&self, _message: &[u8]) -> Result<Signature, SignerError> {

--- a/rust/src/crossmint/mod.rs
+++ b/rust/src/crossmint/mod.rs
@@ -846,9 +846,6 @@ impl SolanaSigner for CrossmintSigner {
         true
     }
 
-    /// Crossmint decides per request whether to rewrite and broadcast the
-    /// transaction or to sign the caller's exact bytes, so both shapes stay
-    /// reachable: an empty encoded transaction means Crossmint broadcast it.
     async fn sign_transaction(
         &self,
         tx: &mut VersionedTransaction,

--- a/rust/src/fordefi/mod.rs
+++ b/rust/src/fordefi/mod.rs
@@ -706,16 +706,32 @@ impl SolanaSigner for FordefiSigner {
         &self,
         tx: &mut VersionedTransaction,
     ) -> Result<SignTransactionResult, SignerError> {
-        let signed_transaction = self.sign_and_serialize(tx).await?;
         if self.chain.is_some() {
-            // Native mode has already broadcast the transaction, so it is
-            // complete regardless of the caller's untouched signature slots.
-            return Ok(SignTransactionResult::Complete(signed_transaction));
+            return Err(SignerError::SigningFailed(
+                "Fordefi native mode broadcasts through its own API; call \
+                 sign_and_send_transaction instead"
+                    .to_string(),
+            ));
         }
+        let signed_transaction = self.sign_and_serialize(tx).await?;
         Ok(TransactionUtil::classify_signed_transaction(
             tx,
             signed_transaction,
         ))
+    }
+
+    async fn sign_and_send_transaction(
+        &self,
+        tx: &mut VersionedTransaction,
+    ) -> Result<Signature, SignerError> {
+        if self.chain.is_none() {
+            return Err(SignerError::SigningFailed(
+                "Fordefi black-box mode only signs; sign the transaction and broadcast the result"
+                    .to_string(),
+            ));
+        }
+        let (_, signature) = self.sign_and_serialize(tx).await?;
+        Ok(signature)
     }
 
     async fn sign_message(&self, message: &[u8]) -> Result<Signature, SignerError> {

--- a/rust/src/fordefi/mod.rs
+++ b/rust/src/fordefi/mod.rs
@@ -68,16 +68,16 @@ pub struct FordefiSignerConfig {
 
 /// Fordefi-based signer using Fordefi's MPC custody API.
 ///
-/// Supports two signing modes, which differ in what `sign_transaction` returns:
+/// Supports two signing modes, which differ in which entry point is available:
 /// - **Black box** (default, `chain` = `None`): Signs raw bytes via `black_box_signature`
-///   and returns nothing else. Fordefi does **not** broadcast; the returned serialized
+///   through `sign_transaction`. Fordefi does **not** broadcast; the returned serialized
 ///   transaction is the locally-assembled signed tx, which the caller submits to an RPC.
+///   `sign_and_send_transaction` is rejected in this mode.
 /// - **Native Solana** (`chain` = `Some(...)`): Uses `solana_transaction` / `solana_message`
-///   API types. Fordefi will modify the transaction (at minimum updating the blockhash,
-///   and optionally adding priority fees) and **auto-broadcasts** it on-chain
-///   (`push_mode: "auto"`). Because the transaction is already submitted, the returned
-///   serialized transaction is **empty** — only the signature, the on-chain
-///   identifier, is returned. The caller's `&mut Transaction` is left untouched.
+///   API types through `sign_and_send_transaction`. Fordefi will modify the transaction
+///   (at minimum updating the blockhash, and optionally adding priority fees),
+///   **auto-broadcasts** it on-chain (`push_mode: "auto"`), and returns the signature,
+///   the on-chain identifier. `sign_transaction` is rejected in this mode.
 pub struct FordefiSigner {
     access_token: String,
     vault_id: String,

--- a/rust/src/fordefi/mod.rs
+++ b/rust/src/fordefi/mod.rs
@@ -602,18 +602,6 @@ impl FordefiSigner {
             })
     }
 
-    /// Sign a transaction end-to-end, dispatching to black box or native path.
-    async fn sign_and_serialize(
-        &self,
-        transaction: &mut VersionedTransaction,
-    ) -> Result<SignedTransaction, SignerError> {
-        if self.chain.is_some() {
-            self.sign_and_serialize_native(transaction).await
-        } else {
-            self.sign_and_serialize_black_box(transaction).await
-        }
-    }
-
     /// Fetch the configured vault from Fordefi.
     async fn fetch_vault(&self) -> Result<VaultResponse, SignerError> {
         let url = format!("{}/api/v1/vaults/{}", self.api_base_url, self.vault_id);
@@ -713,7 +701,7 @@ impl SolanaSigner for FordefiSigner {
                     .to_string(),
             ));
         }
-        let signed_transaction = self.sign_and_serialize(tx).await?;
+        let signed_transaction = self.sign_and_serialize_black_box(tx).await?;
         Ok(TransactionUtil::classify_signed_transaction(
             tx,
             signed_transaction,
@@ -730,7 +718,7 @@ impl SolanaSigner for FordefiSigner {
                     .to_string(),
             ));
         }
-        let (_, signature) = self.sign_and_serialize(tx).await?;
+        let (_, signature) = self.sign_and_serialize_native(tx).await?;
         Ok(signature)
     }
 

--- a/rust/src/fordefi/tests.rs
+++ b/rust/src/fordefi/tests.rs
@@ -930,24 +930,13 @@ async fn test_fordefi_native_sign_transaction_success() {
         .await;
 
     let mut tx = tx;
-    let result = signer.sign_transaction(&mut tx).await;
+    let result = signer.sign_and_send_transaction(&mut tx).await;
     assert!(
         result.is_ok(),
-        "native sign_transaction failed: {:?}",
+        "native sign_and_send_transaction failed: {:?}",
         result.err()
     );
-    let result = result.unwrap();
-    assert!(
-        matches!(result, SignTransactionResult::Complete(_)),
-        "a broadcast native transaction is complete even though the caller's \
-             signature slots stay untouched"
-    );
-    let (serialized_tx, sig) = result.into_signed_transaction();
-    // Native mode auto-broadcasts, so no re-sendable wire tx is returned.
-    assert!(
-        serialized_tx.is_empty(),
-        "native mode should return an empty serialized transaction"
-    );
+    let sig = result.unwrap();
     assert!(sig.verify(&pubkey.to_bytes(), &message_data));
     assert!(
         tx.signatures.iter().all(|s| *s == Signature::default()),
@@ -981,7 +970,7 @@ async fn test_fordefi_native_sign_transaction_missing_raw_transaction() {
         .await;
 
     let mut tx = create_test_transaction(&pubkey);
-    let result = signer.sign_transaction(&mut tx).await;
+    let result = signer.sign_and_send_transaction(&mut tx).await;
     match result.unwrap_err() {
         SignerError::BroadcastUnconfirmed { provider_tx_id, .. } => {
             assert_eq!(provider_tx_id.as_deref(), Some("native-tx-no-raw"));
@@ -1003,7 +992,7 @@ async fn test_native_submit_server_error_is_unconfirmed_without_a_transaction_id
         .await;
 
     let mut tx = create_test_transaction(&pubkey);
-    match signer.sign_transaction(&mut tx).await.unwrap_err() {
+    match signer.sign_and_send_transaction(&mut tx).await.unwrap_err() {
         SignerError::BroadcastUnconfirmed {
             provider_tx_id,
             provider_status,
@@ -1031,7 +1020,7 @@ async fn test_native_submit_accepted_without_an_id_is_unconfirmed() {
         .await;
 
     let mut tx = create_test_transaction(&pubkey);
-    match signer.sign_transaction(&mut tx).await.unwrap_err() {
+    match signer.sign_and_send_transaction(&mut tx).await.unwrap_err() {
         SignerError::BroadcastUnconfirmed { provider_tx_id, .. } => {
             assert_eq!(provider_tx_id, None);
         }
@@ -1052,7 +1041,7 @@ async fn test_native_submit_rejected_by_fordefi_stays_a_plain_failure() {
         .await;
 
     let mut tx = create_test_transaction(&pubkey);
-    match signer.sign_transaction(&mut tx).await.unwrap_err() {
+    match signer.sign_and_send_transaction(&mut tx).await.unwrap_err() {
         SignerError::RemoteApiError(_) => {}
         other => panic!("Expected RemoteApiError, got: {other:?}"),
     }
@@ -1104,7 +1093,7 @@ async fn test_fordefi_native_sign_transaction_failed_state() {
         .await;
 
     let mut tx = create_test_transaction(&pubkey);
-    let result = signer.sign_transaction(&mut tx).await;
+    let result = signer.sign_and_send_transaction(&mut tx).await;
     match result.unwrap_err() {
         SignerError::BroadcastUnconfirmed {
             provider_tx_id,
@@ -1219,7 +1208,7 @@ async fn test_fordefi_native_sign_transaction_poll_timeout_is_broadcast_unconfir
         .await;
 
     let mut tx = create_test_transaction(&pubkey);
-    let result = signer.sign_transaction(&mut tx).await;
+    let result = signer.sign_and_send_transaction(&mut tx).await;
     match result.unwrap_err() {
         SignerError::BroadcastUnconfirmed {
             provider_tx_id,
@@ -1268,7 +1257,7 @@ async fn test_fordefi_native_sign_transaction_malformed_raw_transaction() {
         .await;
 
     let mut tx = create_test_transaction(&pubkey);
-    let result = signer.sign_transaction(&mut tx).await;
+    let result = signer.sign_and_send_transaction(&mut tx).await;
     match result.unwrap_err() {
         SignerError::BroadcastUnconfirmed { provider_tx_id, .. } => {
             assert_eq!(provider_tx_id.as_deref(), Some("native-tx-malformed"));

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -458,6 +458,13 @@ impl SolanaSigner for Signer {
         dispatch_signer!(self, s => s.sign_transaction(tx).await)
     }
 
+    async fn sign_and_send_transaction(
+        &self,
+        tx: &mut sdk_adapter::VersionedTransaction,
+    ) -> Result<sdk_adapter::Signature, SignerError> {
+        dispatch_signer!(self, s => s.sign_and_send_transaction(tx).await)
+    }
+
     async fn sign_message(&self, message: &[u8]) -> Result<sdk_adapter::Signature, SignerError> {
         dispatch_signer!(self, s => s.sign_message(message).await)
     }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -35,6 +35,7 @@ pub mod http_client_config;
 #[cfg(feature = "_remote")]
 mod remote_util;
 mod sdk_adapter;
+pub mod send;
 pub mod signature_util;
 #[cfg(test)]
 pub mod test_util;
@@ -84,6 +85,7 @@ pub mod utila;
 // Re-export core types
 pub use error::SignerError;
 pub use http_client_config::HttpClientConfig;
+pub use send::sign_and_send;
 pub use traits::{SignTransactionResult, SolanaSigner};
 
 // Re-export signer types

--- a/rust/src/send.rs
+++ b/rust/src/send.rs
@@ -16,8 +16,9 @@ use crate::traits::{SignTransactionResult, SolanaSigner};
 ///
 /// # Errors
 ///
-/// [`SignerError::SigningFailed`] when the transaction is still partially signed.
-/// Backend signing errors and anything `send` returns propagate unchanged.
+/// [`SignerError::SigningFailed`] when a broadcasting signer returns no signature,
+/// or when the transaction is still partially signed. Backend signing errors and
+/// anything `send` returns propagate unchanged.
 pub async fn sign_and_send<S, F, Fut>(
     signer: &S,
     tx: &mut VersionedTransaction,
@@ -28,14 +29,20 @@ where
     F: FnOnce(String) -> Fut,
     Fut: Future<Output = Result<Signature, SignerError>>,
 {
-    let result = signer.sign_transaction(tx).await?;
-    let broadcasts = signer.broadcasts_transactions();
-    let is_complete = matches!(result, SignTransactionResult::Complete(_));
-    let (encoded_transaction, signature) = result.into_signed_transaction();
-
-    if broadcasts {
+    if signer.broadcasts_transactions() {
+        let (_, signature) = signer.sign_transaction(tx).await?.into_signed_transaction();
+        if signature == Signature::default() {
+            return Err(SignerError::SigningFailed(
+                "Signer returned no signature for the transaction it broadcast".to_string(),
+            ));
+        }
         return Ok(signature);
     }
+
+    let result = signer.sign_transaction(tx).await?;
+    let is_complete = matches!(result, SignTransactionResult::Complete(_));
+    let (encoded_transaction, _) = result.into_signed_transaction();
+
     if !is_complete {
         return Err(SignerError::SigningFailed(
             "Transaction is still missing signatures after signing and cannot be broadcast"

--- a/rust/src/send.rs
+++ b/rust/src/send.rs
@@ -8,20 +8,16 @@ use crate::traits::{SignTransactionResult, SolanaSigner};
 
 /// Sign `tx` and get it on chain with one call.
 ///
-/// A signer that reports [`SolanaSigner::broadcasts_transactions`] has already
-/// broadcast the transaction through its provider, so its own signature identifies
-/// it and `send` is never called. Any other signer signs, and `send` broadcasts the
-/// encoded wire transaction.
-///
-/// The crate has no RPC client, so the network hop is always injected: implement
-/// `send` with whatever transport the caller already has, an
-/// `RpcClient::send_transaction` call or a relayer endpoint.
+/// A signer that reports [`SolanaSigner::broadcasts_transactions`] broadcasts
+/// through its provider, so its own signature identifies the transaction and `send`
+/// is never called; any other signer signs and `send` broadcasts the encoded wire
+/// transaction. The crate has no RPC client, so the network hop is always
+/// caller-supplied.
 ///
 /// # Errors
 ///
-/// [`SignerError::SigningFailed`] when a signer that does not broadcast leaves the
-/// transaction partially signed, since it cannot land. Backend signing errors and
-/// anything `send` returns propagate unchanged.
+/// [`SignerError::SigningFailed`] when the transaction is still partially signed.
+/// Backend signing errors and anything `send` returns propagate unchanged.
 pub async fn sign_and_send<S, F, Fut>(
     signer: &S,
     tx: &mut VersionedTransaction,

--- a/rust/src/send.rs
+++ b/rust/src/send.rs
@@ -30,7 +30,7 @@ where
     Fut: Future<Output = Result<Signature, SignerError>>,
 {
     if signer.broadcasts_transactions() {
-        let (_, signature) = signer.sign_transaction(tx).await?.into_signed_transaction();
+        let signature = signer.sign_and_send_transaction(tx).await?;
         if signature == Signature::default() {
             return Err(SignerError::SigningFailed(
                 "Signer returned no signature for the transaction it broadcast".to_string(),

--- a/rust/src/send.rs
+++ b/rust/src/send.rs
@@ -1,0 +1,53 @@
+//! Getting a signed transaction on chain, whichever shape the signer has.
+
+use std::future::Future;
+
+use crate::error::SignerError;
+use crate::sdk_adapter::{Signature, VersionedTransaction};
+use crate::traits::{SignTransactionResult, SolanaSigner};
+
+/// Sign `tx` and get it on chain with one call.
+///
+/// A signer that reports [`SolanaSigner::broadcasts_transactions`] has already
+/// broadcast the transaction through its provider, so its own signature identifies
+/// it and `send` is never called. Any other signer signs, and `send` broadcasts the
+/// encoded wire transaction.
+///
+/// The crate has no RPC client, so the network hop is always injected: implement
+/// `send` with whatever transport the caller already has, an
+/// `RpcClient::send_transaction` call or a relayer endpoint.
+///
+/// # Errors
+///
+/// [`SignerError::SigningFailed`] when a signer that does not broadcast leaves the
+/// transaction partially signed, since it cannot land. Backend signing errors and
+/// anything `send` returns propagate unchanged.
+pub async fn sign_and_send<S, F, Fut>(
+    signer: &S,
+    tx: &mut VersionedTransaction,
+    send: F,
+) -> Result<Signature, SignerError>
+where
+    S: SolanaSigner + ?Sized,
+    F: FnOnce(String) -> Fut,
+    Fut: Future<Output = Result<Signature, SignerError>>,
+{
+    let result = signer.sign_transaction(tx).await?;
+    let broadcasts = signer.broadcasts_transactions();
+    let is_complete = matches!(result, SignTransactionResult::Complete(_));
+    let (encoded_transaction, signature) = result.into_signed_transaction();
+
+    if broadcasts {
+        return Ok(signature);
+    }
+    if !is_complete {
+        return Err(SignerError::SigningFailed(
+            "Transaction is still missing signatures after signing and cannot be broadcast"
+                .to_string(),
+        ));
+    }
+    send(encoded_transaction).await
+}
+
+#[cfg(test)]
+mod tests;

--- a/rust/src/send/tests.rs
+++ b/rust/src/send/tests.rs
@@ -55,8 +55,7 @@ impl SolanaSigner for StubSigner {
     }
 }
 
-/// A provider that broadcasts server-side has already put the transaction on
-/// chain, so its own signature identifies it and no broadcast is attempted.
+/// A provider that broadcasts server-side already put the transaction on chain.
 #[tokio::test]
 async fn broadcasting_signer_skips_the_injected_send() {
     let signer = StubSigner::new(true, true);

--- a/rust/src/send/tests.rs
+++ b/rust/src/send/tests.rs
@@ -86,6 +86,23 @@ async fn sign_only_signer_broadcasts_the_encoded_transaction() {
     assert_eq!(signature, broadcast_signature);
 }
 
+/// The signature a broadcasting provider returns is the only handle on the
+/// transaction it just put on chain, so an empty one cannot be passed off as one.
+#[tokio::test]
+async fn broadcasting_signer_without_a_signature_is_rejected() {
+    let mut signer = StubSigner::new(true, true);
+    signer.signature = Signature::default();
+    let mut tx = create_test_transaction(&Pubkey::new_unique());
+
+    let error = sign_and_send(&signer, &mut tx, |_| async {
+        panic!("send must not run for a signer that broadcasts");
+    })
+    .await
+    .unwrap_err();
+
+    assert!(matches!(error, SignerError::SigningFailed(_)));
+}
+
 /// A partially signed transaction cannot land, so it must never be broadcast.
 #[tokio::test]
 async fn partial_signature_is_rejected_before_broadcast() {

--- a/rust/src/send/tests.rs
+++ b/rust/src/send/tests.rs
@@ -46,6 +46,13 @@ impl SolanaSigner for StubSigner {
         })
     }
 
+    async fn sign_and_send_transaction(
+        &self,
+        _tx: &mut VersionedTransaction,
+    ) -> Result<Signature, SignerError> {
+        Ok(self.signature)
+    }
+
     async fn sign_message(&self, _message: &[u8]) -> Result<Signature, SignerError> {
         Ok(self.signature)
     }

--- a/rust/src/send/tests.rs
+++ b/rust/src/send/tests.rs
@@ -1,0 +1,103 @@
+use async_trait::async_trait;
+
+use super::sign_and_send;
+use crate::error::SignerError;
+use crate::sdk_adapter::{Pubkey, Signature, VersionedTransaction};
+use crate::test_util::create_test_transaction;
+use crate::traits::{SignTransactionResult, SolanaSigner};
+
+const ENCODED: &str = "encoded-transaction";
+
+struct StubSigner {
+    broadcasts: bool,
+    complete: bool,
+    signature: Signature,
+}
+
+impl StubSigner {
+    fn new(broadcasts: bool, complete: bool) -> Self {
+        Self {
+            broadcasts,
+            complete,
+            signature: Signature::from([7u8; 64]),
+        }
+    }
+}
+
+#[async_trait]
+impl SolanaSigner for StubSigner {
+    fn pubkey(&self) -> Pubkey {
+        Pubkey::new_unique()
+    }
+
+    fn broadcasts_transactions(&self) -> bool {
+        self.broadcasts
+    }
+
+    async fn sign_transaction(
+        &self,
+        _tx: &mut VersionedTransaction,
+    ) -> Result<SignTransactionResult, SignerError> {
+        let signed = (ENCODED.to_string(), self.signature);
+        Ok(if self.complete {
+            SignTransactionResult::Complete(signed)
+        } else {
+            SignTransactionResult::Partial(signed)
+        })
+    }
+
+    async fn sign_message(&self, _message: &[u8]) -> Result<Signature, SignerError> {
+        Ok(self.signature)
+    }
+
+    async fn is_available(&self) -> bool {
+        true
+    }
+}
+
+/// A provider that broadcasts server-side has already put the transaction on
+/// chain, so its own signature identifies it and no broadcast is attempted.
+#[tokio::test]
+async fn broadcasting_signer_skips_the_injected_send() {
+    let signer = StubSigner::new(true, true);
+    let mut tx = create_test_transaction(&Pubkey::new_unique());
+
+    let signature = sign_and_send(&signer, &mut tx, |_| async {
+        panic!("send must not run for a signer that broadcasts");
+    })
+    .await
+    .unwrap();
+
+    assert_eq!(signature, signer.signature);
+}
+
+#[tokio::test]
+async fn sign_only_signer_broadcasts_the_encoded_transaction() {
+    let signer = StubSigner::new(false, true);
+    let mut tx = create_test_transaction(&Pubkey::new_unique());
+    let broadcast_signature = Signature::from([9u8; 64]);
+
+    let signature = sign_and_send(&signer, &mut tx, |encoded| async move {
+        assert_eq!(encoded, ENCODED);
+        Ok(broadcast_signature)
+    })
+    .await
+    .unwrap();
+
+    assert_eq!(signature, broadcast_signature);
+}
+
+/// A partially signed transaction cannot land, so it must never be broadcast.
+#[tokio::test]
+async fn partial_signature_is_rejected_before_broadcast() {
+    let signer = StubSigner::new(false, false);
+    let mut tx = create_test_transaction(&Pubkey::new_unique());
+
+    let error = sign_and_send(&signer, &mut tx, |_| async {
+        panic!("send must not run for a partially signed transaction");
+    })
+    .await
+    .unwrap_err();
+
+    assert!(matches!(error, SignerError::SigningFailed(_)));
+}

--- a/rust/src/tests/test_fordefi_integration.rs
+++ b/rust/src/tests/test_fordefi_integration.rs
@@ -249,7 +249,7 @@ mod tests {
 
     #[tokio::test]
     #[cfg(feature = "integration-tests")]
-    async fn test_fordefi_native_sign_transaction() {
+    async fn test_fordefi_native_sign_and_send_transaction() {
         let signer = get_native_signer().await;
         let from = signer.pubkey();
 
@@ -281,18 +281,12 @@ mod tests {
         message.recent_blockhash = blockhash;
         let mut transaction: VersionedTransaction = Transaction::new_unsigned(message).into();
 
-        let (serialized_tx, signature) = signer
-            .sign_transaction(&mut transaction)
+        let signature = signer
+            .sign_and_send_transaction(&mut transaction)
             .await
-            .expect("Failed to sign transaction with Fordefi native mode")
-            .into_signed_transaction();
+            .expect("Failed to sign and send transaction with Fordefi native mode");
 
         assert_eq!(signature.as_ref().len(), 64, "Signature should be 64 bytes");
-        // Native mode auto-broadcasts via Fordefi, so no re-sendable wire tx is returned.
-        assert!(
-            serialized_tx.is_empty(),
-            "native mode should return an empty serialized transaction"
-        );
 
         // Fordefi already pushed the transaction; its signature is the Solana txid.
         // Confirm that on-chain rather than re-broadcasting.

--- a/rust/src/traits.rs
+++ b/rust/src/traits.rs
@@ -50,6 +50,36 @@ pub trait SolanaSigner: Send + Sync {
         tx: &mut VersionedTransaction,
     ) -> Result<SignTransactionResult, SignerError>;
 
+    /// Sign a Solana transaction and broadcast it through the provider
+    ///
+    /// Implemented only by signers whose provider executes the transaction
+    /// server-side; every other signer signs and leaves broadcasting to the
+    /// caller. [`broadcasts_transactions`](Self::broadcasts_transactions) reports
+    /// which shape a signer has in its current configuration.
+    ///
+    /// # Arguments
+    ///
+    /// * `tx` - The transaction to sign and broadcast. The provider may rewrite
+    ///   it, in which case `tx` is left untouched and the returned signature
+    ///   identifies the transaction that actually landed.
+    ///
+    /// # Returns
+    ///
+    /// The signature identifying the broadcast transaction.
+    ///
+    /// # Errors
+    ///
+    /// [`SignerError::SigningFailed`] when this signer cannot broadcast.
+    async fn sign_and_send_transaction(
+        &self,
+        _tx: &mut VersionedTransaction,
+    ) -> Result<Signature, SignerError> {
+        Err(SignerError::SigningFailed(
+            "This signer cannot broadcast transactions; sign it and broadcast the result"
+                .to_string(),
+        ))
+    }
+
     /// Sign an arbitrary message
     ///
     /// # Arguments


### PR DESCRIPTION
## Summary
- Ports the `signAndSendTransaction` helper from #270 to the Rust, Python and Go cores: `sign_and_send`, `sign_and_send_transaction`, `core.SignAndSendTransaction`. Each uses the broadcast capability marker the packages already carry (`broadcasts_transactions()`, `broadcasts_transactions`, `TransactionBroadcaster`), so no duck-typed capability helper is needed. No package gains an RPC dependency: the broadcast is a caller-injected function.
- Fixes a Go cancellation bug found while reviewing the same PR: cancelling the context mid-poll on a signer that broadcasts server-side returned `SIGNER_HTTP_ERROR`, so cancellation was indistinguishable from a request that never landed and the caller was free to retry a transaction that may already be executing. Crossmint and Fordefi native mode now return `SIGNER_BROADCAST_UNCONFIRMED` with the provider transaction id.
- The other two parts of #270 are deliberately not ported: abort support is already native in each language (`context.Context`, dropping the future, `asyncio` cancellation), and the deprecated class tier being removed there never existed in these packages.

## Test Plan
- `just rust-test` (sdk-v2/v3/v4 matrices), `just rust-fmt` clean
- `just py-test` (510 passed), `just py-fmt` clean (ruff + mypy strict)
- `go build ./...` and `go test ./...` across every Go module, `gofmt`/`go vet` clean
- New unit tests cover each branch: provider broadcast used as-is, injected sender receives the encoded transaction, missing sender rejected before signing, partial signature never broadcast, and cancelled broadcast polling reported as unconfirmed with the provider transaction id

## Breaking Changes
- None. All additions, plus one error code change on a cancellation path that previously reported a retry-safe failure.