### PR TITLE
chore(ts): v2 branch cleanup

### DIFF
--- a/docs/ADDING_SIGNERS.md
+++ b/docs/ADDING_SIGNERS.md
@@ -555,6 +555,8 @@ CI is a two-phase process. Coordinate with maintainers to prepare `main` before 
 - [ ] Unit tests with vitest + mocks
 - [ ] Integration tests using `runSignerIntegrationTest` + `setup.ts`
 - [ ] Update umbrella package `typescript/packages/keychain/` (see [Umbrella Package](#umbrella-package) — 7 files)
+- [ ] Honor `config?.abortSignal` in every signing method (thread it into `fetchSignerJson` and `signBatchStaggered`)
+- [ ] Add your backend to the capability matrix in `typescript/README.md` ("Signer capabilities")
 - [ ] README with `createXSigner()` as primary usage
 - [ ] `.env.example` with required env vars
 - [ ] CI updates (`typescript-ci.yml`, `typescript-publish.yml`)
@@ -583,9 +585,11 @@ See [`typescript/packages/para/`](../typescript/packages/para/) for a complete r
 Every signer must implement `SolanaSigner<TAddress>` from `@solana/keychain-core`. The interface requires:
 
 - `readonly address: Address<TAddress>`
-- `signMessages(messages): Promise<readonly SignatureDictionary[]>`
-- `signTransactions(transactions): Promise<readonly SignatureDictionary[]>`
+- `signMessages(messages, config?): Promise<readonly SignatureDictionary[]>`
+- `signTransactions(transactions, config?): Promise<readonly SignatureDictionary[]>`
 - `isAvailable(): Promise<boolean>` — health check for the signing backend
+
+The `config` parameter is Kit's optional partial-signer config. Every signing method must honor `config?.abortSignal` — see the abort-support rule under [Key rules](#factory-function--class).
 
 #### Config Interface
 
@@ -691,6 +695,7 @@ class YourSigner<TAddress extends string = string> implements SolanaSigner<TAddr
   ```
   Validate provider-specific response shape (with optional chaining) after the call.
 - **Batch staggering**: support the `requestDelayMs` config field for rate-limited APIs. Validate it with `validateRequestDelayMs()` and implement `signMessages`/`signTransactions` with `signBatchStaggered()` from `@solana/keychain-core` (see any existing signer).
+- **Abort support**: thread `config?.abortSignal` from every signing method into `fetchSignerJson({ abortSignal, ... })` and `signBatchStaggered(items, fn, delayMs, config?.abortSignal)`. `fetchSignerJson` composes the signal with its timeout and rethrows the caller's abort reason unwrapped, so cancellation stays distinguishable from failure — never catch and rewrap it as a signer error.
 - **One-time crypto at construction**: import/validate static key material (PEM parsing, `importPKCS8`, point decompression) once in `create()`/`init()` and store the imported key — only genuinely request-bound work (e.g. minting a per-request JWT) belongs in the request path.
 - Add `cause` to catch blocks to preserve stack traces
 - Add `@throws` JSDoc to factory functions listing the error codes they can throw
@@ -715,6 +720,7 @@ Use vitest with mocked `fetch`. Test:
 - `isAvailable` success + failure
 - Network errors (`fetch` throws — `HTTP_ERROR` code)
 - `requestDelayMs` validation and behavior
+- Abort: an already-aborted `config.abortSignal` rejects with the abort reason (not a `SignerError`) without issuing a request
 
 Run your package's tests during development:
 
@@ -853,6 +859,7 @@ export { createYourSigner } from '@solana/keychain-your-signer';
 **h) Managed-broadcast (sending-signer) backends only** — if your backend rewrites the transaction message and/or broadcasts server-side, its signature cannot be applied to the caller's transaction, so it must be a `SolanaSendingSigner` (see `@solana/keychain-core`) instead of a `SolanaSigner`. That changes the checklist:
 
 - The signer class implements `signAndSendTransactions()` and exposes **no** `signTransactions` (nor `signMessages`, unless the backend genuinely signs messages) — Kit classifies signers by duck-typed method presence, so throwing methods are not enough. See Crossmint, or Fordefi's own-property pattern for a package serving both shapes.
+- `signAndSendTransactions(transactions, config?)` takes Kit's sending-signer config and must honor `config?.abortSignal` like every other signing method. A correctly shaped sending signer is picked up automatically by core's `signAndSendTransaction()` helper and reported by `signerCapabilities()` — no extra registration needed.
 - Add a typed `createKeychainSigner` overload in `keychain/src/create-keychain-signer.ts` returning your sending-signer type (Crossmint and Fordefi-native have precedents), in addition to the switch case.
 - Add your backend to the exclusions in `KeychainKitPluginConfig` (`typescript/packages/kit-plugin/src/keychain-plugin.ts`) — sending signers cannot serve as a Kit client `payer`/`identity` — and mention it in the kit-plugin README.
 - Assert the guard directions in unit tests: `isTransactionPartialSigner()` false and `isTransactionSendingSigner()` true for your instances.

--- a/typescript/packages/aws-kms/src/aws-kms-signer.ts
+++ b/typescript/packages/aws-kms/src/aws-kms-signer.ts
@@ -84,7 +84,6 @@ class AwsKmsSigner<TAddress extends string = string> implements SolanaSigner<TAd
         this.requestDelayMs = config.requestDelayMs || 0;
         validateRequestDelayMs(this.requestDelayMs);
 
-        // Create AWS KMS client
         const clientConfig: {
             credentials?: AwsCredentials;
             region?: string;
@@ -130,12 +129,11 @@ class AwsKmsSigner<TAddress extends string = string> implements SolanaSigner<TAd
 
             return signature as SignatureBytes;
         } catch (error: unknown) {
-            // Re-throw SignerError as-is
+            abortSignal?.throwIfAborted();
             if (error instanceof Error && error.name === 'SignerError') {
                 throw error;
             }
             if (error instanceof Error) {
-                // AWS SDK errors
                 const awsError = error as { $metadata?: { httpStatusCode?: number }; message?: string; name?: string };
                 throwSignerError(SignerErrorCode.REMOTE_API_ERROR, {
                     cause: error,
@@ -190,7 +188,6 @@ class AwsKmsSigner<TAddress extends string = string> implements SolanaSigner<TAd
         return await signBatchStaggered(
             transactions,
             async transaction => {
-                // Sign the transaction message bytes
                 const txMessageBytes = new Uint8Array(transaction.messageBytes);
                 const signatureBytes = await this.signBytes(txMessageBytes, config?.abortSignal);
                 await assertSignatureValid({
@@ -223,7 +220,6 @@ class AwsKmsSigner<TAddress extends string = string> implements SolanaSigner<TAd
                 return false;
             }
 
-            // Verify the key spec is ECC_NIST_EDWARDS25519
             const keySpec = response.KeyMetadata.KeySpec;
             const keyUsage = response.KeyMetadata.KeyUsage;
             const keyState = response.KeyMetadata.KeyState;

--- a/typescript/packages/dfns/src/auth.ts
+++ b/typescript/packages/dfns/src/auth.ts
@@ -80,7 +80,6 @@ export async function signUserAction(
     body: string,
     abortSignal?: AbortSignal,
 ): Promise<string> {
-    // Request a challenge
     const rawChallenge = await fetchSignerJson<unknown>({
         abortSignal,
         init: {
@@ -102,7 +101,6 @@ export async function signUserAction(
 
     const challenge = parseUserActionInitResponse(rawChallenge);
 
-    // Verify credential is allowed
     const allowed = challenge.allowCredentials.key.some(
         c => isObject(c) && typeof c.id === 'string' && c.id === credId,
     );
@@ -112,7 +110,6 @@ export async function signUserAction(
         });
     }
 
-    // Sign the challenge
     const clientData = new TextEncoder().encode(
         JSON.stringify({
             challenge: challenge.challenge,
@@ -123,7 +120,6 @@ export async function signUserAction(
     const clientDataB64 = base64UrlDecoder(clientData);
     const signatureB64 = base64UrlDecoder(await credentialKey.sign(clientData));
 
-    // Submit the signed challenge
     const rawActionResponse = await fetchSignerJson<unknown>({
         abortSignal,
         init: {

--- a/typescript/packages/dfns/src/dfns-signer.ts
+++ b/typescript/packages/dfns/src/dfns-signer.ts
@@ -4,6 +4,7 @@ import {
     assertHttpsUrl,
     assertSignatureValid,
     createSignatureDictionary,
+    ED25519_SIGNATURE_LENGTH,
     fetchSignerJson,
     signBatchStaggered,
     SignerErrorCode,
@@ -445,8 +446,8 @@ function padSignatureComponent(hex: string): Uint8Array {
 function combineSignature(r: string, s: string): SignatureBytes {
     const rBytes = padSignatureComponent(r);
     const sBytes = padSignatureComponent(s);
-    const combined = new Uint8Array(64);
+    const combined = new Uint8Array(ED25519_SIGNATURE_LENGTH);
     combined.set(rBytes, 0);
-    combined.set(sBytes, 32);
+    combined.set(sBytes, ED25519_SIGNATURE_LENGTH / 2);
     return combined as SignatureBytes;
 }

--- a/typescript/packages/fireblocks/src/fireblocks-signer.ts
+++ b/typescript/packages/fireblocks/src/fireblocks-signer.ts
@@ -349,14 +349,12 @@ class FireblocksSigner<TAddress extends string = string> implements SolanaSigner
                 return this.extractSignature(txResponse, false);
             }
 
-            // Check for terminal failure statuses
             if (isTerminalStatus(status)) {
                 throwSignerError(SignerErrorCode.SIGNING_FAILED, {
                     message: `Transaction failed with status: ${txResponse.status}`,
                 });
             }
 
-            // Wait before next poll
             await abortableDelay(this.pollIntervalMs, abortSignal);
         }
 

--- a/typescript/packages/fireblocks/src/jwt.ts
+++ b/typescript/packages/fireblocks/src/jwt.ts
@@ -1,5 +1,5 @@
 import { getBase16Decoder } from '@solana/codecs-strings';
-import { SignerErrorCode, throwSignerError } from '@solana/keychain-core';
+import { normalizePrivateKeyPem, SignerErrorCode, throwSignerError } from '@solana/keychain-core';
 import { importPKCS8, SignJWT } from 'jose';
 
 let base16Decoder: ReturnType<typeof getBase16Decoder> | undefined;
@@ -18,7 +18,7 @@ const JWT_SKEW_LEEWAY_SECS = 60;
  */
 export async function importFireblocksPrivateKey(privateKeyPem: string): Promise<CryptoKey> {
     try {
-        return await importPKCS8(privateKeyPem, 'RS256');
+        return await importPKCS8(normalizePrivateKeyPem(privateKeyPem), 'RS256');
     } catch (error) {
         throwSignerError(SignerErrorCode.INVALID_PRIVATE_KEY, {
             cause: error,
@@ -38,10 +38,8 @@ export async function importFireblocksPrivateKey(privateKeyPem: string): Promise
  */
 export async function createJwt(apiKey: string, privateKey: CryptoKey, uri: string, body: string): Promise<string> {
     try {
-        // SHA256 hash of body
         const bodyHash = await sha256Hex(body);
 
-        // Generate nonce (UUID v4)
         const nonce = crypto.randomUUID();
 
         const now = Math.floor(Date.now() / 1000);

--- a/typescript/packages/fireblocks/src/types.ts
+++ b/typescript/packages/fireblocks/src/types.ts
@@ -157,8 +157,8 @@ export type FireblocksTransactionStatus =
 /**
  * Check whether a Fireblocks transaction has reached a terminal state (polling should stop).
  *
- * Replaces the previously exported `TERMINAL_STATUSES` Set, which was removed
- * because module-level `Set` allocation is a side effect that prevents tree-shaking.
+ * Keep this a function: a module-level `Set` of terminal statuses is a
+ * side-effectful allocation that breaks tree-shaking.
  */
 export function isTerminalStatus(status: string): boolean {
     return (

--- a/typescript/packages/fordefi/src/fordefi-signer.ts
+++ b/typescript/packages/fordefi/src/fordefi-signer.ts
@@ -1,12 +1,13 @@
 import { createPrivateKey, createSign, type KeyObject } from 'node:crypto';
 
 import { Address, assertIsAddress } from '@solana/addresses';
-import { getBase58Decoder, getBase58Encoder, getBase64Encoder } from '@solana/codecs-strings';
+import { getBase58Decoder, getBase58Encoder, getBase64Decoder, getBase64Encoder } from '@solana/codecs-strings';
 import {
     abortableDelay,
     assertHttpsUrl,
     assertSignatureValid,
     createSignatureDictionary,
+    ED25519_SIGNATURE_LENGTH,
     fetchSignerJson,
     idempotencyKeyFromMessage,
     normalizeBaseUrl,
@@ -52,6 +53,11 @@ import type {
 
 const DEFAULT_BASE_URL = 'https://api.fordefi.com';
 const DEFAULT_POLL_INTERVAL_MS = 2000;
+
+let base58Decoder: ReturnType<typeof getBase58Decoder> | undefined;
+let base58Encoder: ReturnType<typeof getBase58Encoder> | undefined;
+let base64Decoder: ReturnType<typeof getBase64Decoder> | undefined;
+let base64Encoder: ReturnType<typeof getBase64Encoder> | undefined;
 const DEFAULT_MAX_POLL_ATTEMPTS = 50;
 const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
 
@@ -355,8 +361,10 @@ class FordefiSigner<TAddress extends string = string> implements MessagePartialS
         let remoteAddress = vault.address;
         if (!remoteAddress && vault.public_key_compressed) {
             try {
-                const keyBytes = new Uint8Array(Buffer.from(vault.public_key_compressed, 'base64'));
-                remoteAddress = getBase58Decoder().decode(keyBytes);
+                base64Encoder ||= getBase64Encoder();
+                base58Decoder ||= getBase58Decoder();
+                const keyBytes = base64Encoder.encode(vault.public_key_compressed);
+                remoteAddress = base58Decoder.decode(keyBytes);
             } catch (error) {
                 return throwSignerError(SignerErrorCode.PARSING_ERROR, {
                     cause: error,
@@ -484,15 +492,25 @@ class FordefiSigner<TAddress extends string = string> implements MessagePartialS
         abortSignal?: AbortSignal,
     ): Promise<{ sigDict: SignatureDictionary; verificationData: Uint8Array }> {
         const bytes = messageBytes instanceof Uint8Array ? messageBytes : new Uint8Array(Array.from(messageBytes));
-        const base64Data = Buffer.from(bytes).toString('base64');
+        base64Decoder ||= getBase64Decoder();
+        const base64Data = base64Decoder.decode(bytes);
 
         const txId = await this.submitBlackBoxSignature(base64Data, abortSignal);
         const result = await this.pollForResult(txId, { pushable: false }, abortSignal);
         const sigBase64 = this.extractSignatureData(result);
-        const sigBytes = new Uint8Array(Buffer.from(sigBase64, 'base64'));
-        if (sigBytes.length !== 64) {
+        let sigBytes: Uint8Array;
+        try {
+            base64Encoder ||= getBase64Encoder();
+            sigBytes = new Uint8Array(base64Encoder.encode(sigBase64));
+        } catch (error) {
+            return throwSignerError(SignerErrorCode.PARSING_ERROR, {
+                cause: error,
+                message: 'Failed to decode Fordefi signature base64',
+            });
+        }
+        if (sigBytes.length !== ED25519_SIGNATURE_LENGTH) {
             return throwSignerError(SignerErrorCode.SIGNING_FAILED, {
-                message: `Expected 64-byte Ed25519 signature, got ${sigBytes.length}`,
+                message: `Expected ${ED25519_SIGNATURE_LENGTH}-byte Ed25519 signature, got ${sigBytes.length}`,
             });
         }
         return {
@@ -527,7 +545,8 @@ class FordefiSigner<TAddress extends string = string> implements MessagePartialS
                 config?.abortSignal?.throwIfAborted();
                 this.assertNativeAutoTransactionSupported(transaction);
 
-                const base64Data = Buffer.from(transaction.messageBytes).toString('base64');
+                base64Decoder ||= getBase64Decoder();
+                const base64Data = base64Decoder.decode(transaction.messageBytes);
                 let txId: string;
                 try {
                     txId = await this.submitSolanaTransaction(base64Data, config?.abortSignal);
@@ -580,7 +599,8 @@ class FordefiSigner<TAddress extends string = string> implements MessagePartialS
         }
 
         const signedWireTx = result.raw_transaction as Base64EncodedWireTransaction;
-        const decodedTransaction = getTransactionDecoder().decode(getBase64Encoder().encode(signedWireTx));
+        base64Encoder ||= getBase64Encoder();
+        const decodedTransaction = getTransactionDecoder().decode(base64Encoder.encode(signedWireTx));
 
         const signerSignature = decodedTransaction.signatures[this.address];
         if (!signerSignature) {
@@ -593,7 +613,8 @@ class FordefiSigner<TAddress extends string = string> implements MessagePartialS
         // Kit resolves the fee payer's signature, whichever slot the version puts it in.
         let transactionSignature: SignatureBytes;
         try {
-            transactionSignature = getBase58Encoder().encode(
+            base58Encoder ||= getBase58Encoder();
+            transactionSignature = base58Encoder.encode(
                 getSignatureFromTransaction(decodedTransaction),
             ) as SignatureBytes;
         } catch (error) {
@@ -683,9 +704,10 @@ class FordefiSigner<TAddress extends string = string> implements MessagePartialS
             type: 'solana_transaction',
             vault_id: this.vaultId,
         };
+        base64Encoder ||= getBase64Encoder();
         return await this.submitTransaction(
             requestBody,
-            await idempotencyKeyFromMessage(Buffer.from(base64Data, 'base64')),
+            await idempotencyKeyFromMessage(base64Encoder.encode(base64Data)),
             abortSignal,
         );
     }
@@ -713,7 +735,8 @@ class FordefiSigner<TAddress extends string = string> implements MessagePartialS
      * Submits the message, polls for completion, and returns the raw 64-byte Ed25519 signature.
      */
     private async signMessage(messageBytes: Uint8Array, abortSignal?: AbortSignal): Promise<SignatureBytes> {
-        const base64Data = Buffer.from(messageBytes).toString('base64');
+        base64Decoder ||= getBase64Decoder();
+        const base64Data = base64Decoder.decode(messageBytes);
 
         const txId = this.chain
             ? await this.submitSolanaMessage(base64Data, abortSignal)
@@ -723,7 +746,8 @@ class FordefiSigner<TAddress extends string = string> implements MessagePartialS
 
         let sigBytes: Uint8Array;
         try {
-            sigBytes = new Uint8Array(Buffer.from(sigBase64, 'base64'));
+            base64Encoder ||= getBase64Encoder();
+            sigBytes = new Uint8Array(base64Encoder.encode(sigBase64));
         } catch (error) {
             return throwSignerError(SignerErrorCode.PARSING_ERROR, {
                 cause: error,
@@ -731,9 +755,9 @@ class FordefiSigner<TAddress extends string = string> implements MessagePartialS
             });
         }
 
-        if (sigBytes.length !== 64) {
+        if (sigBytes.length !== ED25519_SIGNATURE_LENGTH) {
             return throwSignerError(SignerErrorCode.SIGNING_FAILED, {
-                message: `Expected 64-byte Ed25519 signature, got ${sigBytes.length}`,
+                message: `Expected ${ED25519_SIGNATURE_LENGTH}-byte Ed25519 signature, got ${sigBytes.length}`,
             });
         }
 

--- a/typescript/packages/gcp-kms/package.json
+++ b/typescript/packages/gcp-kms/package.json
@@ -47,12 +47,14 @@
     },
     "peerDependencies": {
         "@solana/addresses": ">=8.0.0",
+        "@solana/codecs-strings": ">=8.0.0",
         "@solana/keys": ">=8.0.0",
         "@solana/signers": ">=8.0.0",
         "@solana/transactions": ">=8.0.0"
     },
     "devDependencies": {
         "@solana/addresses": "8.0.0",
+        "@solana/codecs-strings": "8.0.0",
         "@solana/keychain-test-utils": "workspace:*",
         "@solana/keys": "8.0.0",
         "@solana/signers": "8.0.0",

--- a/typescript/packages/gcp-kms/src/gcp-kms-signer.ts
+++ b/typescript/packages/gcp-kms/src/gcp-kms-signer.ts
@@ -1,4 +1,5 @@
 import { Address, assertIsAddress } from '@solana/addresses';
+import { getBase64Decoder, getBase64Encoder } from '@solana/codecs-strings';
 import {
     assertSignatureValid,
     createSignatureDictionary,
@@ -21,6 +22,9 @@ import { Transaction, TransactionWithinSizeLimit, TransactionWithLifetime } from
 import { GoogleAuth } from 'google-auth-library';
 
 import type { GcpKmsSignerConfig } from './types.js';
+
+let base64Encoder: ReturnType<typeof getBase64Encoder> | undefined;
+let base64Decoder: ReturnType<typeof getBase64Decoder> | undefined;
 
 /**
  * Create a Google Cloud KMS-backed signer.
@@ -156,12 +160,13 @@ class GcpKmsSigner<TAddress extends string = string> implements SolanaSigner<TAd
      * Sign message bytes using GCP KMS EdDSA signing
      */
     private async signBytes(messageBytes: Uint8Array, abortSignal?: AbortSignal): Promise<SignatureBytes> {
+        base64Decoder ||= getBase64Decoder();
         try {
             const response = await this.request<AsymmetricSignResponse>(
                 this.buildResourceUrl(':asymmetricSign'),
                 {
                     body: JSON.stringify({
-                        data: Buffer.from(messageBytes).toString('base64'),
+                        data: base64Decoder.decode(messageBytes),
                     }),
                     method: 'POST',
                 },
@@ -174,8 +179,8 @@ class GcpKmsSigner<TAddress extends string = string> implements SolanaSigner<TAd
                 });
             }
 
-            // Ed25519 signatures are 64 bytes
-            const signature = new Uint8Array(Buffer.from(response.signature, 'base64'));
+            base64Encoder ||= getBase64Encoder();
+            const signature = new Uint8Array(base64Encoder.encode(response.signature));
             if (signature.length !== ED25519_SIGNATURE_LENGTH) {
                 throwSignerError(SignerErrorCode.SIGNING_FAILED, {
                     message: `Invalid signature length: expected ${ED25519_SIGNATURE_LENGTH} bytes, got ${signature.length}`,
@@ -184,7 +189,7 @@ class GcpKmsSigner<TAddress extends string = string> implements SolanaSigner<TAd
 
             return signature as SignatureBytes;
         } catch (error: unknown) {
-            // Re-throw SignerError as-is (from request())
+            abortSignal?.throwIfAborted();
             if (error instanceof Error && error.name === 'SignerError') {
                 throw error;
             }
@@ -235,7 +240,6 @@ class GcpKmsSigner<TAddress extends string = string> implements SolanaSigner<TAd
         return await signBatchStaggered(
             transactions,
             async transaction => {
-                // Sign the transaction message bytes
                 const txMessageBytes = new Uint8Array(transaction.messageBytes);
                 const signatureBytes = await this.signBytes(txMessageBytes, config?.abortSignal);
                 await assertSignatureValid({
@@ -266,7 +270,6 @@ class GcpKmsSigner<TAddress extends string = string> implements SolanaSigner<TAd
                 return false;
             }
 
-            // Verify the algorithm is EC_SIGN_ED25519
             return publicKey.algorithm === 'EC_SIGN_ED25519';
         } catch {
             return false;

--- a/typescript/packages/keychain/src/index.ts
+++ b/typescript/packages/keychain/src/index.ts
@@ -1,12 +1,9 @@
-// Core types and utilities (flat export)
 export * from '@solana/keychain-core';
 
-// Unified signer factory, address resolver, and config union
 export { createKeychainSigner } from './create-keychain-signer.js';
 export { resolveAddress } from './resolve-address.js';
 export type { BackendName, KeychainSignerConfig } from './types.js';
 
-// Individual config types (flat re-exports)
 export type { AwsKmsSignerConfig } from '@solana/keychain-aws-kms';
 export type { CdpSignerConfig } from '@solana/keychain-cdp';
 export type { CrossmintSendingSigner, CrossmintSignerConfig } from '@solana/keychain-crossmint';

--- a/typescript/packages/keychain/src/resolve-address.ts
+++ b/typescript/packages/keychain/src/resolve-address.ts
@@ -36,7 +36,6 @@ export async function resolveAddress(config: KeychainSignerConfig): Promise<Addr
             assertIsAddress(config.publicKey);
             return config.publicKey;
 
-        // CDP provides address directly in config
         case 'cdp':
             assertIsAddress(config.address);
             return config.address;

--- a/typescript/packages/kit-plugin/src/__tests__/runtime-guard.test.ts
+++ b/typescript/packages/kit-plugin/src/__tests__/runtime-guard.test.ts
@@ -1,0 +1,80 @@
+import type { Address, SignatureBytes, Transaction } from '@solana/kit';
+import { createClient } from '@solana/kit';
+import { describe, expect, it, vi } from 'vitest';
+
+import { keychainIdentity, keychainPayer, keychainSigner } from '../keychain-plugin.js';
+
+const FAKE_SENDING_SIGNER = {
+    address: 'BLDprCsFyPBSyJDbYYbJXQWvexEuoUJP1zEbrVnNNaR3' as Address,
+    isAvailable: () => Promise.resolve(true),
+    signAndSendTransactions: (transactions: readonly Transaction[]) =>
+        Promise.resolve(transactions.map(() => new Uint8Array(64) as SignatureBytes)),
+};
+
+vi.mock('@solana/keychain', async importOriginal => {
+    const actual = await importOriginal<typeof import('@solana/keychain')>();
+    return {
+        ...actual,
+        createKeychainSigner: vi.fn(() => Promise.resolve(FAKE_SENDING_SIGNER)),
+    };
+});
+
+// The type-level managed-broadcast exclusion does not protect JS callers, so
+// each plugin must refuse a managed-broadcast config at runtime.
+describe('runtime guard against managed-broadcast signers', () => {
+    const CROSSMINT_CONFIG = { apiKey: 'k', backend: 'crossmint', walletLocator: 'w' } as never;
+    const FORDEFI_NATIVE_CONFIG = {
+        accessToken: 't',
+        backend: 'fordefi',
+        chain: 'solana_mainnet',
+        privateKeyPem: 'p',
+        publicKey: 'x',
+        vaultId: 'v',
+    } as never;
+
+    it('keychainSigner rejects a crossmint config before constructing the signer', async () => {
+        const { createKeychainSigner } = await import('@solana/keychain');
+        vi.mocked(createKeychainSigner).mockClear();
+
+        await expect(createClient().use(keychainSigner(CROSSMINT_CONFIG))).rejects.toThrow(
+            /cannot serve as a Kit client/,
+        );
+        expect(createKeychainSigner).not.toHaveBeenCalled();
+    });
+
+    it('keychainPayer rejects a crossmint config before constructing the signer', async () => {
+        const { createKeychainSigner } = await import('@solana/keychain');
+        vi.mocked(createKeychainSigner).mockClear();
+
+        await expect(createClient().use(keychainPayer(CROSSMINT_CONFIG))).rejects.toThrow(
+            /cannot serve as a Kit client/,
+        );
+        expect(createKeychainSigner).not.toHaveBeenCalled();
+    });
+
+    it('keychainIdentity rejects a crossmint config before constructing the signer', async () => {
+        const { createKeychainSigner } = await import('@solana/keychain');
+        vi.mocked(createKeychainSigner).mockClear();
+
+        await expect(createClient().use(keychainIdentity(CROSSMINT_CONFIG))).rejects.toThrow(
+            /cannot serve as a Kit client/,
+        );
+        expect(createKeychainSigner).not.toHaveBeenCalled();
+    });
+
+    it('rejects a fordefi native-mode config before constructing the signer', async () => {
+        const { createKeychainSigner } = await import('@solana/keychain');
+        vi.mocked(createKeychainSigner).mockClear();
+
+        await expect(createClient().use(keychainSigner(FORDEFI_NATIVE_CONFIG))).rejects.toThrow(
+            /cannot serve as a Kit client/,
+        );
+        expect(createKeychainSigner).not.toHaveBeenCalled();
+    });
+
+    it('rejects a factory that returns a signer without partial-signing methods', async () => {
+        const config = { backend: 'memory', privateKey: new Uint8Array(32) } as never;
+
+        await expect(createClient().use(keychainSigner(config))).rejects.toThrow(/EXPECTED_SOLANA_SIGNER/);
+    });
+});

--- a/typescript/packages/kit-plugin/src/keychain-plugin.ts
+++ b/typescript/packages/kit-plugin/src/keychain-plugin.ts
@@ -1,5 +1,5 @@
 import type { FordefiSignerConfig, KeychainSignerConfig } from '@solana/keychain';
-import { createKeychainSigner } from '@solana/keychain';
+import { assertIsSolanaSigner, createKeychainSigner, SignerErrorCode, throwSignerError } from '@solana/keychain';
 import { extendClient } from '@solana/kit';
 
 /**
@@ -15,6 +15,25 @@ import { extendClient } from '@solana/kit';
 export type KeychainKitPluginConfig =
     | Exclude<KeychainSignerConfig, { backend: 'crossmint' | 'fordefi' }>
     | (FordefiSignerConfig & { backend: 'fordefi'; chain?: undefined });
+
+/**
+ * The managed-broadcast exclusion above only protects TypeScript callers, so
+ * the config is also rejected at runtime — before `createKeychainSigner`
+ * runs, since the excluded backends authenticate against their provider
+ * during construction. The signer-shape assertion afterwards is the backstop
+ * for any future backend whose factory returns a sending signer.
+ */
+async function createPartialSigner(config: KeychainKitPluginConfig) {
+    const { backend } = config as KeychainSignerConfig;
+    if (backend === 'crossmint' || (backend === 'fordefi' && (config as { chain?: unknown }).chain !== undefined)) {
+        throwSignerError(SignerErrorCode.CONFIG_ERROR, {
+            message: `The '${backend}' backend broadcasts transactions server-side and cannot serve as a Kit client payer/identity. Create it with createKeychainSigner() and use signAndSendTransaction() instead.`,
+        });
+    }
+    const signer = await createKeychainSigner(config);
+    assertIsSolanaSigner(signer);
+    return signer;
+}
 
 /**
  * Creates a keychain signer from a backend-tagged configuration and sets it
@@ -45,7 +64,7 @@ export type KeychainKitPluginConfig =
  */
 export function keychainSigner(config: KeychainKitPluginConfig) {
     return async <TClient extends object>(client: TClient) => {
-        const signer = await createKeychainSigner(config);
+        const signer = await createPartialSigner(config);
         return extendClient(client, { identity: signer, payer: signer });
     };
 }
@@ -74,7 +93,7 @@ export function keychainSigner(config: KeychainKitPluginConfig) {
  */
 export function keychainPayer(config: KeychainKitPluginConfig) {
     return async <TClient extends object>(client: TClient) => {
-        const payer = await createKeychainSigner(config);
+        const payer = await createPartialSigner(config);
         return extendClient(client, { payer });
     };
 }
@@ -104,7 +123,7 @@ export function keychainPayer(config: KeychainKitPluginConfig) {
  */
 export function keychainIdentity(config: KeychainKitPluginConfig) {
     return async <TClient extends object>(client: TClient) => {
-        const identity = await createKeychainSigner(config);
+        const identity = await createPartialSigner(config);
         return extendClient(client, { identity });
     };
 }

--- a/typescript/packages/openfort/src/openfort-signer.ts
+++ b/typescript/packages/openfort/src/openfort-signer.ts
@@ -179,7 +179,6 @@ class OpenfortSigner<TAddress extends string = string> implements SolanaSigner<T
             });
         }
 
-        // Hex-decode signature (`0x` prefix optional).
         const sigHex = data.signature.startsWith('0x') ? data.signature.slice(2) : data.signature;
         let signatureBytes: SignatureBytes;
         try {

--- a/typescript/packages/privy/src/authorization.ts
+++ b/typescript/packages/privy/src/authorization.ts
@@ -1,4 +1,7 @@
-import { SignerErrorCode, throwSignerError } from '@solana/keychain-core';
+import { getBase64Decoder } from '@solana/codecs-strings';
+import { base64UrlEncoder, normalizePrivateKeyPem, SignerErrorCode, throwSignerError } from '@solana/keychain-core';
+
+let base64Decoder: ReturnType<typeof getBase64Decoder> | undefined;
 
 export type PrivyAuthorizationSignFn = (payload: Uint8Array) => Promise<string> | string;
 
@@ -149,7 +152,8 @@ async function generatePrivyAuthorizationSignature(
             dsaEncoding: 'der',
             key: privateKey,
         });
-        return Buffer.from(signature).toString('base64');
+        base64Decoder ||= getBase64Decoder();
+        return base64Decoder.decode(signature);
     } catch (error) {
         throwSignerError(SignerErrorCode.SIGNING_FAILED, {
             cause: error,
@@ -177,12 +181,14 @@ function parseP256PrivateKey(
     const normalized = unprefixed.replace(/\s+/g, '');
 
     if (unprefixed.includes('-----BEGIN')) {
-        return nodeCrypto.createPrivateKey(unprefixed.replace(/\\n/g, '\n').trim());
+        return nodeCrypto.createPrivateKey(normalizePrivateKeyPem(unprefixed));
     }
 
+    // Keys exported through URL-safe tooling arrive base64url;
+    // base64UrlEncoder accepts both alphabets and optional padding.
     return nodeCrypto.createPrivateKey({
         format: 'der',
-        key: Buffer.from(normalized, 'base64'),
+        key: base64UrlEncoder(normalized),
         type: 'pkcs8',
     });
 }

--- a/typescript/packages/test-utils/src/integration-test-runner.ts
+++ b/typescript/packages/test-utils/src/integration-test-runner.ts
@@ -42,7 +42,6 @@ export async function runSignerIntegrationTest<T extends TestSigner>(
 ): Promise<void> {
     const opts = { ...DEFAULT_OPTIONS, ...options };
 
-    // Validate environment
     validateEnvironment(config.requiredEnvVars);
 
     // Minimal SVM: sysvars + builtins + sigverify + precompiles. No SPL programs (unused) — keeps startup small.
@@ -54,7 +53,6 @@ export async function runSignerIntegrationTest<T extends TestSigner>(
         .withSigverify(true)
         .withPrecompiles();
 
-    // Create signer
     const signer = await config.createSigner();
 
     if (opts.verbose) {
@@ -75,7 +73,6 @@ export async function runSignerIntegrationTest<T extends TestSigner>(
         signer,
     };
 
-    // Run test scenarios
     const scenarios = config.testScenarios ?? ALL_SCENARIOS;
 
     for (const scenario of scenarios) {
@@ -145,12 +142,10 @@ async function testSignTransaction<T extends TestSigner>(context: TestContext<T>
 
     const signedTransaction = await signTransactionMessageWithSigners(transaction);
 
-    // Verify transaction has signatures
     if (!signedTransaction.signatures || Object.keys(signedTransaction.signatures).length === 0) {
         throw new Error('Transaction was not signed - no signatures present');
     }
 
-    // Verify signer's signature is present
     if (!signedTransaction.signatures[signer.address]) {
         throw new Error(`Missing signature for signer address ${signer.address}`);
     }
@@ -270,7 +265,6 @@ async function testBadSignature<T extends TestSigner>(context: TestContext<T>): 
 
     const signedTransaction = await signTransactionMessageWithSigners(transaction);
 
-    // Replace with a known bad signature
     const badSignature: SignaturesMap = {
         [signer.address]: new Uint8Array([
             214, 77, 129, 89, 164, 235, 121, 219, 146, 31, 168, 106, 229, 87, 42, 167, 124, 94, 122, 181, 174, 123, 29,

--- a/typescript/packages/turnkey/src/stamper.ts
+++ b/typescript/packages/turnkey/src/stamper.ts
@@ -90,7 +90,6 @@ export class ApiKeyStamper {
      */
     stamp(message: string): StampResult {
         try {
-            // Sign with P-256 ECDSA + SHA-256 and encode as DER hex.
             const messageBytes = new TextEncoder().encode(message);
             const privateKeyBytes = hexToBytes(this.apiPrivateKey);
             const signatureDerBytes = p256.sign(messageBytes, privateKeyBytes, {
@@ -99,7 +98,7 @@ export class ApiKeyStamper {
             });
             const signatureHex = bytesToHex(signatureDerBytes);
 
-            // Create stamp object (same structure as Turnkey SDK)
+            // Same structure as the Turnkey SDK stamp.
             const stamp = {
                 publicKey: this.apiPublicKey,
                 scheme: 'SIGNATURE_SCHEME_TK_API_P256',

--- a/typescript/packages/turnkey/src/turnkey-signer.ts
+++ b/typescript/packages/turnkey/src/turnkey-signer.ts
@@ -4,6 +4,7 @@ import {
     assertHttpsUrl,
     assertSignatureValid,
     createSignatureDictionary,
+    ED25519_SIGNATURE_LENGTH,
     extractSignatureFromTransactionBytes,
     fetchSignerJson,
     signBatchStaggered,
@@ -202,14 +203,12 @@ class TurnkeySigner<TAddress extends string = string> implements SolanaSigner<TA
             });
         }
 
-        // Pad r and s components to exactly 32 bytes each
         const rPadded = this.padSignatureComponent(signResult.r);
         const sPadded = this.padSignatureComponent(signResult.s);
 
-        // Combine into 64-byte signature
-        const signature = new Uint8Array(64);
+        const signature = new Uint8Array(ED25519_SIGNATURE_LENGTH);
         signature.set(rPadded, 0);
-        signature.set(sPadded, 32);
+        signature.set(sPadded, ED25519_SIGNATURE_LENGTH / 2);
 
         return signature as SignatureBytes;
     }
@@ -224,7 +223,6 @@ class TurnkeySigner<TAddress extends string = string> implements SolanaSigner<TA
         return await signBatchStaggered(
             messages,
             async message => {
-                // Convert message bytes to hex for Turnkey
                 const bytesToHex = getBase16Decoder().decode;
                 const hexMessage = bytesToHex(message.content);
                 const signatureBytes = await this.sign(hexMessage, config?.abortSignal);
@@ -306,16 +304,13 @@ class TurnkeySigner<TAddress extends string = string> implements SolanaSigner<TA
             async transaction => {
                 const wireTransaction = getBase64EncodedWireTransaction(transaction);
 
-                // Convert base64 wire transaction to bytes, then to hex for Turnkey
                 const base64ToBytes = getBase64Encoder().encode;
                 const txBytes = base64ToBytes(wireTransaction);
                 const bytesToHex = getBase16Decoder().decode;
                 const hexTx = bytesToHex(txBytes);
 
-                // Use Turnkey's sign_transaction endpoint which returns the full signed transaction
                 const signedTransactionHex = await this.signTransaction(hexTx, config?.abortSignal);
 
-                // Convert signed transaction hex back to bytes for signature extraction
                 const hexToBytes = getBase16Encoder().encode;
                 const signedTxBytes = hexToBytes(signedTransactionHex);
                 const sigDict = extractSignatureFromTransactionBytes({

--- a/typescript/packages/vault/src/vault-signer.ts
+++ b/typescript/packages/vault/src/vault-signer.ts
@@ -4,6 +4,7 @@ import {
     assertHttpsUrl,
     assertSignatureValid,
     createSignatureDictionary,
+    ED25519_SIGNATURE_LENGTH,
     fetchSignerJson,
     normalizeBaseUrl,
     signBatchStaggered,
@@ -22,6 +23,9 @@ import {
 import { Transaction, TransactionWithinSizeLimit, TransactionWithLifetime } from '@solana/transactions';
 
 import type { VaultKeyReadResponse, VaultPayloadBase64, VaultSignRequest, VaultSignResponse } from './types.js';
+
+let base64Encoder: ReturnType<typeof getBase64Encoder> | undefined;
+let base64Decoder: ReturnType<typeof getBase64Decoder> | undefined;
 
 /**
  * Create a Vault-backed signer.
@@ -103,7 +107,6 @@ class VaultSigner<TAddress extends string = string> implements SolanaSigner<TAdd
      * Vault returns signatures in format: "vault:vN:base64_signature"
      */
     private extractSignatureFromVaultFormat(vaultSignature: string): SignatureBytes {
-        // Remove any Vault version prefix (vault:v1:, vault:v2:, ...)
         const base64Signature = vaultSignature.replace(/^vault:v\d+:/, '');
 
         if (!base64Signature) {
@@ -112,9 +115,22 @@ class VaultSigner<TAddress extends string = string> implements SolanaSigner<TAdd
             });
         }
 
-        // Decode base64 string to Uint8Array (SignatureBytes)
-        const encoder = getBase64Encoder();
-        return encoder.encode(base64Signature) as SignatureBytes;
+        let sigBytes: Uint8Array;
+        try {
+            base64Encoder ||= getBase64Encoder();
+            sigBytes = new Uint8Array(base64Encoder.encode(base64Signature));
+        } catch (error) {
+            return throwSignerError(SignerErrorCode.PARSING_ERROR, {
+                cause: error,
+                message: 'Failed to decode Vault signature base64',
+            });
+        }
+        if (sigBytes.length !== ED25519_SIGNATURE_LENGTH) {
+            return throwSignerError(SignerErrorCode.SIGNING_FAILED, {
+                message: `Invalid signature length: expected ${ED25519_SIGNATURE_LENGTH} bytes, got ${sigBytes.length}`,
+            });
+        }
+        return sigBytes as SignatureBytes;
     }
 
     /**
@@ -157,10 +173,9 @@ class VaultSigner<TAddress extends string = string> implements SolanaSigner<TAdd
         messageBytes: ArrayLike<number>,
         abortSignal?: AbortSignal,
     ): Promise<SignatureBytes> {
-        // Encode message bytes to base64 string for Vault
-        const decoder = getBase64Decoder();
+        base64Decoder ||= getBase64Decoder();
         const bytes = messageBytes instanceof Uint8Array ? messageBytes : new Uint8Array(Array.from(messageBytes));
-        const base64EncodedMessage = decoder.decode(bytes);
+        const base64EncodedMessage = base64Decoder.decode(bytes);
         return await this.signWithVault(base64EncodedMessage, abortSignal);
     }
 
@@ -200,7 +215,6 @@ class VaultSigner<TAddress extends string = string> implements SolanaSigner<TAdd
         return await signBatchStaggered(
             transactions,
             async transaction => {
-                // Sign the transaction message bytes
                 const signatureBytes = await this.signMessageBytes(transaction.messageBytes, config?.abortSignal);
                 await assertSignatureValid({
                     data: transaction.messageBytes,

--- a/typescript/pnpm-lock.yaml
+++ b/typescript/pnpm-lock.yaml
@@ -311,6 +311,9 @@ importers:
       '@solana/addresses':
         specifier: 8.0.0
         version: 8.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/codecs-strings':
+        specifier: 8.0.0
+        version: 8.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/keychain-test-utils':
         specifier: workspace:*
         version: link:../test-utils


### PR DESCRIPTION
- vault: the one signature-decode site the first pass skipped is now guarded — malformed base64 → PARSING_ERROR instead of a raw SolanaError, plus the missing ED25519_SIGNATURE_LENGTH check.
- privy: replaced my hand-rolled base64url translation with core's existing base64UrlEncoder (accepts both alphabets, handles padding, lazy-memoized) — this also gives that previously-dead core export its first real consumer.
- fireblocks: importFireblocksPrivateKey now runs normalizePrivateKeyPem first, so single-line \n-escaped PEM secrets work like they already do in privy/dfns/utila.
- codec memoization: fordefi (all 10 sites), gcp-kms, privy, and vault now use the repo's lazy x ||= getX() idiom instead of constructing a fresh codec per call, matching cdp/dfns/crossmint/fireblocks.

part two of cleanup
closes DEV-935