### PR TITLE
build(go)!: move the Go modules to /v2 and add a publish workflow

### DIFF
--- a/.github/workflows/go-publish.yml
+++ b/.github/workflows/go-publish.yml
@@ -1,0 +1,202 @@
+name: Publish Go Modules (Manual)
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to release, without the leading v (e.g. 2.0.0)'
+        required: true
+        type: string
+      create-github-release:
+        description: 'Create GitHub release'
+        required: true
+        default: true
+        type: boolean
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-go
+  cancel-in-progress: false
+
+env:
+  MODULE_PREFIX: github.com/solana-foundation/solana-keychain
+
+jobs:
+  guard-allowed-branch:
+    name: Guard allowed source branch for release publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: Guard allowed source branch for release publish
+        run: |
+          case "${{ github.ref }}" in
+            refs/heads/main|refs/heads/hotfix/*) ;;
+            *)
+              echo "::error::Publish Go Modules must be run from main or hotfix/*. Current ref: ${{ github.ref }}"
+              exit 1
+              ;;
+          esac
+
+  publish:
+    name: Tag and release Go modules
+    runs-on: ubuntu-latest
+    needs: guard-allowed-branch
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: go/core/go.mod
+          cache-dependency-path: go/**/go.sum
+
+      - name: Validate version
+        id: version
+        run: |
+          VERSION="${{ inputs.version }}"
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::Version '$VERSION' is not semver (expected e.g. 2.0.0 or 2.0.0-rc.1)"
+            exit 1
+          fi
+          MAJOR="${VERSION%%.*}"
+          if [ "$MAJOR" -ge 2 ]; then
+            SUFFIX="/v$MAJOR"
+          else
+            SUFFIX=""
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "suffix=$SUFFIX" >> "$GITHUB_OUTPUT"
+          echo "Releasing v$VERSION (expected module path suffix: '${SUFFIX:-none}')"
+
+      - name: Discover modules
+        id: modules
+        run: |
+          find go -name go.mod -not -path '*/.*' -printf '%h\n' | sort > modules.txt
+          echo "Found $(wc -l < modules.txt) modules:"
+          cat modules.txt
+
+      - name: Verify modules are publishable
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          SUFFIX="${{ steps.version.outputs.suffix }}"
+          FAILED=0
+
+          while read -r DIR; do
+            JSON=$(go mod edit -json "$DIR/go.mod")
+
+            ACTUAL=$(jq -r '.Module.Path' <<<"$JSON")
+            EXPECTED="$MODULE_PREFIX/$DIR$SUFFIX"
+            if [ "$ACTUAL" != "$EXPECTED" ]; then
+              echo "::error file=$DIR/go.mod::module path is '$ACTUAL', expected '$EXPECTED' for v$VERSION"
+              FAILED=1
+            fi
+
+            # A replace is dropped when the module is consumed as a dependency, so
+            # every internal require must name the version this run tags.
+            jq -r --arg p "$MODULE_PREFIX/" \
+              '.Require // [] | .[] | select(.Path | startswith($p)) | "\(.Path) \(.Version)"' <<<"$JSON" \
+            | while read -r RPATH RVERSION; do
+                if [ "$RVERSION" != "v$VERSION" ]; then
+                  echo "::error file=$DIR/go.mod::requires $RPATH at $RVERSION, expected v$VERSION"
+                fi
+              done
+            if jq -e --arg p "$MODULE_PREFIX/" --arg v "v$VERSION" \
+              '.Require // [] | any((.Path | startswith($p)) and .Version != $v)' <<<"$JSON" >/dev/null; then
+              FAILED=1
+            fi
+          done < modules.txt
+
+          if [ "$FAILED" -ne 0 ]; then
+            echo "::error::One or more modules are not publishable at v$VERSION"
+            exit 1
+          fi
+          echo "✓ all modules publishable at v$VERSION"
+
+      - name: Create tags
+        id: tags
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          TAGS=()
+          while read -r DIR; do
+            TAG="$DIR/v$VERSION"
+            if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
+              TAGGED=$(git rev-parse "$TAG^{commit}")
+              if [ "$TAGGED" != "$GITHUB_SHA" ]; then
+                echo "::error::$TAG already points at $TAGGED but this run releases $GITHUB_SHA — bump the version instead of retagging"
+                exit 1
+              fi
+              echo "· tag $TAG already points at this commit"
+            else
+              git tag "$TAG"
+              echo "✓ created tag $TAG"
+            fi
+            TAGS+=("$TAG")
+          done < modules.txt
+
+          git push origin --atomic "${TAGS[@]}"
+          printf '%s\n' "${TAGS[@]}" > tags.txt
+          echo "primary=go/core/v$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub Release
+        if: ${{ inputs.create-github-release }}
+        uses: actions/github-script@v9
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const version = '${{ steps.version.outputs.version }}';
+            const suffix = '${{ steps.version.outputs.suffix }}';
+            const tagName = '${{ steps.tags.outputs.primary }}';
+            const tags = fs.readFileSync('tags.txt', 'utf8').trim().split('\n');
+
+            try {
+              await github.rest.repos.getReleaseByTag({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                tag: tagName,
+              });
+              console.log(`· release ${tagName} already exists, skipping`);
+              return;
+            } catch (e) {
+              if (e.status !== 404) throw e;
+            }
+
+            const modules = tags
+              .map((t) => t.replace(new RegExp(`/v${version}$`), ''))
+              .map((d) => `- \`go get github.com/${context.repo.owner}/${context.repo.repo}/${d}${suffix}@v${version}\``)
+              .join('\n');
+
+            await github.rest.repos.createRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              tag_name: tagName,
+              name: `solana-keychain (Go) v${version}`,
+              body: `Release of solana-keychain v${version} (Go)\n\n${tags.length} modules tagged:\n\n${modules}`,
+              draft: false,
+              prerelease: version.includes('-'),
+            });
+
+            console.log(`✓ created release ${tagName}`);
+
+      - name: Publish summary
+        if: always()
+        run: |
+          {
+            echo "## solana-keychain (Go) Published"
+            echo ""
+            echo "**Version**: \`v${{ steps.version.outputs.version }}\`"
+            echo ""
+            if [ -f tags.txt ]; then
+              echo "**Tags** ($(wc -l < tags.txt)):"
+              echo ""
+              sed 's/^/- `/;s/$/`/' tags.txt
+            else
+              echo "No tags were pushed."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/go-publish.yml
+++ b/.github/workflows/go-publish.yml
@@ -29,11 +29,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Guard allowed source branch for release publish
+        env:
+          REF: ${{ github.ref }}
         run: |
-          case "${{ github.ref }}" in
+          case "$REF" in
             refs/heads/main|refs/heads/hotfix/*) ;;
             *)
-              echo "::error::Publish Go Modules must be run from main or hotfix/*. Current ref: ${{ github.ref }}"
+              echo "::error::Publish Go Modules must be run from main or hotfix/*. Current ref: $REF"
               exit 1
               ;;
           esac
@@ -55,8 +57,10 @@ jobs:
 
       - name: Validate version
         id: version
+        env:
+          VERSION_INPUT: ${{ inputs.version }}
         run: |
-          VERSION="${{ inputs.version }}"
+          VERSION="$VERSION_INPUT"
           if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
             echo "::error::Version '$VERSION' is not semver (expected e.g. 2.0.0 or 2.0.0-rc.1)"
             exit 1

--- a/go/README.md
+++ b/go/README.md
@@ -42,8 +42,8 @@ backend you import (a memory-only consumer pulls no AWS/GCP SDKs and no
 `google.golang.org/api` toolchain floor):
 
 ```bash
-go get github.com/solana-foundation/solana-keychain/go/signers/memory@latest
-go get github.com/solana-foundation/solana-keychain/go/signers/vault@latest
+go get github.com/solana-foundation/solana-keychain/go/signers/memory/v2@latest
+go get github.com/solana-foundation/solana-keychain/go/signers/vault/v2@latest
 ```
 
 Requires **Go 1.25+** (the `gcpkms` module requires the toolchain floor set by
@@ -89,7 +89,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/solana-foundation/solana-keychain/go/signers/memory"
+	"github.com/solana-foundation/solana-keychain/go/signers/memory/v2"
 )
 
 func main() {
@@ -128,7 +128,7 @@ constructor that returns a ready-to-use signer (backends that need a remote
 lookup take a `context.Context` and perform it inline):
 
 ```go
-import "github.com/solana-foundation/solana-keychain/go/signers/vault"
+import "github.com/solana-foundation/solana-keychain/go/signers/vault/v2"
 
 signer, err := vault.New(vault.Config{
 	VaultAddr: "https://vault.example.com",
@@ -139,7 +139,7 @@ signer, err := vault.New(vault.Config{
 ```
 
 ```go
-import "github.com/solana-foundation/solana-keychain/go/signers/privy"
+import "github.com/solana-foundation/solana-keychain/go/signers/privy/v2"
 
 signer, err := privy.New(ctx, privy.Config{
 	AppID:     os.Getenv("PRIVY_APP_ID"),

--- a/go/core/go.mod
+++ b/go/core/go.mod
@@ -1,4 +1,4 @@
-module github.com/solana-foundation/solana-keychain/go/core
+module github.com/solana-foundation/solana-keychain/go/core/v2
 
 go 1.25.0
 

--- a/go/signers/awskms/go.mod
+++ b/go/signers/awskms/go.mod
@@ -1,4 +1,4 @@
-module github.com/solana-foundation/solana-keychain/go/signers/awskms
+module github.com/solana-foundation/solana-keychain/go/signers/awskms/v2
 
 go 1.25.0
 
@@ -8,8 +8,8 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.26
 	github.com/aws/aws-sdk-go-v2/service/kms v1.53.6
 	github.com/gagliardetto/solana-go v1.20.0
-	github.com/solana-foundation/solana-keychain/go/core v0.0.0-00010101000000-000000000000
-	github.com/solana-foundation/solana-keychain/go/testutils v0.0.0-00010101000000-000000000000
+	github.com/solana-foundation/solana-keychain/go/core/v2 v2.0.0
+	github.com/solana-foundation/solana-keychain/go/testutils/v2 v2.0.0
 )
 
 require (
@@ -52,8 +52,8 @@ require (
 	golang.org/x/time v0.11.0 // indirect
 )
 
-replace github.com/solana-foundation/solana-keychain/go/core => ../../core
+replace github.com/solana-foundation/solana-keychain/go/core/v2 => ../../core
 
-replace github.com/solana-foundation/solana-keychain/go/testutils => ../../testutils
+replace github.com/solana-foundation/solana-keychain/go/testutils/v2 => ../../testutils
 
 replace github.com/gagliardetto/solana-go => github.com/sonicfromnewyoke/solana-go v0.0.0-20260817125726-409ee9873f6d

--- a/go/signers/awskms/integration_test.go
+++ b/go/signers/awskms/integration_test.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/gagliardetto/solana-go"
 
-	"github.com/solana-foundation/solana-keychain/go/core"
-	"github.com/solana-foundation/solana-keychain/go/testutils"
+	"github.com/solana-foundation/solana-keychain/go/core/v2"
+	"github.com/solana-foundation/solana-keychain/go/testutils/v2"
 )
 
 // integrationSigner builds a signer against live AWS KMS configured by the

--- a/go/signers/awskms/redaction_test.go
+++ b/go/signers/awskms/redaction_test.go
@@ -3,7 +3,7 @@ package awskms
 import (
 	"testing"
 
-	"github.com/solana-foundation/solana-keychain/go/testutils"
+	"github.com/solana-foundation/solana-keychain/go/testutils/v2"
 )
 
 func TestStringDoesNotLeakConfig(t *testing.T) {

--- a/go/signers/awskms/signer.go
+++ b/go/signers/awskms/signer.go
@@ -10,7 +10,7 @@ import (
 	kmstypes "github.com/aws/aws-sdk-go-v2/service/kms/types"
 	"github.com/gagliardetto/solana-go"
 
-	"github.com/solana-foundation/solana-keychain/go/core"
+	"github.com/solana-foundation/solana-keychain/go/core/v2"
 )
 
 // AWS KMS constants for Ed25519 signing keys.

--- a/go/signers/awskms/signer_test.go
+++ b/go/signers/awskms/signer_test.go
@@ -15,8 +15,8 @@ import (
 	kmstypes "github.com/aws/aws-sdk-go-v2/service/kms/types"
 	"github.com/gagliardetto/solana-go"
 
-	"github.com/solana-foundation/solana-keychain/go/core"
-	"github.com/solana-foundation/solana-keychain/go/testutils"
+	"github.com/solana-foundation/solana-keychain/go/core/v2"
+	"github.com/solana-foundation/solana-keychain/go/testutils/v2"
 )
 
 const (

--- a/go/signers/awskms/types.go
+++ b/go/signers/awskms/types.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/kms"
 
-	"github.com/solana-foundation/solana-keychain/go/core"
+	"github.com/solana-foundation/solana-keychain/go/core/v2"
 )
 
 // API is the subset of the AWS KMS client this signer uses. *kms.Client

--- a/go/signers/cdp/go.mod
+++ b/go/signers/cdp/go.mod
@@ -1,12 +1,12 @@
-module github.com/solana-foundation/solana-keychain/go/signers/cdp
+module github.com/solana-foundation/solana-keychain/go/signers/cdp/v2
 
 go 1.25.0
 
 require (
 	github.com/gagliardetto/solana-go v1.20.0
 	github.com/golang-jwt/jwt/v5 v5.3.1
-	github.com/solana-foundation/solana-keychain/go/core v0.0.0-00010101000000-000000000000
-	github.com/solana-foundation/solana-keychain/go/testutils v0.0.0-00010101000000-000000000000
+	github.com/solana-foundation/solana-keychain/go/core/v2 v2.0.0
+	github.com/solana-foundation/solana-keychain/go/testutils/v2 v2.0.0
 )
 
 require (
@@ -38,8 +38,8 @@ require (
 	golang.org/x/time v0.11.0 // indirect
 )
 
-replace github.com/solana-foundation/solana-keychain/go/core => ../../core
+replace github.com/solana-foundation/solana-keychain/go/core/v2 => ../../core
 
-replace github.com/solana-foundation/solana-keychain/go/testutils => ../../testutils
+replace github.com/solana-foundation/solana-keychain/go/testutils/v2 => ../../testutils
 
 replace github.com/gagliardetto/solana-go => github.com/sonicfromnewyoke/solana-go v0.0.0-20260817125726-409ee9873f6d

--- a/go/signers/cdp/integration_test.go
+++ b/go/signers/cdp/integration_test.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/gagliardetto/solana-go"
 
-	"github.com/solana-foundation/solana-keychain/go/core"
-	"github.com/solana-foundation/solana-keychain/go/testutils"
+	"github.com/solana-foundation/solana-keychain/go/core/v2"
+	"github.com/solana-foundation/solana-keychain/go/testutils/v2"
 )
 
 // integrationSigner builds a signer against the live CDP API configured by

--- a/go/signers/cdp/jwt.go
+++ b/go/signers/cdp/jwt.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/golang-jwt/jwt/v5"
 
-	"github.com/solana-foundation/solana-keychain/go/core"
+	"github.com/solana-foundation/solana-keychain/go/core/v2"
 )
 
 // jwtTTL is the JWT validity window in seconds.

--- a/go/signers/cdp/jwt_test.go
+++ b/go/signers/cdp/jwt_test.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/golang-jwt/jwt/v5"
 
-	"github.com/solana-foundation/solana-keychain/go/core"
-	"github.com/solana-foundation/solana-keychain/go/testutils"
+	"github.com/solana-foundation/solana-keychain/go/core/v2"
+	"github.com/solana-foundation/solana-keychain/go/testutils/v2"
 )
 
 // decodeJWTPart base64url-decodes one JWT segment into a JSON map.

--- a/go/signers/cdp/signer.go
+++ b/go/signers/cdp/signer.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/gagliardetto/solana-go"
 
-	"github.com/solana-foundation/solana-keychain/go/core"
+	"github.com/solana-foundation/solana-keychain/go/core/v2"
 )
 
 const (

--- a/go/signers/cdp/signer_test.go
+++ b/go/signers/cdp/signer_test.go
@@ -15,8 +15,8 @@ import (
 	"github.com/gagliardetto/solana-go"
 	"github.com/gagliardetto/solana-go/base58"
 
-	"github.com/solana-foundation/solana-keychain/go/core"
-	"github.com/solana-foundation/solana-keychain/go/testutils"
+	"github.com/solana-foundation/solana-keychain/go/core/v2"
+	"github.com/solana-foundation/solana-keychain/go/testutils/v2"
 )
 
 const testPubkeyStr = "7EcDhSYGxXyscszYEp35KHN8vvw3svAuLKTzXwCFLtV"

--- a/go/signers/cdp/types.go
+++ b/go/signers/cdp/types.go
@@ -8,7 +8,7 @@ package cdp
 import (
 	"net/http"
 
-	"github.com/solana-foundation/solana-keychain/go/core"
+	"github.com/solana-foundation/solana-keychain/go/core/v2"
 )
 
 // Config configures a CDP signer.

--- a/go/signers/crossmint/client.go
+++ b/go/signers/crossmint/client.go
@@ -10,7 +10,7 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/solana-foundation/solana-keychain/go/core"
+	"github.com/solana-foundation/solana-keychain/go/core/v2"
 )
 
 // walletResponse is the subset of the Crossmint wallet object the signer needs.

--- a/go/signers/crossmint/derive.go
+++ b/go/signers/crossmint/derive.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/gagliardetto/solana-go/base58"
 
-	"github.com/solana-foundation/solana-keychain/go/core"
+	"github.com/solana-foundation/solana-keychain/go/core/v2"
 )
 
 // signerSecretPrefix is the expected prefix of a Crossmint server signer secret.

--- a/go/signers/crossmint/go.mod
+++ b/go/signers/crossmint/go.mod
@@ -1,11 +1,11 @@
-module github.com/solana-foundation/solana-keychain/go/signers/crossmint
+module github.com/solana-foundation/solana-keychain/go/signers/crossmint/v2
 
 go 1.25.0
 
 require (
 	github.com/gagliardetto/solana-go v1.20.0
-	github.com/solana-foundation/solana-keychain/go/core v0.0.0-00010101000000-000000000000
-	github.com/solana-foundation/solana-keychain/go/testutils v0.0.0-00010101000000-000000000000
+	github.com/solana-foundation/solana-keychain/go/core/v2 v2.0.0
+	github.com/solana-foundation/solana-keychain/go/testutils/v2 v2.0.0
 	golang.org/x/crypto v0.53.0
 )
 
@@ -37,8 +37,8 @@ require (
 	golang.org/x/time v0.11.0 // indirect
 )
 
-replace github.com/solana-foundation/solana-keychain/go/core => ../../core
+replace github.com/solana-foundation/solana-keychain/go/core/v2 => ../../core
 
-replace github.com/solana-foundation/solana-keychain/go/testutils => ../../testutils
+replace github.com/solana-foundation/solana-keychain/go/testutils/v2 => ../../testutils
 
 replace github.com/gagliardetto/solana-go => github.com/sonicfromnewyoke/solana-go v0.0.0-20260817125726-409ee9873f6d

--- a/go/signers/crossmint/integration_test.go
+++ b/go/signers/crossmint/integration_test.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/gagliardetto/solana-go"
 
-	"github.com/solana-foundation/solana-keychain/go/core"
-	"github.com/solana-foundation/solana-keychain/go/testutils"
+	"github.com/solana-foundation/solana-keychain/go/core/v2"
+	"github.com/solana-foundation/solana-keychain/go/testutils/v2"
 )
 
 // integrationSigner builds a signer against the live Crossmint API configured

--- a/go/signers/crossmint/signer.go
+++ b/go/signers/crossmint/signer.go
@@ -14,7 +14,7 @@ import (
 	"github.com/gagliardetto/solana-go"
 	"github.com/gagliardetto/solana-go/base58"
 
-	"github.com/solana-foundation/solana-keychain/go/core"
+	"github.com/solana-foundation/solana-keychain/go/core/v2"
 )
 
 // awaitingApprovalDetail is the error detail used whenever a transaction is

--- a/go/signers/crossmint/signer_test.go
+++ b/go/signers/crossmint/signer_test.go
@@ -21,8 +21,8 @@ import (
 	"github.com/gagliardetto/solana-go"
 	"github.com/gagliardetto/solana-go/base58"
 
-	"github.com/solana-foundation/solana-keychain/go/core"
-	"github.com/solana-foundation/solana-keychain/go/testutils"
+	"github.com/solana-foundation/solana-keychain/go/core/v2"
+	"github.com/solana-foundation/solana-keychain/go/testutils/v2"
 )
 
 const (

--- a/go/signers/crossmint/types.go
+++ b/go/signers/crossmint/types.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/solana-foundation/solana-keychain/go/core"
+	"github.com/solana-foundation/solana-keychain/go/core/v2"
 )
 
 const (

--- a/go/signers/dfns/auth.go
+++ b/go/signers/dfns/auth.go
@@ -15,7 +15,7 @@ import (
 	"encoding/pem"
 	"net/http"
 
-	"github.com/solana-foundation/solana-keychain/go/core"
+	"github.com/solana-foundation/solana-keychain/go/core/v2"
 )
 
 // Dfns User Action Signing flow. See

--- a/go/signers/dfns/auth_test.go
+++ b/go/signers/dfns/auth_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/pem"
 	"testing"
 
-	"github.com/solana-foundation/solana-keychain/go/core"
+	"github.com/solana-foundation/solana-keychain/go/core/v2"
 )
 
 // testEd25519PEM is an Ed25519 test key in PKCS#8 PEM format.

--- a/go/signers/dfns/client.go
+++ b/go/signers/dfns/client.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/solana-foundation/solana-keychain/go/core"
+	"github.com/solana-foundation/solana-keychain/go/core/v2"
 )
 
 // do sends a Dfns API request and returns the response body on 2xx.

--- a/go/signers/dfns/go.mod
+++ b/go/signers/dfns/go.mod
@@ -1,11 +1,11 @@
-module github.com/solana-foundation/solana-keychain/go/signers/dfns
+module github.com/solana-foundation/solana-keychain/go/signers/dfns/v2
 
 go 1.25.0
 
 require (
 	github.com/gagliardetto/solana-go v1.20.0
-	github.com/solana-foundation/solana-keychain/go/core v0.0.0-00010101000000-000000000000
-	github.com/solana-foundation/solana-keychain/go/testutils v0.0.0-00010101000000-000000000000
+	github.com/solana-foundation/solana-keychain/go/core/v2 v2.0.0
+	github.com/solana-foundation/solana-keychain/go/testutils/v2 v2.0.0
 )
 
 require (
@@ -37,8 +37,8 @@ require (
 	golang.org/x/time v0.11.0 // indirect
 )
 
-replace github.com/solana-foundation/solana-keychain/go/core => ../../core
+replace github.com/solana-foundation/solana-keychain/go/core/v2 => ../../core
 
-replace github.com/solana-foundation/solana-keychain/go/testutils => ../../testutils
+replace github.com/solana-foundation/solana-keychain/go/testutils/v2 => ../../testutils
 
 replace github.com/gagliardetto/solana-go => github.com/sonicfromnewyoke/solana-go v0.0.0-20260817125726-409ee9873f6d

--- a/go/signers/dfns/integration_test.go
+++ b/go/signers/dfns/integration_test.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/gagliardetto/solana-go"
 
-	"github.com/solana-foundation/solana-keychain/go/core"
-	"github.com/solana-foundation/solana-keychain/go/testutils"
+	"github.com/solana-foundation/solana-keychain/go/core/v2"
+	"github.com/solana-foundation/solana-keychain/go/testutils/v2"
 )
 
 // integrationSigner builds a signer against the live Dfns API configured by

--- a/go/signers/dfns/signer.go
+++ b/go/signers/dfns/signer.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/gagliardetto/solana-go"
 
-	"github.com/solana-foundation/solana-keychain/go/core"
+	"github.com/solana-foundation/solana-keychain/go/core/v2"
 )
 
 // getWalletResponse is the subset of the Dfns wallet object the signer needs.

--- a/go/signers/dfns/signer_test.go
+++ b/go/signers/dfns/signer_test.go
@@ -17,8 +17,8 @@ import (
 
 	"github.com/gagliardetto/solana-go"
 
-	"github.com/solana-foundation/solana-keychain/go/core"
-	"github.com/solana-foundation/solana-keychain/go/testutils"
+	"github.com/solana-foundation/solana-keychain/go/core/v2"
+	"github.com/solana-foundation/solana-keychain/go/testutils/v2"
 )
 
 const (

--- a/go/signers/dfns/types.go
+++ b/go/signers/dfns/types.go
@@ -10,7 +10,7 @@ package dfns
 import (
 	"net/http"
 
-	"github.com/solana-foundation/solana-keychain/go/core"
+	"github.com/solana-foundation/solana-keychain/go/core/v2"
 )
 
 // DefaultAPIBaseURL is the production Dfns API endpoint, used when

--- a/go/signers/fireblocks/client.go
+++ b/go/signers/fireblocks/client.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/gagliardetto/solana-go"
 
-	"github.com/solana-foundation/solana-keychain/go/core"
+	"github.com/solana-foundation/solana-keychain/go/core/v2"
 )
 
 // Fireblocks protocol constants (operation name, source type, and the

--- a/go/signers/fireblocks/go.mod
+++ b/go/signers/fireblocks/go.mod
@@ -1,12 +1,12 @@
-module github.com/solana-foundation/solana-keychain/go/signers/fireblocks
+module github.com/solana-foundation/solana-keychain/go/signers/fireblocks/v2
 
 go 1.25.0
 
 require (
 	github.com/gagliardetto/solana-go v1.20.0
 	github.com/golang-jwt/jwt/v5 v5.3.1
-	github.com/solana-foundation/solana-keychain/go/core v0.0.0-00010101000000-000000000000
-	github.com/solana-foundation/solana-keychain/go/testutils v0.0.0-00010101000000-000000000000
+	github.com/solana-foundation/solana-keychain/go/core/v2 v2.0.0
+	github.com/solana-foundation/solana-keychain/go/testutils/v2 v2.0.0
 )
 
 require (
@@ -38,8 +38,8 @@ require (
 	golang.org/x/time v0.11.0 // indirect
 )
 
-replace github.com/solana-foundation/solana-keychain/go/core => ../../core
+replace github.com/solana-foundation/solana-keychain/go/core/v2 => ../../core
 
-replace github.com/solana-foundation/solana-keychain/go/testutils => ../../testutils
+replace github.com/solana-foundation/solana-keychain/go/testutils/v2 => ../../testutils
 
 replace github.com/gagliardetto/solana-go => github.com/sonicfromnewyoke/solana-go v0.0.0-20260817125726-409ee9873f6d

--- a/go/signers/fireblocks/integration_test.go
+++ b/go/signers/fireblocks/integration_test.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/gagliardetto/solana-go"
 
-	"github.com/solana-foundation/solana-keychain/go/core"
-	"github.com/solana-foundation/solana-keychain/go/testutils"
+	"github.com/solana-foundation/solana-keychain/go/core/v2"
+	"github.com/solana-foundation/solana-keychain/go/testutils/v2"
 )
 
 // integrationSigner builds a signer against the live Fireblocks API configured

--- a/go/signers/fireblocks/jwt.go
+++ b/go/signers/fireblocks/jwt.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/golang-jwt/jwt/v5"
 
-	"github.com/solana-foundation/solana-keychain/go/core"
+	"github.com/solana-foundation/solana-keychain/go/core/v2"
 )
 
 // JWT lifetime constants.

--- a/go/signers/fireblocks/jwt_test.go
+++ b/go/signers/fireblocks/jwt_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/solana-foundation/solana-keychain/go/core"
+	"github.com/solana-foundation/solana-keychain/go/core/v2"
 )
 
 // testRSAKey is a throwaway PKCS#8 RSA key for unit tests only.

--- a/go/signers/fireblocks/signer.go
+++ b/go/signers/fireblocks/signer.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/gagliardetto/solana-go"
 
-	"github.com/solana-foundation/solana-keychain/go/core"
+	"github.com/solana-foundation/solana-keychain/go/core/v2"
 )
 
 // Signer signs with a Solana key held in a Fireblocks vault account. All fields

--- a/go/signers/fireblocks/signer_test.go
+++ b/go/signers/fireblocks/signer_test.go
@@ -19,8 +19,8 @@ import (
 	"github.com/gagliardetto/solana-go"
 	"github.com/golang-jwt/jwt/v5"
 
-	"github.com/solana-foundation/solana-keychain/go/core"
-	"github.com/solana-foundation/solana-keychain/go/testutils"
+	"github.com/solana-foundation/solana-keychain/go/core/v2"
+	"github.com/solana-foundation/solana-keychain/go/testutils/v2"
 )
 
 const (

--- a/go/signers/fireblocks/types.go
+++ b/go/signers/fireblocks/types.go
@@ -10,7 +10,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/solana-foundation/solana-keychain/go/core"
+	"github.com/solana-foundation/solana-keychain/go/core/v2"
 )
 
 // Defaults applied when the corresponding Config fields are zero.

--- a/go/signers/fordefi/client.go
+++ b/go/signers/fordefi/client.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/gagliardetto/solana-go"
 
-	"github.com/solana-foundation/solana-keychain/go/core"
+	"github.com/solana-foundation/solana-keychain/go/core/v2"
 )
 
 // Fordefi protocol constants (request discriminators and the transaction

--- a/go/signers/fordefi/go.mod
+++ b/go/signers/fordefi/go.mod
@@ -1,11 +1,11 @@
-module github.com/solana-foundation/solana-keychain/go/signers/fordefi
+module github.com/solana-foundation/solana-keychain/go/signers/fordefi/v2
 
 go 1.25.0
 
 require (
 	github.com/gagliardetto/solana-go v1.20.0
-	github.com/solana-foundation/solana-keychain/go/core v0.0.0-00010101000000-000000000000
-	github.com/solana-foundation/solana-keychain/go/testutils v0.0.0-00010101000000-000000000000
+	github.com/solana-foundation/solana-keychain/go/core/v2 v2.0.0
+	github.com/solana-foundation/solana-keychain/go/testutils/v2 v2.0.0
 )
 
 require (
@@ -37,8 +37,8 @@ require (
 	golang.org/x/time v0.11.0 // indirect
 )
 
-replace github.com/solana-foundation/solana-keychain/go/core => ../../core
+replace github.com/solana-foundation/solana-keychain/go/core/v2 => ../../core
 
-replace github.com/solana-foundation/solana-keychain/go/testutils => ../../testutils
+replace github.com/solana-foundation/solana-keychain/go/testutils/v2 => ../../testutils
 
 replace github.com/gagliardetto/solana-go => github.com/sonicfromnewyoke/solana-go v0.0.0-20260817125726-409ee9873f6d

--- a/go/signers/fordefi/integration_test.go
+++ b/go/signers/fordefi/integration_test.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/gagliardetto/solana-go"
 
-	"github.com/solana-foundation/solana-keychain/go/core"
-	"github.com/solana-foundation/solana-keychain/go/testutils"
+	"github.com/solana-foundation/solana-keychain/go/core/v2"
+	"github.com/solana-foundation/solana-keychain/go/testutils/v2"
 )
 
 // integrationSigner builds a black-box signer against the live Fordefi API

--- a/go/signers/fordefi/requestsigner.go
+++ b/go/signers/fordefi/requestsigner.go
@@ -10,7 +10,7 @@ import (
 	"encoding/base64"
 	"encoding/pem"
 
-	"github.com/solana-foundation/solana-keychain/go/core"
+	"github.com/solana-foundation/solana-keychain/go/core/v2"
 )
 
 // RequestSigner signs Fordefi API-request payloads for the x-signature header.

--- a/go/signers/fordefi/signer.go
+++ b/go/signers/fordefi/signer.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/gagliardetto/solana-go"
 
-	"github.com/solana-foundation/solana-keychain/go/core"
+	"github.com/solana-foundation/solana-keychain/go/core/v2"
 )
 
 // Timeouts for the two bounded probes (vault ownership verification during New

--- a/go/signers/fordefi/signer_test.go
+++ b/go/signers/fordefi/signer_test.go
@@ -24,8 +24,8 @@ import (
 
 	"github.com/gagliardetto/solana-go"
 
-	"github.com/solana-foundation/solana-keychain/go/core"
-	"github.com/solana-foundation/solana-keychain/go/testutils"
+	"github.com/solana-foundation/solana-keychain/go/core/v2"
+	"github.com/solana-foundation/solana-keychain/go/testutils/v2"
 )
 
 const (

--- a/go/signers/fordefi/types.go
+++ b/go/signers/fordefi/types.go
@@ -9,7 +9,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/solana-foundation/solana-keychain/go/core"
+	"github.com/solana-foundation/solana-keychain/go/core/v2"
 )
 
 // Defaults applied when the corresponding Config fields are zero.

--- a/go/signers/gcpkms/go.mod
+++ b/go/signers/gcpkms/go.mod
@@ -1,4 +1,4 @@
-module github.com/solana-foundation/solana-keychain/go/signers/gcpkms
+module github.com/solana-foundation/solana-keychain/go/signers/gcpkms/v2
 
 go 1.25.8
 
@@ -6,8 +6,8 @@ require (
 	cloud.google.com/go/kms v1.31.0
 	github.com/gagliardetto/solana-go v1.20.0
 	github.com/googleapis/gax-go/v2 v2.22.0
-	github.com/solana-foundation/solana-keychain/go/core v0.0.0-00010101000000-000000000000
-	github.com/solana-foundation/solana-keychain/go/testutils v0.0.0-00010101000000-000000000000
+	github.com/solana-foundation/solana-keychain/go/core/v2 v2.0.0
+	github.com/solana-foundation/solana-keychain/go/testutils/v2 v2.0.0
 	google.golang.org/api v0.287.0
 	google.golang.org/grpc v1.81.1
 )
@@ -66,8 +66,8 @@ require (
 	google.golang.org/protobuf v1.36.11 // indirect
 )
 
-replace github.com/solana-foundation/solana-keychain/go/core => ../../core
+replace github.com/solana-foundation/solana-keychain/go/core/v2 => ../../core
 
-replace github.com/solana-foundation/solana-keychain/go/testutils => ../../testutils
+replace github.com/solana-foundation/solana-keychain/go/testutils/v2 => ../../testutils
 
 replace github.com/gagliardetto/solana-go => github.com/sonicfromnewyoke/solana-go v0.0.0-20260817125726-409ee9873f6d

--- a/go/signers/gcpkms/integration_test.go
+++ b/go/signers/gcpkms/integration_test.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/gagliardetto/solana-go"
 
-	"github.com/solana-foundation/solana-keychain/go/core"
-	"github.com/solana-foundation/solana-keychain/go/testutils"
+	"github.com/solana-foundation/solana-keychain/go/core/v2"
+	"github.com/solana-foundation/solana-keychain/go/testutils/v2"
 )
 
 // integrationSigner builds a signer against live GCP KMS configured by the

--- a/go/signers/gcpkms/redaction_test.go
+++ b/go/signers/gcpkms/redaction_test.go
@@ -3,7 +3,7 @@ package gcpkms
 import (
 	"testing"
 
-	"github.com/solana-foundation/solana-keychain/go/testutils"
+	"github.com/solana-foundation/solana-keychain/go/testutils/v2"
 )
 
 func TestStringDoesNotLeakConfig(t *testing.T) {

--- a/go/signers/gcpkms/signer.go
+++ b/go/signers/gcpkms/signer.go
@@ -7,7 +7,7 @@ import (
 	"cloud.google.com/go/kms/apiv1/kmspb"
 	"github.com/gagliardetto/solana-go"
 
-	"github.com/solana-foundation/solana-keychain/go/core"
+	"github.com/solana-foundation/solana-keychain/go/core/v2"
 )
 
 // Signer signs with an Ed25519 key held in Google Cloud KMS. AsymmetricSign is

--- a/go/signers/gcpkms/signer_test.go
+++ b/go/signers/gcpkms/signer_test.go
@@ -13,8 +13,8 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	"github.com/solana-foundation/solana-keychain/go/core"
-	"github.com/solana-foundation/solana-keychain/go/testutils"
+	"github.com/solana-foundation/solana-keychain/go/core/v2"
+	"github.com/solana-foundation/solana-keychain/go/testutils/v2"
 )
 
 const testKeyName = "projects/test-project/locations/us-east1/keyRings/test-ring/cryptoKeys/test-key/cryptoKeyVersions/1"

--- a/go/signers/memory/go.mod
+++ b/go/signers/memory/go.mod
@@ -1,11 +1,11 @@
-module github.com/solana-foundation/solana-keychain/go/signers/memory
+module github.com/solana-foundation/solana-keychain/go/signers/memory/v2
 
 go 1.25.0
 
 require (
 	github.com/gagliardetto/solana-go v1.20.0
-	github.com/solana-foundation/solana-keychain/go/core v0.0.0-00010101000000-000000000000
-	github.com/solana-foundation/solana-keychain/go/testutils v0.0.0-00010101000000-000000000000
+	github.com/solana-foundation/solana-keychain/go/core/v2 v2.0.0
+	github.com/solana-foundation/solana-keychain/go/testutils/v2 v2.0.0
 )
 
 require (
@@ -37,8 +37,8 @@ require (
 	golang.org/x/time v0.11.0 // indirect
 )
 
-replace github.com/solana-foundation/solana-keychain/go/core => ../../core
+replace github.com/solana-foundation/solana-keychain/go/core/v2 => ../../core
 
-replace github.com/solana-foundation/solana-keychain/go/testutils => ../../testutils
+replace github.com/solana-foundation/solana-keychain/go/testutils/v2 => ../../testutils
 
 replace github.com/gagliardetto/solana-go => github.com/sonicfromnewyoke/solana-go v0.0.0-20260817125726-409ee9873f6d

--- a/go/signers/memory/keypair.go
+++ b/go/signers/memory/keypair.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/gagliardetto/solana-go"
 
-	"github.com/solana-foundation/solana-keychain/go/core"
+	"github.com/solana-foundation/solana-keychain/go/core/v2"
 )
 
 // resolvePrivateKey turns a Config into an ed25519.PrivateKey (the 64-byte

--- a/go/signers/memory/keypair_test.go
+++ b/go/signers/memory/keypair_test.go
@@ -3,8 +3,8 @@ package memory
 import (
 	"testing"
 
-	"github.com/solana-foundation/solana-keychain/go/core"
-	"github.com/solana-foundation/solana-keychain/go/testutils"
+	"github.com/solana-foundation/solana-keychain/go/core/v2"
+	"github.com/solana-foundation/solana-keychain/go/testutils/v2"
 )
 
 func TestPrivateKeyFromBytesInvalidLength(t *testing.T) {

--- a/go/signers/memory/redaction_test.go
+++ b/go/signers/memory/redaction_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/solana-foundation/solana-keychain/go/testutils"
+	"github.com/solana-foundation/solana-keychain/go/testutils/v2"
 )
 
 func TestStringDoesNotLeakSecrets(t *testing.T) {

--- a/go/signers/memory/signer.go
+++ b/go/signers/memory/signer.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/gagliardetto/solana-go"
 
-	"github.com/solana-foundation/solana-keychain/go/core"
+	"github.com/solana-foundation/solana-keychain/go/core/v2"
 )
 
 // Signer is an in-memory Ed25519 signer.

--- a/go/signers/memory/signer_test.go
+++ b/go/signers/memory/signer_test.go
@@ -12,8 +12,8 @@ import (
 
 	"github.com/gagliardetto/solana-go"
 
-	"github.com/solana-foundation/solana-keychain/go/core"
-	"github.com/solana-foundation/solana-keychain/go/testutils"
+	"github.com/solana-foundation/solana-keychain/go/core/v2"
+	"github.com/solana-foundation/solana-keychain/go/testutils/v2"
 )
 
 func u8ArrayString(b []byte) string {

--- a/go/signers/openfort/go.mod
+++ b/go/signers/openfort/go.mod
@@ -1,12 +1,12 @@
-module github.com/solana-foundation/solana-keychain/go/signers/openfort
+module github.com/solana-foundation/solana-keychain/go/signers/openfort/v2
 
 go 1.25.0
 
 require (
 	github.com/gagliardetto/solana-go v1.20.0
 	github.com/golang-jwt/jwt/v5 v5.3.1
-	github.com/solana-foundation/solana-keychain/go/core v0.0.0-00010101000000-000000000000
-	github.com/solana-foundation/solana-keychain/go/testutils v0.0.0-00010101000000-000000000000
+	github.com/solana-foundation/solana-keychain/go/core/v2 v2.0.0
+	github.com/solana-foundation/solana-keychain/go/testutils/v2 v2.0.0
 )
 
 require (
@@ -38,8 +38,8 @@ require (
 	golang.org/x/time v0.11.0 // indirect
 )
 
-replace github.com/solana-foundation/solana-keychain/go/core => ../../core
+replace github.com/solana-foundation/solana-keychain/go/core/v2 => ../../core
 
-replace github.com/solana-foundation/solana-keychain/go/testutils => ../../testutils
+replace github.com/solana-foundation/solana-keychain/go/testutils/v2 => ../../testutils
 
 replace github.com/gagliardetto/solana-go => github.com/sonicfromnewyoke/solana-go v0.0.0-20260817125726-409ee9873f6d

--- a/go/signers/openfort/integration_test.go
+++ b/go/signers/openfort/integration_test.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/gagliardetto/solana-go"
 
-	"github.com/solana-foundation/solana-keychain/go/core"
-	"github.com/solana-foundation/solana-keychain/go/testutils"
+	"github.com/solana-foundation/solana-keychain/go/core/v2"
+	"github.com/solana-foundation/solana-keychain/go/testutils/v2"
 )
 
 // integrationSigner builds a signer against the live Openfort API using

--- a/go/signers/openfort/jwt.go
+++ b/go/signers/openfort/jwt.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/golang-jwt/jwt/v5"
 
-	"github.com/solana-foundation/solana-keychain/go/core"
+	"github.com/solana-foundation/solana-keychain/go/core/v2"
 )
 
 // jwtLifetimeSecs is how long a wallet-auth JWT stays valid.

--- a/go/signers/openfort/jwt_test.go
+++ b/go/signers/openfort/jwt_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/solana-foundation/solana-keychain/go/core"
+	"github.com/solana-foundation/solana-keychain/go/core/v2"
 )
 
 // p256PKCS8DER is a minimal valid P-256 PKCS#8 DER private key whose scalar is

--- a/go/signers/openfort/redaction_test.go
+++ b/go/signers/openfort/redaction_test.go
@@ -3,7 +3,7 @@ package openfort
 import (
 	"testing"
 
-	"github.com/solana-foundation/solana-keychain/go/testutils"
+	"github.com/solana-foundation/solana-keychain/go/testutils/v2"
 )
 
 func TestStringDoesNotLeakSecrets(t *testing.T) {

--- a/go/signers/openfort/signer.go
+++ b/go/signers/openfort/signer.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/gagliardetto/solana-go"
 
-	"github.com/solana-foundation/solana-keychain/go/core"
+	"github.com/solana-foundation/solana-keychain/go/core/v2"
 )
 
 const (

--- a/go/signers/openfort/signer_test.go
+++ b/go/signers/openfort/signer_test.go
@@ -15,8 +15,8 @@ import (
 	"github.com/gagliardetto/solana-go"
 	"github.com/golang-jwt/jwt/v5"
 
-	"github.com/solana-foundation/solana-keychain/go/core"
-	"github.com/solana-foundation/solana-keychain/go/testutils"
+	"github.com/solana-foundation/solana-keychain/go/core/v2"
+	"github.com/solana-foundation/solana-keychain/go/testutils/v2"
 )
 
 const (

--- a/go/signers/openfort/types.go
+++ b/go/signers/openfort/types.go
@@ -14,7 +14,7 @@ package openfort
 import (
 	"net/http"
 
-	"github.com/solana-foundation/solana-keychain/go/core"
+	"github.com/solana-foundation/solana-keychain/go/core/v2"
 )
 
 // Config configures an Openfort signer.

--- a/go/signers/para/go.mod
+++ b/go/signers/para/go.mod
@@ -1,11 +1,11 @@
-module github.com/solana-foundation/solana-keychain/go/signers/para
+module github.com/solana-foundation/solana-keychain/go/signers/para/v2
 
 go 1.25.0
 
 require (
 	github.com/gagliardetto/solana-go v1.20.0
-	github.com/solana-foundation/solana-keychain/go/core v0.0.0-00010101000000-000000000000
-	github.com/solana-foundation/solana-keychain/go/testutils v0.0.0-00010101000000-000000000000
+	github.com/solana-foundation/solana-keychain/go/core/v2 v2.0.0
+	github.com/solana-foundation/solana-keychain/go/testutils/v2 v2.0.0
 )
 
 require (
@@ -37,8 +37,8 @@ require (
 	golang.org/x/time v0.11.0 // indirect
 )
 
-replace github.com/solana-foundation/solana-keychain/go/core => ../../core
+replace github.com/solana-foundation/solana-keychain/go/core/v2 => ../../core
 
-replace github.com/solana-foundation/solana-keychain/go/testutils => ../../testutils
+replace github.com/solana-foundation/solana-keychain/go/testutils/v2 => ../../testutils
 
 replace github.com/gagliardetto/solana-go => github.com/sonicfromnewyoke/solana-go v0.0.0-20260817125726-409ee9873f6d

--- a/go/signers/para/integration_test.go
+++ b/go/signers/para/integration_test.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/gagliardetto/solana-go"
 
-	"github.com/solana-foundation/solana-keychain/go/core"
-	"github.com/solana-foundation/solana-keychain/go/testutils"
+	"github.com/solana-foundation/solana-keychain/go/core/v2"
+	"github.com/solana-foundation/solana-keychain/go/testutils/v2"
 )
 
 // integrationSigner builds a signer against the live Para API using

--- a/go/signers/para/signer.go
+++ b/go/signers/para/signer.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/gagliardetto/solana-go"
 
-	"github.com/solana-foundation/solana-keychain/go/core"
+	"github.com/solana-foundation/solana-keychain/go/core/v2"
 )
 
 // Signer signs Solana transactions and messages via Para's wallet API. All

--- a/go/signers/para/signer_test.go
+++ b/go/signers/para/signer_test.go
@@ -17,8 +17,8 @@ import (
 
 	"github.com/gagliardetto/solana-go"
 
-	"github.com/solana-foundation/solana-keychain/go/core"
-	"github.com/solana-foundation/solana-keychain/go/testutils"
+	"github.com/solana-foundation/solana-keychain/go/core/v2"
+	"github.com/solana-foundation/solana-keychain/go/testutils/v2"
 )
 
 // testWalletID is a syntactically valid Para wallet UUID used across tests.

--- a/go/signers/para/types.go
+++ b/go/signers/para/types.go
@@ -6,7 +6,7 @@ package para
 import (
 	"net/http"
 
-	"github.com/solana-foundation/solana-keychain/go/core"
+	"github.com/solana-foundation/solana-keychain/go/core/v2"
 )
 
 // DefaultBaseURL is Para's production API endpoint.

--- a/go/signers/privy/authorization.go
+++ b/go/signers/privy/authorization.go
@@ -15,7 +15,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/solana-foundation/solana-keychain/go/core"
+	"github.com/solana-foundation/solana-keychain/go/core/v2"
 )
 
 // DefaultAuthorizationRequestExpiryMs is the privy-request-expiry window applied

--- a/go/signers/privy/authorization_test.go
+++ b/go/signers/privy/authorization_test.go
@@ -10,8 +10,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/solana-foundation/solana-keychain/go/core"
-	"github.com/solana-foundation/solana-keychain/go/testutils"
+	"github.com/solana-foundation/solana-keychain/go/core/v2"
+	"github.com/solana-foundation/solana-keychain/go/testutils/v2"
 )
 
 // testP256PKCS8PEM and testP256PKCS8Base64 are the same fixed P-256 PKCS#8 key

--- a/go/signers/privy/go.mod
+++ b/go/signers/privy/go.mod
@@ -1,11 +1,11 @@
-module github.com/solana-foundation/solana-keychain/go/signers/privy
+module github.com/solana-foundation/solana-keychain/go/signers/privy/v2
 
 go 1.25.0
 
 require (
 	github.com/gagliardetto/solana-go v1.20.0
-	github.com/solana-foundation/solana-keychain/go/core v0.0.0-00010101000000-000000000000
-	github.com/solana-foundation/solana-keychain/go/testutils v0.0.0-00010101000000-000000000000
+	github.com/solana-foundation/solana-keychain/go/core/v2 v2.0.0
+	github.com/solana-foundation/solana-keychain/go/testutils/v2 v2.0.0
 )
 
 require (
@@ -37,8 +37,8 @@ require (
 	golang.org/x/time v0.11.0 // indirect
 )
 
-replace github.com/solana-foundation/solana-keychain/go/core => ../../core
+replace github.com/solana-foundation/solana-keychain/go/core/v2 => ../../core
 
-replace github.com/solana-foundation/solana-keychain/go/testutils => ../../testutils
+replace github.com/solana-foundation/solana-keychain/go/testutils/v2 => ../../testutils
 
 replace github.com/gagliardetto/solana-go => github.com/sonicfromnewyoke/solana-go v0.0.0-20260817125726-409ee9873f6d

--- a/go/signers/privy/integration_test.go
+++ b/go/signers/privy/integration_test.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/gagliardetto/solana-go"
 
-	"github.com/solana-foundation/solana-keychain/go/core"
-	"github.com/solana-foundation/solana-keychain/go/testutils"
+	"github.com/solana-foundation/solana-keychain/go/core/v2"
+	"github.com/solana-foundation/solana-keychain/go/testutils/v2"
 )
 
 // integrationSigner builds a signer against the live Privy API configured by

--- a/go/signers/privy/signer.go
+++ b/go/signers/privy/signer.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/gagliardetto/solana-go"
 
-	"github.com/solana-foundation/solana-keychain/go/core"
+	"github.com/solana-foundation/solana-keychain/go/core/v2"
 )
 
 // Signer signs with a Privy wallet via Privy's REST API. All fields are

--- a/go/signers/privy/signer_test.go
+++ b/go/signers/privy/signer_test.go
@@ -18,8 +18,8 @@ import (
 
 	"github.com/gagliardetto/solana-go"
 
-	"github.com/solana-foundation/solana-keychain/go/core"
-	"github.com/solana-foundation/solana-keychain/go/testutils"
+	"github.com/solana-foundation/solana-keychain/go/core/v2"
+	"github.com/solana-foundation/solana-keychain/go/testutils/v2"
 )
 
 const (

--- a/go/signers/privy/types.go
+++ b/go/signers/privy/types.go
@@ -7,7 +7,7 @@ package privy
 import (
 	"net/http"
 
-	"github.com/solana-foundation/solana-keychain/go/core"
+	"github.com/solana-foundation/solana-keychain/go/core/v2"
 )
 
 // DefaultAPIBaseURL is the Privy API base URL used when Config.APIBaseURL is

--- a/go/signers/turnkey/go.mod
+++ b/go/signers/turnkey/go.mod
@@ -1,11 +1,11 @@
-module github.com/solana-foundation/solana-keychain/go/signers/turnkey
+module github.com/solana-foundation/solana-keychain/go/signers/turnkey/v2
 
 go 1.25.0
 
 require (
 	github.com/gagliardetto/solana-go v1.20.0
-	github.com/solana-foundation/solana-keychain/go/core v0.0.0-00010101000000-000000000000
-	github.com/solana-foundation/solana-keychain/go/testutils v0.0.0-00010101000000-000000000000
+	github.com/solana-foundation/solana-keychain/go/core/v2 v2.0.0
+	github.com/solana-foundation/solana-keychain/go/testutils/v2 v2.0.0
 )
 
 require (
@@ -37,8 +37,8 @@ require (
 	golang.org/x/time v0.11.0 // indirect
 )
 
-replace github.com/solana-foundation/solana-keychain/go/core => ../../core
+replace github.com/solana-foundation/solana-keychain/go/core/v2 => ../../core
 
-replace github.com/solana-foundation/solana-keychain/go/testutils => ../../testutils
+replace github.com/solana-foundation/solana-keychain/go/testutils/v2 => ../../testutils
 
 replace github.com/gagliardetto/solana-go => github.com/sonicfromnewyoke/solana-go v0.0.0-20260817125726-409ee9873f6d

--- a/go/signers/turnkey/integration_test.go
+++ b/go/signers/turnkey/integration_test.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/gagliardetto/solana-go"
 
-	"github.com/solana-foundation/solana-keychain/go/core"
-	"github.com/solana-foundation/solana-keychain/go/testutils"
+	"github.com/solana-foundation/solana-keychain/go/core/v2"
+	"github.com/solana-foundation/solana-keychain/go/testutils/v2"
 )
 
 // integrationSigner builds a signer against the live Turnkey API configured by

--- a/go/signers/turnkey/redaction_test.go
+++ b/go/signers/turnkey/redaction_test.go
@@ -3,7 +3,7 @@ package turnkey
 import (
 	"testing"
 
-	"github.com/solana-foundation/solana-keychain/go/testutils"
+	"github.com/solana-foundation/solana-keychain/go/testutils/v2"
 )
 
 func TestStringDoesNotLeakSecrets(t *testing.T) {

--- a/go/signers/turnkey/signer.go
+++ b/go/signers/turnkey/signer.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/gagliardetto/solana-go"
 
-	"github.com/solana-foundation/solana-keychain/go/core"
+	"github.com/solana-foundation/solana-keychain/go/core/v2"
 )
 
 // Turnkey API paths.

--- a/go/signers/turnkey/signer_test.go
+++ b/go/signers/turnkey/signer_test.go
@@ -21,8 +21,8 @@ import (
 
 	"github.com/gagliardetto/solana-go"
 
-	"github.com/solana-foundation/solana-keychain/go/core"
-	"github.com/solana-foundation/solana-keychain/go/testutils"
+	"github.com/solana-foundation/solana-keychain/go/core/v2"
+	"github.com/solana-foundation/solana-keychain/go/testutils/v2"
 )
 
 // newTestAPIKeys generates a P-256 API key pair: hex private scalar and hex

--- a/go/signers/turnkey/stamp.go
+++ b/go/signers/turnkey/stamp.go
@@ -11,7 +11,7 @@ import (
 	"encoding/json"
 	"math/big"
 
-	"github.com/solana-foundation/solana-keychain/go/core"
+	"github.com/solana-foundation/solana-keychain/go/core/v2"
 )
 
 // stampScheme is the signature scheme Turnkey expects for API-key stamps.

--- a/go/signers/turnkey/types.go
+++ b/go/signers/turnkey/types.go
@@ -7,7 +7,7 @@ package turnkey
 import (
 	"net/http"
 
-	"github.com/solana-foundation/solana-keychain/go/core"
+	"github.com/solana-foundation/solana-keychain/go/core/v2"
 )
 
 // DefaultAPIBaseURL is the Turnkey API endpoint used when Config.APIBaseURL is

--- a/go/signers/utila/client.go
+++ b/go/signers/utila/client.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/golang-jwt/jwt/v5"
 
-	"github.com/solana-foundation/solana-keychain/go/core"
+	"github.com/solana-foundation/solana-keychain/go/core/v2"
 )
 
 // parseSigningKey normalizes and parses the service-account RSA private key:

--- a/go/signers/utila/go.mod
+++ b/go/signers/utila/go.mod
@@ -1,12 +1,12 @@
-module github.com/solana-foundation/solana-keychain/go/signers/utila
+module github.com/solana-foundation/solana-keychain/go/signers/utila/v2
 
 go 1.25.0
 
 require (
 	github.com/gagliardetto/solana-go v1.20.0
 	github.com/golang-jwt/jwt/v5 v5.3.1
-	github.com/solana-foundation/solana-keychain/go/core v0.0.0-00010101000000-000000000000
-	github.com/solana-foundation/solana-keychain/go/testutils v0.0.0-00010101000000-000000000000
+	github.com/solana-foundation/solana-keychain/go/core/v2 v2.0.0
+	github.com/solana-foundation/solana-keychain/go/testutils/v2 v2.0.0
 )
 
 require (
@@ -38,8 +38,8 @@ require (
 	golang.org/x/time v0.11.0 // indirect
 )
 
-replace github.com/solana-foundation/solana-keychain/go/core => ../../core
+replace github.com/solana-foundation/solana-keychain/go/core/v2 => ../../core
 
-replace github.com/solana-foundation/solana-keychain/go/testutils => ../../testutils
+replace github.com/solana-foundation/solana-keychain/go/testutils/v2 => ../../testutils
 
 replace github.com/gagliardetto/solana-go => github.com/sonicfromnewyoke/solana-go v0.0.0-20260817125726-409ee9873f6d

--- a/go/signers/utila/integration_test.go
+++ b/go/signers/utila/integration_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/gagliardetto/solana-go"
 
-	"github.com/solana-foundation/solana-keychain/go/testutils"
+	"github.com/solana-foundation/solana-keychain/go/testutils/v2"
 )
 
 // integrationSigner builds a signer against the live Utila API configured by

--- a/go/signers/utila/signer.go
+++ b/go/signers/utila/signer.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/gagliardetto/solana-go"
 
-	"github.com/solana-foundation/solana-keychain/go/core"
+	"github.com/solana-foundation/solana-keychain/go/core/v2"
 )
 
 // Signer signs transactions with a Solana wallet held in a Utila vault:

--- a/go/signers/utila/signer_test.go
+++ b/go/signers/utila/signer_test.go
@@ -19,8 +19,8 @@ import (
 	"github.com/gagliardetto/solana-go"
 	"github.com/golang-jwt/jwt/v5"
 
-	"github.com/solana-foundation/solana-keychain/go/core"
-	"github.com/solana-foundation/solana-keychain/go/testutils"
+	"github.com/solana-foundation/solana-keychain/go/core/v2"
+	"github.com/solana-foundation/solana-keychain/go/testutils/v2"
 )
 
 const (

--- a/go/signers/utila/types.go
+++ b/go/signers/utila/types.go
@@ -9,7 +9,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/solana-foundation/solana-keychain/go/core"
+	"github.com/solana-foundation/solana-keychain/go/core/v2"
 )
 
 // Defaults applied to optional Config fields.

--- a/go/signers/vault/go.mod
+++ b/go/signers/vault/go.mod
@@ -1,11 +1,11 @@
-module github.com/solana-foundation/solana-keychain/go/signers/vault
+module github.com/solana-foundation/solana-keychain/go/signers/vault/v2
 
 go 1.25.0
 
 require (
 	github.com/gagliardetto/solana-go v1.20.0
-	github.com/solana-foundation/solana-keychain/go/core v0.0.0-00010101000000-000000000000
-	github.com/solana-foundation/solana-keychain/go/testutils v0.0.0-00010101000000-000000000000
+	github.com/solana-foundation/solana-keychain/go/core/v2 v2.0.0
+	github.com/solana-foundation/solana-keychain/go/testutils/v2 v2.0.0
 )
 
 require (
@@ -37,8 +37,8 @@ require (
 	golang.org/x/time v0.11.0 // indirect
 )
 
-replace github.com/solana-foundation/solana-keychain/go/core => ../../core
+replace github.com/solana-foundation/solana-keychain/go/core/v2 => ../../core
 
-replace github.com/solana-foundation/solana-keychain/go/testutils => ../../testutils
+replace github.com/solana-foundation/solana-keychain/go/testutils/v2 => ../../testutils
 
 replace github.com/gagliardetto/solana-go => github.com/sonicfromnewyoke/solana-go v0.0.0-20260817125726-409ee9873f6d

--- a/go/signers/vault/integration_test.go
+++ b/go/signers/vault/integration_test.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/gagliardetto/solana-go"
 
-	"github.com/solana-foundation/solana-keychain/go/core"
-	"github.com/solana-foundation/solana-keychain/go/testutils"
+	"github.com/solana-foundation/solana-keychain/go/core/v2"
+	"github.com/solana-foundation/solana-keychain/go/testutils/v2"
 )
 
 // integrationSigner builds a signer against the live Vault configured by the

--- a/go/signers/vault/redaction_test.go
+++ b/go/signers/vault/redaction_test.go
@@ -3,7 +3,7 @@ package vault
 import (
 	"testing"
 
-	"github.com/solana-foundation/solana-keychain/go/testutils"
+	"github.com/solana-foundation/solana-keychain/go/testutils/v2"
 )
 
 func TestStringDoesNotLeakSecrets(t *testing.T) {

--- a/go/signers/vault/signer.go
+++ b/go/signers/vault/signer.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/gagliardetto/solana-go"
 
-	"github.com/solana-foundation/solana-keychain/go/core"
+	"github.com/solana-foundation/solana-keychain/go/core/v2"
 )
 
 // signRequest is the transit sign request body: the base64-encoded payload.

--- a/go/signers/vault/signer_test.go
+++ b/go/signers/vault/signer_test.go
@@ -14,8 +14,8 @@ import (
 
 	"github.com/gagliardetto/solana-go"
 
-	"github.com/solana-foundation/solana-keychain/go/core"
-	"github.com/solana-foundation/solana-keychain/go/testutils"
+	"github.com/solana-foundation/solana-keychain/go/core/v2"
+	"github.com/solana-foundation/solana-keychain/go/testutils/v2"
 )
 
 const (

--- a/go/signers/vault/types.go
+++ b/go/signers/vault/types.go
@@ -10,7 +10,7 @@ package vault
 import (
 	"net/http"
 
-	"github.com/solana-foundation/solana-keychain/go/core"
+	"github.com/solana-foundation/solana-keychain/go/core/v2"
 )
 
 // Config configures a Vault signer.

--- a/go/testutils/go.mod
+++ b/go/testutils/go.mod
@@ -1,4 +1,4 @@
-module github.com/solana-foundation/solana-keychain/go/testutils
+module github.com/solana-foundation/solana-keychain/go/testutils/v2
 
 go 1.25.0
 
@@ -22,7 +22,7 @@ require (
 	github.com/mitchellh/go-testing-interface v1.14.1 // indirect
 	github.com/mostynb/zstdpool-freelist v0.0.0-20201229113212-927304c0c3b1 // indirect
 	github.com/oasisprotocol/curve25519-voi v0.0.0-20251114093237-2ab5a27a1729 // indirect
-	github.com/solana-foundation/solana-keychain/go/core v0.0.0-00010101000000-000000000000
+	github.com/solana-foundation/solana-keychain/go/core/v2 v2.0.0
 	github.com/streamingfast/logging v0.0.0-20250404134358-92b15d2fbd2e // indirect
 	github.com/tyler-smith/go-bip39 v1.1.0 // indirect
 	go.mongodb.org/mongo-driver/v2 v2.5.0 // indirect
@@ -37,4 +37,4 @@ require (
 
 replace github.com/gagliardetto/solana-go => github.com/sonicfromnewyoke/solana-go v0.0.0-20260817125726-409ee9873f6d
 
-replace github.com/solana-foundation/solana-keychain/go/core => ../core
+replace github.com/solana-foundation/solana-keychain/go/core/v2 => ../core

--- a/go/testutils/testing.go
+++ b/go/testutils/testing.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/solana-foundation/solana-keychain/go/core"
+	"github.com/solana-foundation/solana-keychain/go/core/v2"
 )
 
 // RequireEnv returns the trimmed value of the environment variable key, failing

--- a/justfile
+++ b/justfile
@@ -642,9 +642,9 @@ go-release-prep version:
         echo "==> $dir"
         (cd "$dir" && \
             go mod edit \
-                -dropreplace=github.com/solana-foundation/solana-keychain/go/core \
-                -dropreplace=github.com/solana-foundation/solana-keychain/go/testutils \
-                -require=github.com/solana-foundation/solana-keychain/go/core@{{version}} \
-                -require=github.com/solana-foundation/solana-keychain/go/testutils@{{version}} && \
+                -dropreplace=github.com/solana-foundation/solana-keychain/go/core/v2 \
+                -dropreplace=github.com/solana-foundation/solana-keychain/go/testutils/v2 \
+                -require=github.com/solana-foundation/solana-keychain/go/core/v2@{{version}} \
+                -require=github.com/solana-foundation/solana-keychain/go/testutils/v2@{{version}} && \
             go mod tidy)
     done


### PR DESCRIPTION
## Summary
- Move all sixteen Go modules under `go/` to `/v2` module paths. Go requires a major version suffix from v2 onward; the suffix is not required to be a directory, so code stays where it is. Internal requires move off the `v0.0.0-00010101000000-000000000000` placeholder (illegal at v2: `invalid: should be v2, not v0`) onto `v2.0.0`, and the in-repo `replace` directives are retargeted to the new paths.
- Add `.github/workflows/go-publish.yml`: manual dispatch, guarded to `main`/`hotfix/*`, discovers modules with `find` so new signers need no workflow edit. It refuses to tag unless every module path carries the right major suffix for the requested version and every internal require names that version, then pushes all tags atomically and cuts one GitHub release.
- Carry `just go-release-prep` and `go/README.md` to the new paths.

## Test Plan
- `go build ./...` and `go test -race -count=1 ./...` pass in all sixteen modules.
- `gofmt -l go/` clean.
- Publish workflow's verify step was exercised locally: it fails on the pre-migration tree and passes on the migrated tree.

## Breaking Changes
- Go import paths gain a `/v2` suffix, e.g. `github.com/solana-foundation/solana-keychain/go/signers/vault/v2`. No Go module tags exist yet, so no published consumer is affected.

## Follow-up (blocked)
- `github.com/gagliardetto/solana-go` stays at `v1.20.0` with the fork `replace`. That repo now redirects to `solana-foundation/solana-go`, whose `main` merged SIMD-0385 V1 transaction support and has an open release-please PR for `1.23.0`. Once tagged, the sixteen fork `replace` lines can be deleted and the require bumped to `v1.23.0` — verified locally that all sixteen modules build and every test passes against that tree. Until then `signers/fireblocks` uses `solana.MessageVersionV1` in non-test code, which is only reachable via the `replace`, so it is not consumable by an external caller.
- The v2 branch of solana-go is **not** the thing to wait for: it is behind `main` and does not carry SIMD-0385.