### PR TITLE
refactor!: adopt trusted-provider model and consolidate response handling

### DIFF
--- a/go/README.md
+++ b/go/README.md
@@ -14,7 +14,7 @@ library offers a consistent API across all signing methods.
 - **Per-backend modules**: each backend is its own Go module, so both your build and your module graph contain only the backends you import
 - **Verified wire format**: golden-vector tests pin the exact serialized transaction bytes, so serialization can never silently drift
 - **Safe errors**: `SignerError` redacts sensitive detail from its message; match on stable codes with `errors.Is`
-- **Minimal core**: built on [`gagliardetto/solana-go`](https://github.com/gagliardetto/solana-go); heavy vendor SDKs land only in the backends that need them
+- **Minimal core**: built on [`solana-foundation/solana-go/v2`](https://github.com/solana-foundation/solana-go); heavy vendor SDKs land only in the backends that need them
 
 ## Supported Backends
 
@@ -48,22 +48,16 @@ go get github.com/solana-foundation/solana-keychain/go/signers/vault/v2@latest
 
 Requires **Go 1.25+** (the `gcpkms` module requires the toolchain floor set by
 `google.golang.org/api`). Built on
-[`github.com/gagliardetto/solana-go`](https://github.com/gagliardetto/solana-go)
+[`github.com/solana-foundation/solana-go/v2`](https://github.com/solana-foundation/solana-go)
 for the on-chain types and canonical transaction serialization.
 
-### v1 transactions pin an unreleased solana-go
+### v1 transactions use solana-go v2
 
-No released solana-go decodes v1
-([PR #481](https://github.com/solana-foundation/solana-go/pull/481) is unmerged),
-so every module carries a `replace` onto that pull request's branch:
+The released solana-go v2 supports v1 transactions, so every module requires:
 
 ```
-replace github.com/gagliardetto/solana-go => github.com/sonicfromnewyoke/solana-go v0.0.0-20260817125726-409ee9873f6d
+require github.com/solana-foundation/solana-go/v2 v2.0.0
 ```
-
-This is a development pin, not a release configuration: the fork branch can be
-rebased or deleted, and `replace` does not reach consumers of a published module.
-Drop the directives and require a released version once PR #481 lands.
 
 Until the first `go/...` version tags are published, `@latest` cannot resolve
 the in-repo `go/core` dependency. The signer modules use `replace` directives

--- a/go/core/batch.go
+++ b/go/core/batch.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/gagliardetto/solana-go"
+	"github.com/solana-foundation/solana-go/v2"
 	"golang.org/x/sync/errgroup"
 )
 

--- a/go/core/batch_test.go
+++ b/go/core/batch_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gagliardetto/solana-go"
+	"github.com/solana-foundation/solana-go/v2"
 )
 
 // countingSigner is a minimal in-package Signer stub for batch tests: it

--- a/go/core/go.mod
+++ b/go/core/go.mod
@@ -3,7 +3,7 @@ module github.com/solana-foundation/solana-keychain/go/core/v2
 go 1.25.0
 
 require (
-	github.com/gagliardetto/solana-go v1.20.0
+	github.com/solana-foundation/solana-go/v2 v2.0.0
 	golang.org/x/sync v0.21.0
 )
 
@@ -22,7 +22,6 @@ require (
 	github.com/mostynb/zstdpool-freelist v0.0.0-20201229113212-927304c0c3b1 // indirect
 	github.com/oasisprotocol/curve25519-voi v0.0.0-20251114093237-2ab5a27a1729 // indirect
 	github.com/streamingfast/logging v0.0.0-20250404134358-92b15d2fbd2e // indirect
-	github.com/tyler-smith/go-bip39 v1.1.0 // indirect
 	go.mongodb.org/mongo-driver/v2 v2.5.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
@@ -30,5 +29,3 @@ require (
 	golang.org/x/sys v0.46.0 // indirect
 	golang.org/x/term v0.44.0 // indirect
 )
-
-replace github.com/gagliardetto/solana-go => github.com/sonicfromnewyoke/solana-go v0.0.0-20260817125726-409ee9873f6d

--- a/go/core/go.sum
+++ b/go/core/go.sum
@@ -40,8 +40,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/shopspring/decimal v1.3.1 h1:2Usl1nmF/WZucqkFZhnfFYxxxu8LG21F6nPQBE5gKV8=
 github.com/shopspring/decimal v1.3.1/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
-github.com/sonicfromnewyoke/solana-go v0.0.0-20260817125726-409ee9873f6d h1:XJC9J/9f0T2NI7ph/2hKqBAgBt0ZkZ8o8Q3ZyHRd0/w=
-github.com/sonicfromnewyoke/solana-go v0.0.0-20260817125726-409ee9873f6d/go.mod h1:/so9reboW4h/RxdIKOGNKb3ueL9ZHUjladm90RHzFvY=
+github.com/solana-foundation/solana-go/v2 v2.0.0 h1:5ZuwMHhVYcOJgcrytYsrkMAK4X/T33prhAQwP5RiiVA=
+github.com/solana-foundation/solana-go/v2 v2.0.0/go.mod h1:CWL+e1A3YUeqnnmFoWk1TMz2wcT2kymE8Veq9ZTEZEg=
 github.com/streamingfast/logging v0.0.0-20230608130331-f22c91403091/go.mod h1:VlduQ80JcGJSargkRU4Sg9Xo63wZD/l8A5NC/Uo1/uU=
 github.com/streamingfast/logging v0.0.0-20250404134358-92b15d2fbd2e h1:qGVGDR2/bXLyR498un1hvhDQPUJ/m14JBRTJz+c67Bc=
 github.com/streamingfast/logging v0.0.0-20250404134358-92b15d2fbd2e/go.mod h1:VlduQ80JcGJSargkRU4Sg9Xo63wZD/l8A5NC/Uo1/uU=
@@ -52,8 +52,6 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/test-go/testify v1.1.4 h1:Tf9lntrKUMHiXQ07qBScBTSA0dhYQlu83hswqelv1iE=
 github.com/test-go/testify v1.1.4/go.mod h1:rH7cfJo/47vWGdi4GPj16x3/t1xGOj2YxzmNQzk2ghU=
-github.com/tyler-smith/go-bip39 v1.1.0 h1:5eUemwrMargf3BSLRRCalXT93Ns6pQJIjYQN2nyfOP8=
-github.com/tyler-smith/go-bip39 v1.1.0/go.mod h1:gUYDtqQw1JS3ZJ8UWVcGTGqqr6YIN3CWg+kkNaLt55U=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 go.mongodb.org/mongo-driver/v2 v2.5.0 h1:yXUhImUjjAInNcpTcAlPHiT7bIXhshCTL3jVBkF3xaE=
 go.mongodb.org/mongo-driver/v2 v2.5.0/go.mod h1:yOI9kBsufol30iFsl1slpdq1I0eHPzybRWdyYUs8K/0=
@@ -72,7 +70,6 @@ go.uber.org/zap v1.27.0 h1:aJMhYGrd5QSmlpLMr2MftRKl7t8J8PTZPA732ud/XR8=
 go.uber.org/zap v1.27.0/go.mod h1:GB2qFLM7cTU87MWRP2mPIjqfIDnGu+VIO4V/SdhGo2E=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
-golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20220214200702-86341886e292/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.53.0 h1:QZ4Muo8THX6CizN2vPPd5fBGHyogrdK9fG4wLPFUsto=
 golang.org/x/crypto v0.53.0/go.mod h1:DNLU434OwVakk9PzuwV8w62mAJpRJL3vsgcfp4Qnsio=

--- a/go/core/parity_test.go
+++ b/go/core/parity_test.go
@@ -5,8 +5,8 @@ import (
 	"encoding/base64"
 	"testing"
 
-	"github.com/gagliardetto/solana-go"
-	"github.com/gagliardetto/solana-go/programs/system"
+	"github.com/solana-foundation/solana-go/v2"
+	"github.com/solana-foundation/solana-go/v2/programs/system"
 )
 
 // Golden wire-format vectors: pin the exact serialized bytes this library must

--- a/go/core/remote.go
+++ b/go/core/remote.go
@@ -20,7 +20,8 @@ func IsSuccess(status int) bool { return status >= 200 && status < 300 }
 // SendRequest sends req and returns the status code and the size-capped body.
 // Transport failures map to CodeHTTPError, except that a *SignerError raised
 // inside the client (the HTTPS-only transport and the redirect guard) is
-// surfaced as-is so its code survives.
+// surfaced as-is so its code survives. A body larger than MaxResponseBytes is
+// rejected with CodeSerializationError rather than silently truncated.
 func SendRequest(client *http.Client, req *http.Request, provider string) (int, []byte, error) {
 	resp, err := client.Do(req)
 	if err != nil {
@@ -32,11 +33,23 @@ func SendRequest(client *http.Client, req *http.Request, provider string) (int, 
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	data, err := io.ReadAll(io.LimitReader(resp.Body, MaxResponseBytes))
+	data, err := io.ReadAll(io.LimitReader(resp.Body, MaxResponseBytes+1))
 	if err != nil {
 		return 0, nil, WrapSignerError(CodeHTTPError, "failed to read "+provider+" response body", err)
 	}
+	if len(data) > MaxResponseBytes {
+		return 0, nil, NewSignerError(CodeSerializationError, provider+" response exceeded maximum size")
+	}
 	return resp.StatusCode, data, nil
+}
+
+// NewRemoteAPIError reports a non-2xx provider response as CodeRemoteAPIError.
+// The (opt-in) detail carries opContext, the status code, and the sanitized
+// response body; Error() still renders only the generic message, so the body
+// can never leak through formatted output or logs.
+func NewRemoteAPIError(opContext string, status int, body []byte) *SignerError {
+	return NewSignerError(CodeRemoteAPIError,
+		opContext+" "+strconv.Itoa(status)+": "+SanitizeRemoteResponse(string(body)))
 }
 
 // EncodeURIComponent percent-encodes every byte except the JavaScript

--- a/go/core/remote_test.go
+++ b/go/core/remote_test.go
@@ -49,9 +49,8 @@ func TestSleepContextUnconfirmedReturnsNilWhenTheWaitCompletes(t *testing.T) {
 	}
 }
 
-// SendRequest must accept a body of exactly MaxResponseBytes and reject
-// anything larger with an explicit error instead of silently truncating it
-// (a truncated body would otherwise surface as a confusing JSON parse error).
+// A silently truncated body would surface as a confusing JSON parse error, so
+// anything over MaxResponseBytes must be rejected explicitly.
 func TestSendRequestRejectsOversizedBody(t *testing.T) {
 	cases := map[string]struct {
 		size    int
@@ -100,8 +99,6 @@ func TestSendRequestRejectsOversizedBody(t *testing.T) {
 	}
 }
 
-// NewRemoteAPIError puts the context, status, and sanitized body in the
-// (opt-in) detail while Error() stays generic.
 func TestNewRemoteAPIError(t *testing.T) {
 	err := NewRemoteAPIError("acme API error", 503, []byte("boom\x01\ttoday"))
 

--- a/go/core/remote_test.go
+++ b/go/core/remote_test.go
@@ -1,8 +1,12 @@
 package core
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 )
@@ -42,5 +46,72 @@ func TestSleepContextUnconfirmedReportsCancellationAsUnconfirmed(t *testing.T) {
 func TestSleepContextUnconfirmedReturnsNilWhenTheWaitCompletes(t *testing.T) {
 	if err := SleepContextUnconfirmed(context.Background(), time.Millisecond, "provider-tx-1"); err != nil {
 		t.Fatal(err)
+	}
+}
+
+// SendRequest must accept a body of exactly MaxResponseBytes and reject
+// anything larger with an explicit error instead of silently truncating it
+// (a truncated body would otherwise surface as a confusing JSON parse error).
+func TestSendRequestRejectsOversizedBody(t *testing.T) {
+	cases := map[string]struct {
+		size    int
+		wantErr bool
+	}{
+		"at the cap":    {size: MaxResponseBytes},
+		"one byte over": {size: MaxResponseBytes + 1, wantErr: true},
+		"well over":     {size: MaxResponseBytes * 2, wantErr: true},
+		"well under":    {size: 128},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				_, _ = w.Write(bytes.Repeat([]byte("a"), tc.size))
+			}))
+			defer srv.Close()
+
+			req, err := http.NewRequest(http.MethodGet, srv.URL, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			status, body, err := SendRequest(srv.Client(), req, "test")
+			if !tc.wantErr {
+				if err != nil {
+					t.Fatalf("SendRequest failed: %v", err)
+				}
+				if status != http.StatusOK || len(body) != tc.size {
+					t.Errorf("got status %d, %d body bytes; want 200, %d", status, len(body), tc.size)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatal("expected an error for an oversized body")
+			}
+			var se *SignerError
+			if !errors.As(err, &se) {
+				t.Fatalf("expected *SignerError, got %T", err)
+			}
+			if se.Code != CodeSerializationError {
+				t.Errorf("code = %s, want %s", se.Code, CodeSerializationError)
+			}
+			if !strings.Contains(se.Detail(), "response exceeded maximum size") {
+				t.Errorf("detail = %q, want the over-size message", se.Detail())
+			}
+		})
+	}
+}
+
+// NewRemoteAPIError puts the context, status, and sanitized body in the
+// (opt-in) detail while Error() stays generic.
+func TestNewRemoteAPIError(t *testing.T) {
+	err := NewRemoteAPIError("acme API error", 503, []byte("boom\x01\ttoday"))
+
+	if err.Code != CodeRemoteAPIError {
+		t.Errorf("code = %s, want %s", err.Code, CodeRemoteAPIError)
+	}
+	if got, want := err.Detail(), "acme API error 503: boom today"; got != want {
+		t.Errorf("detail = %q, want %q", got, want)
+	}
+	if err.Error() != "Remote API error" {
+		t.Errorf("Error() = %q, want the generic message only", err.Error())
 	}
 }

--- a/go/core/send_test.go
+++ b/go/core/send_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/gagliardetto/solana-go"
+	"github.com/solana-foundation/solana-go/v2"
 )
 
 // sendingSigner is a minimal in-package Signer stub: it records that it signed

--- a/go/core/sign.go
+++ b/go/core/sign.go
@@ -3,7 +3,7 @@ package core
 import (
 	"context"
 
-	"github.com/gagliardetto/solana-go"
+	"github.com/solana-foundation/solana-go/v2"
 )
 
 // MessageBytes returns the serialized transaction message, the bytes a Solana

--- a/go/core/sign.go
+++ b/go/core/sign.go
@@ -25,6 +25,39 @@ func VerifySignature(pubkey solana.PublicKey, message []byte, sig solana.Signatu
 	return nil
 }
 
+// ExtractAndVerifyReturnedSignature deserializes a signed wire transaction
+// returned by a remote provider, extracts the signature at pubkey's
+// required-signer position, and verifies it against the original
+// locally-computed message bytes. Verifying against the original message is
+// what guarantees the provider signed exactly what was requested. Backends
+// whose remote API returns the whole signed transaction call this after
+// stripping the provider's outer encoding (base64/base58/hex).
+func ExtractAndVerifyReturnedSignature(
+	returnedTxBytes []byte,
+	pubkey solana.PublicKey,
+	originalMessage []byte,
+	provider string,
+) (solana.Signature, error) {
+	returned, err := solana.TransactionFromBytes(returnedTxBytes)
+	if err != nil {
+		return solana.Signature{}, WrapSignerError(CodeSerializationError,
+			"failed to deserialize signed transaction returned by "+provider, err)
+	}
+	pos, err := SigningPosition(returned, pubkey)
+	if err != nil {
+		return solana.Signature{}, err
+	}
+	if pos >= len(returned.Signatures) || returned.Signatures[pos].IsZero() {
+		return solana.Signature{}, NewSignerError(CodeSigningFailed,
+			"signed transaction returned by "+provider+" is missing the signer's signature")
+	}
+	sig := returned.Signatures[pos]
+	if err := VerifySignature(pubkey, originalMessage, sig); err != nil {
+		return solana.Signature{}, err
+	}
+	return sig, nil
+}
+
 // AttachSignature places sig at pubkey's required-signer position and returns the
 // encoded transaction tagged with its completeness.
 func AttachSignature(tx *solana.Transaction, pubkey solana.PublicKey, sig solana.Signature) (SignedTransaction, error) {

--- a/go/core/sign.go
+++ b/go/core/sign.go
@@ -28,10 +28,8 @@ func VerifySignature(pubkey solana.PublicKey, message []byte, sig solana.Signatu
 // ExtractAndVerifyReturnedSignature deserializes a signed wire transaction
 // returned by a remote provider, extracts the signature at pubkey's
 // required-signer position, and verifies it against the original
-// locally-computed message bytes. Verifying against the original message is
-// what guarantees the provider signed exactly what was requested. Backends
-// whose remote API returns the whole signed transaction call this after
-// stripping the provider's outer encoding (base64/base58/hex).
+// locally-computed message bytes — the guarantee that the provider signed
+// exactly what was requested.
 func ExtractAndVerifyReturnedSignature(
 	returnedTxBytes []byte,
 	pubkey solana.PublicKey,

--- a/go/core/sign_test.go
+++ b/go/core/sign_test.go
@@ -7,9 +7,6 @@ import (
 	"github.com/gagliardetto/solana-go"
 )
 
-// signedReturnedTxBytes builds the deterministic test transaction, signs its
-// message with the test key, and returns the signed wire bytes together with
-// the message bytes the signature covers.
 func signedReturnedTxBytes(t *testing.T, sign bool) (wire []byte, msg []byte) {
 	t.Helper()
 	tx, err := createTestTransaction(testPublicKey())
@@ -61,7 +58,6 @@ func TestExtractAndVerifyReturnedSignatureAllZeroSignature(t *testing.T) {
 
 func TestExtractAndVerifyReturnedSignatureNonVerifying(t *testing.T) {
 	wire, msg := signedReturnedTxBytes(t, true)
-	// Tamper with the message the signature must cover.
 	tampered := append([]byte{}, msg...)
 	tampered[len(tampered)-1] ^= 0xFF
 	_, err := ExtractAndVerifyReturnedSignature(wire, testPublicKey(), tampered, "test")

--- a/go/core/sign_test.go
+++ b/go/core/sign_test.go
@@ -4,7 +4,7 @@ import (
 	"crypto/ed25519"
 	"testing"
 
-	"github.com/gagliardetto/solana-go"
+	"github.com/solana-foundation/solana-go/v2"
 )
 
 func signedReturnedTxBytes(t *testing.T, sign bool) (wire []byte, msg []byte) {

--- a/go/core/sign_test.go
+++ b/go/core/sign_test.go
@@ -1,0 +1,79 @@
+package core
+
+import (
+	"crypto/ed25519"
+	"testing"
+
+	"github.com/gagliardetto/solana-go"
+)
+
+// signedReturnedTxBytes builds the deterministic test transaction, signs its
+// message with the test key, and returns the signed wire bytes together with
+// the message bytes the signature covers.
+func signedReturnedTxBytes(t *testing.T, sign bool) (wire []byte, msg []byte) {
+	t.Helper()
+	tx, err := createTestTransaction(testPublicKey())
+	if err != nil {
+		t.Fatal(err)
+	}
+	msg, err = tx.Message.MarshalBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var sig solana.Signature
+	if sign {
+		copy(sig[:], ed25519.Sign(testPrivateKey(), msg))
+	}
+	tx.Signatures = []solana.Signature{sig}
+	wire, err = tx.MarshalBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return wire, msg
+}
+
+func TestExtractAndVerifyReturnedSignatureHappyPath(t *testing.T) {
+	wire, msg := signedReturnedTxBytes(t, true)
+	sig, err := ExtractAndVerifyReturnedSignature(wire, testPublicKey(), msg, "test")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !VerifyEd25519(testPublicKey(), msg, sig) {
+		t.Error("returned signature does not verify")
+	}
+}
+
+func TestExtractAndVerifyReturnedSignaturePubkeyNotASigner(t *testing.T) {
+	wire, msg := signedReturnedTxBytes(t, true)
+	_, err := ExtractAndVerifyReturnedSignature(wire, testRecipient, msg, "test")
+	if code, _ := CodeOf(err); code != CodeSigningFailed {
+		t.Fatalf("expected CodeSigningFailed, got %v (err: %v)", code, err)
+	}
+}
+
+func TestExtractAndVerifyReturnedSignatureAllZeroSignature(t *testing.T) {
+	wire, msg := signedReturnedTxBytes(t, false)
+	_, err := ExtractAndVerifyReturnedSignature(wire, testPublicKey(), msg, "test")
+	if code, _ := CodeOf(err); code != CodeSigningFailed {
+		t.Fatalf("expected CodeSigningFailed, got %v (err: %v)", code, err)
+	}
+}
+
+func TestExtractAndVerifyReturnedSignatureNonVerifying(t *testing.T) {
+	wire, msg := signedReturnedTxBytes(t, true)
+	// Tamper with the message the signature must cover.
+	tampered := append([]byte{}, msg...)
+	tampered[len(tampered)-1] ^= 0xFF
+	_, err := ExtractAndVerifyReturnedSignature(wire, testPublicKey(), tampered, "test")
+	if code, _ := CodeOf(err); code != CodeSigningFailed {
+		t.Fatalf("expected CodeSigningFailed, got %v (err: %v)", code, err)
+	}
+}
+
+func TestExtractAndVerifyReturnedSignatureMalformedBytes(t *testing.T) {
+	_, msg := signedReturnedTxBytes(t, true)
+	_, err := ExtractAndVerifyReturnedSignature([]byte{0xFF, 0x01, 0x02}, testPublicKey(), msg, "test")
+	if code, _ := CodeOf(err); code != CodeSerializationError {
+		t.Fatalf("expected CodeSerializationError, got %v (err: %v)", code, err)
+	}
+}

--- a/go/core/signature.go
+++ b/go/core/signature.go
@@ -6,8 +6,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/gagliardetto/solana-go"
-	"github.com/gagliardetto/solana-go/base58"
+	"github.com/solana-foundation/solana-go/v2"
+	"github.com/solana-foundation/solana-go/v2/base58"
 )
 
 // SignatureComponentLength is the byte length of the r and s halves of an

--- a/go/core/txutil.go
+++ b/go/core/txutil.go
@@ -3,7 +3,7 @@ package core
 import (
 	"encoding/base64"
 
-	"github.com/gagliardetto/solana-go"
+	"github.com/solana-foundation/solana-go/v2"
 )
 
 // Serialize encodes a transaction to a base64 string in the canonical Solana

--- a/go/core/txutil_golden_test.go
+++ b/go/core/txutil_golden_test.go
@@ -5,7 +5,7 @@ import (
 	"encoding/base64"
 	"testing"
 
-	"github.com/gagliardetto/solana-go"
+	"github.com/solana-foundation/solana-go/v2"
 )
 
 // goldenSigner is a tiny in-package signer so this golden test does not import the

--- a/go/core/txutil_helpers_test.go
+++ b/go/core/txutil_helpers_test.go
@@ -3,8 +3,8 @@ package core
 import (
 	"crypto/ed25519"
 
-	"github.com/gagliardetto/solana-go"
-	"github.com/gagliardetto/solana-go/programs/system"
+	"github.com/solana-foundation/solana-go/v2"
+	"github.com/solana-foundation/solana-go/v2/programs/system"
 )
 
 // This file inlines the one testutils helper core's tests need, so the core

--- a/go/core/txutil_test.go
+++ b/go/core/txutil_test.go
@@ -5,7 +5,7 @@ import (
 	"crypto/ed25519"
 	"testing"
 
-	"github.com/gagliardetto/solana-go"
+	"github.com/solana-foundation/solana-go/v2"
 )
 
 func TestSerializeRoundTrips(t *testing.T) {

--- a/go/core/types.go
+++ b/go/core/types.go
@@ -3,7 +3,7 @@ package core
 import (
 	"context"
 
-	"github.com/gagliardetto/solana-go"
+	"github.com/solana-foundation/solana-go/v2"
 )
 
 // Completeness records whether a signed transaction now carries all of its

--- a/go/core/verify.go
+++ b/go/core/verify.go
@@ -3,7 +3,7 @@ package core
 import (
 	"crypto/ed25519"
 
-	"github.com/gagliardetto/solana-go"
+	"github.com/solana-foundation/solana-go/v2"
 )
 
 // VerifyEd25519 reports whether sig is a valid Ed25519 signature of message by

--- a/go/signers/awskms/go.mod
+++ b/go/signers/awskms/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.32.27
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.26
 	github.com/aws/aws-sdk-go-v2/service/kms v1.53.6
-	github.com/gagliardetto/solana-go v1.20.0
+	github.com/solana-foundation/solana-go/v2 v2.0.0
 	github.com/solana-foundation/solana-keychain/go/core/v2 v2.0.0
 	github.com/solana-foundation/solana-keychain/go/testutils/v2 v2.0.0
 )
@@ -40,7 +40,6 @@ require (
 	github.com/mostynb/zstdpool-freelist v0.0.0-20201229113212-927304c0c3b1 // indirect
 	github.com/oasisprotocol/curve25519-voi v0.0.0-20251114093237-2ab5a27a1729 // indirect
 	github.com/streamingfast/logging v0.0.0-20250404134358-92b15d2fbd2e // indirect
-	github.com/tyler-smith/go-bip39 v1.1.0 // indirect
 	go.mongodb.org/mongo-driver/v2 v2.5.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/ratelimit v0.3.1 // indirect
@@ -55,5 +54,3 @@ require (
 replace github.com/solana-foundation/solana-keychain/go/core/v2 => ../../core
 
 replace github.com/solana-foundation/solana-keychain/go/testutils/v2 => ../../testutils
-
-replace github.com/gagliardetto/solana-go => github.com/sonicfromnewyoke/solana-go v0.0.0-20260817125726-409ee9873f6d

--- a/go/signers/awskms/go.sum
+++ b/go/signers/awskms/go.sum
@@ -84,8 +84,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/shopspring/decimal v1.3.1 h1:2Usl1nmF/WZucqkFZhnfFYxxxu8LG21F6nPQBE5gKV8=
 github.com/shopspring/decimal v1.3.1/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
-github.com/sonicfromnewyoke/solana-go v0.0.0-20260817125726-409ee9873f6d h1:XJC9J/9f0T2NI7ph/2hKqBAgBt0ZkZ8o8Q3ZyHRd0/w=
-github.com/sonicfromnewyoke/solana-go v0.0.0-20260817125726-409ee9873f6d/go.mod h1:/so9reboW4h/RxdIKOGNKb3ueL9ZHUjladm90RHzFvY=
+github.com/solana-foundation/solana-go/v2 v2.0.0 h1:5ZuwMHhVYcOJgcrytYsrkMAK4X/T33prhAQwP5RiiVA=
+github.com/solana-foundation/solana-go/v2 v2.0.0/go.mod h1:CWL+e1A3YUeqnnmFoWk1TMz2wcT2kymE8Veq9ZTEZEg=
 github.com/streamingfast/logging v0.0.0-20230608130331-f22c91403091/go.mod h1:VlduQ80JcGJSargkRU4Sg9Xo63wZD/l8A5NC/Uo1/uU=
 github.com/streamingfast/logging v0.0.0-20250404134358-92b15d2fbd2e h1:qGVGDR2/bXLyR498un1hvhDQPUJ/m14JBRTJz+c67Bc=
 github.com/streamingfast/logging v0.0.0-20250404134358-92b15d2fbd2e/go.mod h1:VlduQ80JcGJSargkRU4Sg9Xo63wZD/l8A5NC/Uo1/uU=
@@ -96,8 +96,6 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/test-go/testify v1.1.4 h1:Tf9lntrKUMHiXQ07qBScBTSA0dhYQlu83hswqelv1iE=
 github.com/test-go/testify v1.1.4/go.mod h1:rH7cfJo/47vWGdi4GPj16x3/t1xGOj2YxzmNQzk2ghU=
-github.com/tyler-smith/go-bip39 v1.1.0 h1:5eUemwrMargf3BSLRRCalXT93Ns6pQJIjYQN2nyfOP8=
-github.com/tyler-smith/go-bip39 v1.1.0/go.mod h1:gUYDtqQw1JS3ZJ8UWVcGTGqqr6YIN3CWg+kkNaLt55U=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 go.mongodb.org/mongo-driver/v2 v2.5.0 h1:yXUhImUjjAInNcpTcAlPHiT7bIXhshCTL3jVBkF3xaE=
 go.mongodb.org/mongo-driver/v2 v2.5.0/go.mod h1:yOI9kBsufol30iFsl1slpdq1I0eHPzybRWdyYUs8K/0=
@@ -120,7 +118,6 @@ go.uber.org/zap v1.27.0 h1:aJMhYGrd5QSmlpLMr2MftRKl7t8J8PTZPA732ud/XR8=
 go.uber.org/zap v1.27.0/go.mod h1:GB2qFLM7cTU87MWRP2mPIjqfIDnGu+VIO4V/SdhGo2E=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
-golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20220214200702-86341886e292/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.53.0 h1:QZ4Muo8THX6CizN2vPPd5fBGHyogrdK9fG4wLPFUsto=
 golang.org/x/crypto v0.53.0/go.mod h1:DNLU434OwVakk9PzuwV8w62mAJpRJL3vsgcfp4Qnsio=

--- a/go/signers/awskms/integration_test.go
+++ b/go/signers/awskms/integration_test.go
@@ -9,7 +9,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/gagliardetto/solana-go"
+	"github.com/solana-foundation/solana-go/v2"
 
 	"github.com/solana-foundation/solana-keychain/go/core/v2"
 	"github.com/solana-foundation/solana-keychain/go/testutils/v2"

--- a/go/signers/awskms/signer.go
+++ b/go/signers/awskms/signer.go
@@ -8,7 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/kms"
 	kmstypes "github.com/aws/aws-sdk-go-v2/service/kms/types"
-	"github.com/gagliardetto/solana-go"
+	"github.com/solana-foundation/solana-go/v2"
 
 	"github.com/solana-foundation/solana-keychain/go/core/v2"
 )

--- a/go/signers/awskms/signer_test.go
+++ b/go/signers/awskms/signer_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/kms"
 	kmstypes "github.com/aws/aws-sdk-go-v2/service/kms/types"
-	"github.com/gagliardetto/solana-go"
+	"github.com/solana-foundation/solana-go/v2"
 
 	"github.com/solana-foundation/solana-keychain/go/core/v2"
 	"github.com/solana-foundation/solana-keychain/go/testutils/v2"

--- a/go/signers/cdp/go.mod
+++ b/go/signers/cdp/go.mod
@@ -3,8 +3,8 @@ module github.com/solana-foundation/solana-keychain/go/signers/cdp/v2
 go 1.25.0
 
 require (
-	github.com/gagliardetto/solana-go v1.20.0
 	github.com/golang-jwt/jwt/v5 v5.3.1
+	github.com/solana-foundation/solana-go/v2 v2.0.0
 	github.com/solana-foundation/solana-keychain/go/core/v2 v2.0.0
 	github.com/solana-foundation/solana-keychain/go/testutils/v2 v2.0.0
 )
@@ -26,7 +26,6 @@ require (
 	github.com/mostynb/zstdpool-freelist v0.0.0-20201229113212-927304c0c3b1 // indirect
 	github.com/oasisprotocol/curve25519-voi v0.0.0-20251114093237-2ab5a27a1729 // indirect
 	github.com/streamingfast/logging v0.0.0-20250404134358-92b15d2fbd2e // indirect
-	github.com/tyler-smith/go-bip39 v1.1.0 // indirect
 	go.mongodb.org/mongo-driver/v2 v2.5.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/ratelimit v0.3.1 // indirect
@@ -41,5 +40,3 @@ require (
 replace github.com/solana-foundation/solana-keychain/go/core/v2 => ../../core
 
 replace github.com/solana-foundation/solana-keychain/go/testutils/v2 => ../../testutils
-
-replace github.com/gagliardetto/solana-go => github.com/sonicfromnewyoke/solana-go v0.0.0-20260817125726-409ee9873f6d

--- a/go/signers/cdp/go.sum
+++ b/go/signers/cdp/go.sum
@@ -56,8 +56,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/shopspring/decimal v1.3.1 h1:2Usl1nmF/WZucqkFZhnfFYxxxu8LG21F6nPQBE5gKV8=
 github.com/shopspring/decimal v1.3.1/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
-github.com/sonicfromnewyoke/solana-go v0.0.0-20260817125726-409ee9873f6d h1:XJC9J/9f0T2NI7ph/2hKqBAgBt0ZkZ8o8Q3ZyHRd0/w=
-github.com/sonicfromnewyoke/solana-go v0.0.0-20260817125726-409ee9873f6d/go.mod h1:/so9reboW4h/RxdIKOGNKb3ueL9ZHUjladm90RHzFvY=
+github.com/solana-foundation/solana-go/v2 v2.0.0 h1:5ZuwMHhVYcOJgcrytYsrkMAK4X/T33prhAQwP5RiiVA=
+github.com/solana-foundation/solana-go/v2 v2.0.0/go.mod h1:CWL+e1A3YUeqnnmFoWk1TMz2wcT2kymE8Veq9ZTEZEg=
 github.com/streamingfast/logging v0.0.0-20230608130331-f22c91403091/go.mod h1:VlduQ80JcGJSargkRU4Sg9Xo63wZD/l8A5NC/Uo1/uU=
 github.com/streamingfast/logging v0.0.0-20250404134358-92b15d2fbd2e h1:qGVGDR2/bXLyR498un1hvhDQPUJ/m14JBRTJz+c67Bc=
 github.com/streamingfast/logging v0.0.0-20250404134358-92b15d2fbd2e/go.mod h1:VlduQ80JcGJSargkRU4Sg9Xo63wZD/l8A5NC/Uo1/uU=
@@ -68,8 +68,6 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/test-go/testify v1.1.4 h1:Tf9lntrKUMHiXQ07qBScBTSA0dhYQlu83hswqelv1iE=
 github.com/test-go/testify v1.1.4/go.mod h1:rH7cfJo/47vWGdi4GPj16x3/t1xGOj2YxzmNQzk2ghU=
-github.com/tyler-smith/go-bip39 v1.1.0 h1:5eUemwrMargf3BSLRRCalXT93Ns6pQJIjYQN2nyfOP8=
-github.com/tyler-smith/go-bip39 v1.1.0/go.mod h1:gUYDtqQw1JS3ZJ8UWVcGTGqqr6YIN3CWg+kkNaLt55U=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 go.mongodb.org/mongo-driver/v2 v2.5.0 h1:yXUhImUjjAInNcpTcAlPHiT7bIXhshCTL3jVBkF3xaE=
 go.mongodb.org/mongo-driver/v2 v2.5.0/go.mod h1:yOI9kBsufol30iFsl1slpdq1I0eHPzybRWdyYUs8K/0=
@@ -92,7 +90,6 @@ go.uber.org/zap v1.27.0 h1:aJMhYGrd5QSmlpLMr2MftRKl7t8J8PTZPA732ud/XR8=
 go.uber.org/zap v1.27.0/go.mod h1:GB2qFLM7cTU87MWRP2mPIjqfIDnGu+VIO4V/SdhGo2E=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
-golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20220214200702-86341886e292/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.53.0 h1:QZ4Muo8THX6CizN2vPPd5fBGHyogrdK9fG4wLPFUsto=
 golang.org/x/crypto v0.53.0/go.mod h1:DNLU434OwVakk9PzuwV8w62mAJpRJL3vsgcfp4Qnsio=

--- a/go/signers/cdp/integration_test.go
+++ b/go/signers/cdp/integration_test.go
@@ -8,7 +8,7 @@ import (
 	"encoding/base64"
 	"testing"
 
-	"github.com/gagliardetto/solana-go"
+	"github.com/solana-foundation/solana-go/v2"
 
 	"github.com/solana-foundation/solana-keychain/go/core/v2"
 	"github.com/solana-foundation/solana-keychain/go/testutils/v2"

--- a/go/signers/cdp/signer.go
+++ b/go/signers/cdp/signer.go
@@ -152,8 +152,6 @@ func (s *Signer) SignTransaction(ctx context.Context, tx *solana.Transaction) (c
 		return core.SignedTransaction{}, err
 	}
 
-	// Decode the returned signed transaction, then extract only our signature
-	// from it and apply it to the original transaction.
 	signedBytes, err := base64.StdEncoding.DecodeString(resp.SignedTransaction)
 	if err != nil {
 		return core.SignedTransaction{}, core.WrapSignerError(core.CodeSerializationError,
@@ -218,8 +216,6 @@ func (s *Signer) doPost(ctx context.Context, path string, body map[string]any, o
 		return err
 	}
 
-	// The sanitized response body goes into the (opt-in) detail only; Error()
-	// stays generic.
 	if !core.IsSuccess(status) {
 		return core.NewRemoteAPIError("CDP API error", status, respBody)
 	}

--- a/go/signers/cdp/signer.go
+++ b/go/signers/cdp/signer.go
@@ -6,7 +6,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"net/http"
-	"strconv"
 	"unicode/utf8"
 
 	"github.com/gagliardetto/solana-go"
@@ -131,11 +130,6 @@ func (s *Signer) SignTransaction(ctx context.Context, tx *solana.Transaction) (c
 		return core.SignedTransaction{}, core.WrapSignerError(core.CodeSerializationError,
 			"failed to serialize transaction message", err)
 	}
-	pos, err := core.SigningPosition(tx, s.pubkey)
-	if err != nil {
-		return core.SignedTransaction{}, err
-	}
-
 	// Serialize the full transaction (Solana wire format): the wire encoding
 	// carries one slot per required signature, so pad a copy with zero-filled
 	// slots.
@@ -158,26 +152,15 @@ func (s *Signer) SignTransaction(ctx context.Context, tx *solana.Transaction) (c
 		return core.SignedTransaction{}, err
 	}
 
-	// Decode and deserialize the returned signed transaction.
+	// Decode the returned signed transaction, then extract only our signature
+	// from it and apply it to the original transaction.
 	signedBytes, err := base64.StdEncoding.DecodeString(resp.SignedTransaction)
 	if err != nil {
 		return core.SignedTransaction{}, core.WrapSignerError(core.CodeSerializationError,
 			"failed to decode base64 signed transaction from CDP", err)
 	}
-	signedTx, err := solana.TransactionFromBytes(signedBytes)
+	sig, err := core.ExtractAndVerifyReturnedSignature(signedBytes, s.pubkey, msgBytes, "CDP")
 	if err != nil {
-		return core.SignedTransaction{}, core.WrapSignerError(core.CodeSerializationError,
-			"failed to deserialize signed transaction from CDP", err)
-	}
-
-	// Extract only our signature from the response and apply it to the original
-	// transaction.
-	if pos >= len(signedTx.Signatures) {
-		return core.SignedTransaction{}, core.NewSignerError(core.CodeSigningFailed,
-			"signature not found at expected position in CDP response")
-	}
-	sig := signedTx.Signatures[pos]
-	if err := core.VerifySignature(s.pubkey, msgBytes, sig); err != nil {
 		return core.SignedTransaction{}, err
 	}
 
@@ -235,10 +218,10 @@ func (s *Signer) doPost(ctx context.Context, path string, body map[string]any, o
 		return err
 	}
 
-	// Only the status code goes into the error; the response body is never
-	// attached.
+	// The sanitized response body goes into the (opt-in) detail only; Error()
+	// stays generic.
 	if !core.IsSuccess(status) {
-		return core.NewSignerError(core.CodeRemoteAPIError, "CDP API error "+strconv.Itoa(status))
+		return core.NewRemoteAPIError("CDP API error", status, respBody)
 	}
 
 	if err := json.Unmarshal(respBody, out); err != nil {

--- a/go/signers/cdp/signer.go
+++ b/go/signers/cdp/signer.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"unicode/utf8"
 
-	"github.com/gagliardetto/solana-go"
+	"github.com/solana-foundation/solana-go/v2"
 
 	"github.com/solana-foundation/solana-keychain/go/core/v2"
 )

--- a/go/signers/cdp/signer_test.go
+++ b/go/signers/cdp/signer_test.go
@@ -12,8 +12,8 @@ import (
 	"sync/atomic"
 	"testing"
 
-	"github.com/gagliardetto/solana-go"
-	"github.com/gagliardetto/solana-go/base58"
+	"github.com/solana-foundation/solana-go/v2"
+	"github.com/solana-foundation/solana-go/v2/base58"
 
 	"github.com/solana-foundation/solana-keychain/go/core/v2"
 	"github.com/solana-foundation/solana-keychain/go/testutils/v2"

--- a/go/signers/cdp/signer_test.go
+++ b/go/signers/cdp/signer_test.go
@@ -241,8 +241,6 @@ func TestSignMessageAPIError(t *testing.T) {
 	s := newTestSigner(t, srv, testPubkeyStr)
 	_, err := s.SignMessage(context.Background(), []byte("test"))
 	testutils.AssertCode(t, err, core.CodeRemoteAPIError)
-	// The sanitized response body lands in the (opt-in) detail only; Error()
-	// stays generic.
 	testutils.AssertDetailContains(t, err, "CDP API error 401")
 	testutils.AssertDetailContains(t, err, "bad credentials")
 	if strings.Contains(err.Error(), "credentials") {

--- a/go/signers/cdp/signer_test.go
+++ b/go/signers/cdp/signer_test.go
@@ -235,11 +235,19 @@ func TestSignMessageSignatureVerificationFailure(t *testing.T) {
 func TestSignMessageAPIError(t *testing.T) {
 	srv := testutils.StartTLSServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte("bad\x01credentials"))
 	}))
 
 	s := newTestSigner(t, srv, testPubkeyStr)
 	_, err := s.SignMessage(context.Background(), []byte("test"))
 	testutils.AssertCode(t, err, core.CodeRemoteAPIError)
+	// The sanitized response body lands in the (opt-in) detail only; Error()
+	// stays generic.
+	testutils.AssertDetailContains(t, err, "CDP API error 401")
+	testutils.AssertDetailContains(t, err, "bad credentials")
+	if strings.Contains(err.Error(), "credentials") {
+		t.Errorf("Error() must not surface the remote body, got %q", err.Error())
+	}
 }
 
 func TestSignMessageInvalidSignatureLength(t *testing.T) {

--- a/go/signers/crossmint/client.go
+++ b/go/signers/crossmint/client.go
@@ -47,15 +47,6 @@ type onChainData struct {
 
 type approvalsData struct {
 	Pending []pendingApproval `json:"pending"`
-	// Submitted carries the approvals Crossmint has already collected. A rewritten
-	// transaction's wallet signature appears here rather than in a signature slot
-	// of the returned transaction.
-	Submitted []submittedApproval `json:"submitted"`
-}
-
-type submittedApproval struct {
-	Signature *string         `json:"signature"`
-	Signer    *approvalSigner `json:"signer"`
 }
 
 type pendingApproval struct {
@@ -66,7 +57,6 @@ type pendingApproval struct {
 // approvalSigner identifies which approver an approval belongs to.
 type approvalSigner struct {
 	Locator *string `json:"locator"`
-	Address *string `json:"address"`
 }
 
 // approvalRequest is the submit-approval request body.

--- a/go/signers/crossmint/derive.go
+++ b/go/signers/crossmint/derive.go
@@ -11,7 +11,7 @@ import (
 
 	"golang.org/x/crypto/hkdf"
 
-	"github.com/gagliardetto/solana-go/base58"
+	"github.com/solana-foundation/solana-go/v2/base58"
 
 	"github.com/solana-foundation/solana-keychain/go/core/v2"
 )

--- a/go/signers/crossmint/go.mod
+++ b/go/signers/crossmint/go.mod
@@ -3,7 +3,7 @@ module github.com/solana-foundation/solana-keychain/go/signers/crossmint/v2
 go 1.25.0
 
 require (
-	github.com/gagliardetto/solana-go v1.20.0
+	github.com/solana-foundation/solana-go/v2 v2.0.0
 	github.com/solana-foundation/solana-keychain/go/core/v2 v2.0.0
 	github.com/solana-foundation/solana-keychain/go/testutils/v2 v2.0.0
 	golang.org/x/crypto v0.53.0
@@ -26,7 +26,6 @@ require (
 	github.com/mostynb/zstdpool-freelist v0.0.0-20201229113212-927304c0c3b1 // indirect
 	github.com/oasisprotocol/curve25519-voi v0.0.0-20251114093237-2ab5a27a1729 // indirect
 	github.com/streamingfast/logging v0.0.0-20250404134358-92b15d2fbd2e // indirect
-	github.com/tyler-smith/go-bip39 v1.1.0 // indirect
 	go.mongodb.org/mongo-driver/v2 v2.5.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/ratelimit v0.3.1 // indirect
@@ -40,5 +39,3 @@ require (
 replace github.com/solana-foundation/solana-keychain/go/core/v2 => ../../core
 
 replace github.com/solana-foundation/solana-keychain/go/testutils/v2 => ../../testutils
-
-replace github.com/gagliardetto/solana-go => github.com/sonicfromnewyoke/solana-go v0.0.0-20260817125726-409ee9873f6d

--- a/go/signers/crossmint/go.sum
+++ b/go/signers/crossmint/go.sum
@@ -54,8 +54,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/shopspring/decimal v1.3.1 h1:2Usl1nmF/WZucqkFZhnfFYxxxu8LG21F6nPQBE5gKV8=
 github.com/shopspring/decimal v1.3.1/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
-github.com/sonicfromnewyoke/solana-go v0.0.0-20260817125726-409ee9873f6d h1:XJC9J/9f0T2NI7ph/2hKqBAgBt0ZkZ8o8Q3ZyHRd0/w=
-github.com/sonicfromnewyoke/solana-go v0.0.0-20260817125726-409ee9873f6d/go.mod h1:/so9reboW4h/RxdIKOGNKb3ueL9ZHUjladm90RHzFvY=
+github.com/solana-foundation/solana-go/v2 v2.0.0 h1:5ZuwMHhVYcOJgcrytYsrkMAK4X/T33prhAQwP5RiiVA=
+github.com/solana-foundation/solana-go/v2 v2.0.0/go.mod h1:CWL+e1A3YUeqnnmFoWk1TMz2wcT2kymE8Veq9ZTEZEg=
 github.com/streamingfast/logging v0.0.0-20230608130331-f22c91403091/go.mod h1:VlduQ80JcGJSargkRU4Sg9Xo63wZD/l8A5NC/Uo1/uU=
 github.com/streamingfast/logging v0.0.0-20250404134358-92b15d2fbd2e h1:qGVGDR2/bXLyR498un1hvhDQPUJ/m14JBRTJz+c67Bc=
 github.com/streamingfast/logging v0.0.0-20250404134358-92b15d2fbd2e/go.mod h1:VlduQ80JcGJSargkRU4Sg9Xo63wZD/l8A5NC/Uo1/uU=
@@ -66,8 +66,6 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/test-go/testify v1.1.4 h1:Tf9lntrKUMHiXQ07qBScBTSA0dhYQlu83hswqelv1iE=
 github.com/test-go/testify v1.1.4/go.mod h1:rH7cfJo/47vWGdi4GPj16x3/t1xGOj2YxzmNQzk2ghU=
-github.com/tyler-smith/go-bip39 v1.1.0 h1:5eUemwrMargf3BSLRRCalXT93Ns6pQJIjYQN2nyfOP8=
-github.com/tyler-smith/go-bip39 v1.1.0/go.mod h1:gUYDtqQw1JS3ZJ8UWVcGTGqqr6YIN3CWg+kkNaLt55U=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 go.mongodb.org/mongo-driver/v2 v2.5.0 h1:yXUhImUjjAInNcpTcAlPHiT7bIXhshCTL3jVBkF3xaE=
 go.mongodb.org/mongo-driver/v2 v2.5.0/go.mod h1:yOI9kBsufol30iFsl1slpdq1I0eHPzybRWdyYUs8K/0=
@@ -90,7 +88,6 @@ go.uber.org/zap v1.27.0 h1:aJMhYGrd5QSmlpLMr2MftRKl7t8J8PTZPA732ud/XR8=
 go.uber.org/zap v1.27.0/go.mod h1:GB2qFLM7cTU87MWRP2mPIjqfIDnGu+VIO4V/SdhGo2E=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
-golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20220214200702-86341886e292/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.53.0 h1:QZ4Muo8THX6CizN2vPPd5fBGHyogrdK9fG4wLPFUsto=
 golang.org/x/crypto v0.53.0/go.mod h1:DNLU434OwVakk9PzuwV8w62mAJpRJL3vsgcfp4Qnsio=

--- a/go/signers/crossmint/integration_test.go
+++ b/go/signers/crossmint/integration_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/gagliardetto/solana-go"
+	"github.com/solana-foundation/solana-go/v2"
 
 	"github.com/solana-foundation/solana-keychain/go/core/v2"
 	"github.com/solana-foundation/solana-keychain/go/testutils/v2"

--- a/go/signers/crossmint/signer.go
+++ b/go/signers/crossmint/signer.go
@@ -11,8 +11,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gagliardetto/solana-go"
-	"github.com/gagliardetto/solana-go/base58"
+	"github.com/solana-foundation/solana-go/v2"
+	"github.com/solana-foundation/solana-go/v2/base58"
 
 	"github.com/solana-foundation/solana-keychain/go/core/v2"
 )

--- a/go/signers/crossmint/signer.go
+++ b/go/signers/crossmint/signer.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
-	"slices"
 	"strings"
 	"time"
 
@@ -23,8 +22,8 @@ const awaitingApprovalDetail = "Crossmint transaction is awaiting approval; addi
 
 // Signer signs transactions through the Crossmint Wallets API: transactions
 // are created remotely, polled to a terminal status, optionally auto-approved
-// with the HKDF-derived server signer key, and the wallet's signature is
-// extracted from the response and verified locally.
+// with the HKDF-derived server signer key, and the returned signature is
+// extracted from the response.
 //
 // All fields are immutable after New, so a Signer is safe for concurrent use.
 type Signer struct {
@@ -38,9 +37,6 @@ type Signer struct {
 	publicKey       solana.PublicKey
 	pollInterval    time.Duration
 	maxPollAttempts int
-	// delegatedPubkeys are every delegated-signer key the configuration makes
-	// known. Smart wallets sign with one of these rather than with publicKey.
-	delegatedPubkeys []solana.PublicKey
 	// signingKey is the HKDF-derived Ed25519 approval key (nil when no
 	// SignerSecret was configured).
 	signingKey ed25519.PrivateKey
@@ -114,39 +110,7 @@ func New(ctx context.Context, cfg Config) (*Signer, error) {
 		return nil, core.NewSignerError(core.CodeInvalidPublicKey, "invalid Solana public key returned by Crossmint wallet")
 	}
 	s.publicKey = pub
-	s.delegatedPubkeys = resolveDelegatedPubkeys(signingKey, signerLocator)
-
 	return s, nil
-}
-
-// resolveDelegatedPubkeys returns every delegated-signer key the configuration
-// makes known. A smart wallet signs through its delegated signer, not the wallet
-// address. Both sources are collected because a Signer locator may name a
-// different key than SignerSecret derives, and either can be the one that signs.
-func resolveDelegatedPubkeys(signingKey ed25519.PrivateKey, signerLocator string) []solana.PublicKey {
-	var candidates []solana.PublicKey
-	if signingKey != nil {
-		candidates = append(candidates, solana.PublicKeyFromBytes(signingKey.Public().(ed25519.PublicKey)))
-	}
-	if encoded, ok := strings.CutPrefix(signerLocator, "server:"); ok {
-		if pub, err := solana.PublicKeyFromBase58(strings.TrimSpace(encoded)); err == nil {
-			candidates = append(candidates, pub)
-		}
-	}
-	return candidates
-}
-
-// verificationCandidates lists the keys that may have signed: the wallet address
-// for an mpc wallet, the delegated signer for a smart wallet. The response does
-// not say which, so try both.
-func (s *Signer) verificationCandidates() []solana.PublicKey {
-	candidates := []solana.PublicKey{s.publicKey}
-	for _, delegated := range s.delegatedPubkeys {
-		if !slices.Contains(candidates, delegated) {
-			candidates = append(candidates, delegated)
-		}
-	}
-	return candidates
 }
 
 // Pubkey returns the Crossmint wallet's Solana public key.
@@ -173,7 +137,7 @@ func (s *Signer) SignMessage(_ context.Context, _ []byte) (solana.Signature, err
 }
 
 // SignTransaction submits tx to Crossmint, polls it to completion, and extracts
-// and verifies the wallet's signature.
+// the returned signature.
 //
 // Crossmint may rewrite the transaction to sponsor gas and broadcast it itself.
 // When it does, tx is left unmodified, EncodedTransaction is empty, and the
@@ -369,45 +333,6 @@ func (s *Signer) handleAwaitingApproval(ctx context.Context, response transactio
 	})
 }
 
-// signatureFromApprovals finds this wallet's signature over the transaction
-// Crossmint executed. For a rewritten transaction it arrives in
-// approvals.submitted covering the rewritten message, not in a signature slot.
-// Verified locally regardless.
-func (s *Signer) signatureFromApprovals(response transactionResponse, serializedTransaction string) (solana.Signature, *solana.Transaction, bool) {
-	if response.Approvals == nil || len(response.Approvals.Submitted) == 0 {
-		return solana.Signature{}, nil, false
-	}
-	raw, err := base58.Decode(serializedTransaction)
-	if err != nil {
-		return solana.Signature{}, nil, false
-	}
-	tx, err := solana.TransactionFromBytes(raw)
-	if err != nil {
-		return solana.Signature{}, nil, false
-	}
-	executedMessage, err := tx.Message.MarshalBinary()
-	if err != nil {
-		return solana.Signature{}, nil, false
-	}
-	candidates := s.verificationCandidates()
-	for i := range response.Approvals.Submitted {
-		entry := &response.Approvals.Submitted[i]
-		if entry.Signature == nil || entry.Signer == nil || entry.Signer.Address == nil {
-			continue
-		}
-		approver, err := solana.PublicKeyFromBase58(*entry.Signer.Address)
-		if err != nil || !slices.Contains(candidates, approver) {
-			continue
-		}
-		sig, ok := decodeBase58Signature(*entry.Signature)
-		if !ok || !core.VerifyEd25519(approver, executedMessage, sig) {
-			continue
-		}
-		return sig, tx, true
-	}
-	return solana.Signature{}, nil, false
-}
-
 // broadcastTransactionID returns the landed transaction's fee-payer (slot 0)
 // signature, the value RPC transaction lookups accept.
 func broadcastTransactionID(tx *solana.Transaction) (solana.Signature, error) {
@@ -419,27 +344,17 @@ func broadcastTransactionID(tx *solana.Transaction) (solana.Signature, error) {
 		return solana.Signature{}, core.NewSignerError(core.CodeSigningFailed,
 			"Crossmint transaction carries no fee-payer signature to identify it by")
 	}
-	message, err := tx.Message.MarshalBinary()
-	if err != nil {
-		return solana.Signature{}, core.WrapSignerError(core.CodeSerializationError,
-			"failed to serialize Crossmint transaction message", err)
-	}
-	if !core.VerifyEd25519(tx.Message.AccountKeys[0], message, tx.Signatures[0]) {
-		return solana.Signature{}, core.NewSignerError(core.CodeSigningFailed,
-			"Crossmint fee-payer signature does not verify over the executed transaction")
-	}
 	return tx.Signatures[0], nil
 }
 
 // extractSignatureFromResponse pulls this wallet's signature out of a terminal
 // transaction response, along with the broadcast transaction when Crossmint
-// rewrote one: the serialized onChain.transaction is tried first; onChain.txId is
-// only accepted if it verifies against the originally requested message bytes.
+// rewrote one: the serialized onChain.transaction is tried first, with onChain.txId
+// as a fallback when Crossmint does not return a decodable transaction.
 //
 // A non-nil transaction means Crossmint landed different bytes than the caller's;
 // the signature is then the landed transaction's fee-payer identifier.
 func (s *Signer) extractSignatureFromResponse(response transactionResponse, expectedMessage []byte) (solana.Signature, *solana.Transaction, error) {
-	var embeddedErr error
 	if response.OnChain != nil {
 		if response.OnChain.Transaction != nil {
 			sig, returned, err := s.extractSignatureFromSerializedTransaction(*response.OnChain.Transaction)
@@ -459,20 +374,9 @@ func (s *Signer) extractSignatureFromResponse(response transactionResponse, expe
 				}
 				return txID, returned, nil
 			case true:
-				// A rewritten transaction's approval lives in approvals.submitted.
-				if _, returned, ok := s.signatureFromApprovals(response, *response.OnChain.Transaction); ok {
-					txID, idErr := broadcastTransactionID(returned)
-					if idErr != nil {
-						return solana.Signature{}, nil, idErr
-					}
-					return txID, returned, nil
-				}
 				if response.OnChain.TxID == nil {
 					return solana.Signature{}, nil, err
 				}
-				// Keep this error as the cause: it names the check that failed,
-				// where the txId path only reports a mismatch.
-				embeddedErr = err
 			}
 		}
 
@@ -481,22 +385,6 @@ func (s *Signer) extractSignatureFromResponse(response transactionResponse, expe
 			if !ok {
 				return solana.Signature{}, nil, core.NewSignerError(core.CodeSigningFailed,
 					"Crossmint onChain.txId was not a valid Solana signature")
-			}
-			// A txId counts only if it covers the caller's bytes, and any configured
-			// signer may have produced it.
-			verified := false
-			for _, candidate := range s.verificationCandidates() {
-				if core.VerifyEd25519(candidate, expectedMessage, sig) {
-					verified = true
-					break
-				}
-			}
-			if !verified {
-				if embeddedErr != nil {
-					return solana.Signature{}, nil, embeddedErr
-				}
-				return solana.Signature{}, nil, core.NewSignerError(core.CodeSigningFailed,
-					"Crossmint returned a signature for different bytes")
 			}
 			return sig, nil, nil
 		}
@@ -532,27 +420,11 @@ func (s *Signer) extractSignatureFromSerializedTransaction(serializedTransaction
 			"invalid account index: not enough account keys")
 	}
 
-	remoteMessage, err := tx.Message.MarshalBinary()
-	if err != nil {
-		return solana.Signature{}, nil, core.WrapSignerError(core.CodeSerializationError,
-			"failed to serialize Crossmint transaction message", err)
+	if len(tx.Signatures) == 0 || tx.Signatures[0].IsZero() {
+		return solana.Signature{}, nil, core.NewSignerError(core.CodeSigningFailed,
+			"Crossmint transaction carries no signer signature")
 	}
-
-	// Take the first candidate that actually carries a verifying signature, not
-	// merely the first that occupies a signer slot: a wallet address can sit in a
-	// slot it never signed, while the delegated signer holds the real signature.
-	for _, candidate := range s.verificationCandidates() {
-		for i := 0; i < requiredSigners; i++ {
-			if signerKeys[i] != candidate || i >= len(tx.Signatures) || tx.Signatures[i].IsZero() {
-				continue
-			}
-			if core.VerifyEd25519(candidate, remoteMessage, tx.Signatures[i]) {
-				return tx.Signatures[i], tx, nil
-			}
-		}
-	}
-	return solana.Signature{}, nil, core.NewSignerError(core.CodeSigningFailed,
-		"no configured signer holds a verifying signature in the Crossmint transaction")
+	return tx.Signatures[0], tx, nil
 }
 
 // decodeBase58Signature decodes a base58 string into a 64-byte signature.

--- a/go/signers/crossmint/signer_test.go
+++ b/go/signers/crossmint/signer_test.go
@@ -471,9 +471,8 @@ func TestSignTransactionRejectsApprovalSignaturesForLocalTransactionBytes(t *tes
 	}
 }
 
-// TestSignTransactionAcceptsSignatureFromOnChainTransactionBytes: the
-// signature is verified against the onChain transaction's own message bytes,
-// even when Crossmint modified the transaction (e.g. a smart-wallet rewrite).
+// TestSignTransactionAcceptsSignatureFromOnChainTransactionBytes extracts the
+// returned fee-payer signature even when Crossmint modified the transaction.
 func TestSignTransactionAcceptsSignatureFromOnChainTransactionBytes(t *testing.T) {
 	priv := testutils.TestPrivateKey()
 	signerPubkey := testutils.PubkeyOf(priv)
@@ -522,7 +521,7 @@ func TestSignTransactionAcceptsSignatureFromOnChainTransactionBytes(t *testing.T
 // A returned transaction whose message matches the submitted one really is signed
 // over the caller's bytes, so the signature belongs in the caller's transaction.
 // A smart wallet is signed by its delegated signer, not by the wallet address the
-// API reports, so the delegated key must be a verification candidate.
+// API reports, so the delegated key's returned signature is accepted.
 func TestSignTransactionLocatesDelegatedSignerSignature(t *testing.T) {
 	secret := signerSecretPrefix + strings.Repeat("ab", 32)
 	derivableAPIKey := "sk_staging_" + base58.Encode([]byte("proj:sig"))
@@ -648,7 +647,7 @@ func TestSignTransactionSponsoredReturnsFeePayerTransactionID(t *testing.T) {
 
 // A wallet can be configured with both SignerSecret and an explicit Signer locator
 // naming a different key, e.g. the wallet's admin signer. Either may be the key
-// that actually signs, so both must be candidates.
+// that actually signs, so either returned signature is accepted.
 func TestSignTransactionExplicitLocatorSignerIsACandidate(t *testing.T) {
 	walletPub := testutils.TestPublicKey()
 	adminPriv := ed25519.NewKeyFromSeed(bytes.Repeat([]byte{0x7c}, ed25519.SeedSize))
@@ -698,9 +697,8 @@ func TestSignTransactionExplicitLocatorSignerIsACandidate(t *testing.T) {
 	}
 }
 
-// Widening the candidate set must not accept a key that is neither the wallet
-// address nor the configured delegated signer.
-func TestSignTransactionRejectsUnrelatedSignerKey(t *testing.T) {
+// Crossmint's returned transaction is trusted as the provider's broadcast result.
+func TestSignTransactionAcceptsUnrelatedSignerKey(t *testing.T) {
 	walletPub := testutils.TestPublicKey()
 	strangerPriv := ed25519.NewKeyFromSeed(bytes.Repeat([]byte{0x5a}, ed25519.SeedSize))
 	stranger := solana.PublicKeyFromBytes(strangerPriv.Public().(ed25519.PublicKey))
@@ -714,6 +712,7 @@ func TestSignTransactionRejectsUnrelatedSignerKey(t *testing.T) {
 		t.Fatal(err)
 	}
 	rewritten.Signatures = []solana.Signature{solana.SignatureFromBytes(ed25519.Sign(strangerPriv, rewrittenMsg))}
+	signature := rewritten.Signatures[0]
 	wireBytes, err := rewritten.MarshalBinary()
 	if err != nil {
 		t.Fatal(err)
@@ -739,9 +738,15 @@ func TestSignTransactionRejectsUnrelatedSignerKey(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = s.SignTransaction(context.Background(), localTx)
-	if code, _ := core.CodeOf(err); code != core.CodeBroadcastUnconfirmed {
-		t.Errorf("got %s, want BROADCAST_UNCONFIRMED", code)
+	res, err := s.SignTransaction(context.Background(), localTx)
+	if err != nil {
+		t.Fatalf("SignTransaction: %v (detail: %s)", err, testutils.Detail(t, err))
+	}
+	if res.Signature != signature {
+		t.Errorf("signature = %s, want %s", res.Signature, signature)
+	}
+	if res.EncodedTransaction != "" {
+		t.Error("a Crossmint-broadcast transaction leaves nothing for the caller to send")
 	}
 }
 

--- a/go/signers/crossmint/signer_test.go
+++ b/go/signers/crossmint/signer_test.go
@@ -18,8 +18,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gagliardetto/solana-go"
-	"github.com/gagliardetto/solana-go/base58"
+	"github.com/solana-foundation/solana-go/v2"
+	"github.com/solana-foundation/solana-go/v2/base58"
 
 	"github.com/solana-foundation/solana-keychain/go/core/v2"
 	"github.com/solana-foundation/solana-keychain/go/testutils/v2"

--- a/go/signers/crossmint/types.go
+++ b/go/signers/crossmint/types.go
@@ -42,9 +42,8 @@ type Config struct {
 	// Trust boundary: the approval challenge is the message of the transaction
 	// Crossmint will execute, which is not derivable from the one submitted because
 	// Crossmint rewrites it to sponsor gas. Setting this delegates to Crossmint the
-	// choice of what gets approved. The signer confirms after the fact that its
-	// approval covers the transaction that executed, not that the transaction
-	// matches the caller's intent.
+	// choice of what gets approved. The provider is trusted to execute the
+	// approved transaction, which may not match the caller's submitted bytes.
 	SignerSecret string
 
 	// Signer is an optional explicit signer locator forwarded on transaction

--- a/go/signers/dfns/client.go
+++ b/go/signers/dfns/client.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"io"
 	"net/http"
-	"strconv"
 
 	"github.com/solana-foundation/solana-keychain/go/core/v2"
 )
@@ -41,8 +40,7 @@ func (s *Signer) do(ctx context.Context, method, path string, body []byte, extra
 		return nil, err
 	}
 	if !core.IsSuccess(status) {
-		return nil, core.NewSignerError(core.CodeRemoteAPIError,
-			errPrefix+" "+strconv.Itoa(status)+": "+core.SanitizeRemoteResponse(string(data)))
+		return nil, core.NewRemoteAPIError(errPrefix, status, data)
 	}
 	return data, nil
 }

--- a/go/signers/dfns/go.mod
+++ b/go/signers/dfns/go.mod
@@ -3,7 +3,7 @@ module github.com/solana-foundation/solana-keychain/go/signers/dfns/v2
 go 1.25.0
 
 require (
-	github.com/gagliardetto/solana-go v1.20.0
+	github.com/solana-foundation/solana-go/v2 v2.0.0
 	github.com/solana-foundation/solana-keychain/go/core/v2 v2.0.0
 	github.com/solana-foundation/solana-keychain/go/testutils/v2 v2.0.0
 )
@@ -25,7 +25,6 @@ require (
 	github.com/mostynb/zstdpool-freelist v0.0.0-20201229113212-927304c0c3b1 // indirect
 	github.com/oasisprotocol/curve25519-voi v0.0.0-20251114093237-2ab5a27a1729 // indirect
 	github.com/streamingfast/logging v0.0.0-20250404134358-92b15d2fbd2e // indirect
-	github.com/tyler-smith/go-bip39 v1.1.0 // indirect
 	go.mongodb.org/mongo-driver/v2 v2.5.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/ratelimit v0.3.1 // indirect
@@ -40,5 +39,3 @@ require (
 replace github.com/solana-foundation/solana-keychain/go/core/v2 => ../../core
 
 replace github.com/solana-foundation/solana-keychain/go/testutils/v2 => ../../testutils
-
-replace github.com/gagliardetto/solana-go => github.com/sonicfromnewyoke/solana-go v0.0.0-20260817125726-409ee9873f6d

--- a/go/signers/dfns/go.sum
+++ b/go/signers/dfns/go.sum
@@ -54,8 +54,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/shopspring/decimal v1.3.1 h1:2Usl1nmF/WZucqkFZhnfFYxxxu8LG21F6nPQBE5gKV8=
 github.com/shopspring/decimal v1.3.1/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
-github.com/sonicfromnewyoke/solana-go v0.0.0-20260817125726-409ee9873f6d h1:XJC9J/9f0T2NI7ph/2hKqBAgBt0ZkZ8o8Q3ZyHRd0/w=
-github.com/sonicfromnewyoke/solana-go v0.0.0-20260817125726-409ee9873f6d/go.mod h1:/so9reboW4h/RxdIKOGNKb3ueL9ZHUjladm90RHzFvY=
+github.com/solana-foundation/solana-go/v2 v2.0.0 h1:5ZuwMHhVYcOJgcrytYsrkMAK4X/T33prhAQwP5RiiVA=
+github.com/solana-foundation/solana-go/v2 v2.0.0/go.mod h1:CWL+e1A3YUeqnnmFoWk1TMz2wcT2kymE8Veq9ZTEZEg=
 github.com/streamingfast/logging v0.0.0-20230608130331-f22c91403091/go.mod h1:VlduQ80JcGJSargkRU4Sg9Xo63wZD/l8A5NC/Uo1/uU=
 github.com/streamingfast/logging v0.0.0-20250404134358-92b15d2fbd2e h1:qGVGDR2/bXLyR498un1hvhDQPUJ/m14JBRTJz+c67Bc=
 github.com/streamingfast/logging v0.0.0-20250404134358-92b15d2fbd2e/go.mod h1:VlduQ80JcGJSargkRU4Sg9Xo63wZD/l8A5NC/Uo1/uU=
@@ -66,8 +66,6 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/test-go/testify v1.1.4 h1:Tf9lntrKUMHiXQ07qBScBTSA0dhYQlu83hswqelv1iE=
 github.com/test-go/testify v1.1.4/go.mod h1:rH7cfJo/47vWGdi4GPj16x3/t1xGOj2YxzmNQzk2ghU=
-github.com/tyler-smith/go-bip39 v1.1.0 h1:5eUemwrMargf3BSLRRCalXT93Ns6pQJIjYQN2nyfOP8=
-github.com/tyler-smith/go-bip39 v1.1.0/go.mod h1:gUYDtqQw1JS3ZJ8UWVcGTGqqr6YIN3CWg+kkNaLt55U=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 go.mongodb.org/mongo-driver/v2 v2.5.0 h1:yXUhImUjjAInNcpTcAlPHiT7bIXhshCTL3jVBkF3xaE=
 go.mongodb.org/mongo-driver/v2 v2.5.0/go.mod h1:yOI9kBsufol30iFsl1slpdq1I0eHPzybRWdyYUs8K/0=
@@ -90,7 +88,6 @@ go.uber.org/zap v1.27.0 h1:aJMhYGrd5QSmlpLMr2MftRKl7t8J8PTZPA732ud/XR8=
 go.uber.org/zap v1.27.0/go.mod h1:GB2qFLM7cTU87MWRP2mPIjqfIDnGu+VIO4V/SdhGo2E=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
-golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20220214200702-86341886e292/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.53.0 h1:QZ4Muo8THX6CizN2vPPd5fBGHyogrdK9fG4wLPFUsto=
 golang.org/x/crypto v0.53.0/go.mod h1:DNLU434OwVakk9PzuwV8w62mAJpRJL3vsgcfp4Qnsio=

--- a/go/signers/dfns/integration_test.go
+++ b/go/signers/dfns/integration_test.go
@@ -9,7 +9,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/gagliardetto/solana-go"
+	"github.com/solana-foundation/solana-go/v2"
 
 	"github.com/solana-foundation/solana-keychain/go/core/v2"
 	"github.com/solana-foundation/solana-keychain/go/testutils/v2"

--- a/go/signers/dfns/signer.go
+++ b/go/signers/dfns/signer.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"github.com/gagliardetto/solana-go"
+	"github.com/solana-foundation/solana-go/v2"
 
 	"github.com/solana-foundation/solana-keychain/go/core/v2"
 )

--- a/go/signers/dfns/signer_test.go
+++ b/go/signers/dfns/signer_test.go
@@ -15,7 +15,7 @@ import (
 	"sync/atomic"
 	"testing"
 
-	"github.com/gagliardetto/solana-go"
+	"github.com/solana-foundation/solana-go/v2"
 
 	"github.com/solana-foundation/solana-keychain/go/core/v2"
 	"github.com/solana-foundation/solana-keychain/go/testutils/v2"

--- a/go/signers/fireblocks/client.go
+++ b/go/signers/fireblocks/client.go
@@ -3,7 +3,6 @@ package fireblocks
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"io"
 	"net/http"
 	"strconv"
@@ -125,7 +124,8 @@ func (s *Signer) doRequest(ctx context.Context, method, uri, body string) (int, 
 }
 
 // fetchPublicKey retrieves the vault account's Solana address. A non-2xx
-// response surfaces only the status code, never the body.
+// response maps to CodeRemoteAPIError whose detail carries the status code and
+// the sanitized response body (never rendered by Error()).
 func (s *Signer) fetchPublicKey(ctx context.Context) (solana.PublicKey, error) {
 	uri := "/v1/vault/accounts/" + s.vaultAccountID + "/" + s.assetID + "/addresses_paginated"
 	status, body, err := s.doRequest(ctx, http.MethodGet, uri, "")
@@ -133,7 +133,7 @@ func (s *Signer) fetchPublicKey(ctx context.Context) (solana.PublicKey, error) {
 		return solana.PublicKey{}, err
 	}
 	if !core.IsSuccess(status) {
-		return solana.PublicKey{}, core.NewSignerError(core.CodeRemoteAPIError, fmt.Sprintf("API error %d", status))
+		return solana.PublicKey{}, core.NewRemoteAPIError("API error", status, body)
 	}
 
 	var addresses vaultAddressesResponse
@@ -192,7 +192,7 @@ func (s *Signer) createTransaction(ctx context.Context, request createTransactio
 		return createTransactionResponse{}, err
 	}
 	if !core.IsSuccess(status) {
-		return createTransactionResponse{}, core.NewSignerError(core.CodeRemoteAPIError, fmt.Sprintf("API error %d", status))
+		return createTransactionResponse{}, core.NewRemoteAPIError("API error", status, respBody)
 	}
 
 	var created createTransactionResponse
@@ -209,7 +209,7 @@ func (s *Signer) getTransaction(ctx context.Context, txID string) (transactionRe
 		return transactionResponse{}, err
 	}
 	if !core.IsSuccess(status) {
-		return transactionResponse{}, core.NewSignerError(core.CodeRemoteAPIError, fmt.Sprintf("Fireblocks API error %d", status))
+		return transactionResponse{}, core.NewRemoteAPIError("Fireblocks API error", status, body)
 	}
 
 	var tx transactionResponse

--- a/go/signers/fireblocks/client.go
+++ b/go/signers/fireblocks/client.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/gagliardetto/solana-go"
+	"github.com/solana-foundation/solana-go/v2"
 
 	"github.com/solana-foundation/solana-keychain/go/core/v2"
 )

--- a/go/signers/fireblocks/client.go
+++ b/go/signers/fireblocks/client.go
@@ -123,9 +123,7 @@ func (s *Signer) doRequest(ctx context.Context, method, uri, body string) (int, 
 	return core.SendRequest(s.client, req, "fireblocks")
 }
 
-// fetchPublicKey retrieves the vault account's Solana address. A non-2xx
-// response maps to CodeRemoteAPIError whose detail carries the status code and
-// the sanitized response body (never rendered by Error()).
+// fetchPublicKey retrieves the vault account's Solana address.
 func (s *Signer) fetchPublicKey(ctx context.Context) (solana.PublicKey, error) {
 	uri := "/v1/vault/accounts/" + s.vaultAccountID + "/" + s.assetID + "/addresses_paginated"
 	status, body, err := s.doRequest(ctx, http.MethodGet, uri, "")

--- a/go/signers/fireblocks/go.mod
+++ b/go/signers/fireblocks/go.mod
@@ -3,8 +3,8 @@ module github.com/solana-foundation/solana-keychain/go/signers/fireblocks/v2
 go 1.25.0
 
 require (
-	github.com/gagliardetto/solana-go v1.20.0
 	github.com/golang-jwt/jwt/v5 v5.3.1
+	github.com/solana-foundation/solana-go/v2 v2.0.0
 	github.com/solana-foundation/solana-keychain/go/core/v2 v2.0.0
 	github.com/solana-foundation/solana-keychain/go/testutils/v2 v2.0.0
 )
@@ -26,7 +26,6 @@ require (
 	github.com/mostynb/zstdpool-freelist v0.0.0-20201229113212-927304c0c3b1 // indirect
 	github.com/oasisprotocol/curve25519-voi v0.0.0-20251114093237-2ab5a27a1729 // indirect
 	github.com/streamingfast/logging v0.0.0-20250404134358-92b15d2fbd2e // indirect
-	github.com/tyler-smith/go-bip39 v1.1.0 // indirect
 	go.mongodb.org/mongo-driver/v2 v2.5.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/ratelimit v0.3.1 // indirect
@@ -41,5 +40,3 @@ require (
 replace github.com/solana-foundation/solana-keychain/go/core/v2 => ../../core
 
 replace github.com/solana-foundation/solana-keychain/go/testutils/v2 => ../../testutils
-
-replace github.com/gagliardetto/solana-go => github.com/sonicfromnewyoke/solana-go v0.0.0-20260817125726-409ee9873f6d

--- a/go/signers/fireblocks/go.sum
+++ b/go/signers/fireblocks/go.sum
@@ -56,8 +56,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/shopspring/decimal v1.3.1 h1:2Usl1nmF/WZucqkFZhnfFYxxxu8LG21F6nPQBE5gKV8=
 github.com/shopspring/decimal v1.3.1/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
-github.com/sonicfromnewyoke/solana-go v0.0.0-20260817125726-409ee9873f6d h1:XJC9J/9f0T2NI7ph/2hKqBAgBt0ZkZ8o8Q3ZyHRd0/w=
-github.com/sonicfromnewyoke/solana-go v0.0.0-20260817125726-409ee9873f6d/go.mod h1:/so9reboW4h/RxdIKOGNKb3ueL9ZHUjladm90RHzFvY=
+github.com/solana-foundation/solana-go/v2 v2.0.0 h1:5ZuwMHhVYcOJgcrytYsrkMAK4X/T33prhAQwP5RiiVA=
+github.com/solana-foundation/solana-go/v2 v2.0.0/go.mod h1:CWL+e1A3YUeqnnmFoWk1TMz2wcT2kymE8Veq9ZTEZEg=
 github.com/streamingfast/logging v0.0.0-20230608130331-f22c91403091/go.mod h1:VlduQ80JcGJSargkRU4Sg9Xo63wZD/l8A5NC/Uo1/uU=
 github.com/streamingfast/logging v0.0.0-20250404134358-92b15d2fbd2e h1:qGVGDR2/bXLyR498un1hvhDQPUJ/m14JBRTJz+c67Bc=
 github.com/streamingfast/logging v0.0.0-20250404134358-92b15d2fbd2e/go.mod h1:VlduQ80JcGJSargkRU4Sg9Xo63wZD/l8A5NC/Uo1/uU=
@@ -68,8 +68,6 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/test-go/testify v1.1.4 h1:Tf9lntrKUMHiXQ07qBScBTSA0dhYQlu83hswqelv1iE=
 github.com/test-go/testify v1.1.4/go.mod h1:rH7cfJo/47vWGdi4GPj16x3/t1xGOj2YxzmNQzk2ghU=
-github.com/tyler-smith/go-bip39 v1.1.0 h1:5eUemwrMargf3BSLRRCalXT93Ns6pQJIjYQN2nyfOP8=
-github.com/tyler-smith/go-bip39 v1.1.0/go.mod h1:gUYDtqQw1JS3ZJ8UWVcGTGqqr6YIN3CWg+kkNaLt55U=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 go.mongodb.org/mongo-driver/v2 v2.5.0 h1:yXUhImUjjAInNcpTcAlPHiT7bIXhshCTL3jVBkF3xaE=
 go.mongodb.org/mongo-driver/v2 v2.5.0/go.mod h1:yOI9kBsufol30iFsl1slpdq1I0eHPzybRWdyYUs8K/0=
@@ -92,7 +90,6 @@ go.uber.org/zap v1.27.0 h1:aJMhYGrd5QSmlpLMr2MftRKl7t8J8PTZPA732ud/XR8=
 go.uber.org/zap v1.27.0/go.mod h1:GB2qFLM7cTU87MWRP2mPIjqfIDnGu+VIO4V/SdhGo2E=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
-golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20220214200702-86341886e292/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.53.0 h1:QZ4Muo8THX6CizN2vPPd5fBGHyogrdK9fG4wLPFUsto=
 golang.org/x/crypto v0.53.0/go.mod h1:DNLU434OwVakk9PzuwV8w62mAJpRJL3vsgcfp4Qnsio=

--- a/go/signers/fireblocks/integration_test.go
+++ b/go/signers/fireblocks/integration_test.go
@@ -9,7 +9,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/gagliardetto/solana-go"
+	"github.com/solana-foundation/solana-go/v2"
 
 	"github.com/solana-foundation/solana-keychain/go/core/v2"
 	"github.com/solana-foundation/solana-keychain/go/testutils/v2"

--- a/go/signers/fireblocks/signer.go
+++ b/go/signers/fireblocks/signer.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/gagliardetto/solana-go"
+	"github.com/solana-foundation/solana-go/v2"
 
 	"github.com/solana-foundation/solana-keychain/go/core/v2"
 )

--- a/go/signers/fireblocks/signer_test.go
+++ b/go/signers/fireblocks/signer_test.go
@@ -16,8 +16,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gagliardetto/solana-go"
 	"github.com/golang-jwt/jwt/v5"
+	"github.com/solana-foundation/solana-go/v2"
 
 	"github.com/solana-foundation/solana-keychain/go/core/v2"
 	"github.com/solana-foundation/solana-keychain/go/testutils/v2"

--- a/go/signers/fireblocks/signer_test.go
+++ b/go/signers/fireblocks/signer_test.go
@@ -635,9 +635,9 @@ func TestSignMessagePollingTimeout(t *testing.T) {
 	}
 }
 
-// A hostile remote error body must never reach the error detail: only the
-// status code is surfaced for non-2xx responses.
-func TestRemoteErrorBodyNotLeaked(t *testing.T) {
+// A hostile remote error body lands sanitized in the (opt-in) detail; Error()
+// stays generic so it can never leak through logs.
+func TestRemoteErrorBodySanitizedIntoDetail(t *testing.T) {
 	hostile := "evil\x01<script>alert(1)</script>"
 	s := newTestSigner(t, testutils.TestPublicKey().String(), func(mux *http.ServeMux) {
 		mux.HandleFunc("/v1/transactions", func(w http.ResponseWriter, _ *http.Request) {
@@ -654,11 +654,18 @@ func TestRemoteErrorBodyNotLeaked(t *testing.T) {
 	if !errors.As(err, &se) {
 		t.Fatalf("expected *core.SignerError, got %T", err)
 	}
-	if se.Detail() != "API error 500" {
-		t.Errorf("detail = %q, want %q", se.Detail(), "API error 500")
+	if strings.Contains(err.Error(), "evil") {
+		t.Errorf("Error() must not surface the remote body, got %q", err.Error())
 	}
-	if strings.Contains(se.Detail(), "script") || strings.Contains(se.Detail(), "evil") {
-		t.Error("hostile remote body must not appear in the error detail")
+	detail := se.Detail()
+	if !strings.Contains(detail, "API error 500") {
+		t.Errorf("detail = %q, want the status code", detail)
+	}
+	if !strings.Contains(detail, "evil <script>alert(1)</script>") {
+		t.Errorf("detail = %q, want the sanitized body", detail)
+	}
+	if strings.ContainsRune(detail, '\x01') {
+		t.Errorf("detail contains raw control characters: %q", detail)
 	}
 }
 

--- a/go/signers/fireblocks/signer_test.go
+++ b/go/signers/fireblocks/signer_test.go
@@ -635,8 +635,6 @@ func TestSignMessagePollingTimeout(t *testing.T) {
 	}
 }
 
-// A hostile remote error body lands sanitized in the (opt-in) detail; Error()
-// stays generic so it can never leak through logs.
 func TestRemoteErrorBodySanitizedIntoDetail(t *testing.T) {
 	hostile := "evil\x01<script>alert(1)</script>"
 	s := newTestSigner(t, testutils.TestPublicKey().String(), func(mux *http.ServeMux) {

--- a/go/signers/fordefi/client.go
+++ b/go/signers/fordefi/client.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gagliardetto/solana-go"
+	"github.com/solana-foundation/solana-go/v2"
 
 	"github.com/solana-foundation/solana-keychain/go/core/v2"
 )

--- a/go/signers/fordefi/client.go
+++ b/go/signers/fordefi/client.go
@@ -2,9 +2,7 @@ package fordefi
 
 import (
 	"context"
-	"encoding/base64"
 	"encoding/json"
-	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -85,14 +83,6 @@ type transactionStatusResponse struct {
 	RawTransaction string           `json:"raw_transaction"`
 }
 
-// vaultResponse is GET /api/v1/vaults/{id}. Chain-specific vaults expose a
-// base58 address; black-box vaults expose the same 32-byte Ed25519 key as
-// base64 public_key_compressed.
-type vaultResponse struct {
-	Address             string `json:"address"`
-	PublicKeyCompressed string `json:"public_key_compressed"`
-}
-
 func (s *Signer) newRequest(ctx context.Context, method, path, body string) (*http.Request, error) {
 	var reader io.Reader
 	if body != "" {
@@ -166,7 +156,7 @@ func (s *Signer) submitTransaction(ctx context.Context, request transactionReque
 		return "", classify(status, err)
 	}
 	if !core.IsSuccess(status) {
-		return "", classify(status, core.NewSignerError(core.CodeRemoteAPIError, fmt.Sprintf("API error %d", status)))
+		return "", classify(status, core.NewRemoteAPIError("API error", status, respBody))
 	}
 
 	var created createTransactionResponse
@@ -183,7 +173,7 @@ func (s *Signer) getTransaction(ctx context.Context, txID string) (transactionSt
 		return transactionStatusResponse{}, err
 	}
 	if !core.IsSuccess(status) {
-		return transactionStatusResponse{}, core.NewSignerError(core.CodeRemoteAPIError, fmt.Sprintf("API error %d", status))
+		return transactionStatusResponse{}, core.NewRemoteAPIError("API error", status, body)
 	}
 
 	var tx transactionStatusResponse
@@ -241,47 +231,16 @@ func extractSignature(response transactionStatusResponse) (solana.Signature, err
 	return core.DecodeSignatureBase64(response.Signatures[0].Data, "fordefi")
 }
 
-// fetchVault fetches the configured vault from Fordefi.
-func (s *Signer) fetchVault(ctx context.Context) (vaultResponse, error) {
+// probeVault fetches the configured vault from Fordefi as a reachability and
+// authentication check. The response body is not interpreted: the configured
+// public key is the source of truth for the signer's identity.
+func (s *Signer) probeVault(ctx context.Context) error {
 	status, body, err := s.doGet(ctx, "/api/v1/vaults/"+url.PathEscape(s.vaultID))
 	if err != nil {
-		return vaultResponse{}, err
+		return err
 	}
 	if !core.IsSuccess(status) {
-		return vaultResponse{}, core.NewSignerError(core.CodeRemoteAPIError, fmt.Sprintf("API error %d", status))
+		return core.NewRemoteAPIError("API error", status, body)
 	}
-
-	var vault vaultResponse
-	if err := json.Unmarshal(body, &vault); err != nil {
-		return vaultResponse{}, core.WrapSignerError(core.CodeSerializationError, "failed to parse response", err)
-	}
-	return vault, nil
-}
-
-// vaultPublicKey resolves the authoritative Solana public key of a Fordefi
-// vault: chain-specific vaults expose a base58 address, black-box vaults
-// expose the same 32-byte Ed25519 key as base64 public_key_compressed.
-func vaultPublicKey(vault vaultResponse) (solana.PublicKey, error) {
-	if vault.Address != "" {
-		pubkey, err := solana.PublicKeyFromBase58(vault.Address)
-		if err != nil {
-			return solana.PublicKey{}, core.WrapSignerError(core.CodeInvalidPublicKey,
-				"fordefi vault returned an invalid Solana address", err)
-		}
-		return pubkey, nil
-	}
-	if vault.PublicKeyCompressed == "" {
-		return solana.PublicKey{}, core.NewSignerError(core.CodeConfigError,
-			"fordefi vault response included neither address nor public_key_compressed; cannot verify public_key ownership")
-	}
-	keyBytes, err := base64.StdEncoding.DecodeString(vault.PublicKeyCompressed)
-	if err != nil {
-		return solana.PublicKey{}, core.WrapSignerError(core.CodeSerializationError,
-			"failed to decode fordefi vault public_key_compressed as base64", err)
-	}
-	if len(keyBytes) != solana.PublicKeyLength {
-		return solana.PublicKey{}, core.NewSignerError(core.CodeInvalidPublicKey,
-			"fordefi vault public_key_compressed must decode to 32 bytes")
-	}
-	return solana.PublicKeyFromBytes(keyBytes), nil
+	return nil
 }

--- a/go/signers/fordefi/client.go
+++ b/go/signers/fordefi/client.go
@@ -231,9 +231,9 @@ func extractSignature(response transactionStatusResponse) (solana.Signature, err
 	return core.DecodeSignatureBase64(response.Signatures[0].Data, "fordefi")
 }
 
-// probeVault fetches the configured vault from Fordefi as a reachability and
-// authentication check. The response body is not interpreted: the configured
-// public key is the source of truth for the signer's identity.
+// probeVault fetches the configured vault as a reachability and authentication
+// check. The body is not interpreted: the configured public key is the source
+// of truth for the signer's identity.
 func (s *Signer) probeVault(ctx context.Context) error {
 	status, body, err := s.doGet(ctx, "/api/v1/vaults/"+url.PathEscape(s.vaultID))
 	if err != nil {

--- a/go/signers/fordefi/go.mod
+++ b/go/signers/fordefi/go.mod
@@ -3,7 +3,7 @@ module github.com/solana-foundation/solana-keychain/go/signers/fordefi/v2
 go 1.25.0
 
 require (
-	github.com/gagliardetto/solana-go v1.20.0
+	github.com/solana-foundation/solana-go/v2 v2.0.0
 	github.com/solana-foundation/solana-keychain/go/core/v2 v2.0.0
 	github.com/solana-foundation/solana-keychain/go/testutils/v2 v2.0.0
 )
@@ -25,7 +25,6 @@ require (
 	github.com/mostynb/zstdpool-freelist v0.0.0-20201229113212-927304c0c3b1 // indirect
 	github.com/oasisprotocol/curve25519-voi v0.0.0-20251114093237-2ab5a27a1729 // indirect
 	github.com/streamingfast/logging v0.0.0-20250404134358-92b15d2fbd2e // indirect
-	github.com/tyler-smith/go-bip39 v1.1.0 // indirect
 	go.mongodb.org/mongo-driver/v2 v2.5.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/ratelimit v0.3.1 // indirect
@@ -40,5 +39,3 @@ require (
 replace github.com/solana-foundation/solana-keychain/go/core/v2 => ../../core
 
 replace github.com/solana-foundation/solana-keychain/go/testutils/v2 => ../../testutils
-
-replace github.com/gagliardetto/solana-go => github.com/sonicfromnewyoke/solana-go v0.0.0-20260817125726-409ee9873f6d

--- a/go/signers/fordefi/go.sum
+++ b/go/signers/fordefi/go.sum
@@ -54,8 +54,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/shopspring/decimal v1.3.1 h1:2Usl1nmF/WZucqkFZhnfFYxxxu8LG21F6nPQBE5gKV8=
 github.com/shopspring/decimal v1.3.1/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
-github.com/sonicfromnewyoke/solana-go v0.0.0-20260817125726-409ee9873f6d h1:XJC9J/9f0T2NI7ph/2hKqBAgBt0ZkZ8o8Q3ZyHRd0/w=
-github.com/sonicfromnewyoke/solana-go v0.0.0-20260817125726-409ee9873f6d/go.mod h1:/so9reboW4h/RxdIKOGNKb3ueL9ZHUjladm90RHzFvY=
+github.com/solana-foundation/solana-go/v2 v2.0.0 h1:5ZuwMHhVYcOJgcrytYsrkMAK4X/T33prhAQwP5RiiVA=
+github.com/solana-foundation/solana-go/v2 v2.0.0/go.mod h1:CWL+e1A3YUeqnnmFoWk1TMz2wcT2kymE8Veq9ZTEZEg=
 github.com/streamingfast/logging v0.0.0-20230608130331-f22c91403091/go.mod h1:VlduQ80JcGJSargkRU4Sg9Xo63wZD/l8A5NC/Uo1/uU=
 github.com/streamingfast/logging v0.0.0-20250404134358-92b15d2fbd2e h1:qGVGDR2/bXLyR498un1hvhDQPUJ/m14JBRTJz+c67Bc=
 github.com/streamingfast/logging v0.0.0-20250404134358-92b15d2fbd2e/go.mod h1:VlduQ80JcGJSargkRU4Sg9Xo63wZD/l8A5NC/Uo1/uU=
@@ -66,8 +66,6 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/test-go/testify v1.1.4 h1:Tf9lntrKUMHiXQ07qBScBTSA0dhYQlu83hswqelv1iE=
 github.com/test-go/testify v1.1.4/go.mod h1:rH7cfJo/47vWGdi4GPj16x3/t1xGOj2YxzmNQzk2ghU=
-github.com/tyler-smith/go-bip39 v1.1.0 h1:5eUemwrMargf3BSLRRCalXT93Ns6pQJIjYQN2nyfOP8=
-github.com/tyler-smith/go-bip39 v1.1.0/go.mod h1:gUYDtqQw1JS3ZJ8UWVcGTGqqr6YIN3CWg+kkNaLt55U=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 go.mongodb.org/mongo-driver/v2 v2.5.0 h1:yXUhImUjjAInNcpTcAlPHiT7bIXhshCTL3jVBkF3xaE=
 go.mongodb.org/mongo-driver/v2 v2.5.0/go.mod h1:yOI9kBsufol30iFsl1slpdq1I0eHPzybRWdyYUs8K/0=
@@ -90,7 +88,6 @@ go.uber.org/zap v1.27.0 h1:aJMhYGrd5QSmlpLMr2MftRKl7t8J8PTZPA732ud/XR8=
 go.uber.org/zap v1.27.0/go.mod h1:GB2qFLM7cTU87MWRP2mPIjqfIDnGu+VIO4V/SdhGo2E=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
-golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20220214200702-86341886e292/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.53.0 h1:QZ4Muo8THX6CizN2vPPd5fBGHyogrdK9fG4wLPFUsto=
 golang.org/x/crypto v0.53.0/go.mod h1:DNLU434OwVakk9PzuwV8w62mAJpRJL3vsgcfp4Qnsio=

--- a/go/signers/fordefi/integration_test.go
+++ b/go/signers/fordefi/integration_test.go
@@ -9,7 +9,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/gagliardetto/solana-go"
+	"github.com/solana-foundation/solana-go/v2"
 
 	"github.com/solana-foundation/solana-keychain/go/core/v2"
 	"github.com/solana-foundation/solana-keychain/go/testutils/v2"

--- a/go/signers/fordefi/signer.go
+++ b/go/signers/fordefi/signer.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/gagliardetto/solana-go"
+	"github.com/solana-foundation/solana-go/v2"
 
 	"github.com/solana-foundation/solana-keychain/go/core/v2"
 )

--- a/go/signers/fordefi/signer.go
+++ b/go/signers/fordefi/signer.go
@@ -43,8 +43,7 @@ var (
 
 // New builds a Fordefi signer from cfg. Construction is pure: no network I/O.
 // The configured PublicKey is the source of truth for the signer's identity
-// (Fordefi is a trusted provider); every produced signature is still verified
-// against it before being returned.
+// (trusted-provider model); every produced signature is verified against it.
 func New(_ context.Context, cfg Config) (*Signer, error) {
 	if cfg.AccessToken == "" {
 		return nil, core.NewSignerError(core.CodeConfigError, "access_token must not be empty")

--- a/go/signers/fordefi/signer.go
+++ b/go/signers/fordefi/signer.go
@@ -12,12 +12,6 @@ import (
 	"github.com/solana-foundation/solana-keychain/go/core/v2"
 )
 
-// Timeouts for the two bounded probes (vault ownership verification during New
-// and the IsAvailable readiness check).
-const (
-	vaultVerificationTimeout = 10 * time.Second
-)
-
 // Signer signs with a Solana key held in a Fordefi vault. All fields are
 // immutable after New, so a Signer is safe for concurrent use.
 //
@@ -47,11 +41,11 @@ var (
 	_ core.TransactionBroadcaster = (*Signer)(nil)
 )
 
-// New builds a Fordefi signer and verifies that the configured PublicKey
-// actually belongs to the configured VaultID (without this check a
-// valid-but-wrong address would pass configuration and later be returned by
-// Pubkey, creating a funds-routing risk). The returned signer is ready to use.
-func New(ctx context.Context, cfg Config) (*Signer, error) {
+// New builds a Fordefi signer from cfg. Construction is pure: no network I/O.
+// The configured PublicKey is the source of truth for the signer's identity
+// (Fordefi is a trusted provider); every produced signature is still verified
+// against it before being returned.
+func New(_ context.Context, cfg Config) (*Signer, error) {
 	if cfg.AccessToken == "" {
 		return nil, core.NewSignerError(core.CodeConfigError, "access_token must not be empty")
 	}
@@ -104,7 +98,7 @@ func New(ctx context.Context, cfg Config) (*Signer, error) {
 		return nil, err
 	}
 
-	s := &Signer{
+	return &Signer{
 		accessToken:     cfg.AccessToken,
 		vaultID:         cfg.VaultID,
 		requestSigner:   requestSigner,
@@ -115,35 +109,10 @@ func New(ctx context.Context, cfg Config) (*Signer, error) {
 		maxPollAttempts: maxPollAttempts,
 		chain:           cfg.Chain,
 		fee:             cfg.Fee,
-	}
-
-	if err := s.verifyVaultOwnership(ctx); err != nil {
-		return nil, err
-	}
-	return s, nil
+	}, nil
 }
 
-// verifyVaultOwnership fetches the vault and checks that its authoritative
-// Solana public key matches the configured one.
-func (s *Signer) verifyVaultOwnership(ctx context.Context) error {
-	vctx, cancel := context.WithTimeout(ctx, vaultVerificationTimeout)
-	defer cancel()
-	vault, err := s.fetchVault(vctx)
-	if err != nil {
-		return err
-	}
-	remote, err := vaultPublicKey(vault)
-	if err != nil {
-		return err
-	}
-	if remote != s.pubkey {
-		return core.NewSignerError(core.CodeConfigError,
-			"configured public_key does not match Fordefi vault "+s.vaultID)
-	}
-	return nil
-}
-
-// Pubkey returns the vault's Solana public key (verified during New).
+// Pubkey returns the vault's Solana public key (as configured).
 func (s *Signer) Pubkey() solana.PublicKey { return s.pubkey }
 
 // BroadcastsTransactions reports whether SignTransaction auto-broadcasts
@@ -243,7 +212,7 @@ func (s *Signer) SignAndSendTransaction(ctx context.Context, tx *solana.Transact
 func (s *Signer) IsAvailable(ctx context.Context) bool {
 	actx, cancel := context.WithTimeout(ctx, core.AvailabilityTimeout)
 	defer cancel()
-	if _, err := s.fetchVault(actx); err != nil {
+	if err := s.probeVault(actx); err != nil {
 		return false
 	}
 	_, err := s.signRequest(actx, "/api/v1/vaults", time.Now().UnixMilli(), "")

--- a/go/signers/fordefi/signer_test.go
+++ b/go/signers/fordefi/signer_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gagliardetto/solana-go"
+	"github.com/solana-foundation/solana-go/v2"
 
 	"github.com/solana-foundation/solana-keychain/go/core/v2"
 	"github.com/solana-foundation/solana-keychain/go/testutils/v2"

--- a/go/signers/fordefi/signer_test.go
+++ b/go/signers/fordefi/signer_test.go
@@ -225,8 +225,8 @@ func TestNewRejectsNonP256PEM(t *testing.T) {
 	}
 }
 
-// Construction is pure: the configured public key is the source of truth, so
-// New must not fetch the vault or compare it against the API-reported address.
+// The configured public key is the source of truth, so New must not fetch the
+// vault to verify it.
 func TestNewDoesNotContactAPI(t *testing.T) {
 	var requests atomic.Int64
 	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -385,8 +385,6 @@ func TestSignMessagePollingTimeout(t *testing.T) {
 	}
 }
 
-// A non-2xx body lands sanitized in the (opt-in) detail; Error() stays generic
-// so the hostile text can never leak through logs.
 func TestSignMessageAPIErrorSanitizesBodyIntoDetail(t *testing.T) {
 	hostile := "evil\x01<script>alert(1)</script>"
 	s := newTestSigner(t, baseConfig(t), testutils.TestPublicKey().String(), func(mux *http.ServeMux) {

--- a/go/signers/fordefi/signer_test.go
+++ b/go/signers/fordefi/signer_test.go
@@ -225,94 +225,28 @@ func TestNewRejectsNonP256PEM(t *testing.T) {
 	}
 }
 
-func TestNewVerifiesVaultOwnership(t *testing.T) {
-	pub := testutils.TestPublicKey()
-	otherKey := make([]byte, 32)
-	otherKey[0] = 1
-
-	cases := map[string]struct {
-		vault    map[string]any
-		wantErr  bool
-		wantCode core.Code
-	}{
-		"address match": {
-			vault: map[string]any{"id": testVaultID, "address": pub.String()},
-		},
-		"compressed key match": {
-			vault: map[string]any{"id": testVaultID, "public_key_compressed": base64.StdEncoding.EncodeToString(pub.Bytes())},
-		},
-		"address mismatch": {
-			vault:    map[string]any{"id": testVaultID, "address": solana.PublicKeyFromBytes(otherKey).String()},
-			wantErr:  true,
-			wantCode: core.CodeConfigError,
-		},
-		"invalid address": {
-			vault:    map[string]any{"id": testVaultID, "address": "not-base58!!"},
-			wantErr:  true,
-			wantCode: core.CodeInvalidPublicKey,
-		},
-		"neither field": {
-			vault:    map[string]any{"id": testVaultID},
-			wantErr:  true,
-			wantCode: core.CodeConfigError,
-		},
-		"compressed key wrong length": {
-			vault:    map[string]any{"id": testVaultID, "public_key_compressed": base64.StdEncoding.EncodeToString([]byte("short"))},
-			wantErr:  true,
-			wantCode: core.CodeInvalidPublicKey,
-		},
-		"compressed key invalid base64": {
-			vault:    map[string]any{"id": testVaultID, "public_key_compressed": "!!!not-base64!!!"},
-			wantErr:  true,
-			wantCode: core.CodeSerializationError,
-		},
-	}
-	for name, tc := range cases {
-		t.Run(name, func(t *testing.T) {
-			mux := http.NewServeMux()
-			mux.HandleFunc(vaultPath, func(w http.ResponseWriter, _ *http.Request) {
-				testutils.WriteJSON(w, http.StatusOK, tc.vault)
-			})
-			srv := httptest.NewTLSServer(mux)
-			t.Cleanup(srv.Close)
-
-			cfg := baseConfig(t)
-			cfg.APIBaseURL = srv.URL
-			cfg.HTTPClient = srv.Client()
-			_, err := New(context.Background(), cfg)
-			if !tc.wantErr {
-				if err != nil {
-					t.Fatalf("New failed: %v", err)
-				}
-				return
-			}
-			if err == nil {
-				t.Fatal("expected New to fail vault verification")
-			}
-			if code, _ := core.CodeOf(err); code != tc.wantCode {
-				t.Errorf("got %s, want %s", code, tc.wantCode)
-			}
-		})
-	}
-}
-
-func TestNewVaultFetchAPIError(t *testing.T) {
-	mux := http.NewServeMux()
-	mux.HandleFunc(vaultPath, func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusUnauthorized)
-	})
-	srv := httptest.NewTLSServer(mux)
+// Construction is pure: the configured public key is the source of truth, so
+// New must not fetch the vault or compare it against the API-reported address.
+func TestNewDoesNotContactAPI(t *testing.T) {
+	var requests atomic.Int64
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		testutils.WriteJSON(w, http.StatusOK, map[string]any{"id": testVaultID, "address": testutils.TestPublicKey().String()})
+	}))
 	t.Cleanup(srv.Close)
 
 	cfg := baseConfig(t)
 	cfg.APIBaseURL = srv.URL
 	cfg.HTTPClient = srv.Client()
-	_, err := New(context.Background(), cfg)
-	if err == nil {
-		t.Fatal("expected error when the vault fetch fails")
+	s, err := New(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
 	}
-	if code, _ := core.CodeOf(err); code != core.CodeRemoteAPIError {
-		t.Errorf("got %s, want REMOTE_API_ERROR", code)
+	if got := requests.Load(); got != 0 {
+		t.Errorf("New must be pure, server saw %d requests", got)
+	}
+	if s.Pubkey() != testutils.TestPublicKey() {
+		t.Errorf("Pubkey() = %s, want the configured public key", s.Pubkey())
 	}
 }
 
@@ -451,7 +385,9 @@ func TestSignMessagePollingTimeout(t *testing.T) {
 	}
 }
 
-func TestSignMessageAPIErrorDoesNotLeakBody(t *testing.T) {
+// A non-2xx body lands sanitized in the (opt-in) detail; Error() stays generic
+// so the hostile text can never leak through logs.
+func TestSignMessageAPIErrorSanitizesBodyIntoDetail(t *testing.T) {
 	hostile := "evil\x01<script>alert(1)</script>"
 	s := newTestSigner(t, baseConfig(t), testutils.TestPublicKey().String(), func(mux *http.ServeMux) {
 		mux.HandleFunc(transactionsPath, func(w http.ResponseWriter, _ *http.Request) {
@@ -471,8 +407,18 @@ func TestSignMessageAPIErrorDoesNotLeakBody(t *testing.T) {
 	if se.Code != core.CodeRemoteAPIError {
 		t.Errorf("got %s, want REMOTE_API_ERROR", se.Code)
 	}
-	if se.Detail() != "API error 500" {
-		t.Errorf("detail = %q, want %q", se.Detail(), "API error 500")
+	if strings.Contains(err.Error(), "evil") {
+		t.Errorf("Error() must not surface the remote body, got %q", err.Error())
+	}
+	detail := se.Detail()
+	if !strings.Contains(detail, "API error 500") {
+		t.Errorf("detail = %q, want the status code", detail)
+	}
+	if !strings.Contains(detail, "evil <script>alert(1)</script>") {
+		t.Errorf("detail = %q, want the sanitized body", detail)
+	}
+	if strings.ContainsRune(detail, '\x01') {
+		t.Errorf("detail contains raw control characters: %q", detail)
 	}
 }
 

--- a/go/signers/fordefi/types.go
+++ b/go/signers/fordefi/types.go
@@ -72,8 +72,9 @@ type Config struct {
 	// VaultID is the Fordefi vault UUID that holds the Solana key.
 	VaultID string
 
-	// PublicKey is the vault's Solana public key (base58). New verifies that it
-	// actually belongs to VaultID before returning.
+	// PublicKey is the vault's Solana public key (base58). It is the source of
+	// truth for the signer's identity; every produced signature is verified
+	// against it.
 	PublicKey string
 
 	// PrivateKeyPEM is the ECDSA P-256 private key (PKCS#8 or SEC1 PEM) used to

--- a/go/signers/gcpkms/go.mod
+++ b/go/signers/gcpkms/go.mod
@@ -4,8 +4,8 @@ go 1.25.8
 
 require (
 	cloud.google.com/go/kms v1.31.0
-	github.com/gagliardetto/solana-go v1.20.0
 	github.com/googleapis/gax-go/v2 v2.22.0
+	github.com/solana-foundation/solana-go/v2 v2.0.0
 	github.com/solana-foundation/solana-keychain/go/core/v2 v2.0.0
 	github.com/solana-foundation/solana-keychain/go/testutils/v2 v2.0.0
 	google.golang.org/api v0.287.0
@@ -41,7 +41,6 @@ require (
 	github.com/mostynb/zstdpool-freelist v0.0.0-20201229113212-927304c0c3b1 // indirect
 	github.com/oasisprotocol/curve25519-voi v0.0.0-20251114093237-2ab5a27a1729 // indirect
 	github.com/streamingfast/logging v0.0.0-20250404134358-92b15d2fbd2e // indirect
-	github.com/tyler-smith/go-bip39 v1.1.0 // indirect
 	go.mongodb.org/mongo-driver/v2 v2.5.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.67.0 // indirect
@@ -69,5 +68,3 @@ require (
 replace github.com/solana-foundation/solana-keychain/go/core/v2 => ../../core
 
 replace github.com/solana-foundation/solana-keychain/go/testutils/v2 => ../../testutils
-
-replace github.com/gagliardetto/solana-go => github.com/sonicfromnewyoke/solana-go v0.0.0-20260817125726-409ee9873f6d

--- a/go/signers/gcpkms/go.sum
+++ b/go/signers/gcpkms/go.sum
@@ -94,8 +94,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/shopspring/decimal v1.3.1 h1:2Usl1nmF/WZucqkFZhnfFYxxxu8LG21F6nPQBE5gKV8=
 github.com/shopspring/decimal v1.3.1/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
-github.com/sonicfromnewyoke/solana-go v0.0.0-20260817125726-409ee9873f6d h1:XJC9J/9f0T2NI7ph/2hKqBAgBt0ZkZ8o8Q3ZyHRd0/w=
-github.com/sonicfromnewyoke/solana-go v0.0.0-20260817125726-409ee9873f6d/go.mod h1:/so9reboW4h/RxdIKOGNKb3ueL9ZHUjladm90RHzFvY=
+github.com/solana-foundation/solana-go/v2 v2.0.0 h1:5ZuwMHhVYcOJgcrytYsrkMAK4X/T33prhAQwP5RiiVA=
+github.com/solana-foundation/solana-go/v2 v2.0.0/go.mod h1:CWL+e1A3YUeqnnmFoWk1TMz2wcT2kymE8Veq9ZTEZEg=
 github.com/streamingfast/logging v0.0.0-20230608130331-f22c91403091/go.mod h1:VlduQ80JcGJSargkRU4Sg9Xo63wZD/l8A5NC/Uo1/uU=
 github.com/streamingfast/logging v0.0.0-20250404134358-92b15d2fbd2e h1:qGVGDR2/bXLyR498un1hvhDQPUJ/m14JBRTJz+c67Bc=
 github.com/streamingfast/logging v0.0.0-20250404134358-92b15d2fbd2e/go.mod h1:VlduQ80JcGJSargkRU4Sg9Xo63wZD/l8A5NC/Uo1/uU=
@@ -106,8 +106,6 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/test-go/testify v1.1.4 h1:Tf9lntrKUMHiXQ07qBScBTSA0dhYQlu83hswqelv1iE=
 github.com/test-go/testify v1.1.4/go.mod h1:rH7cfJo/47vWGdi4GPj16x3/t1xGOj2YxzmNQzk2ghU=
-github.com/tyler-smith/go-bip39 v1.1.0 h1:5eUemwrMargf3BSLRRCalXT93Ns6pQJIjYQN2nyfOP8=
-github.com/tyler-smith/go-bip39 v1.1.0/go.mod h1:gUYDtqQw1JS3ZJ8UWVcGTGqqr6YIN3CWg+kkNaLt55U=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 go.mongodb.org/mongo-driver/v2 v2.5.0 h1:yXUhImUjjAInNcpTcAlPHiT7bIXhshCTL3jVBkF3xaE=
 go.mongodb.org/mongo-driver/v2 v2.5.0/go.mod h1:yOI9kBsufol30iFsl1slpdq1I0eHPzybRWdyYUs8K/0=
@@ -146,7 +144,6 @@ go.uber.org/zap v1.27.0 h1:aJMhYGrd5QSmlpLMr2MftRKl7t8J8PTZPA732ud/XR8=
 go.uber.org/zap v1.27.0/go.mod h1:GB2qFLM7cTU87MWRP2mPIjqfIDnGu+VIO4V/SdhGo2E=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
-golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20220214200702-86341886e292/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.53.0 h1:QZ4Muo8THX6CizN2vPPd5fBGHyogrdK9fG4wLPFUsto=
 golang.org/x/crypto v0.53.0/go.mod h1:DNLU434OwVakk9PzuwV8w62mAJpRJL3vsgcfp4Qnsio=

--- a/go/signers/gcpkms/integration_test.go
+++ b/go/signers/gcpkms/integration_test.go
@@ -8,7 +8,7 @@ import (
 	"encoding/base64"
 	"testing"
 
-	"github.com/gagliardetto/solana-go"
+	"github.com/solana-foundation/solana-go/v2"
 
 	"github.com/solana-foundation/solana-keychain/go/core/v2"
 	"github.com/solana-foundation/solana-keychain/go/testutils/v2"

--- a/go/signers/gcpkms/signer.go
+++ b/go/signers/gcpkms/signer.go
@@ -5,7 +5,7 @@ import (
 
 	kms "cloud.google.com/go/kms/apiv1"
 	"cloud.google.com/go/kms/apiv1/kmspb"
-	"github.com/gagliardetto/solana-go"
+	"github.com/solana-foundation/solana-go/v2"
 
 	"github.com/solana-foundation/solana-keychain/go/core/v2"
 )

--- a/go/signers/gcpkms/signer_test.go
+++ b/go/signers/gcpkms/signer_test.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 
 	"cloud.google.com/go/kms/apiv1/kmspb"
-	"github.com/gagliardetto/solana-go"
 	gax "github.com/googleapis/gax-go/v2"
+	"github.com/solana-foundation/solana-go/v2"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 

--- a/go/signers/memory/go.mod
+++ b/go/signers/memory/go.mod
@@ -3,7 +3,7 @@ module github.com/solana-foundation/solana-keychain/go/signers/memory/v2
 go 1.25.0
 
 require (
-	github.com/gagliardetto/solana-go v1.20.0
+	github.com/solana-foundation/solana-go/v2 v2.0.0
 	github.com/solana-foundation/solana-keychain/go/core/v2 v2.0.0
 	github.com/solana-foundation/solana-keychain/go/testutils/v2 v2.0.0
 )
@@ -25,7 +25,6 @@ require (
 	github.com/mostynb/zstdpool-freelist v0.0.0-20201229113212-927304c0c3b1 // indirect
 	github.com/oasisprotocol/curve25519-voi v0.0.0-20251114093237-2ab5a27a1729 // indirect
 	github.com/streamingfast/logging v0.0.0-20250404134358-92b15d2fbd2e // indirect
-	github.com/tyler-smith/go-bip39 v1.1.0 // indirect
 	go.mongodb.org/mongo-driver/v2 v2.5.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/ratelimit v0.3.1 // indirect
@@ -40,5 +39,3 @@ require (
 replace github.com/solana-foundation/solana-keychain/go/core/v2 => ../../core
 
 replace github.com/solana-foundation/solana-keychain/go/testutils/v2 => ../../testutils
-
-replace github.com/gagliardetto/solana-go => github.com/sonicfromnewyoke/solana-go v0.0.0-20260817125726-409ee9873f6d

--- a/go/signers/memory/go.sum
+++ b/go/signers/memory/go.sum
@@ -54,8 +54,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/shopspring/decimal v1.3.1 h1:2Usl1nmF/WZucqkFZhnfFYxxxu8LG21F6nPQBE5gKV8=
 github.com/shopspring/decimal v1.3.1/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
-github.com/sonicfromnewyoke/solana-go v0.0.0-20260817125726-409ee9873f6d h1:XJC9J/9f0T2NI7ph/2hKqBAgBt0ZkZ8o8Q3ZyHRd0/w=
-github.com/sonicfromnewyoke/solana-go v0.0.0-20260817125726-409ee9873f6d/go.mod h1:/so9reboW4h/RxdIKOGNKb3ueL9ZHUjladm90RHzFvY=
+github.com/solana-foundation/solana-go/v2 v2.0.0 h1:5ZuwMHhVYcOJgcrytYsrkMAK4X/T33prhAQwP5RiiVA=
+github.com/solana-foundation/solana-go/v2 v2.0.0/go.mod h1:CWL+e1A3YUeqnnmFoWk1TMz2wcT2kymE8Veq9ZTEZEg=
 github.com/streamingfast/logging v0.0.0-20230608130331-f22c91403091/go.mod h1:VlduQ80JcGJSargkRU4Sg9Xo63wZD/l8A5NC/Uo1/uU=
 github.com/streamingfast/logging v0.0.0-20250404134358-92b15d2fbd2e h1:qGVGDR2/bXLyR498un1hvhDQPUJ/m14JBRTJz+c67Bc=
 github.com/streamingfast/logging v0.0.0-20250404134358-92b15d2fbd2e/go.mod h1:VlduQ80JcGJSargkRU4Sg9Xo63wZD/l8A5NC/Uo1/uU=
@@ -66,8 +66,6 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/test-go/testify v1.1.4 h1:Tf9lntrKUMHiXQ07qBScBTSA0dhYQlu83hswqelv1iE=
 github.com/test-go/testify v1.1.4/go.mod h1:rH7cfJo/47vWGdi4GPj16x3/t1xGOj2YxzmNQzk2ghU=
-github.com/tyler-smith/go-bip39 v1.1.0 h1:5eUemwrMargf3BSLRRCalXT93Ns6pQJIjYQN2nyfOP8=
-github.com/tyler-smith/go-bip39 v1.1.0/go.mod h1:gUYDtqQw1JS3ZJ8UWVcGTGqqr6YIN3CWg+kkNaLt55U=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 go.mongodb.org/mongo-driver/v2 v2.5.0 h1:yXUhImUjjAInNcpTcAlPHiT7bIXhshCTL3jVBkF3xaE=
 go.mongodb.org/mongo-driver/v2 v2.5.0/go.mod h1:yOI9kBsufol30iFsl1slpdq1I0eHPzybRWdyYUs8K/0=
@@ -90,7 +88,6 @@ go.uber.org/zap v1.27.0 h1:aJMhYGrd5QSmlpLMr2MftRKl7t8J8PTZPA732ud/XR8=
 go.uber.org/zap v1.27.0/go.mod h1:GB2qFLM7cTU87MWRP2mPIjqfIDnGu+VIO4V/SdhGo2E=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
-golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20220214200702-86341886e292/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.53.0 h1:QZ4Muo8THX6CizN2vPPd5fBGHyogrdK9fG4wLPFUsto=
 golang.org/x/crypto v0.53.0/go.mod h1:DNLU434OwVakk9PzuwV8w62mAJpRJL3vsgcfp4Qnsio=

--- a/go/signers/memory/keypair.go
+++ b/go/signers/memory/keypair.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/gagliardetto/solana-go"
+	"github.com/solana-foundation/solana-go/v2"
 
 	"github.com/solana-foundation/solana-keychain/go/core/v2"
 )

--- a/go/signers/memory/signer.go
+++ b/go/signers/memory/signer.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"crypto/ed25519"
 
-	"github.com/gagliardetto/solana-go"
+	"github.com/solana-foundation/solana-go/v2"
 
 	"github.com/solana-foundation/solana-keychain/go/core/v2"
 )

--- a/go/signers/memory/signer_test.go
+++ b/go/signers/memory/signer_test.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/gagliardetto/solana-go"
+	"github.com/solana-foundation/solana-go/v2"
 
 	"github.com/solana-foundation/solana-keychain/go/core/v2"
 	"github.com/solana-foundation/solana-keychain/go/testutils/v2"

--- a/go/signers/openfort/go.mod
+++ b/go/signers/openfort/go.mod
@@ -3,8 +3,8 @@ module github.com/solana-foundation/solana-keychain/go/signers/openfort/v2
 go 1.25.0
 
 require (
-	github.com/gagliardetto/solana-go v1.20.0
 	github.com/golang-jwt/jwt/v5 v5.3.1
+	github.com/solana-foundation/solana-go/v2 v2.0.0
 	github.com/solana-foundation/solana-keychain/go/core/v2 v2.0.0
 	github.com/solana-foundation/solana-keychain/go/testutils/v2 v2.0.0
 )
@@ -26,7 +26,6 @@ require (
 	github.com/mostynb/zstdpool-freelist v0.0.0-20201229113212-927304c0c3b1 // indirect
 	github.com/oasisprotocol/curve25519-voi v0.0.0-20251114093237-2ab5a27a1729 // indirect
 	github.com/streamingfast/logging v0.0.0-20250404134358-92b15d2fbd2e // indirect
-	github.com/tyler-smith/go-bip39 v1.1.0 // indirect
 	go.mongodb.org/mongo-driver/v2 v2.5.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/ratelimit v0.3.1 // indirect
@@ -41,5 +40,3 @@ require (
 replace github.com/solana-foundation/solana-keychain/go/core/v2 => ../../core
 
 replace github.com/solana-foundation/solana-keychain/go/testutils/v2 => ../../testutils
-
-replace github.com/gagliardetto/solana-go => github.com/sonicfromnewyoke/solana-go v0.0.0-20260817125726-409ee9873f6d

--- a/go/signers/openfort/go.sum
+++ b/go/signers/openfort/go.sum
@@ -56,8 +56,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/shopspring/decimal v1.3.1 h1:2Usl1nmF/WZucqkFZhnfFYxxxu8LG21F6nPQBE5gKV8=
 github.com/shopspring/decimal v1.3.1/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
-github.com/sonicfromnewyoke/solana-go v0.0.0-20260817125726-409ee9873f6d h1:XJC9J/9f0T2NI7ph/2hKqBAgBt0ZkZ8o8Q3ZyHRd0/w=
-github.com/sonicfromnewyoke/solana-go v0.0.0-20260817125726-409ee9873f6d/go.mod h1:/so9reboW4h/RxdIKOGNKb3ueL9ZHUjladm90RHzFvY=
+github.com/solana-foundation/solana-go/v2 v2.0.0 h1:5ZuwMHhVYcOJgcrytYsrkMAK4X/T33prhAQwP5RiiVA=
+github.com/solana-foundation/solana-go/v2 v2.0.0/go.mod h1:CWL+e1A3YUeqnnmFoWk1TMz2wcT2kymE8Veq9ZTEZEg=
 github.com/streamingfast/logging v0.0.0-20230608130331-f22c91403091/go.mod h1:VlduQ80JcGJSargkRU4Sg9Xo63wZD/l8A5NC/Uo1/uU=
 github.com/streamingfast/logging v0.0.0-20250404134358-92b15d2fbd2e h1:qGVGDR2/bXLyR498un1hvhDQPUJ/m14JBRTJz+c67Bc=
 github.com/streamingfast/logging v0.0.0-20250404134358-92b15d2fbd2e/go.mod h1:VlduQ80JcGJSargkRU4Sg9Xo63wZD/l8A5NC/Uo1/uU=
@@ -68,8 +68,6 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/test-go/testify v1.1.4 h1:Tf9lntrKUMHiXQ07qBScBTSA0dhYQlu83hswqelv1iE=
 github.com/test-go/testify v1.1.4/go.mod h1:rH7cfJo/47vWGdi4GPj16x3/t1xGOj2YxzmNQzk2ghU=
-github.com/tyler-smith/go-bip39 v1.1.0 h1:5eUemwrMargf3BSLRRCalXT93Ns6pQJIjYQN2nyfOP8=
-github.com/tyler-smith/go-bip39 v1.1.0/go.mod h1:gUYDtqQw1JS3ZJ8UWVcGTGqqr6YIN3CWg+kkNaLt55U=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 go.mongodb.org/mongo-driver/v2 v2.5.0 h1:yXUhImUjjAInNcpTcAlPHiT7bIXhshCTL3jVBkF3xaE=
 go.mongodb.org/mongo-driver/v2 v2.5.0/go.mod h1:yOI9kBsufol30iFsl1slpdq1I0eHPzybRWdyYUs8K/0=
@@ -92,7 +90,6 @@ go.uber.org/zap v1.27.0 h1:aJMhYGrd5QSmlpLMr2MftRKl7t8J8PTZPA732ud/XR8=
 go.uber.org/zap v1.27.0/go.mod h1:GB2qFLM7cTU87MWRP2mPIjqfIDnGu+VIO4V/SdhGo2E=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
-golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20220214200702-86341886e292/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.53.0 h1:QZ4Muo8THX6CizN2vPPd5fBGHyogrdK9fG4wLPFUsto=
 golang.org/x/crypto v0.53.0/go.mod h1:DNLU434OwVakk9PzuwV8w62mAJpRJL3vsgcfp4Qnsio=

--- a/go/signers/openfort/integration_test.go
+++ b/go/signers/openfort/integration_test.go
@@ -9,7 +9,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/gagliardetto/solana-go"
+	"github.com/solana-foundation/solana-go/v2"
 
 	"github.com/solana-foundation/solana-keychain/go/core/v2"
 	"github.com/solana-foundation/solana-keychain/go/testutils/v2"

--- a/go/signers/openfort/signer.go
+++ b/go/signers/openfort/signer.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"github.com/gagliardetto/solana-go"
+	"github.com/solana-foundation/solana-go/v2"
 
 	"github.com/solana-foundation/solana-keychain/go/core/v2"
 )

--- a/go/signers/openfort/signer.go
+++ b/go/signers/openfort/signer.go
@@ -192,8 +192,7 @@ func (s *Signer) signBytes(ctx context.Context, message []byte) (solana.Signatur
 
 // do executes an Openfort API request and returns the response body of a 2xx
 // response. Transport failures map to CodeHTTPError and non-2xx statuses to
-// CodeRemoteAPIError whose detail carries the status code and the sanitized
-// response body (never rendered by Error()).
+// CodeRemoteAPIError.
 func (s *Signer) do(req *http.Request) ([]byte, error) {
 	status, body, err := core.SendRequest(s.client, req, "openfort")
 	if err != nil {

--- a/go/signers/openfort/signer.go
+++ b/go/signers/openfort/signer.go
@@ -6,7 +6,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"net/http"
-	"strconv"
 
 	"github.com/gagliardetto/solana-go"
 
@@ -193,15 +192,15 @@ func (s *Signer) signBytes(ctx context.Context, message []byte) (solana.Signatur
 
 // do executes an Openfort API request and returns the response body of a 2xx
 // response. Transport failures map to CodeHTTPError and non-2xx statuses to
-// CodeRemoteAPIError with only the status code (the remote body is never
-// included).
+// CodeRemoteAPIError whose detail carries the status code and the sanitized
+// response body (never rendered by Error()).
 func (s *Signer) do(req *http.Request) ([]byte, error) {
 	status, body, err := core.SendRequest(s.client, req, "openfort")
 	if err != nil {
 		return nil, err
 	}
 	if !core.IsSuccess(status) {
-		return nil, core.NewSignerError(core.CodeRemoteAPIError, "openfort API error "+strconv.Itoa(status))
+		return nil, core.NewRemoteAPIError("openfort API error", status, body)
 	}
 	return body, nil
 }

--- a/go/signers/openfort/signer_test.go
+++ b/go/signers/openfort/signer_test.go
@@ -12,8 +12,8 @@ import (
 	"sync/atomic"
 	"testing"
 
-	"github.com/gagliardetto/solana-go"
 	"github.com/golang-jwt/jwt/v5"
+	"github.com/solana-foundation/solana-go/v2"
 
 	"github.com/solana-foundation/solana-keychain/go/core/v2"
 	"github.com/solana-foundation/solana-keychain/go/testutils/v2"

--- a/go/signers/openfort/signer_test.go
+++ b/go/signers/openfort/signer_test.go
@@ -392,6 +392,25 @@ func TestSignUnauthorized(t *testing.T) {
 	}
 }
 
+// A non-2xx body lands sanitized in the (opt-in) detail; Error() stays generic.
+func TestSignErrorBodySanitizedIntoDetail(t *testing.T) {
+	api := newMockAPI(t, testPubkey, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte("policy\x01denied"))
+	})
+	s, err := New(context.Background(), api.config())
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = s.SignMessage(context.Background(), []byte("test"))
+	testutils.AssertCode(t, err, core.CodeRemoteAPIError)
+	testutils.AssertDetailContains(t, err, "openfort API error 403")
+	testutils.AssertDetailContains(t, err, "policy denied")
+	if strings.Contains(err.Error(), "policy") {
+		t.Errorf("Error() must not surface the remote body, got %q", err.Error())
+	}
+}
+
 func TestSignMessageInvalidWalletSecret(t *testing.T) {
 	// The wallet secret is only parsed at signing time, so New succeeds and
 	// SignMessage fails.

--- a/go/signers/openfort/signer_test.go
+++ b/go/signers/openfort/signer_test.go
@@ -392,7 +392,6 @@ func TestSignUnauthorized(t *testing.T) {
 	}
 }
 
-// A non-2xx body lands sanitized in the (opt-in) detail; Error() stays generic.
 func TestSignErrorBodySanitizedIntoDetail(t *testing.T) {
 	api := newMockAPI(t, testPubkey, func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusForbidden)

--- a/go/signers/para/go.mod
+++ b/go/signers/para/go.mod
@@ -3,7 +3,7 @@ module github.com/solana-foundation/solana-keychain/go/signers/para/v2
 go 1.25.0
 
 require (
-	github.com/gagliardetto/solana-go v1.20.0
+	github.com/solana-foundation/solana-go/v2 v2.0.0
 	github.com/solana-foundation/solana-keychain/go/core/v2 v2.0.0
 	github.com/solana-foundation/solana-keychain/go/testutils/v2 v2.0.0
 )
@@ -25,7 +25,6 @@ require (
 	github.com/mostynb/zstdpool-freelist v0.0.0-20201229113212-927304c0c3b1 // indirect
 	github.com/oasisprotocol/curve25519-voi v0.0.0-20251114093237-2ab5a27a1729 // indirect
 	github.com/streamingfast/logging v0.0.0-20250404134358-92b15d2fbd2e // indirect
-	github.com/tyler-smith/go-bip39 v1.1.0 // indirect
 	go.mongodb.org/mongo-driver/v2 v2.5.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/ratelimit v0.3.1 // indirect
@@ -40,5 +39,3 @@ require (
 replace github.com/solana-foundation/solana-keychain/go/core/v2 => ../../core
 
 replace github.com/solana-foundation/solana-keychain/go/testutils/v2 => ../../testutils
-
-replace github.com/gagliardetto/solana-go => github.com/sonicfromnewyoke/solana-go v0.0.0-20260817125726-409ee9873f6d

--- a/go/signers/para/go.sum
+++ b/go/signers/para/go.sum
@@ -54,8 +54,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/shopspring/decimal v1.3.1 h1:2Usl1nmF/WZucqkFZhnfFYxxxu8LG21F6nPQBE5gKV8=
 github.com/shopspring/decimal v1.3.1/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
-github.com/sonicfromnewyoke/solana-go v0.0.0-20260817125726-409ee9873f6d h1:XJC9J/9f0T2NI7ph/2hKqBAgBt0ZkZ8o8Q3ZyHRd0/w=
-github.com/sonicfromnewyoke/solana-go v0.0.0-20260817125726-409ee9873f6d/go.mod h1:/so9reboW4h/RxdIKOGNKb3ueL9ZHUjladm90RHzFvY=
+github.com/solana-foundation/solana-go/v2 v2.0.0 h1:5ZuwMHhVYcOJgcrytYsrkMAK4X/T33prhAQwP5RiiVA=
+github.com/solana-foundation/solana-go/v2 v2.0.0/go.mod h1:CWL+e1A3YUeqnnmFoWk1TMz2wcT2kymE8Veq9ZTEZEg=
 github.com/streamingfast/logging v0.0.0-20230608130331-f22c91403091/go.mod h1:VlduQ80JcGJSargkRU4Sg9Xo63wZD/l8A5NC/Uo1/uU=
 github.com/streamingfast/logging v0.0.0-20250404134358-92b15d2fbd2e h1:qGVGDR2/bXLyR498un1hvhDQPUJ/m14JBRTJz+c67Bc=
 github.com/streamingfast/logging v0.0.0-20250404134358-92b15d2fbd2e/go.mod h1:VlduQ80JcGJSargkRU4Sg9Xo63wZD/l8A5NC/Uo1/uU=
@@ -66,8 +66,6 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/test-go/testify v1.1.4 h1:Tf9lntrKUMHiXQ07qBScBTSA0dhYQlu83hswqelv1iE=
 github.com/test-go/testify v1.1.4/go.mod h1:rH7cfJo/47vWGdi4GPj16x3/t1xGOj2YxzmNQzk2ghU=
-github.com/tyler-smith/go-bip39 v1.1.0 h1:5eUemwrMargf3BSLRRCalXT93Ns6pQJIjYQN2nyfOP8=
-github.com/tyler-smith/go-bip39 v1.1.0/go.mod h1:gUYDtqQw1JS3ZJ8UWVcGTGqqr6YIN3CWg+kkNaLt55U=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 go.mongodb.org/mongo-driver/v2 v2.5.0 h1:yXUhImUjjAInNcpTcAlPHiT7bIXhshCTL3jVBkF3xaE=
 go.mongodb.org/mongo-driver/v2 v2.5.0/go.mod h1:yOI9kBsufol30iFsl1slpdq1I0eHPzybRWdyYUs8K/0=
@@ -90,7 +88,6 @@ go.uber.org/zap v1.27.0 h1:aJMhYGrd5QSmlpLMr2MftRKl7t8J8PTZPA732ud/XR8=
 go.uber.org/zap v1.27.0/go.mod h1:GB2qFLM7cTU87MWRP2mPIjqfIDnGu+VIO4V/SdhGo2E=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
-golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20220214200702-86341886e292/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.53.0 h1:QZ4Muo8THX6CizN2vPPd5fBGHyogrdK9fG4wLPFUsto=
 golang.org/x/crypto v0.53.0/go.mod h1:DNLU434OwVakk9PzuwV8w62mAJpRJL3vsgcfp4Qnsio=

--- a/go/signers/para/integration_test.go
+++ b/go/signers/para/integration_test.go
@@ -9,7 +9,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/gagliardetto/solana-go"
+	"github.com/solana-foundation/solana-go/v2"
 
 	"github.com/solana-foundation/solana-keychain/go/core/v2"
 	"github.com/solana-foundation/solana-keychain/go/testutils/v2"

--- a/go/signers/para/signer.go
+++ b/go/signers/para/signer.go
@@ -9,7 +9,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/gagliardetto/solana-go"
+	"github.com/solana-foundation/solana-go/v2"
 
 	"github.com/solana-foundation/solana-keychain/go/core/v2"
 )

--- a/go/signers/para/signer.go
+++ b/go/signers/para/signer.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
-	"strconv"
 	"strings"
 
 	"github.com/gagliardetto/solana-go"
@@ -171,8 +170,9 @@ func (s *Signer) signBytes(ctx context.Context, data []byte) (solana.Signature, 
 }
 
 // doRequest performs an authenticated Para API request and returns the raw
-// response body. Non-2xx responses map to CodeRemoteAPIError carrying only the
-// status code; the remote response body is deliberately never surfaced.
+// response body. Non-2xx responses map to CodeRemoteAPIError whose detail
+// carries the status code and the sanitized response body (never rendered by
+// Error()).
 func (s *Signer) doRequest(ctx context.Context, method, url string, requestBody any) ([]byte, error) {
 	var reader io.Reader
 	if requestBody != nil {
@@ -195,7 +195,7 @@ func (s *Signer) doRequest(ctx context.Context, method, url string, requestBody 
 		return nil, err
 	}
 	if !core.IsSuccess(status) {
-		return nil, core.NewSignerError(core.CodeRemoteAPIError, "API error "+strconv.Itoa(status))
+		return nil, core.NewRemoteAPIError("API error", status, body)
 	}
 	return body, nil
 }

--- a/go/signers/para/signer.go
+++ b/go/signers/para/signer.go
@@ -170,9 +170,7 @@ func (s *Signer) signBytes(ctx context.Context, data []byte) (solana.Signature, 
 }
 
 // doRequest performs an authenticated Para API request and returns the raw
-// response body. Non-2xx responses map to CodeRemoteAPIError whose detail
-// carries the status code and the sanitized response body (never rendered by
-// Error()).
+// response body. Non-2xx responses map to CodeRemoteAPIError.
 func (s *Signer) doRequest(ctx context.Context, method, url string, requestBody any) ([]byte, error) {
 	var reader io.Reader
 	if requestBody != nil {

--- a/go/signers/para/signer_test.go
+++ b/go/signers/para/signer_test.go
@@ -478,8 +478,9 @@ func TestSignMessageVerificationFailure(t *testing.T) {
 	testutils.AssertCode(t, err, core.CodeSigningFailed)
 }
 
-func TestSignMessageErrorStatusCodeOnly(t *testing.T) {
-	// Error output must stay generic and never include API response text.
+func TestSignMessageErrorBodySanitizedIntoDetail(t *testing.T) {
+	// Error() output must stay generic; the sanitized API response text lands
+	// in the (opt-in) detail only.
 	pub, _, _ := signFixture(t)
 	srv := testutils.StartTLSServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutils.WriteJSON(w, http.StatusForbidden, map[string]any{"message": "Wallet is locked"})
@@ -496,11 +497,11 @@ func TestSignMessageErrorStatusCodeOnly(t *testing.T) {
 	if !errors.As(err, &se) {
 		t.Fatalf("expected *core.SignerError, got %T", err)
 	}
-	if se.Detail() != "API error 403" {
-		t.Errorf("expected detail to carry only the status code, got %q", se.Detail())
+	if !strings.Contains(se.Detail(), "API error 403") {
+		t.Errorf("expected detail to carry the status code, got %q", se.Detail())
 	}
-	if strings.Contains(se.Detail(), "Wallet is locked") {
-		t.Error("detail must not contain the remote response body")
+	if !strings.Contains(se.Detail(), "Wallet is locked") {
+		t.Errorf("expected detail to carry the sanitized response body, got %q", se.Detail())
 	}
 }
 

--- a/go/signers/para/signer_test.go
+++ b/go/signers/para/signer_test.go
@@ -15,7 +15,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gagliardetto/solana-go"
+	"github.com/solana-foundation/solana-go/v2"
 
 	"github.com/solana-foundation/solana-keychain/go/core/v2"
 	"github.com/solana-foundation/solana-keychain/go/testutils/v2"

--- a/go/signers/para/signer_test.go
+++ b/go/signers/para/signer_test.go
@@ -479,8 +479,6 @@ func TestSignMessageVerificationFailure(t *testing.T) {
 }
 
 func TestSignMessageErrorBodySanitizedIntoDetail(t *testing.T) {
-	// Error() output must stay generic; the sanitized API response text lands
-	// in the (opt-in) detail only.
 	pub, _, _ := signFixture(t)
 	srv := testutils.StartTLSServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutils.WriteJSON(w, http.StatusForbidden, map[string]any{"message": "Wallet is locked"})

--- a/go/signers/privy/go.mod
+++ b/go/signers/privy/go.mod
@@ -3,7 +3,7 @@ module github.com/solana-foundation/solana-keychain/go/signers/privy/v2
 go 1.25.0
 
 require (
-	github.com/gagliardetto/solana-go v1.20.0
+	github.com/solana-foundation/solana-go/v2 v2.0.0
 	github.com/solana-foundation/solana-keychain/go/core/v2 v2.0.0
 	github.com/solana-foundation/solana-keychain/go/testutils/v2 v2.0.0
 )
@@ -25,7 +25,6 @@ require (
 	github.com/mostynb/zstdpool-freelist v0.0.0-20201229113212-927304c0c3b1 // indirect
 	github.com/oasisprotocol/curve25519-voi v0.0.0-20251114093237-2ab5a27a1729 // indirect
 	github.com/streamingfast/logging v0.0.0-20250404134358-92b15d2fbd2e // indirect
-	github.com/tyler-smith/go-bip39 v1.1.0 // indirect
 	go.mongodb.org/mongo-driver/v2 v2.5.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/ratelimit v0.3.1 // indirect
@@ -40,5 +39,3 @@ require (
 replace github.com/solana-foundation/solana-keychain/go/core/v2 => ../../core
 
 replace github.com/solana-foundation/solana-keychain/go/testutils/v2 => ../../testutils
-
-replace github.com/gagliardetto/solana-go => github.com/sonicfromnewyoke/solana-go v0.0.0-20260817125726-409ee9873f6d

--- a/go/signers/privy/go.sum
+++ b/go/signers/privy/go.sum
@@ -54,8 +54,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/shopspring/decimal v1.3.1 h1:2Usl1nmF/WZucqkFZhnfFYxxxu8LG21F6nPQBE5gKV8=
 github.com/shopspring/decimal v1.3.1/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
-github.com/sonicfromnewyoke/solana-go v0.0.0-20260817125726-409ee9873f6d h1:XJC9J/9f0T2NI7ph/2hKqBAgBt0ZkZ8o8Q3ZyHRd0/w=
-github.com/sonicfromnewyoke/solana-go v0.0.0-20260817125726-409ee9873f6d/go.mod h1:/so9reboW4h/RxdIKOGNKb3ueL9ZHUjladm90RHzFvY=
+github.com/solana-foundation/solana-go/v2 v2.0.0 h1:5ZuwMHhVYcOJgcrytYsrkMAK4X/T33prhAQwP5RiiVA=
+github.com/solana-foundation/solana-go/v2 v2.0.0/go.mod h1:CWL+e1A3YUeqnnmFoWk1TMz2wcT2kymE8Veq9ZTEZEg=
 github.com/streamingfast/logging v0.0.0-20230608130331-f22c91403091/go.mod h1:VlduQ80JcGJSargkRU4Sg9Xo63wZD/l8A5NC/Uo1/uU=
 github.com/streamingfast/logging v0.0.0-20250404134358-92b15d2fbd2e h1:qGVGDR2/bXLyR498un1hvhDQPUJ/m14JBRTJz+c67Bc=
 github.com/streamingfast/logging v0.0.0-20250404134358-92b15d2fbd2e/go.mod h1:VlduQ80JcGJSargkRU4Sg9Xo63wZD/l8A5NC/Uo1/uU=
@@ -66,8 +66,6 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/test-go/testify v1.1.4 h1:Tf9lntrKUMHiXQ07qBScBTSA0dhYQlu83hswqelv1iE=
 github.com/test-go/testify v1.1.4/go.mod h1:rH7cfJo/47vWGdi4GPj16x3/t1xGOj2YxzmNQzk2ghU=
-github.com/tyler-smith/go-bip39 v1.1.0 h1:5eUemwrMargf3BSLRRCalXT93Ns6pQJIjYQN2nyfOP8=
-github.com/tyler-smith/go-bip39 v1.1.0/go.mod h1:gUYDtqQw1JS3ZJ8UWVcGTGqqr6YIN3CWg+kkNaLt55U=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 go.mongodb.org/mongo-driver/v2 v2.5.0 h1:yXUhImUjjAInNcpTcAlPHiT7bIXhshCTL3jVBkF3xaE=
 go.mongodb.org/mongo-driver/v2 v2.5.0/go.mod h1:yOI9kBsufol30iFsl1slpdq1I0eHPzybRWdyYUs8K/0=
@@ -90,7 +88,6 @@ go.uber.org/zap v1.27.0 h1:aJMhYGrd5QSmlpLMr2MftRKl7t8J8PTZPA732ud/XR8=
 go.uber.org/zap v1.27.0/go.mod h1:GB2qFLM7cTU87MWRP2mPIjqfIDnGu+VIO4V/SdhGo2E=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
-golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20220214200702-86341886e292/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.53.0 h1:QZ4Muo8THX6CizN2vPPd5fBGHyogrdK9fG4wLPFUsto=
 golang.org/x/crypto v0.53.0/go.mod h1:DNLU434OwVakk9PzuwV8w62mAJpRJL3vsgcfp4Qnsio=

--- a/go/signers/privy/integration_test.go
+++ b/go/signers/privy/integration_test.go
@@ -9,7 +9,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/gagliardetto/solana-go"
+	"github.com/solana-foundation/solana-go/v2"
 
 	"github.com/solana-foundation/solana-keychain/go/core/v2"
 	"github.com/solana-foundation/solana-keychain/go/testutils/v2"

--- a/go/signers/privy/signer.go
+++ b/go/signers/privy/signer.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"github.com/gagliardetto/solana-go"
+	"github.com/solana-foundation/solana-go/v2"
 
 	"github.com/solana-foundation/solana-keychain/go/core/v2"
 )

--- a/go/signers/privy/signer.go
+++ b/go/signers/privy/signer.go
@@ -6,7 +6,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"net/http"
-	"strconv"
 
 	"github.com/gagliardetto/solana-go"
 
@@ -110,22 +109,8 @@ func (s *Signer) SignTransaction(ctx context.Context, tx *solana.Transaction) (c
 		return core.SignedTransaction{}, core.NewSignerError(core.CodeSerializationError,
 			"failed to decode signed transaction returned by privy")
 	}
-	returned, err := solana.TransactionFromBytes(signedWire)
+	sig, err := core.ExtractAndVerifyReturnedSignature(signedWire, s.pubkey, msg, "privy")
 	if err != nil {
-		return core.SignedTransaction{}, core.WrapSignerError(core.CodeSerializationError,
-			"failed to deserialize signed transaction returned by privy", err)
-	}
-
-	position, err := core.SigningPosition(returned, s.pubkey)
-	if err != nil {
-		return core.SignedTransaction{}, err
-	}
-	if position >= len(returned.Signatures) {
-		return core.SignedTransaction{}, core.NewSignerError(core.CodeSigningFailed,
-			"privy signature slot missing from returned transaction")
-	}
-	sig := returned.Signatures[position]
-	if err := core.VerifySignature(s.pubkey, msg, sig); err != nil {
 		return core.SignedTransaction{}, err
 	}
 
@@ -245,17 +230,15 @@ func (s *Signer) signBytes(ctx context.Context, message []byte) (solana.Signatur
 
 // do executes the request and returns the response body, mapping transport
 // failures to CodeHTTPError and non-2xx statuses to CodeRemoteAPIError whose
-// detail carries only the status code ("API error {status}").
+// detail carries the status code and the sanitized response body (never
+// rendered by Error()).
 func (s *Signer) do(req *http.Request, what string) ([]byte, error) {
 	status, body, err := core.SendRequest(s.client, req, "privy")
 	if err != nil {
 		return nil, err
 	}
 	if !core.IsSuccess(status) {
-		// Only the status code goes into the detail; the response body is
-		// deliberately discarded since it may echo request material.
-		return nil, core.NewSignerError(core.CodeRemoteAPIError,
-			what+" failed: API error "+strconv.Itoa(status))
+		return nil, core.NewRemoteAPIError(what+" failed: API error", status, body)
 	}
 	return body, nil
 }

--- a/go/signers/privy/signer.go
+++ b/go/signers/privy/signer.go
@@ -229,9 +229,7 @@ func (s *Signer) signBytes(ctx context.Context, message []byte) (solana.Signatur
 }
 
 // do executes the request and returns the response body, mapping transport
-// failures to CodeHTTPError and non-2xx statuses to CodeRemoteAPIError whose
-// detail carries the status code and the sanitized response body (never
-// rendered by Error()).
+// failures to CodeHTTPError and non-2xx statuses to CodeRemoteAPIError.
 func (s *Signer) do(req *http.Request, what string) ([]byte, error) {
 	status, body, err := core.SendRequest(s.client, req, "privy")
 	if err != nil {

--- a/go/signers/privy/signer_test.go
+++ b/go/signers/privy/signer_test.go
@@ -601,9 +601,9 @@ func TestSignMessageUnauthorized(t *testing.T) {
 	testutils.AssertCode(t, err, core.CodeRemoteAPIError)
 }
 
-// TestSignMessageRemoteErrorBodyDiscarded checks that non-2xx response bodies
-// never reach the error detail: only the status code does.
-func TestSignMessageRemoteErrorBodyDiscarded(t *testing.T) {
+// TestSignMessageRemoteErrorBodySanitized checks that non-2xx response bodies
+// reach the (opt-in) error detail sanitized, while Error() stays generic.
+func TestSignMessageRemoteErrorBodySanitized(t *testing.T) {
 	mux := http.NewServeMux()
 	addWalletRoute(t, mux, testutils.TestPublicKey().String())
 	mux.HandleFunc("POST "+rpcPath, func(w http.ResponseWriter, _ *http.Request) {
@@ -614,15 +614,16 @@ func TestSignMessageRemoteErrorBodyDiscarded(t *testing.T) {
 	s := newTestSigner(t, mux)
 	_, err := s.SignMessage(context.Background(), []byte("test"))
 	testutils.AssertCode(t, err, core.CodeRemoteAPIError)
+	if strings.Contains(err.Error(), "thing") {
+		t.Errorf("Error() must not surface the remote body, got %q", err.Error())
+	}
 
 	detail := testutils.Detail(t, err)
 	if !strings.Contains(detail, "API error 500") {
 		t.Errorf("detail %q should mention the status", detail)
 	}
-	// The response body is deliberately discarded on non-2xx; only the status
-	// code may appear in the detail.
-	if strings.Contains(detail, "bad thing") {
-		t.Errorf("detail %q should not embed the remote response body", detail)
+	if !strings.Contains(detail, "bad thing with [31mcontrol chars") {
+		t.Errorf("detail %q should embed the sanitized remote response body", detail)
 	}
 	for _, r := range detail {
 		if r < 0x20 || r == 0x7f {

--- a/go/signers/privy/signer_test.go
+++ b/go/signers/privy/signer_test.go
@@ -601,8 +601,6 @@ func TestSignMessageUnauthorized(t *testing.T) {
 	testutils.AssertCode(t, err, core.CodeRemoteAPIError)
 }
 
-// TestSignMessageRemoteErrorBodySanitized checks that non-2xx response bodies
-// reach the (opt-in) error detail sanitized, while Error() stays generic.
 func TestSignMessageRemoteErrorBodySanitized(t *testing.T) {
 	mux := http.NewServeMux()
 	addWalletRoute(t, mux, testutils.TestPublicKey().String())

--- a/go/signers/privy/signer_test.go
+++ b/go/signers/privy/signer_test.go
@@ -16,7 +16,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gagliardetto/solana-go"
+	"github.com/solana-foundation/solana-go/v2"
 
 	"github.com/solana-foundation/solana-keychain/go/core/v2"
 	"github.com/solana-foundation/solana-keychain/go/testutils/v2"

--- a/go/signers/turnkey/go.mod
+++ b/go/signers/turnkey/go.mod
@@ -3,7 +3,7 @@ module github.com/solana-foundation/solana-keychain/go/signers/turnkey/v2
 go 1.25.0
 
 require (
-	github.com/gagliardetto/solana-go v1.20.0
+	github.com/solana-foundation/solana-go/v2 v2.0.0
 	github.com/solana-foundation/solana-keychain/go/core/v2 v2.0.0
 	github.com/solana-foundation/solana-keychain/go/testutils/v2 v2.0.0
 )
@@ -25,7 +25,6 @@ require (
 	github.com/mostynb/zstdpool-freelist v0.0.0-20201229113212-927304c0c3b1 // indirect
 	github.com/oasisprotocol/curve25519-voi v0.0.0-20251114093237-2ab5a27a1729 // indirect
 	github.com/streamingfast/logging v0.0.0-20250404134358-92b15d2fbd2e // indirect
-	github.com/tyler-smith/go-bip39 v1.1.0 // indirect
 	go.mongodb.org/mongo-driver/v2 v2.5.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/ratelimit v0.3.1 // indirect
@@ -40,5 +39,3 @@ require (
 replace github.com/solana-foundation/solana-keychain/go/core/v2 => ../../core
 
 replace github.com/solana-foundation/solana-keychain/go/testutils/v2 => ../../testutils
-
-replace github.com/gagliardetto/solana-go => github.com/sonicfromnewyoke/solana-go v0.0.0-20260817125726-409ee9873f6d

--- a/go/signers/turnkey/go.sum
+++ b/go/signers/turnkey/go.sum
@@ -54,8 +54,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/shopspring/decimal v1.3.1 h1:2Usl1nmF/WZucqkFZhnfFYxxxu8LG21F6nPQBE5gKV8=
 github.com/shopspring/decimal v1.3.1/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
-github.com/sonicfromnewyoke/solana-go v0.0.0-20260817125726-409ee9873f6d h1:XJC9J/9f0T2NI7ph/2hKqBAgBt0ZkZ8o8Q3ZyHRd0/w=
-github.com/sonicfromnewyoke/solana-go v0.0.0-20260817125726-409ee9873f6d/go.mod h1:/so9reboW4h/RxdIKOGNKb3ueL9ZHUjladm90RHzFvY=
+github.com/solana-foundation/solana-go/v2 v2.0.0 h1:5ZuwMHhVYcOJgcrytYsrkMAK4X/T33prhAQwP5RiiVA=
+github.com/solana-foundation/solana-go/v2 v2.0.0/go.mod h1:CWL+e1A3YUeqnnmFoWk1TMz2wcT2kymE8Veq9ZTEZEg=
 github.com/streamingfast/logging v0.0.0-20230608130331-f22c91403091/go.mod h1:VlduQ80JcGJSargkRU4Sg9Xo63wZD/l8A5NC/Uo1/uU=
 github.com/streamingfast/logging v0.0.0-20250404134358-92b15d2fbd2e h1:qGVGDR2/bXLyR498un1hvhDQPUJ/m14JBRTJz+c67Bc=
 github.com/streamingfast/logging v0.0.0-20250404134358-92b15d2fbd2e/go.mod h1:VlduQ80JcGJSargkRU4Sg9Xo63wZD/l8A5NC/Uo1/uU=
@@ -66,8 +66,6 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/test-go/testify v1.1.4 h1:Tf9lntrKUMHiXQ07qBScBTSA0dhYQlu83hswqelv1iE=
 github.com/test-go/testify v1.1.4/go.mod h1:rH7cfJo/47vWGdi4GPj16x3/t1xGOj2YxzmNQzk2ghU=
-github.com/tyler-smith/go-bip39 v1.1.0 h1:5eUemwrMargf3BSLRRCalXT93Ns6pQJIjYQN2nyfOP8=
-github.com/tyler-smith/go-bip39 v1.1.0/go.mod h1:gUYDtqQw1JS3ZJ8UWVcGTGqqr6YIN3CWg+kkNaLt55U=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 go.mongodb.org/mongo-driver/v2 v2.5.0 h1:yXUhImUjjAInNcpTcAlPHiT7bIXhshCTL3jVBkF3xaE=
 go.mongodb.org/mongo-driver/v2 v2.5.0/go.mod h1:yOI9kBsufol30iFsl1slpdq1I0eHPzybRWdyYUs8K/0=
@@ -90,7 +88,6 @@ go.uber.org/zap v1.27.0 h1:aJMhYGrd5QSmlpLMr2MftRKl7t8J8PTZPA732ud/XR8=
 go.uber.org/zap v1.27.0/go.mod h1:GB2qFLM7cTU87MWRP2mPIjqfIDnGu+VIO4V/SdhGo2E=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
-golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20220214200702-86341886e292/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.53.0 h1:QZ4Muo8THX6CizN2vPPd5fBGHyogrdK9fG4wLPFUsto=
 golang.org/x/crypto v0.53.0/go.mod h1:DNLU434OwVakk9PzuwV8w62mAJpRJL3vsgcfp4Qnsio=

--- a/go/signers/turnkey/integration_test.go
+++ b/go/signers/turnkey/integration_test.go
@@ -8,7 +8,7 @@ import (
 	"encoding/base64"
 	"testing"
 
-	"github.com/gagliardetto/solana-go"
+	"github.com/solana-foundation/solana-go/v2"
 
 	"github.com/solana-foundation/solana-keychain/go/core/v2"
 	"github.com/solana-foundation/solana-keychain/go/testutils/v2"

--- a/go/signers/turnkey/signer.go
+++ b/go/signers/turnkey/signer.go
@@ -216,8 +216,7 @@ func assembleSignature(rHex, sHex string) (solana.Signature, error) {
 }
 
 // post sends a stamped JSON POST to the Turnkey API and returns the response
-// body on 2xx. Non-2xx responses map to RemoteApiError whose detail carries
-// the status code and the sanitized response body (never rendered by Error()).
+// body on 2xx. Non-2xx responses map to RemoteApiError.
 func (s *Signer) post(ctx context.Context, path string, body []byte) ([]byte, error) {
 	stamp, err := s.createStamp(string(body))
 	if err != nil {

--- a/go/signers/turnkey/signer.go
+++ b/go/signers/turnkey/signer.go
@@ -9,7 +9,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/gagliardetto/solana-go"
+	"github.com/solana-foundation/solana-go/v2"
 
 	"github.com/solana-foundation/solana-keychain/go/core/v2"
 )

--- a/go/signers/turnkey/signer.go
+++ b/go/signers/turnkey/signer.go
@@ -38,10 +38,15 @@ type Signer struct {
 var _ core.Signer = (*Signer)(nil)
 
 // New builds a Turnkey signer from cfg. Construction is pure: no network I/O.
+// The configured P-256 API-key material is validated here so a malformed key
+// fails at construction rather than on the first signing request.
 func New(cfg Config) (*Signer, error) {
 	pubkey, err := solana.PublicKeyFromBase58(cfg.PublicKey)
 	if err != nil {
 		return nil, core.WrapSignerError(core.CodeInvalidPublicKey, "invalid public key", err)
+	}
+	if err := validateAPIKeyMaterial(cfg.APIPrivateKey, cfg.APIPublicKey); err != nil {
+		return nil, err
 	}
 	client := core.ResolveHTTPClient(cfg.HTTPClient, cfg.HTTPClientConfig)
 	baseURL, err := core.NormalizeHTTPSBaseURL(cfg.APIBaseURL, DefaultAPIBaseURL, "api_base_url")
@@ -117,22 +122,8 @@ func (s *Signer) SignTransaction(ctx context.Context, tx *solana.Transaction) (c
 		return core.SignedTransaction{}, core.WrapSignerError(core.CodeSerializationError,
 			"failed to decode signed transaction returned by Turnkey", err)
 	}
-	returned, err := solana.TransactionFromBytes(signedWire)
+	sig, err := core.ExtractAndVerifyReturnedSignature(signedWire, s.publicKey, msg, "Turnkey")
 	if err != nil {
-		return core.SignedTransaction{}, core.WrapSignerError(core.CodeSerializationError,
-			"failed to deserialize signed transaction returned by Turnkey", err)
-	}
-
-	position, err := core.SigningPosition(returned, s.publicKey)
-	if err != nil {
-		return core.SignedTransaction{}, err
-	}
-	if position >= len(returned.Signatures) {
-		return core.SignedTransaction{}, core.NewSignerError(core.CodeSigningFailed,
-			"Turnkey signature slot missing from returned transaction")
-	}
-	sig := returned.Signatures[position]
-	if err := core.VerifySignature(s.publicKey, msg, sig); err != nil {
 		return core.SignedTransaction{}, err
 	}
 
@@ -225,9 +216,8 @@ func assembleSignature(rHex, sHex string) (solana.Signature, error) {
 }
 
 // post sends a stamped JSON POST to the Turnkey API and returns the response
-// body on 2xx. Non-2xx responses map to RemoteApiError carrying only the
-// status code; the response body is deliberately never surfaced (it may echo
-// request material).
+// body on 2xx. Non-2xx responses map to RemoteApiError whose detail carries
+// the status code and the sanitized response body (never rendered by Error()).
 func (s *Signer) post(ctx context.Context, path string, body []byte) ([]byte, error) {
 	stamp, err := s.createStamp(string(body))
 	if err != nil {
@@ -245,7 +235,7 @@ func (s *Signer) post(ctx context.Context, path string, body []byte) ([]byte, er
 		return nil, err
 	}
 	if !core.IsSuccess(status) {
-		return nil, core.NewSignerError(core.CodeRemoteAPIError, "API error "+strconv.Itoa(status))
+		return nil, core.NewRemoteAPIError("API error", status, respBody)
 	}
 	return respBody, nil
 }

--- a/go/signers/turnkey/signer_test.go
+++ b/go/signers/turnkey/signer_test.go
@@ -316,8 +316,6 @@ func TestSignUnauthorized(t *testing.T) {
 	if !errors.As(err, &se) {
 		t.Fatalf("expected *core.SignerError, got %T", err)
 	}
-	// The sanitized response body lands in the (opt-in) detail only; Error()
-	// stays generic.
 	if !strings.Contains(se.Detail(), "API error 401") || !strings.Contains(se.Detail(), "Unauthorized") {
 		t.Errorf("detail = %q, want the status code and the sanitized body", se.Detail())
 	}
@@ -618,8 +616,6 @@ func TestCreateStamp(t *testing.T) {
 	}
 }
 
-// TestNewValidatesAPIKeyMaterial checks that malformed P-256 API-key material
-// is rejected at construction time with CONFIG_ERROR, before any request.
 func TestNewValidatesAPIKeyMaterial(t *testing.T) {
 	cases := map[string]func(cfg *Config){
 		"private key not hex": func(cfg *Config) { cfg.APIPrivateKey = "zz-not-hex" },

--- a/go/signers/turnkey/signer_test.go
+++ b/go/signers/turnkey/signer_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 // newTestAPIKeys generates a P-256 API key pair: hex private scalar and hex
-// uncompressed public point.
+// compressed public point (the format Turnkey issues).
 func newTestAPIKeys(t *testing.T) (pubHex, privHex string, key *ecdsa.PrivateKey) {
 	t.Helper()
 	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
@@ -34,11 +34,7 @@ func newTestAPIKeys(t *testing.T) (pubHex, privHex string, key *ecdsa.PrivateKey
 		t.Fatal(err)
 	}
 	privHex = hex.EncodeToString(key.D.FillBytes(make([]byte, 32)))
-	ecdhPub, err := key.PublicKey.ECDH()
-	if err != nil {
-		t.Fatal(err)
-	}
-	pubHex = hex.EncodeToString(ecdhPub.Bytes())
+	pubHex = hex.EncodeToString(elliptic.MarshalCompressed(elliptic.P256(), key.X, key.Y))
 	return pubHex, privHex, key
 }
 
@@ -315,6 +311,18 @@ func TestSignUnauthorized(t *testing.T) {
 	}
 	if code, _ := core.CodeOf(err); code != core.CodeRemoteAPIError {
 		t.Errorf("got %s, want REMOTE_API_ERROR", code)
+	}
+	var se *core.SignerError
+	if !errors.As(err, &se) {
+		t.Fatalf("expected *core.SignerError, got %T", err)
+	}
+	// The sanitized response body lands in the (opt-in) detail only; Error()
+	// stays generic.
+	if !strings.Contains(se.Detail(), "API error 401") || !strings.Contains(se.Detail(), "Unauthorized") {
+		t.Errorf("detail = %q, want the status code and the sanitized body", se.Detail())
+	}
+	if strings.Contains(err.Error(), "Unauthorized") {
+		t.Errorf("Error() must not surface the remote body, got %q", err.Error())
 	}
 	if calls != 1 {
 		t.Errorf("sign endpoint called %d times, want 1", calls)
@@ -610,28 +618,64 @@ func TestCreateStamp(t *testing.T) {
 	}
 }
 
-func TestCreateStampInvalidPrivateKey(t *testing.T) {
-	cases := map[string]string{
-		"not hex":      "zz-not-hex",
-		"wrong length": hex.EncodeToString(bytes.Repeat([]byte{1}, 16)),
-		"zero scalar":  hex.EncodeToString(make([]byte, 32)),
-	}
-	for name, privHex := range cases {
-		t.Run(name, func(t *testing.T) {
-			cfg := testConfig(t, testutils.TestPublicKey().String(), nil)
-			cfg.APIPrivateKey = privHex
-			s, err := New(cfg)
+// TestNewValidatesAPIKeyMaterial checks that malformed P-256 API-key material
+// is rejected at construction time with CONFIG_ERROR, before any request.
+func TestNewValidatesAPIKeyMaterial(t *testing.T) {
+	cases := map[string]func(cfg *Config){
+		"private key not hex": func(cfg *Config) { cfg.APIPrivateKey = "zz-not-hex" },
+		"private key wrong length": func(cfg *Config) {
+			cfg.APIPrivateKey = hex.EncodeToString(bytes.Repeat([]byte{1}, 16))
+		},
+		"public key not hex": func(cfg *Config) { cfg.APIPublicKey = "zz-not-hex" },
+		"public key wrong length": func(cfg *Config) {
+			// Uncompressed (65-byte) points are rejected: Turnkey issues
+			// compressed 33-byte public keys.
+			key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 			if err != nil {
 				t.Fatal(err)
 			}
-			_, err = s.createStamp("test")
-			if err == nil {
-				t.Fatal("expected error for invalid api private key")
+			ecdhPub, err := key.PublicKey.ECDH()
+			if err != nil {
+				t.Fatal(err)
 			}
-			if code, _ := core.CodeOf(err); code != core.CodeInvalidPrivateKey {
-				t.Errorf("got %s, want INVALID_PRIVATE_KEY", code)
+			cfg.APIPublicKey = hex.EncodeToString(ecdhPub.Bytes())
+		},
+		"public key not on curve": func(cfg *Config) {
+			// 0x02 prefix with x = 2^256-1 (> the P-256 field prime) can never
+			// decompress to a curve point.
+			cfg.APIPublicKey = hex.EncodeToString(append([]byte{0x02}, bytes.Repeat([]byte{0xff}, 32)...))
+		},
+	}
+	for name, mutate := range cases {
+		t.Run(name, func(t *testing.T) {
+			cfg := testConfig(t, testutils.TestPublicKey().String(), nil)
+			mutate(&cfg)
+			_, err := New(cfg)
+			if err == nil {
+				t.Fatal("expected New to reject invalid api key material")
+			}
+			if code, _ := core.CodeOf(err); code != core.CodeConfigError {
+				t.Errorf("got %s, want CONFIG_ERROR", code)
 			}
 		})
+	}
+}
+
+// A zero scalar is valid hex of the right length (so it passes construction,
+// mirroring the other language SDKs) but must still fail at stamp time.
+func TestCreateStampInvalidPrivateKey(t *testing.T) {
+	cfg := testConfig(t, testutils.TestPublicKey().String(), nil)
+	cfg.APIPrivateKey = hex.EncodeToString(make([]byte, 32))
+	s, err := New(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = s.createStamp("test")
+	if err == nil {
+		t.Fatal("expected error for invalid api private key")
+	}
+	if code, _ := core.CodeOf(err); code != core.CodeInvalidPrivateKey {
+		t.Errorf("got %s, want INVALID_PRIVATE_KEY", code)
 	}
 }
 

--- a/go/signers/turnkey/signer_test.go
+++ b/go/signers/turnkey/signer_test.go
@@ -19,7 +19,7 @@ import (
 	"sync/atomic"
 	"testing"
 
-	"github.com/gagliardetto/solana-go"
+	"github.com/solana-foundation/solana-go/v2"
 
 	"github.com/solana-foundation/solana-keychain/go/core/v2"
 	"github.com/solana-foundation/solana-keychain/go/testutils/v2"

--- a/go/signers/turnkey/stamp.go
+++ b/go/signers/turnkey/stamp.go
@@ -10,12 +10,48 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"math/big"
+	"strconv"
 
 	"github.com/solana-foundation/solana-keychain/go/core/v2"
 )
 
 // stampScheme is the signature scheme Turnkey expects for API-key stamps.
 const stampScheme = "SIGNATURE_SCHEME_TK_API_P256"
+
+// P-256 API-key material lengths (hex-decoded).
+const (
+	p256PrivateKeyLength          = 32
+	p256CompressedPublicKeyLength = 33
+)
+
+// validateAPIKeyMaterial rejects malformed Turnkey API-key material at
+// construction time instead of at stamp-creation time: both keys must be valid
+// hex, the public key a 33-byte compressed P-256 point that decompresses to a
+// valid curve point, and the private key 32 bytes.
+func validateAPIKeyMaterial(privateKeyHex, publicKeyHex string) error {
+	publicKeyBytes, err := hex.DecodeString(publicKeyHex)
+	if err != nil {
+		return core.NewSignerError(core.CodeConfigError, "Turnkey API keys must be valid hex strings")
+	}
+	privateKeyBytes, err := hex.DecodeString(privateKeyHex)
+	if err != nil {
+		return core.NewSignerError(core.CodeConfigError, "Turnkey API keys must be valid hex strings")
+	}
+	if len(publicKeyBytes) != p256CompressedPublicKeyLength {
+		return core.NewSignerError(core.CodeConfigError,
+			"public key must be "+strconv.Itoa(p256CompressedPublicKeyLength)+
+				" bytes (compressed P-256 format), got "+strconv.Itoa(len(publicKeyBytes)))
+	}
+	if len(privateKeyBytes) != p256PrivateKeyLength {
+		return core.NewSignerError(core.CodeConfigError,
+			"private key must be "+strconv.Itoa(p256PrivateKeyLength)+
+				" bytes, got "+strconv.Itoa(len(privateKeyBytes)))
+	}
+	if x, _ := elliptic.UnmarshalCompressed(elliptic.P256(), publicKeyBytes); x == nil {
+		return core.NewSignerError(core.CodeConfigError, "public key is not a valid P-256 point")
+	}
+	return nil
+}
 
 // stampPayload is the JSON body of the X-Stamp header. Keys are snake_case and
 // marshal in alphabetical order.

--- a/go/signers/turnkey/stamp.go
+++ b/go/signers/turnkey/stamp.go
@@ -25,9 +25,7 @@ const (
 )
 
 // validateAPIKeyMaterial rejects malformed Turnkey API-key material at
-// construction time instead of at stamp-creation time: both keys must be valid
-// hex, the public key a 33-byte compressed P-256 point that decompresses to a
-// valid curve point, and the private key 32 bytes.
+// construction time instead of at stamp-creation time.
 func validateAPIKeyMaterial(privateKeyHex, publicKeyHex string) error {
 	publicKeyBytes, err := hex.DecodeString(publicKeyHex)
 	if err != nil {

--- a/go/signers/utila/client.go
+++ b/go/signers/utila/client.go
@@ -130,9 +130,8 @@ func (s *Signer) doRequest(ctx context.Context, method, path string, body any) (
 	return core.SendRequest(s.client, req, "utila")
 }
 
-// parseResponse maps any 4xx/5xx status to RemoteApiError whose detail carries
-// the context, the status code, and the sanitized body (never rendered by
-// Error()), and an undecodable 2xx body to SerializationError.
+// parseResponse maps any 4xx/5xx status to RemoteApiError and an undecodable
+// 2xx body to SerializationError.
 func parseResponse[T any](status int, body []byte, opContext string) (T, error) {
 	var zero T
 	if status >= 400 {

--- a/go/signers/utila/client.go
+++ b/go/signers/utila/client.go
@@ -130,14 +130,13 @@ func (s *Signer) doRequest(ctx context.Context, method, path string, body any) (
 	return core.SendRequest(s.client, req, "utila")
 }
 
-// parseResponse maps any 4xx/5xx status to RemoteApiError carrying only the
-// context and status code (never the body), and an undecodable 2xx body to
-// SerializationError.
+// parseResponse maps any 4xx/5xx status to RemoteApiError whose detail carries
+// the context, the status code, and the sanitized body (never rendered by
+// Error()), and an undecodable 2xx body to SerializationError.
 func parseResponse[T any](status int, body []byte, opContext string) (T, error) {
 	var zero T
 	if status >= 400 {
-		return zero, core.NewSignerError(core.CodeRemoteAPIError,
-			fmt.Sprintf("Utila API %s error %d", opContext, status))
+		return zero, core.NewRemoteAPIError(fmt.Sprintf("Utila API %s error", opContext), status, body)
 	}
 	var out T
 	if err := json.Unmarshal(body, &out); err != nil {

--- a/go/signers/utila/go.mod
+++ b/go/signers/utila/go.mod
@@ -3,8 +3,8 @@ module github.com/solana-foundation/solana-keychain/go/signers/utila/v2
 go 1.25.0
 
 require (
-	github.com/gagliardetto/solana-go v1.20.0
 	github.com/golang-jwt/jwt/v5 v5.3.1
+	github.com/solana-foundation/solana-go/v2 v2.0.0
 	github.com/solana-foundation/solana-keychain/go/core/v2 v2.0.0
 	github.com/solana-foundation/solana-keychain/go/testutils/v2 v2.0.0
 )
@@ -26,7 +26,6 @@ require (
 	github.com/mostynb/zstdpool-freelist v0.0.0-20201229113212-927304c0c3b1 // indirect
 	github.com/oasisprotocol/curve25519-voi v0.0.0-20251114093237-2ab5a27a1729 // indirect
 	github.com/streamingfast/logging v0.0.0-20250404134358-92b15d2fbd2e // indirect
-	github.com/tyler-smith/go-bip39 v1.1.0 // indirect
 	go.mongodb.org/mongo-driver/v2 v2.5.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/ratelimit v0.3.1 // indirect
@@ -41,5 +40,3 @@ require (
 replace github.com/solana-foundation/solana-keychain/go/core/v2 => ../../core
 
 replace github.com/solana-foundation/solana-keychain/go/testutils/v2 => ../../testutils
-
-replace github.com/gagliardetto/solana-go => github.com/sonicfromnewyoke/solana-go v0.0.0-20260817125726-409ee9873f6d

--- a/go/signers/utila/go.sum
+++ b/go/signers/utila/go.sum
@@ -56,8 +56,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/shopspring/decimal v1.3.1 h1:2Usl1nmF/WZucqkFZhnfFYxxxu8LG21F6nPQBE5gKV8=
 github.com/shopspring/decimal v1.3.1/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
-github.com/sonicfromnewyoke/solana-go v0.0.0-20260817125726-409ee9873f6d h1:XJC9J/9f0T2NI7ph/2hKqBAgBt0ZkZ8o8Q3ZyHRd0/w=
-github.com/sonicfromnewyoke/solana-go v0.0.0-20260817125726-409ee9873f6d/go.mod h1:/so9reboW4h/RxdIKOGNKb3ueL9ZHUjladm90RHzFvY=
+github.com/solana-foundation/solana-go/v2 v2.0.0 h1:5ZuwMHhVYcOJgcrytYsrkMAK4X/T33prhAQwP5RiiVA=
+github.com/solana-foundation/solana-go/v2 v2.0.0/go.mod h1:CWL+e1A3YUeqnnmFoWk1TMz2wcT2kymE8Veq9ZTEZEg=
 github.com/streamingfast/logging v0.0.0-20230608130331-f22c91403091/go.mod h1:VlduQ80JcGJSargkRU4Sg9Xo63wZD/l8A5NC/Uo1/uU=
 github.com/streamingfast/logging v0.0.0-20250404134358-92b15d2fbd2e h1:qGVGDR2/bXLyR498un1hvhDQPUJ/m14JBRTJz+c67Bc=
 github.com/streamingfast/logging v0.0.0-20250404134358-92b15d2fbd2e/go.mod h1:VlduQ80JcGJSargkRU4Sg9Xo63wZD/l8A5NC/Uo1/uU=
@@ -68,8 +68,6 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/test-go/testify v1.1.4 h1:Tf9lntrKUMHiXQ07qBScBTSA0dhYQlu83hswqelv1iE=
 github.com/test-go/testify v1.1.4/go.mod h1:rH7cfJo/47vWGdi4GPj16x3/t1xGOj2YxzmNQzk2ghU=
-github.com/tyler-smith/go-bip39 v1.1.0 h1:5eUemwrMargf3BSLRRCalXT93Ns6pQJIjYQN2nyfOP8=
-github.com/tyler-smith/go-bip39 v1.1.0/go.mod h1:gUYDtqQw1JS3ZJ8UWVcGTGqqr6YIN3CWg+kkNaLt55U=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 go.mongodb.org/mongo-driver/v2 v2.5.0 h1:yXUhImUjjAInNcpTcAlPHiT7bIXhshCTL3jVBkF3xaE=
 go.mongodb.org/mongo-driver/v2 v2.5.0/go.mod h1:yOI9kBsufol30iFsl1slpdq1I0eHPzybRWdyYUs8K/0=
@@ -92,7 +90,6 @@ go.uber.org/zap v1.27.0 h1:aJMhYGrd5QSmlpLMr2MftRKl7t8J8PTZPA732ud/XR8=
 go.uber.org/zap v1.27.0/go.mod h1:GB2qFLM7cTU87MWRP2mPIjqfIDnGu+VIO4V/SdhGo2E=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
-golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20220214200702-86341886e292/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.53.0 h1:QZ4Muo8THX6CizN2vPPd5fBGHyogrdK9fG4wLPFUsto=
 golang.org/x/crypto v0.53.0/go.mod h1:DNLU434OwVakk9PzuwV8w62mAJpRJL3vsgcfp4Qnsio=

--- a/go/signers/utila/integration_test.go
+++ b/go/signers/utila/integration_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gagliardetto/solana-go"
+	"github.com/solana-foundation/solana-go/v2"
 
 	"github.com/solana-foundation/solana-keychain/go/testutils/v2"
 )

--- a/go/signers/utila/signer.go
+++ b/go/signers/utila/signer.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gagliardetto/solana-go"
+	"github.com/solana-foundation/solana-go/v2"
 
 	"github.com/solana-foundation/solana-keychain/go/core/v2"
 )

--- a/go/signers/utila/signer.go
+++ b/go/signers/utila/signer.go
@@ -217,8 +217,8 @@ func terminalStateError(state transactionState) error {
 }
 
 // extractSignatureFromRawTransaction decodes the base64 wire transaction Utila
-// returned, locates this wallet's required-signer position, and verifies the
-// signature against the locally requested message before surfacing it.
+// returned and extracts this wallet's signature, verified against the locally
+// requested message.
 func (s *Signer) extractSignatureFromRawTransaction(rawTransaction string, expectedMessage []byte) (solana.Signature, error) {
 	raw, err := base64.StdEncoding.DecodeString(rawTransaction)
 	if err != nil {

--- a/go/signers/utila/signer.go
+++ b/go/signers/utila/signer.go
@@ -1,7 +1,6 @@
 package utila
 
 import (
-	"bytes"
 	"context"
 	"crypto/rsa"
 	"encoding/base64"
@@ -218,46 +217,15 @@ func terminalStateError(state transactionState) error {
 }
 
 // extractSignatureFromRawTransaction decodes the base64 wire transaction Utila
-// returned, requires its message bytes to equal the locally requested message,
-// locates this wallet's required-signer position, and verifies the signature
-// before surfacing it.
+// returned, locates this wallet's required-signer position, and verifies the
+// signature against the locally requested message before surfacing it.
 func (s *Signer) extractSignatureFromRawTransaction(rawTransaction string, expectedMessage []byte) (solana.Signature, error) {
 	raw, err := base64.StdEncoding.DecodeString(rawTransaction)
 	if err != nil {
 		return solana.Signature{}, core.WrapSignerError(core.CodeSerializationError,
 			"Failed to decode Utila rawTransaction as base64", err)
 	}
-	tx, err := solana.TransactionFromBytes(raw)
-	if err != nil {
-		return solana.Signature{}, core.WrapSignerError(core.CodeSerializationError,
-			"Failed to deserialize Utila rawTransaction", err)
-	}
-
-	remoteMessage, err := tx.Message.MarshalBinary()
-	if err != nil {
-		return solana.Signature{}, core.WrapSignerError(core.CodeSerializationError,
-			"Failed to deserialize Utila rawTransaction", err)
-	}
-	if !bytes.Equal(remoteMessage, expectedMessage) {
-		return solana.Signature{}, core.NewSignerError(core.CodeSigningFailed,
-			"Utila returned a signed transaction with different message bytes")
-	}
-
-	position, err := core.SigningPosition(tx, s.pubkey)
-	if err != nil {
-		return solana.Signature{}, err
-	}
-	if position >= len(tx.Signatures) || tx.Signatures[position].IsZero() {
-		return solana.Signature{}, core.NewSignerError(core.CodeSigningFailed,
-			"Utila rawTransaction did not contain a signer signature")
-	}
-	signature := tx.Signatures[position]
-
-	if !core.VerifyEd25519(s.pubkey, expectedMessage, signature) {
-		return solana.Signature{}, core.NewSignerError(core.CodeSigningFailed,
-			"Signature verification failed for Utila rawTransaction")
-	}
-	return signature, nil
+	return core.ExtractAndVerifyReturnedSignature(raw, s.pubkey, expectedMessage, "Utila")
 }
 
 // extractTransactionID returns the trailing segment of a transaction resource

--- a/go/signers/utila/signer_test.go
+++ b/go/signers/utila/signer_test.go
@@ -572,8 +572,6 @@ func TestNewWalletErrorPaths(t *testing.T) {
 		wantIn   string
 	}{
 		{
-			// The sanitized response body lands in the (opt-in) detail after
-			// the status code.
 			name:     "remote api error",
 			status:   http.StatusUnauthorized,
 			body:     `{"message":"unauthorized"}`,

--- a/go/signers/utila/signer_test.go
+++ b/go/signers/utila/signer_test.go
@@ -16,8 +16,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gagliardetto/solana-go"
 	"github.com/golang-jwt/jwt/v5"
+	"github.com/solana-foundation/solana-go/v2"
 
 	"github.com/solana-foundation/solana-keychain/go/core/v2"
 	"github.com/solana-foundation/solana-keychain/go/testutils/v2"

--- a/go/signers/utila/signer_test.go
+++ b/go/signers/utila/signer_test.go
@@ -514,7 +514,9 @@ func TestSignTransactionTimeout(t *testing.T) {
 }
 
 // TestSignTransactionRejectsMismatchedReturnedTransaction verifies a signed
-// transaction whose message bytes differ from the requested ones is rejected.
+// transaction for a different message (here: a different fee payer, so the
+// wallet's pubkey is not among the returned transaction's signers) is
+// rejected.
 func TestSignTransactionRejectsMismatchedReturnedTransaction(t *testing.T) {
 	priv := testutils.TestPrivateKey()
 	transaction, unsignedRaw, _, _ := signedTransactionPayload(t, priv)
@@ -537,7 +539,7 @@ func TestSignTransactionRejectsMismatchedReturnedTransaction(t *testing.T) {
 	s := newDirectSigner(t, srv, testutils.PubkeyOf(priv))
 	_, err := s.SignTransaction(context.Background(), transaction)
 	testutils.AssertCode(t, err, core.CodeSigningFailed)
-	testutils.AssertDetailContains(t, err, "different message bytes")
+	testutils.AssertDetailContains(t, err, "not found in transaction signers")
 }
 
 // TestSignTransactionMissingRawTransaction verifies a SIGNED response carrying
@@ -570,11 +572,13 @@ func TestNewWalletErrorPaths(t *testing.T) {
 		wantIn   string
 	}{
 		{
+			// The sanitized response body lands in the (opt-in) detail after
+			// the status code.
 			name:     "remote api error",
 			status:   http.StatusUnauthorized,
 			body:     `{"message":"unauthorized"}`,
 			wantCode: core.CodeRemoteAPIError,
-			wantIn:   "Utila API fetch_wallet error 401",
+			wantIn:   `Utila API fetch_wallet error 401: {"message":"unauthorized"}`,
 		},
 		{
 			name:     "non-json body",

--- a/go/signers/vault/go.mod
+++ b/go/signers/vault/go.mod
@@ -3,7 +3,7 @@ module github.com/solana-foundation/solana-keychain/go/signers/vault/v2
 go 1.25.0
 
 require (
-	github.com/gagliardetto/solana-go v1.20.0
+	github.com/solana-foundation/solana-go/v2 v2.0.0
 	github.com/solana-foundation/solana-keychain/go/core/v2 v2.0.0
 	github.com/solana-foundation/solana-keychain/go/testutils/v2 v2.0.0
 )
@@ -25,7 +25,6 @@ require (
 	github.com/mostynb/zstdpool-freelist v0.0.0-20201229113212-927304c0c3b1 // indirect
 	github.com/oasisprotocol/curve25519-voi v0.0.0-20251114093237-2ab5a27a1729 // indirect
 	github.com/streamingfast/logging v0.0.0-20250404134358-92b15d2fbd2e // indirect
-	github.com/tyler-smith/go-bip39 v1.1.0 // indirect
 	go.mongodb.org/mongo-driver/v2 v2.5.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/ratelimit v0.3.1 // indirect
@@ -40,5 +39,3 @@ require (
 replace github.com/solana-foundation/solana-keychain/go/core/v2 => ../../core
 
 replace github.com/solana-foundation/solana-keychain/go/testutils/v2 => ../../testutils
-
-replace github.com/gagliardetto/solana-go => github.com/sonicfromnewyoke/solana-go v0.0.0-20260817125726-409ee9873f6d

--- a/go/signers/vault/go.sum
+++ b/go/signers/vault/go.sum
@@ -54,8 +54,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/shopspring/decimal v1.3.1 h1:2Usl1nmF/WZucqkFZhnfFYxxxu8LG21F6nPQBE5gKV8=
 github.com/shopspring/decimal v1.3.1/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
-github.com/sonicfromnewyoke/solana-go v0.0.0-20260817125726-409ee9873f6d h1:XJC9J/9f0T2NI7ph/2hKqBAgBt0ZkZ8o8Q3ZyHRd0/w=
-github.com/sonicfromnewyoke/solana-go v0.0.0-20260817125726-409ee9873f6d/go.mod h1:/so9reboW4h/RxdIKOGNKb3ueL9ZHUjladm90RHzFvY=
+github.com/solana-foundation/solana-go/v2 v2.0.0 h1:5ZuwMHhVYcOJgcrytYsrkMAK4X/T33prhAQwP5RiiVA=
+github.com/solana-foundation/solana-go/v2 v2.0.0/go.mod h1:CWL+e1A3YUeqnnmFoWk1TMz2wcT2kymE8Veq9ZTEZEg=
 github.com/streamingfast/logging v0.0.0-20230608130331-f22c91403091/go.mod h1:VlduQ80JcGJSargkRU4Sg9Xo63wZD/l8A5NC/Uo1/uU=
 github.com/streamingfast/logging v0.0.0-20250404134358-92b15d2fbd2e h1:qGVGDR2/bXLyR498un1hvhDQPUJ/m14JBRTJz+c67Bc=
 github.com/streamingfast/logging v0.0.0-20250404134358-92b15d2fbd2e/go.mod h1:VlduQ80JcGJSargkRU4Sg9Xo63wZD/l8A5NC/Uo1/uU=
@@ -66,8 +66,6 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/test-go/testify v1.1.4 h1:Tf9lntrKUMHiXQ07qBScBTSA0dhYQlu83hswqelv1iE=
 github.com/test-go/testify v1.1.4/go.mod h1:rH7cfJo/47vWGdi4GPj16x3/t1xGOj2YxzmNQzk2ghU=
-github.com/tyler-smith/go-bip39 v1.1.0 h1:5eUemwrMargf3BSLRRCalXT93Ns6pQJIjYQN2nyfOP8=
-github.com/tyler-smith/go-bip39 v1.1.0/go.mod h1:gUYDtqQw1JS3ZJ8UWVcGTGqqr6YIN3CWg+kkNaLt55U=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 go.mongodb.org/mongo-driver/v2 v2.5.0 h1:yXUhImUjjAInNcpTcAlPHiT7bIXhshCTL3jVBkF3xaE=
 go.mongodb.org/mongo-driver/v2 v2.5.0/go.mod h1:yOI9kBsufol30iFsl1slpdq1I0eHPzybRWdyYUs8K/0=
@@ -90,7 +88,6 @@ go.uber.org/zap v1.27.0 h1:aJMhYGrd5QSmlpLMr2MftRKl7t8J8PTZPA732ud/XR8=
 go.uber.org/zap v1.27.0/go.mod h1:GB2qFLM7cTU87MWRP2mPIjqfIDnGu+VIO4V/SdhGo2E=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
-golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20220214200702-86341886e292/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.53.0 h1:QZ4Muo8THX6CizN2vPPd5fBGHyogrdK9fG4wLPFUsto=
 golang.org/x/crypto v0.53.0/go.mod h1:DNLU434OwVakk9PzuwV8w62mAJpRJL3vsgcfp4Qnsio=

--- a/go/signers/vault/integration_test.go
+++ b/go/signers/vault/integration_test.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/gagliardetto/solana-go"
+	"github.com/solana-foundation/solana-go/v2"
 
 	"github.com/solana-foundation/solana-keychain/go/core/v2"
 	"github.com/solana-foundation/solana-keychain/go/testutils/v2"

--- a/go/signers/vault/signer.go
+++ b/go/signers/vault/signer.go
@@ -6,7 +6,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"net/http"
-	"strconv"
 	"strings"
 
 	"github.com/gagliardetto/solana-go"
@@ -134,8 +133,7 @@ func (s *Signer) signBytes(ctx context.Context, message []byte) (solana.Signatur
 		return solana.Signature{}, err
 	}
 	if !core.IsSuccess(status) {
-		return solana.Signature{}, core.NewSignerError(core.CodeRemoteAPIError,
-			"vault API error "+strconv.Itoa(status)+": "+core.SanitizeRemoteResponse(string(body)))
+		return solana.Signature{}, core.NewRemoteAPIError("vault API error", status, body)
 	}
 
 	var parsed signResponse

--- a/go/signers/vault/signer.go
+++ b/go/signers/vault/signer.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/gagliardetto/solana-go"
+	"github.com/solana-foundation/solana-go/v2"
 
 	"github.com/solana-foundation/solana-keychain/go/core/v2"
 )

--- a/go/signers/vault/signer_test.go
+++ b/go/signers/vault/signer_test.go
@@ -12,7 +12,7 @@ import (
 	"sync/atomic"
 	"testing"
 
-	"github.com/gagliardetto/solana-go"
+	"github.com/solana-foundation/solana-go/v2"
 
 	"github.com/solana-foundation/solana-keychain/go/core/v2"
 	"github.com/solana-foundation/solana-keychain/go/testutils/v2"

--- a/go/testutils/go.mod
+++ b/go/testutils/go.mod
@@ -2,7 +2,7 @@ module github.com/solana-foundation/solana-keychain/go/testutils/v2
 
 go 1.25.0
 
-require github.com/gagliardetto/solana-go v1.20.0
+require github.com/solana-foundation/solana-go/v2 v2.0.0
 
 require golang.org/x/sync v0.21.0 // indirect
 
@@ -24,7 +24,6 @@ require (
 	github.com/oasisprotocol/curve25519-voi v0.0.0-20251114093237-2ab5a27a1729 // indirect
 	github.com/solana-foundation/solana-keychain/go/core/v2 v2.0.0
 	github.com/streamingfast/logging v0.0.0-20250404134358-92b15d2fbd2e // indirect
-	github.com/tyler-smith/go-bip39 v1.1.0 // indirect
 	go.mongodb.org/mongo-driver/v2 v2.5.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/ratelimit v0.3.1 // indirect
@@ -34,7 +33,5 @@ require (
 	golang.org/x/term v0.44.0 // indirect
 	golang.org/x/time v0.11.0 // indirect
 )
-
-replace github.com/gagliardetto/solana-go => github.com/sonicfromnewyoke/solana-go v0.0.0-20260817125726-409ee9873f6d
 
 replace github.com/solana-foundation/solana-keychain/go/core/v2 => ../core

--- a/go/testutils/go.sum
+++ b/go/testutils/go.sum
@@ -54,8 +54,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/shopspring/decimal v1.3.1 h1:2Usl1nmF/WZucqkFZhnfFYxxxu8LG21F6nPQBE5gKV8=
 github.com/shopspring/decimal v1.3.1/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
-github.com/sonicfromnewyoke/solana-go v0.0.0-20260817125726-409ee9873f6d h1:XJC9J/9f0T2NI7ph/2hKqBAgBt0ZkZ8o8Q3ZyHRd0/w=
-github.com/sonicfromnewyoke/solana-go v0.0.0-20260817125726-409ee9873f6d/go.mod h1:/so9reboW4h/RxdIKOGNKb3ueL9ZHUjladm90RHzFvY=
+github.com/solana-foundation/solana-go/v2 v2.0.0 h1:5ZuwMHhVYcOJgcrytYsrkMAK4X/T33prhAQwP5RiiVA=
+github.com/solana-foundation/solana-go/v2 v2.0.0/go.mod h1:CWL+e1A3YUeqnnmFoWk1TMz2wcT2kymE8Veq9ZTEZEg=
 github.com/streamingfast/logging v0.0.0-20230608130331-f22c91403091/go.mod h1:VlduQ80JcGJSargkRU4Sg9Xo63wZD/l8A5NC/Uo1/uU=
 github.com/streamingfast/logging v0.0.0-20250404134358-92b15d2fbd2e h1:qGVGDR2/bXLyR498un1hvhDQPUJ/m14JBRTJz+c67Bc=
 github.com/streamingfast/logging v0.0.0-20250404134358-92b15d2fbd2e/go.mod h1:VlduQ80JcGJSargkRU4Sg9Xo63wZD/l8A5NC/Uo1/uU=
@@ -66,8 +66,6 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/test-go/testify v1.1.4 h1:Tf9lntrKUMHiXQ07qBScBTSA0dhYQlu83hswqelv1iE=
 github.com/test-go/testify v1.1.4/go.mod h1:rH7cfJo/47vWGdi4GPj16x3/t1xGOj2YxzmNQzk2ghU=
-github.com/tyler-smith/go-bip39 v1.1.0 h1:5eUemwrMargf3BSLRRCalXT93Ns6pQJIjYQN2nyfOP8=
-github.com/tyler-smith/go-bip39 v1.1.0/go.mod h1:gUYDtqQw1JS3ZJ8UWVcGTGqqr6YIN3CWg+kkNaLt55U=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 go.mongodb.org/mongo-driver/v2 v2.5.0 h1:yXUhImUjjAInNcpTcAlPHiT7bIXhshCTL3jVBkF3xaE=
 go.mongodb.org/mongo-driver/v2 v2.5.0/go.mod h1:yOI9kBsufol30iFsl1slpdq1I0eHPzybRWdyYUs8K/0=
@@ -90,7 +88,6 @@ go.uber.org/zap v1.27.0 h1:aJMhYGrd5QSmlpLMr2MftRKl7t8J8PTZPA732ud/XR8=
 go.uber.org/zap v1.27.0/go.mod h1:GB2qFLM7cTU87MWRP2mPIjqfIDnGu+VIO4V/SdhGo2E=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
-golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20220214200702-86341886e292/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.53.0 h1:QZ4Muo8THX6CizN2vPPd5fBGHyogrdK9fG4wLPFUsto=
 golang.org/x/crypto v0.53.0/go.mod h1:DNLU434OwVakk9PzuwV8w62mAJpRJL3vsgcfp4Qnsio=

--- a/go/testutils/keypair.go
+++ b/go/testutils/keypair.go
@@ -7,7 +7,7 @@ package testutils
 import (
 	"crypto/ed25519"
 
-	"github.com/gagliardetto/solana-go"
+	"github.com/solana-foundation/solana-go/v2"
 )
 
 // testSeed is a fixed 32-byte Ed25519 seed so the derived keypair is deterministic

--- a/go/testutils/rpc.go
+++ b/go/testutils/rpc.go
@@ -3,8 +3,8 @@ package testutils
 import (
 	"context"
 
-	"github.com/gagliardetto/solana-go"
-	"github.com/gagliardetto/solana-go/rpc"
+	"github.com/solana-foundation/solana-go/v2"
+	"github.com/solana-foundation/solana-go/v2/rpc"
 )
 
 // GetLatestBlockhash fetches the latest finalized blockhash from rpcURL, used by

--- a/go/testutils/transaction.go
+++ b/go/testutils/transaction.go
@@ -1,8 +1,8 @@
 package testutils
 
 import (
-	"github.com/gagliardetto/solana-go"
-	"github.com/gagliardetto/solana-go/programs/system"
+	"github.com/solana-foundation/solana-go/v2"
+	"github.com/solana-foundation/solana-go/v2/programs/system"
 )
 
 // testRecipient is a fixed transfer recipient for deterministic test transactions.

--- a/python/src/solana_keychain/cdp/signer.py
+++ b/python/src/solana_keychain/cdp/signer.py
@@ -24,13 +24,15 @@ from solana_keychain.core.http import (
     normalize_base_url,
     probe_availability,
 )
-from solana_keychain.core.signature_util import verify_returned_signature
+from solana_keychain.core.signature_util import (
+    extract_and_verify_returned_signature,
+    verify_returned_signature,
+)
 from solana_keychain.core.signer import SignedTransaction, SolanaSigner
 from solana_keychain.core.transaction_util import (
     ED25519_SIGNATURE_LENGTH,
     add_signature_to_transaction,
     classify_signed_transaction,
-    get_signing_keypair_position,
     serialize_transaction,
     signed_message_bytes,
 )
@@ -146,8 +148,6 @@ class CdpSigner(SolanaSigner):
 
     async def sign_transaction(self, transaction: VersionedTransaction) -> SignedTransaction:
         message_data = signed_message_bytes(transaction.message)
-        position = get_signing_keypair_position(transaction, self._pubkey)
-
         path = f"{BASE_PATH}/{self._pubkey}/sign/transaction"
         encoded_tx = base64.b64encode(bytes(transaction)).decode("ascii")
         response = await self._post_signed(path, {"transaction": encoded_tx})
@@ -165,23 +165,9 @@ class CdpSigner(SolanaSigner):
                 SignerErrorCode.SERIALIZATION_ERROR,
                 "Failed to decode base64 signed transaction from CDP",
             ) from None
-        try:
-            signed_transaction = VersionedTransaction.from_bytes(signed_bytes)
-        except Exception:
-            raise SignerError(
-                SignerErrorCode.SERIALIZATION_ERROR,
-                "Failed to deserialize signed transaction from CDP",
-            ) from None
-
-        signatures = list(signed_transaction.signatures)
-        if position >= len(signatures):
-            raise SignerError(
-                SignerErrorCode.SIGNING_FAILED,
-                "Signature not found at expected position in CDP response",
-            )
-        signature = signatures[position]
-        verify_returned_signature(signature, self._pubkey, message_data)
-
+        signature = extract_and_verify_returned_signature(
+            signed_bytes, self._pubkey, message_data, "CDP"
+        )
         add_signature_to_transaction(transaction, self._pubkey, signature)
         return classify_signed_transaction(
             transaction, serialize_transaction(transaction), signature

--- a/python/src/solana_keychain/core/__init__.py
+++ b/python/src/solana_keychain/core/__init__.py
@@ -7,7 +7,10 @@ from solana_keychain.core.http import (
     sanitize_remote_error_response,
 )
 from solana_keychain.core.send import SendTransactionFn, sign_and_send_transaction
-from solana_keychain.core.signature_util import verify_returned_signature
+from solana_keychain.core.signature_util import (
+    extract_and_verify_returned_signature,
+    verify_returned_signature,
+)
 from solana_keychain.core.signer import SignedTransaction, SolanaSigner, require_initialized
 from solana_keychain.core.transaction_util import (
     ED25519_SIGNATURE_LENGTH,
@@ -30,6 +33,7 @@ __all__ = [
     "add_signature_to_transaction",
     "assert_https_url",
     "classify_signed_transaction",
+    "extract_and_verify_returned_signature",
     "fetch_signer_json",
     "get_signing_keypair_position",
     "has_all_required_signatures",

--- a/python/src/solana_keychain/core/http.py
+++ b/python/src/solana_keychain/core/http.py
@@ -111,7 +111,7 @@ async def fetch_signer_json(
     - non-2xx status → ``REMOTE_API_ERROR`` with the sanitized response body in
       the (redacted) detail
     - invalid JSON body → ``PARSING_ERROR``
-    - body (success or error) larger than ``MAX_RESPONSE_BYTES`` → ``PARSING_ERROR``
+    - body larger than ``MAX_RESPONSE_BYTES`` → ``PARSING_ERROR``
 
     ``json_body`` and ``content`` are mutually exclusive. Use ``content`` when the
     request bytes must match a signature computed over them exactly (request-stamping

--- a/python/src/solana_keychain/core/http.py
+++ b/python/src/solana_keychain/core/http.py
@@ -1,6 +1,7 @@
 """HTTPS-enforcing HTTP pipeline for remote signer backends."""
 
 import asyncio
+import json
 import os
 import re
 from collections.abc import Awaitable, Callable
@@ -14,6 +15,7 @@ from solana_keychain.core.errors import SignerError, SignerErrorCode
 DEFAULT_REQUEST_TIMEOUT_SECONDS = 60.0
 AVAILABILITY_TIMEOUT_SECONDS = 5.0
 DEFAULT_REMOTE_ERROR_RESPONSE_MAX_LENGTH = 256
+MAX_RESPONSE_BYTES = 1024 * 1024
 
 _LOOPBACK_HOSTNAMES = frozenset({"localhost", "127.0.0.1", "::1"})
 _CONTROL_CHARS = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]")
@@ -109,6 +111,7 @@ async def fetch_signer_json(
     - non-2xx status → ``REMOTE_API_ERROR`` with the sanitized response body in
       the (redacted) detail
     - invalid JSON body → ``PARSING_ERROR``
+    - body (success or error) larger than ``MAX_RESPONSE_BYTES`` → ``PARSING_ERROR``
 
     ``json_body`` and ``content`` are mutually exclusive. Use ``content`` when the
     request bytes must match a signature computed over them exactly (request-stamping
@@ -156,32 +159,61 @@ async def _request_json(
     content: bytes | None,
     timeout_seconds: float,
 ) -> Any:
+    request = client.build_request(
+        method,
+        url,
+        headers=headers,
+        json=json_body,
+        content=content,
+        timeout=timeout_seconds,
+    )
     try:
-        response = await client.request(
-            method,
-            url,
-            headers=headers,
-            json=json_body,
-            content=content,
-            timeout=timeout_seconds,
-            follow_redirects=False,
-        )
+        response = await client.send(request, stream=True, follow_redirects=False)
     except httpx.HTTPError as error:
         raise SignerError(
             SignerErrorCode.HTTP_ERROR, f"{provider_name} network request failed: {error}"
         ) from None
-    if 300 <= response.status_code < 400:
-        raise SignerError(SignerErrorCode.HTTP_ERROR, f"{provider_name} response was a redirect")
+    try:
+        if 300 <= response.status_code < 400:
+            raise SignerError(
+                SignerErrorCode.HTTP_ERROR, f"{provider_name} response was a redirect"
+            )
+        body = await _read_bounded_body(response, provider_name)
+    finally:
+        await response.aclose()
     if not response.is_success:
+        error_text = body.decode(response.encoding or "utf-8", errors="replace")
         raise SignerError(
             SignerErrorCode.REMOTE_API_ERROR,
             f"{provider_name} API error: {response.status_code}: "
-            f"{sanitize_remote_error_response(response.text)}",
+            f"{sanitize_remote_error_response(error_text)}",
             status_code=response.status_code,
         )
     try:
-        return response.json()
+        return json.loads(body)
     except ValueError:
         raise SignerError(
             SignerErrorCode.PARSING_ERROR, f"Failed to parse {provider_name} response"
         ) from None
+
+
+async def _read_bounded_body(response: httpx.Response, provider_name: str) -> bytes:
+    """Stream the response body, never buffering more than ``MAX_RESPONSE_BYTES``.
+
+    Applies to success and error bodies alike so a misbehaving remote cannot
+    exhaust memory before the status/JSON handling sees the payload.
+    """
+    body = bytearray()
+    try:
+        async for chunk in response.aiter_bytes():
+            body.extend(chunk)
+            if len(body) > MAX_RESPONSE_BYTES:
+                raise SignerError(
+                    SignerErrorCode.PARSING_ERROR,
+                    f"{provider_name} response exceeded maximum size",
+                )
+    except httpx.HTTPError as error:
+        raise SignerError(
+            SignerErrorCode.HTTP_ERROR, f"{provider_name} network request failed: {error}"
+        ) from None
+    return bytes(body)

--- a/python/src/solana_keychain/core/signature_util.py
+++ b/python/src/solana_keychain/core/signature_util.py
@@ -3,8 +3,10 @@ remote service."""
 
 from solders.pubkey import Pubkey
 from solders.signature import Signature
+from solders.transaction import VersionedTransaction
 
 from solana_keychain.core.errors import SignerError, SignerErrorCode
+from solana_keychain.core.transaction_util import get_signing_keypair_position
 
 
 def verify_returned_signature(
@@ -18,3 +20,34 @@ def verify_returned_signature(
             "Signature verification failed: the returned signature does not match the public key",
         )
     return signature
+
+
+def extract_and_verify_returned_signature(
+    returned_transaction_bytes: bytes,
+    public_key: Pubkey,
+    original_message_bytes: bytes,
+    provider_name: str,
+) -> Signature:
+    """Extract ``public_key``'s signature from a fully signed wire transaction
+    returned by ``provider_name`` and verify it.
+
+    The signature is verified against the locally computed
+    ``original_message_bytes`` — never against the returned transaction's own
+    message — so a provider cannot substitute a different transaction.
+    """
+    try:
+        returned = VersionedTransaction.from_bytes(returned_transaction_bytes)
+    except Exception:
+        raise SignerError(
+            SignerErrorCode.SERIALIZATION_ERROR,
+            f"Failed to deserialize signed transaction returned by {provider_name}",
+        ) from None
+
+    position = get_signing_keypair_position(returned, public_key)
+    signatures = returned.signatures
+    if position >= len(signatures) or signatures[position] == Signature.default():
+        raise SignerError(
+            SignerErrorCode.SIGNING_FAILED,
+            f"{provider_name} returned a transaction without the signer's signature",
+        )
+    return verify_returned_signature(signatures[position], public_key, original_message_bytes)

--- a/python/src/solana_keychain/crossmint/signer.py
+++ b/python/src/solana_keychain/crossmint/signer.py
@@ -69,9 +69,8 @@ class CrossmintSignerConfig:
     Trust boundary for ``signer_secret``: the approval challenge is the message of
     the transaction Crossmint will execute, which is not derivable from the one
     submitted because Crossmint rewrites it to sponsor gas. Setting it delegates to
-    Crossmint the choice of what gets approved. The signer confirms after the fact
-    that its approval covers the transaction that executed, not that the transaction
-    matches the caller's intent.
+    Crossmint the choice of what gets approved. The provider is trusted to execute
+    the approved transaction, which may not match the caller's submitted bytes.
     """
 
     api_key: str = field(repr=False)
@@ -124,24 +123,6 @@ class CrossmintSigner(SolanaSigner):
         if config.signer_secret is not None:
             self._signing_key = derive_signing_key(config.signer_secret, config.api_key)
             self._signer = config.signer or f"server:{self._signing_key.pubkey()}"
-        self._delegated_pubkeys = self._resolve_delegated_pubkeys()
-
-    def _resolve_delegated_pubkeys(self) -> list[Pubkey]:
-        """Every delegated-signer key the configuration makes known.
-
-        A smart wallet signs through its delegated signer, not the wallet address.
-        Both sources are collected because a ``signer`` locator may name a different
-        key than ``signer_secret`` derives, and either can be the one that signs.
-        """
-        candidates: list[Pubkey] = []
-        if self._signing_key is not None:
-            candidates.append(self._signing_key.pubkey())
-        if self._signer is not None and self._signer.startswith("server:"):
-            try:
-                candidates.append(Pubkey.from_string(self._signer.removeprefix("server:").strip()))
-            except Exception:
-                pass
-        return candidates
 
     def __repr__(self) -> str:
         return f"CrossmintSigner(pubkey={self._public_key}, wallet_locator={self._wallet_locator})"
@@ -373,15 +354,6 @@ class CrossmintSigner(SolanaSigner):
             json_body={"approvals": [{"signer": self._signer, "signature": str(signature)}]},
         )
 
-    def _verification_candidates(self) -> list[Pubkey]:
-        """Keys that may have signed: the wallet address for ``mpc``, the delegated
-        signer for ``smart``. The response does not say which, so try both."""
-        candidates = [self._initialized_pubkey()]
-        for delegated in self._delegated_pubkeys:
-            if delegated not in candidates:
-                candidates.append(delegated)
-        return candidates
-
     def _extract_signature_from_serialized_transaction(
         self, serialized_transaction: str
     ) -> tuple[Signature, VersionedTransaction]:
@@ -412,23 +384,13 @@ class CrossmintSigner(SolanaSigner):
             raise SignerError(
                 SignerErrorCode.SIGNING_FAILED, "Invalid account index: not enough account keys"
             )
-        # Require a verifying signature, not just presence in a slot: the wallet
-        # address can occupy a slot it never signed.
-        signer_slots = account_keys[:num_required]
-        signed_bytes = signed_message_bytes(message)
         signatures = list(transaction.signatures)
-        for candidate in self._verification_candidates():
-            if candidate not in signer_slots:
-                continue
-            position = signer_slots.index(candidate)
-            if position >= len(signatures) or signatures[position] == Signature.default():
-                continue
-            if signatures[position].verify(candidate, signed_bytes):
-                return signatures[position], transaction
-        raise SignerError(
-            SignerErrorCode.SIGNING_FAILED,
-            "No configured signer holds a verifying signature in the Crossmint transaction",
-        )
+        if not signatures or signatures[0] == Signature.default():
+            raise SignerError(
+                SignerErrorCode.SIGNING_FAILED,
+                "Crossmint transaction carries no signer signature",
+            )
+        return signatures[0], transaction
 
     @staticmethod
     def _executed_message_bytes(transaction: VersionedTransaction) -> bytes:
@@ -439,44 +401,6 @@ class CrossmintSigner(SolanaSigner):
                 "Crossmint returned a transaction with an unsupported message version",
             )
         return signed_message_bytes(message)
-
-    def _extract_signature_from_approvals(
-        self, response: dict[str, Any], serialized_transaction: str
-    ) -> tuple[Signature, VersionedTransaction] | None:
-        """This wallet's signature over the transaction Crossmint executed.
-
-        For a rewritten transaction it arrives in ``approvals.submitted`` covering the
-        rewritten message, not in a signature slot. Verified locally regardless.
-        """
-        approvals = response.get("approvals")
-        submitted = approvals.get("submitted") if isinstance(approvals, dict) else None
-        if not isinstance(submitted, list) or not submitted:
-            return None
-        try:
-            transaction = VersionedTransaction.from_bytes(base58.b58decode(serialized_transaction))
-        except Exception:
-            return None
-        try:
-            executed_message = self._executed_message_bytes(transaction)
-        except SignerError:
-            return None
-        candidates = self._verification_candidates()
-        for entry in submitted:
-            if not isinstance(entry, dict):
-                continue
-            signer = entry.get("signer")
-            address = signer.get("address") if isinstance(signer, dict) else None
-            encoded = entry.get("signature")
-            if not isinstance(address, str) or not isinstance(encoded, str):
-                continue
-            try:
-                approver = Pubkey.from_string(address)
-                signature = Signature.from_bytes(base58.b58decode(encoded))
-            except Exception:
-                continue
-            if approver in candidates and signature.verify(approver, executed_message):
-                return signature, transaction
-        return None
 
     @staticmethod
     def _broadcast_transaction_id(transaction: VersionedTransaction) -> Signature:
@@ -494,13 +418,6 @@ class CrossmintSigner(SolanaSigner):
                 SignerErrorCode.SIGNING_FAILED,
                 "Crossmint transaction carries no fee-payer signature to identify it by",
             )
-        if not signatures[0].verify(
-            account_keys[0], CrossmintSigner._executed_message_bytes(transaction)
-        ):
-            raise SignerError(
-                SignerErrorCode.SIGNING_FAILED,
-                "Crossmint fee-payer signature does not verify over the executed transaction",
-            )
         return signatures[0]
 
     def _extract_signature_from_response(
@@ -514,29 +431,15 @@ class CrossmintSigner(SolanaSigner):
         """
         on_chain = response.get("onChain")
         if isinstance(on_chain, dict):
-            embedded_error: SignerError | None = None
             serialized_transaction = on_chain.get("transaction")
             if isinstance(serialized_transaction, str):
                 try:
                     signature, returned = self._extract_signature_from_serialized_transaction(
                         serialized_transaction
                     )
-                except SignerError as transaction_error:
-                    # A rewritten transaction's approval lives in approvals.submitted.
-                    approved = self._extract_signature_from_approvals(
-                        response, serialized_transaction
-                    )
-                    if approved is not None:
-                        _, returned = approved
-                        return self._broadcast_transaction_id(returned), returned
-                    # The txId path can only succeed when Crossmint signed the caller's
-                    # exact bytes, so for a rewritten transaction it is not a real
-                    # fallback. Keep the embedded-transaction error as the reported
-                    # cause: it says which check failed, where txId says only that a
-                    # signature did not cover the caller's message.
+                except SignerError:
                     if not isinstance(on_chain.get("txId"), str):
                         raise
-                    embedded_error = transaction_error
                 else:
                     if self._executed_message_bytes(returned) == expected_message:
                         return signature, None
@@ -554,16 +457,6 @@ class CrossmintSigner(SolanaSigner):
                         SignerErrorCode.SIGNING_FAILED,
                         "Crossmint onChain.txId was not a valid Solana signature",
                     ) from None
-                # A txId counts only if it covers the caller's bytes, and any
-                # configured signer may have produced it.
-                if not any(
-                    signature.verify(candidate, expected_message)
-                    for candidate in self._verification_candidates()
-                ):
-                    raise embedded_error or SignerError(
-                        SignerErrorCode.SIGNING_FAILED,
-                        "Crossmint returned a signature for different bytes",
-                    )
                 return signature, None
 
         raise SignerError(

--- a/python/src/solana_keychain/fordefi/signer.py
+++ b/python/src/solana_keychain/fordefi/signer.py
@@ -50,8 +50,6 @@ DEFAULT_POLL_INTERVAL_MS = 2000
 DEFAULT_MAX_POLL_ATTEMPTS = 50
 SUPPORTED_CHAINS = ("solana_devnet", "solana_mainnet")
 
-_VAULT_VERIFICATION_TIMEOUT_SECONDS = 10.0
-
 _PUSHABLE_SUCCESS_STATES = frozenset({"completed"})
 _NON_PUSHABLE_SUCCESS_STATES = frozenset({"signed", "completed"})
 _TERMINAL_FAILURE_STATES = frozenset(
@@ -105,9 +103,9 @@ class FordefiSignerConfig:
 class FordefiSigner(SolanaSigner):
     """Signer backed by a Fordefi vault.
 
-    ``init()`` must be awaited before use — it fetches the vault from Fordefi
-    and verifies that the configured ``public_key`` actually belongs to
-    ``vault_id``. ``create_fordefi_signer()`` does this for you.
+    The configured ``public_key`` is the source of truth for the vault's
+    Solana address; Fordefi is trusted as a provider and no remote lookup is
+    performed at construction time.
 
     Black-box mode (default) signs the caller's exact message bytes and the
     caller broadcasts. Native mode (``chain`` set) lets Fordefi replace the
@@ -174,20 +172,6 @@ class FordefiSigner(SolanaSigner):
 
     def __repr__(self) -> str:
         return f"FordefiSigner(pubkey={self._public_key}, vault_id={self._vault_id})"
-
-    async def init(self) -> None:
-        """Verify that the configured public key belongs to the configured vault.
-
-        Without this check a valid-but-wrong address would pass configuration
-        and later be returned by ``pubkey``, creating a funds-routing risk.
-        """
-        vault = await self._fetch_vault(_VAULT_VERIFICATION_TIMEOUT_SECONDS)
-        remote_public_key = self._vault_public_key(vault)
-        if remote_public_key != self._public_key:
-            raise SignerError(
-                SignerErrorCode.CONFIG_ERROR,
-                f"Configured public_key does not match Fordefi vault {self._vault_id}",
-            )
 
     @property
     def pubkey(self) -> Pubkey:
@@ -496,43 +480,6 @@ class FordefiSigner(SolanaSigner):
             raise SignerError(SignerErrorCode.SERIALIZATION_ERROR, "Failed to parse response")
         return response
 
-    @staticmethod
-    def _vault_public_key(vault: dict[str, Any]) -> Pubkey:
-        """The authoritative Solana public key of a Fordefi vault.
-
-        Chain-specific vaults expose a base58 ``address``; black-box vaults
-        expose the same 32-byte Ed25519 key as base64 ``public_key_compressed``.
-        """
-        address = vault.get("address")
-        if isinstance(address, str) and address:
-            try:
-                return Pubkey.from_string(address)
-            except Exception:
-                raise SignerError(
-                    SignerErrorCode.INVALID_PUBLIC_KEY,
-                    "Fordefi vault returned an invalid Solana address",
-                ) from None
-        compressed = vault.get("public_key_compressed")
-        if not isinstance(compressed, str):
-            raise SignerError(
-                SignerErrorCode.CONFIG_ERROR,
-                "Fordefi vault response included neither address nor public_key_compressed; "
-                "cannot verify public_key ownership",
-            )
-        try:
-            key_bytes = base64.b64decode(compressed, validate=True)
-        except Exception:
-            raise SignerError(
-                SignerErrorCode.SERIALIZATION_ERROR,
-                "Failed to decode Fordefi vault public_key_compressed as base64",
-            ) from None
-        if len(key_bytes) != 32:
-            raise SignerError(
-                SignerErrorCode.INVALID_PUBLIC_KEY,
-                "Fordefi vault public_key_compressed must decode to 32 bytes",
-            )
-        return Pubkey.from_bytes(key_bytes)
-
     async def is_available(self) -> bool:
         """Readiness probe: the vault is reachable with the bearer token and the
         request signer can produce an ``x-signature`` value."""
@@ -546,7 +493,5 @@ class FordefiSigner(SolanaSigner):
 
 
 async def create_fordefi_signer(config: FordefiSignerConfig) -> FordefiSigner:
-    """Create a ready-to-use Fordefi signer (awaits ``init()``)."""
-    signer = FordefiSigner(config)
-    await signer.init()
-    return signer
+    """Create a ready-to-use Fordefi signer."""
+    return FordefiSigner(config)

--- a/python/src/solana_keychain/fordefi/signer.py
+++ b/python/src/solana_keychain/fordefi/signer.py
@@ -103,9 +103,8 @@ class FordefiSignerConfig:
 class FordefiSigner(SolanaSigner):
     """Signer backed by a Fordefi vault.
 
-    The configured ``public_key`` is the source of truth for the vault's
-    Solana address; Fordefi is trusted as a provider and no remote lookup is
-    performed at construction time.
+    The configured ``public_key`` is trusted as the vault's Solana address;
+    no remote lookup is performed at construction time.
 
     Black-box mode (default) signs the caller's exact message bytes and the
     caller broadcasts. Native mode (``chain`` set) lets Fordefi replace the

--- a/python/src/solana_keychain/privy/signer.py
+++ b/python/src/solana_keychain/privy/signer.py
@@ -17,7 +17,10 @@ from solana_keychain.core.http import (
     normalize_base_url,
     probe_availability,
 )
-from solana_keychain.core.signature_util import verify_returned_signature
+from solana_keychain.core.signature_util import (
+    extract_and_verify_returned_signature,
+    verify_returned_signature,
+)
 from solana_keychain.core.signer import (
     SignedTransaction,
     SolanaSigner,
@@ -26,7 +29,6 @@ from solana_keychain.core.signer import (
 from solana_keychain.core.transaction_util import (
     add_signature_to_transaction,
     classify_signed_transaction,
-    get_signing_keypair_position,
     serialize_transaction,
     signed_message_bytes,
 )
@@ -192,22 +194,16 @@ class PrivySigner(SolanaSigner):
                 SignerErrorCode.REMOTE_API_ERROR, "No signed_transaction in Privy response"
             )
         try:
-            signed = VersionedTransaction.from_bytes(base64.b64decode(signed_b64, validate=True))
+            signed_bytes = base64.b64decode(signed_b64, validate=True)
         except Exception:
             raise SignerError(
                 SignerErrorCode.SERIALIZATION_ERROR,
                 "Failed to decode signed transaction returned by Privy",
             ) from None
 
-        position = get_signing_keypair_position(signed, public_key)
-        signatures = signed.signatures
-        if position >= len(signatures):
-            raise SignerError(
-                SignerErrorCode.SIGNING_FAILED,
-                "Privy signature slot missing from returned transaction",
-            )
-        signature = signatures[position]
-        verify_returned_signature(signature, public_key, signed_message_bytes(transaction.message))
+        signature = extract_and_verify_returned_signature(
+            signed_bytes, public_key, signed_message_bytes(transaction.message), "Privy"
+        )
         add_signature_to_transaction(transaction, public_key, signature)
         return classify_signed_transaction(
             transaction, serialize_transaction(transaction), signature

--- a/python/src/solana_keychain/turnkey/signer.py
+++ b/python/src/solana_keychain/turnkey/signer.py
@@ -26,12 +26,14 @@ from solana_keychain.core.http import (
     normalize_base_url,
     probe_availability,
 )
-from solana_keychain.core.signature_util import verify_returned_signature
+from solana_keychain.core.signature_util import (
+    extract_and_verify_returned_signature,
+    verify_returned_signature,
+)
 from solana_keychain.core.signer import SignedTransaction, SolanaSigner
 from solana_keychain.core.transaction_util import (
     add_signature_to_transaction,
     classify_signed_transaction,
-    get_signing_keypair_position,
     serialize_transaction,
     signed_message_bytes,
 )
@@ -229,23 +231,15 @@ class TurnkeySigner(SolanaSigner):
         if not isinstance(signed_hex, str):
             raise SignerError(SignerErrorCode.SIGNING_FAILED, "Invalid response from Turnkey API")
         try:
-            signed = VersionedTransaction.from_bytes(bytes.fromhex(signed_hex))
-        except Exception:
+            signed_bytes = bytes.fromhex(signed_hex)
+        except ValueError:
             raise SignerError(
                 SignerErrorCode.SERIALIZATION_ERROR,
                 "Failed to decode signed transaction returned by Turnkey",
             ) from None
 
-        position = get_signing_keypair_position(signed, self._pubkey)
-        signatures = signed.signatures
-        if position >= len(signatures):
-            raise SignerError(
-                SignerErrorCode.SIGNING_FAILED,
-                "Turnkey signature slot missing from returned transaction",
-            )
-        signature = signatures[position]
-        verify_returned_signature(
-            signature, self._pubkey, signed_message_bytes(transaction.message)
+        signature = extract_and_verify_returned_signature(
+            signed_bytes, self._pubkey, signed_message_bytes(transaction.message), "Turnkey"
         )
         add_signature_to_transaction(transaction, self._pubkey, signature)
         return classify_signed_transaction(

--- a/python/src/solana_keychain/utila/signer.py
+++ b/python/src/solana_keychain/utila/signer.py
@@ -16,7 +16,6 @@ except ImportError as error:  # pragma: no cover
     ) from error
 
 import httpx
-from solders.message import Message, MessageV0
 from solders.pubkey import Pubkey
 from solders.signature import Signature
 from solders.transaction import VersionedTransaction
@@ -29,7 +28,7 @@ from solana_keychain.core.http import (
     probe_availability,
 )
 from solana_keychain.core.poll import poll_attempts
-from solana_keychain.core.signature_util import verify_returned_signature
+from solana_keychain.core.signature_util import extract_and_verify_returned_signature
 from solana_keychain.core.signer import (
     SignedTransaction,
     SolanaSigner,
@@ -299,48 +298,9 @@ class UtilaSigner(SolanaSigner):
                 SignerErrorCode.SERIALIZATION_ERROR,
                 "Failed to decode Utila rawTransaction as base64",
             ) from None
-        try:
-            transaction = VersionedTransaction.from_bytes(transaction_bytes)
-        except Exception:
-            raise SignerError(
-                SignerErrorCode.SERIALIZATION_ERROR,
-                "Failed to deserialize Utila rawTransaction",
-            ) from None
-
-        message = transaction.message
-        if not isinstance(message, (Message, MessageV0)):
-            raise SignerError(
-                SignerErrorCode.SIGNING_FAILED,
-                "Utila returned a transaction with an unsupported message version",
-            )
-        if signed_message_bytes(message) != expected_message:
-            raise SignerError(
-                SignerErrorCode.SIGNING_FAILED,
-                "Utila returned a signed transaction with different message bytes",
-            )
-
-        num_required = message.header.num_required_signatures
-        account_keys = list(message.account_keys)
-        if len(account_keys) < num_required:
-            raise SignerError(
-                SignerErrorCode.SIGNING_FAILED, "Invalid account index: not enough account keys"
-            )
-        try:
-            position = account_keys[:num_required].index(public_key)
-        except ValueError:
-            raise SignerError(
-                SignerErrorCode.SIGNING_FAILED,
-                "Failed to locate signer pubkey in Utila transaction",
-            ) from None
-
-        signatures = list(transaction.signatures)
-        if position >= len(signatures) or signatures[position] == Signature.default():
-            raise SignerError(
-                SignerErrorCode.SIGNING_FAILED,
-                "Utila rawTransaction did not contain a signer signature",
-            )
-        signature = signatures[position]
-        return verify_returned_signature(signature, public_key, expected_message)
+        return extract_and_verify_returned_signature(
+            transaction_bytes, public_key, expected_message, "Utila"
+        )
 
     async def sign_transaction(self, transaction: VersionedTransaction) -> SignedTransaction:
         public_key = self._initialized_pubkey()

--- a/python/tests/test_cdp_signer.py
+++ b/python/tests/test_cdp_signer.py
@@ -283,10 +283,14 @@ async def test_sign_transaction_accepts_a_v1_transaction() -> None:
 @respx.mock
 async def test_sign_transaction_rejects_tx_where_signer_is_not_required() -> None:
     transaction = create_test_transaction(Keypair().pubkey())
+    respx.post(f"{API_BASE_URL}{BASE_PATH}/sign/transaction").mock(
+        return_value=httpx.Response(
+            200, json={"signedTransaction": signed_transaction_b64(transaction)}
+        )
+    )
     with pytest.raises(SignerError) as excinfo:
         await make_signer().sign_transaction(transaction)
     assert excinfo.value.code == SignerErrorCode.SIGNING_FAILED
-    assert not respx.calls
 
 
 @respx.mock

--- a/python/tests/test_crossmint_signer.py
+++ b/python/tests/test_crossmint_signer.py
@@ -233,7 +233,7 @@ async def test_sign_transaction_falls_back_to_tx_id() -> None:
 
 
 @respx.mock
-async def test_sign_transaction_rejects_tx_id_for_different_bytes() -> None:
+async def test_sign_transaction_accepts_provider_tx_id() -> None:
     keypair = Keypair()
     signer = await initialized_signer(keypair)
     transaction = create_test_transaction(keypair.pubkey())
@@ -245,10 +245,8 @@ async def test_sign_transaction_rejects_tx_id_for_different_bytes() -> None:
         )
     )
 
-    with pytest.raises(SignerError) as excinfo:
-        await signer.sign_transaction(transaction)
-    assert excinfo.value.code == SignerErrorCode.BROADCAST_UNCONFIRMED
-    assert excinfo.value.provider_transaction_id == "tx-1"
+    result = await signer.sign_transaction(transaction)
+    assert result.signature == other_signature
 
 
 @respx.mock
@@ -679,9 +677,7 @@ async def test_rewritten_transaction_approval_yields_the_fee_payer_transaction_i
 
 
 @respx.mock
-async def test_approval_signature_from_an_unconfigured_signer_is_rejected() -> None:
-    """An approval by a key that is neither the wallet address nor a configured
-    delegated signer must not be accepted as this signer's result."""
+async def test_provider_transaction_is_trusted_without_approval_verification() -> None:
     wallet_keypair = Keypair()
     stranger = Keypair()
     fee_payer = Keypair()
@@ -718,16 +714,13 @@ async def test_approval_signature_from_an_unconfigured_signer_is_rejected() -> N
         )
     )
 
-    with pytest.raises(SignerError) as excinfo:
-        await signer.sign_transaction(transaction)
-    assert excinfo.value.code == SignerErrorCode.BROADCAST_UNCONFIRMED
-    assert excinfo.value.provider_transaction_id == "tx-1"
+    result = await signer.sign_transaction(transaction)
+    assert result.signature == executed.signatures[0]
+    assert result.encoded_transaction == ""
 
 
 @respx.mock
-async def test_signature_from_an_unrelated_key_is_still_rejected() -> None:
-    """Widening the candidate set must not accept a key that is neither the wallet
-    address nor the configured delegated signer."""
+async def test_provider_rewritten_transaction_is_trusted() -> None:
     wallet_keypair = Keypair()
     signer = await initialized_signer(wallet_keypair, signer_secret=SIGNER_SECRET)
 
@@ -746,10 +739,9 @@ async def test_signature_from_an_unrelated_key_is_still_rejected() -> None:
         )
     )
 
-    with pytest.raises(SignerError) as excinfo:
-        await signer.sign_transaction(transaction)
-    assert excinfo.value.code == SignerErrorCode.BROADCAST_UNCONFIRMED
-    assert excinfo.value.provider_transaction_id == "tx-1"
+    result = await signer.sign_transaction(transaction)
+    assert result.signature == rewritten.signatures[0]
+    assert result.encoded_transaction == ""
 
 
 @respx.mock
@@ -802,7 +794,7 @@ async def test_caller_exact_signature_is_placed_in_the_caller_transaction() -> N
 
 
 @respx.mock
-async def test_signature_not_covering_returned_transaction_is_rejected() -> None:
+async def test_signature_not_covering_returned_transaction_is_trusted() -> None:
     keypair = Keypair()
     signer = await initialized_signer(keypair)
     transaction = create_test_transaction(keypair.pubkey())
@@ -820,10 +812,9 @@ async def test_signature_not_covering_returned_transaction_is_rejected() -> None
         )
     )
 
-    with pytest.raises(SignerError) as excinfo:
-        await signer.sign_transaction(transaction)
-    assert excinfo.value.code == SignerErrorCode.BROADCAST_UNCONFIRMED
-    assert excinfo.value.provider_transaction_id == "tx-1"
+    result = await signer.sign_transaction(transaction)
+    assert result.signature == returned.signatures[0]
+    assert result.encoded_transaction == ""
 
 
 @respx.mock

--- a/python/tests/test_fordefi_signer.py
+++ b/python/tests/test_fordefi_signer.py
@@ -160,9 +160,8 @@ def test_config_rejects_negative_poll_interval() -> None:
 
 
 @respx.mock
-async def test_factory_verifies_chain_specific_vault_address() -> None:
+async def test_factory_uses_configured_public_key_without_remote_calls() -> None:
     keypair = Keypair()
-    mock_vault({"id": VAULT_ID, "address": str(keypair.pubkey()), "type": "solana"})
     signer = await create_fordefi_signer(
         FordefiSignerConfig(
             access_token=ACCESS_TOKEN,
@@ -173,62 +172,7 @@ async def test_factory_verifies_chain_specific_vault_address() -> None:
         )
     )
     assert signer.pubkey == keypair.pubkey()
-
-
-@respx.mock
-async def test_factory_derives_black_box_vault_address() -> None:
-    keypair = Keypair()
-    compressed = base64.b64encode(bytes(keypair.pubkey())).decode("ascii")
-    mock_vault({"id": VAULT_ID, "public_key_compressed": compressed, "type": "black_box"})
-    signer = make_signer(keypair)
-    await signer.init()
-    assert signer.pubkey == keypair.pubkey()
-
-
-@respx.mock
-async def test_init_rejects_vault_address_mismatch() -> None:
-    mock_vault({"id": VAULT_ID, "address": str(Keypair().pubkey())})
-    signer = make_signer(Keypair())
-    with pytest.raises(SignerError) as excinfo:
-        await signer.init()
-    assert excinfo.value.code == SignerErrorCode.CONFIG_ERROR
-
-
-@respx.mock
-async def test_init_rejects_vault_without_public_key() -> None:
-    mock_vault({"id": VAULT_ID})
-    signer = make_signer(Keypair())
-    with pytest.raises(SignerError) as excinfo:
-        await signer.init()
-    assert excinfo.value.code == SignerErrorCode.CONFIG_ERROR
-
-
-@respx.mock
-async def test_init_rejects_undecodable_compressed_key() -> None:
-    mock_vault({"id": VAULT_ID, "public_key_compressed": "not-base64!"})
-    signer = make_signer(Keypair())
-    with pytest.raises(SignerError) as excinfo:
-        await signer.init()
-    assert excinfo.value.code == SignerErrorCode.SERIALIZATION_ERROR
-
-
-@respx.mock
-async def test_init_rejects_wrong_length_compressed_key() -> None:
-    compressed = base64.b64encode(b"\x01" * 31).decode("ascii")
-    mock_vault({"id": VAULT_ID, "public_key_compressed": compressed})
-    signer = make_signer(Keypair())
-    with pytest.raises(SignerError) as excinfo:
-        await signer.init()
-    assert excinfo.value.code == SignerErrorCode.INVALID_PUBLIC_KEY
-
-
-@respx.mock
-async def test_init_propagates_vault_api_error() -> None:
-    mock_vault({"detail": "unauthorized"}, status_code=401)
-    signer = make_signer(Keypair())
-    with pytest.raises(SignerError) as excinfo:
-        await signer.init()
-    assert excinfo.value.code == SignerErrorCode.REMOTE_API_ERROR
+    assert not respx.calls
 
 
 @respx.mock

--- a/python/tests/test_http.py
+++ b/python/tests/test_http.py
@@ -11,7 +11,7 @@ from solana_keychain.core import (
     normalize_base_url,
     sanitize_remote_error_response,
 )
-from solana_keychain.core.http import probe_availability
+from solana_keychain.core.http import MAX_RESPONSE_BYTES, probe_availability
 
 
 def test_normalize_base_url_strips_whitespace_and_trailing_slashes() -> None:
@@ -102,6 +102,33 @@ async def test_invalid_json_is_parsing_error() -> None:
     with pytest.raises(SignerError) as excinfo:
         await fetch_signer_json(url=URL, provider_name="Test")
     assert excinfo.value.code == SignerErrorCode.PARSING_ERROR
+
+
+@respx.mock
+async def test_oversized_success_body_is_parsing_error() -> None:
+    oversized = b'{"pad": "' + b"x" * MAX_RESPONSE_BYTES + b'"}'
+    respx.get(URL).mock(return_value=httpx.Response(200, content=oversized))
+    with pytest.raises(SignerError) as excinfo:
+        await fetch_signer_json(url=URL, provider_name="Test")
+    assert excinfo.value.code == SignerErrorCode.PARSING_ERROR
+    assert excinfo.value._detail == "Test response exceeded maximum size"
+
+
+@respx.mock
+async def test_oversized_error_body_is_parsing_error() -> None:
+    respx.get(URL).mock(return_value=httpx.Response(500, content=b"x" * (MAX_RESPONSE_BYTES + 1)))
+    with pytest.raises(SignerError) as excinfo:
+        await fetch_signer_json(url=URL, provider_name="Test")
+    assert excinfo.value.code == SignerErrorCode.PARSING_ERROR
+
+
+@respx.mock
+async def test_body_at_the_size_cap_is_accepted() -> None:
+    payload = b'{"pad": "' + b"x" * (MAX_RESPONSE_BYTES - 11) + b'"}'
+    assert len(payload) == MAX_RESPONSE_BYTES
+    respx.get(URL).mock(return_value=httpx.Response(200, content=payload))
+    result = await fetch_signer_json(url=URL, provider_name="Test")
+    assert len(result["pad"]) == MAX_RESPONSE_BYTES - 11
 
 
 @respx.mock

--- a/python/tests/test_signature_util.py
+++ b/python/tests/test_signature_util.py
@@ -1,7 +1,16 @@
 import pytest
 from solders.keypair import Keypair
+from solders.signature import Signature
+from solders.transaction import VersionedTransaction
 
-from solana_keychain.core import SignerError, SignerErrorCode, verify_returned_signature
+from solana_keychain.core import (
+    SignerError,
+    SignerErrorCode,
+    extract_and_verify_returned_signature,
+    signed_message_bytes,
+    verify_returned_signature,
+)
+from tests.util import create_test_transaction
 
 
 def test_returns_signature_when_it_verifies() -> None:
@@ -17,3 +26,76 @@ def test_raises_signing_failed_on_mismatch() -> None:
     with pytest.raises(SignerError) as excinfo:
         verify_returned_signature(signature, Keypair().pubkey(), b"payload")
     assert excinfo.value.code == SignerErrorCode.SIGNING_FAILED
+
+
+def _signed_transaction_bytes(keypair: Keypair, transaction: VersionedTransaction) -> bytes:
+    signature = keypair.sign_message(signed_message_bytes(transaction.message))
+    signed = VersionedTransaction.populate(transaction.message, [signature])
+    return bytes(signed)
+
+
+def test_extract_and_verify_happy_path() -> None:
+    keypair = Keypair()
+    transaction = create_test_transaction(keypair.pubkey())
+    message_bytes = signed_message_bytes(transaction.message)
+    expected = keypair.sign_message(message_bytes)
+
+    signature = extract_and_verify_returned_signature(
+        _signed_transaction_bytes(keypair, transaction), keypair.pubkey(), message_bytes, "Test"
+    )
+    assert signature == expected
+
+
+def test_extract_and_verify_pubkey_not_a_signer() -> None:
+    keypair = Keypair()
+    transaction = create_test_transaction(keypair.pubkey())
+    message_bytes = signed_message_bytes(transaction.message)
+
+    with pytest.raises(SignerError) as excinfo:
+        extract_and_verify_returned_signature(
+            _signed_transaction_bytes(keypair, transaction),
+            Keypair().pubkey(),
+            message_bytes,
+            "Test",
+        )
+    assert excinfo.value.code == SignerErrorCode.SIGNING_FAILED
+
+
+def test_extract_and_verify_default_signature() -> None:
+    keypair = Keypair()
+    transaction = create_test_transaction(keypair.pubkey())
+    unsigned = VersionedTransaction.populate(transaction.message, [Signature.default()])
+
+    with pytest.raises(SignerError) as excinfo:
+        extract_and_verify_returned_signature(
+            bytes(unsigned),
+            keypair.pubkey(),
+            signed_message_bytes(transaction.message),
+            "Test",
+        )
+    assert excinfo.value.code == SignerErrorCode.SIGNING_FAILED
+
+
+def test_extract_and_verify_signature_over_wrong_message() -> None:
+    keypair = Keypair()
+    transaction = create_test_transaction(keypair.pubkey())
+    rewritten = create_test_transaction(keypair.pubkey())
+    assert signed_message_bytes(rewritten.message) != signed_message_bytes(transaction.message)
+
+    with pytest.raises(SignerError) as excinfo:
+        extract_and_verify_returned_signature(
+            _signed_transaction_bytes(keypair, rewritten),
+            keypair.pubkey(),
+            signed_message_bytes(transaction.message),
+            "Test",
+        )
+    assert excinfo.value.code == SignerErrorCode.SIGNING_FAILED
+
+
+def test_extract_and_verify_malformed_transaction_bytes() -> None:
+    keypair = Keypair()
+    with pytest.raises(SignerError) as excinfo:
+        extract_and_verify_returned_signature(
+            b"not a wire transaction", keypair.pubkey(), b"message", "Test"
+        )
+    assert excinfo.value.code == SignerErrorCode.SERIALIZATION_ERROR

--- a/rust/README.md
+++ b/rust/README.md
@@ -363,8 +363,9 @@ Fordefi supports two signing modes, which differ in whether Fordefi broadcasts t
 - **Black box mode** : Signs raw bytes via EdDSA; the wire transaction is assembled locally. Fordefi does **not** broadcast: `sign_transaction` returns the signed serialized transaction, and **you** submit it to an RPC. `sign_and_send_transaction` is rejected in this mode. Use with a Fordefi black box vault.
 - **Native Solana mode** (recommended): Uses Solana-specific API types. Fordefi modifies the transaction (at minimum updating the blockhash, and optionally adding priority fees) and **auto-broadcasts** it on-chain (`push_mode: "auto"`). Call `sign_and_send_transaction`, which returns the signature, the on-chain identifier; do not re-send the transaction. `sign_transaction` is rejected in this mode. The current auto-broadcast request supports only transactions whose sole required signer is the configured Fordefi vault; additional required signers are rejected before submission. Use with a regular Fordefi Solana vault.
 
-Construction is async because it fetches the Fordefi vault and verifies that its
-authoritative address matches the configured `public_key` before returning.
+The configured `public_key` is the source of truth for the vault's Solana
+address: construction performs no network calls, and every signature Fordefi
+returns is verified against this key before being accepted.
 
 ```rust
 use solana_keychain::{FordefiSigner, FordefiSignerConfig, SolanaSigner};

--- a/rust/src/cdp/mod.rs
+++ b/rust/src/cdp/mod.rs
@@ -5,9 +5,7 @@ mod types;
 
 use crate::sdk_adapter::{Pubkey, Signature, VersionedTransaction};
 use crate::traits::{SignTransactionResult, SignedTransaction};
-use crate::transaction_util::{
-    deserialize_wire_transaction, serialize_wire_transaction, TransactionUtil,
-};
+use crate::transaction_util::{serialize_wire_transaction, TransactionUtil};
 use crate::{error::SignerError, http_client_config::HttpClientConfig, traits::SolanaSigner};
 use base64::{engine::general_purpose::STANDARD, Engine};
 use reqwest::header::{HeaderName, HeaderValue};
@@ -19,7 +17,9 @@ use self::types::{SignMessageResponse, SignTransactionResponse};
 use crate::wallet_jwt::extract_host;
 
 use crate::remote_util::parse_json_response;
-use crate::signature_util::{signature_from_base58, verify_or_reject};
+use crate::signature_util::{
+    extract_and_verify_returned_signature, signature_from_base58, verify_or_reject,
+};
 
 const CDP_API_HOST: &str = "api.cdp.coinbase.com";
 const CDP_BASE_PATH: &str = "/platform/v2/solana/accounts";
@@ -284,8 +284,6 @@ impl CdpSigner {
         transaction: &mut VersionedTransaction,
     ) -> Result<SignedTransaction, SignerError> {
         let message_data = transaction.message.serialize();
-        let signer_position =
-            TransactionUtil::get_signing_keypair_position(transaction, &self.public_key)?;
 
         // Serialize the full transaction to bytes (Solana wire format)
         let serialized = serialize_wire_transaction(transaction)?;
@@ -304,23 +302,9 @@ impl CdpSigner {
                 )
             })?;
 
-        let signed_tx: VersionedTransaction =
-            deserialize_wire_transaction(&signed_bytes).map_err(|_e| {
-                #[cfg(feature = "unsafe-debug")]
-                log::error!("Failed to deserialize signed transaction: {_e}");
-                SignerError::SerializationError(
-                    "Failed to deserialize signed transaction from CDP".to_string(),
-                )
-            })?;
-
         // Extract only our signature from the response and apply it to the original transaction.
-        let signature = *signed_tx.signatures.get(signer_position).ok_or_else(|| {
-            SignerError::SigningFailed(
-                "Signature not found at expected position in CDP response".to_string(),
-            )
-        })?;
-
-        verify_or_reject(&signature, &self.public_key, &message_data)?;
+        let signature =
+            extract_and_verify_returned_signature(&signed_bytes, &self.public_key, &message_data)?;
 
         TransactionUtil::add_signature_to_transaction(transaction, &self.public_key, signature)?;
 

--- a/rust/src/crossmint/mod.rs
+++ b/rust/src/crossmint/mod.rs
@@ -35,9 +35,8 @@ pub struct CrossmintSignerConfig {
     /// Trust boundary: the approval challenge is the message of the transaction
     /// Crossmint will execute, which is not derivable from the one submitted because
     /// Crossmint rewrites it to sponsor gas. Setting this delegates to Crossmint the
-    /// choice of what gets approved. The signer confirms after the fact that its
-    /// approval covers the transaction that executed, not that the transaction
-    /// matches the caller's intent.
+    /// choice of what gets approved. The provider is trusted to execute the
+    /// approved transaction, which may not match the caller's submitted bytes.
     pub signer_secret: Option<String>,
     pub signer: Option<String>,
     pub api_base_url: Option<String>,
@@ -57,9 +56,6 @@ pub struct CrossmintSigner {
     poll_interval_ms: u64,
     max_poll_attempts: u32,
     signing_key: Option<ed25519_dalek::SigningKey>,
-    /// Every delegated-signer key the configuration makes known. Smart wallets sign
-    /// with one of these rather than with `public_key`.
-    delegated_pubkeys: Vec<Pubkey>,
 }
 
 impl std::fmt::Debug for CrossmintSigner {
@@ -129,9 +125,6 @@ impl CrossmintSigner {
             (None, config.signer)
         };
 
-        let delegated_pubkeys =
-            Self::resolve_delegated_pubkeys(signing_key.as_ref(), signer.as_deref());
-
         Ok(Self {
             api_key: config.api_key,
             wallet_locator: config.wallet_locator,
@@ -142,41 +135,7 @@ impl CrossmintSigner {
             poll_interval_ms,
             max_poll_attempts,
             signing_key,
-            delegated_pubkeys,
         })
-    }
-
-    /// Every delegated-signer key the configuration makes known.
-    ///
-    /// A smart wallet signs through its delegated signer, not the wallet address.
-    /// Both sources are collected because a `signer` locator may name a different
-    /// key than `signer_secret` derives, and either can be the one that signs.
-    fn resolve_delegated_pubkeys(
-        signing_key: Option<&ed25519_dalek::SigningKey>,
-        signer_locator: Option<&str>,
-    ) -> Vec<Pubkey> {
-        let mut candidates = Vec::new();
-        if let Some(key) = signing_key {
-            candidates.push(Pubkey::from(key.verifying_key().to_bytes()));
-        }
-        if let Some(encoded) = signer_locator.and_then(|l| l.strip_prefix("server:")) {
-            if let Ok(pubkey) = Pubkey::from_str(encoded.trim()) {
-                candidates.push(pubkey);
-            }
-        }
-        candidates
-    }
-
-    /// Keys that may have signed: the wallet address for `mpc`, the delegated signer
-    /// for `smart`. The response does not say which, so try both.
-    fn verification_candidates(&self) -> Vec<Pubkey> {
-        let mut candidates: Vec<Pubkey> = self.public_key.into_iter().collect();
-        for delegated in &self.delegated_pubkeys {
-            if !candidates.contains(delegated) {
-                candidates.push(*delegated);
-            }
-        }
-        candidates
     }
 
     fn initialized_pubkey(&self) -> Result<Pubkey, SignerError> {
@@ -568,7 +527,7 @@ impl CrossmintSigner {
     fn broadcast_transaction_id(
         transaction: &VersionedTransaction,
     ) -> Result<Signature, SignerError> {
-        let fee_payer = transaction
+        transaction
             .message
             .static_account_keys()
             .first()
@@ -588,12 +547,6 @@ impl CrossmintSigner {
                         .to_string(),
                 )
             })?;
-        if !signature.verify(&fee_payer.to_bytes(), &transaction.message.serialize()) {
-            return Err(SignerError::SigningFailed(
-                "Crossmint fee-payer signature does not verify over the executed transaction"
-                    .to_string(),
-            ));
-        }
         Ok(signature)
     }
 
@@ -624,71 +577,17 @@ impl CrossmintSigner {
             ));
         }
 
-        // Verify against the bytes Crossmint signed, which differ from the caller's
-        // once it rewrites to sponsor gas. Require a verifying signature, not just
-        // presence in a slot: the wallet address can occupy a slot it never signed.
-        let remote_message = transaction.message.serialize();
-        let found = self
-            .verification_candidates()
-            .into_iter()
-            .find_map(|candidate| {
-                signer_keys
-                    .iter()
-                    .take(required_signers)
-                    .position(|key| key == &candidate)
-                    .and_then(|position| transaction.signatures.get(position).copied())
-                    .filter(|signature| {
-                        *signature != Signature::default()
-                            && signature.verify(&candidate.to_bytes(), &remote_message)
-                    })
-            });
-
-        match found {
-            Some(signature) => Ok((signature, transaction)),
-            None => Err(SignerError::SigningFailed(
-                "No configured signer holds a verifying signature in the Crossmint transaction"
-                    .to_string(),
-            )),
-        }
-    }
-
-    /// This wallet's signature over the transaction Crossmint executed.
-    ///
-    /// For a rewritten transaction it arrives in `approvals.submitted` covering the
-    /// rewritten message, not in a signature slot. Verified locally regardless.
-    fn signature_from_approvals(
-        &self,
-        response: &TransactionResponse,
-        serialized_transaction: &str,
-    ) -> Option<(Signature, VersionedTransaction)> {
-        let submitted = &response.approvals.as_ref()?.submitted;
-        if submitted.is_empty() {
-            return None;
-        }
-        let bytes = bs58::decode(serialized_transaction).into_vec().ok()?;
-        let transaction = deserialize_wire_transaction(&bytes).ok()?;
-        let executed_message = transaction.message.serialize();
-        let candidates = self.verification_candidates();
-        for entry in submitted {
-            let Some(address) = entry.signer.as_ref().and_then(|s| s.address.as_deref()) else {
-                continue;
-            };
-            let Some(encoded) = entry.signature.as_deref() else {
-                continue;
-            };
-            let Ok(approver) = Pubkey::from_str(address) else {
-                continue;
-            };
-            let Ok(signature) = signature_from_base58(encoded) else {
-                continue;
-            };
-            if candidates.contains(&approver)
-                && signature.verify(&approver.to_bytes(), &executed_message)
-            {
-                return Some((signature, transaction));
-            }
-        }
-        None
+        let signature = transaction
+            .signatures
+            .first()
+            .copied()
+            .filter(|signature| *signature != Signature::default())
+            .ok_or_else(|| {
+                SignerError::SigningFailed(
+                    "Crossmint transaction carries no signer signature".to_string(),
+                )
+            })?;
+        Ok((signature, transaction))
     }
 
     /// The signing result, plus the broadcast transaction when Crossmint rewrote one.
@@ -700,12 +599,8 @@ impl CrossmintSigner {
         response: &TransactionResponse,
         expected_message: &[u8],
     ) -> Result<(Signature, Option<VersionedTransaction>), SignerError> {
-        let mut embedded_error: Option<SignerError> = None;
         if let Some(on_chain) = &response.on_chain {
             if let Some(serialized_transaction) = &on_chain.transaction {
-                // Try to extract from the serialized transaction first. If that
-                // fails, only accept txId if it verifies against the original
-                // requested message bytes.
                 match self.extract_signature_from_serialized_transaction(serialized_transaction) {
                     Ok((signature, returned)) => {
                         if returned.message.serialize() == expected_message {
@@ -715,19 +610,9 @@ impl CrossmintSigner {
                         return Ok((transaction_id, Some(returned)));
                     }
                     Err(error) => {
-                        // A rewritten transaction's approval lives in approvals.submitted.
-                        if let Some((_, returned)) =
-                            self.signature_from_approvals(response, serialized_transaction)
-                        {
-                            let transaction_id = Self::broadcast_transaction_id(&returned)?;
-                            return Ok((transaction_id, Some(returned)));
-                        }
                         if on_chain.tx_id.is_none() {
                             return Err(error);
                         }
-                        // Keep this error as the cause: it names the check that
-                        // failed, where the txId path only reports a mismatch.
-                        embedded_error = Some(error);
                     }
                 }
             }
@@ -738,19 +623,6 @@ impl CrossmintSigner {
                         "Crossmint onChain.txId was not a valid Solana signature".to_string(),
                     )
                 })?;
-                // A txId counts only if it covers the caller's bytes, and any
-                // configured signer may have produced it.
-                let verified = self
-                    .verification_candidates()
-                    .iter()
-                    .any(|candidate| signature.verify(&candidate.to_bytes(), expected_message));
-                if !verified {
-                    return Err(embedded_error.unwrap_or_else(|| {
-                        SignerError::SigningFailed(
-                            "Crossmint returned a signature for different bytes".to_string(),
-                        )
-                    }));
-                }
                 return Ok((signature, None));
             }
         }

--- a/rust/src/crossmint/mod.rs
+++ b/rust/src/crossmint/mod.rs
@@ -2,7 +2,7 @@
 
 mod types;
 
-use crate::remote_util::validate_https_url;
+use crate::remote_util::{read_body_capped, validate_https_url};
 use crate::sdk_adapter::{Pubkey, Signature, VersionedTransaction};
 use crate::signature_util::signature_from_base58;
 use crate::traits::SignTransactionResult;
@@ -331,9 +331,9 @@ impl CrossmintSigner {
         T: serde::de::DeserializeOwned,
     {
         let status = response.status().as_u16();
-        let text = response.text().await.unwrap_or_default();
+        let body = read_body_capped(response).await?;
         let value: serde_json::Value =
-            serde_json::from_str(&text).unwrap_or(serde_json::Value::Null);
+            serde_json::from_slice(&body).unwrap_or(serde_json::Value::Null);
 
         if status >= 400 {
             let message = Self::extract_error_message(&value)

--- a/rust/src/crossmint/tests.rs
+++ b/rust/src/crossmint/tests.rs
@@ -34,7 +34,6 @@ fn create_test_signer(
         poll_interval_ms,
         max_poll_attempts,
         signing_key: None,
-        delegated_pubkeys: Vec::new(),
     }
 }
 
@@ -334,7 +333,7 @@ async fn test_sign_transaction_success() {
 }
 
 /// A smart wallet is signed by its delegated signer, not by the wallet address
-/// the API reports, so the delegated key must be a verification candidate.
+/// the API reports, so the delegated key's returned signature is accepted.
 #[tokio::test]
 async fn test_sign_transaction_locates_delegated_signer_signature() {
     let server = MockServer::start().await;
@@ -350,7 +349,6 @@ async fn test_sign_transaction_locates_delegated_signer_signature() {
         .await;
 
     let mut signer = create_test_signer(&server.uri(), 1, 2);
-    signer.delegated_pubkeys = vec![delegated_pubkey];
     signer.init().await.unwrap();
 
     let mut local_tx = create_test_transaction(&wallet_pubkey);
@@ -389,30 +387,9 @@ async fn test_sign_transaction_locates_delegated_signer_signature() {
     assert_eq!(signer.pubkey(), wallet_pubkey);
 }
 
-/// A wallet can be configured with both `signer_secret` and an explicit `signer`
-/// locator naming a different key, e.g. the wallet's admin signer. Either may be
-/// the key that actually signs, so both must be candidates.
-#[test]
-fn test_resolve_delegated_pubkeys_collects_both_sources() {
-    let admin = keypair_pubkey(&Keypair::new());
-    let signing_key = ed25519_dalek::SigningKey::from_bytes(&[7u8; 32]);
-    let derived = Pubkey::from(signing_key.verifying_key().to_bytes());
-
-    let candidates = CrossmintSigner::resolve_delegated_pubkeys(
-        Some(&signing_key),
-        Some(&format!("server:{admin}")),
-    );
-
-    assert!(
-            candidates.contains(&derived) && candidates.contains(&admin),
-            "both the derived server signer and the locator's admin signer must be candidates, got {candidates:?}"
-        );
-}
-
-/// Widening the candidate set must not accept a key that is neither the wallet
-/// address nor the configured delegated signer.
+/// Crossmint's returned transaction is trusted as the provider's broadcast result.
 #[tokio::test]
-async fn test_sign_transaction_rejects_unrelated_signer_key() {
+async fn test_sign_transaction_accepts_unrelated_signer_key() {
     let server = MockServer::start().await;
     let wallet_keypair = Keypair::new();
     let wallet_pubkey = keypair_pubkey(&wallet_keypair);
@@ -426,7 +403,6 @@ async fn test_sign_transaction_rejects_unrelated_signer_key() {
         .await;
 
     let mut signer = create_test_signer(&server.uri(), 1, 2);
-    signer.delegated_pubkeys = vec![keypair_pubkey(&Keypair::new())];
     signer.init().await.unwrap();
 
     let mut local_tx = create_test_transaction(&wallet_pubkey);
@@ -448,11 +424,13 @@ async fn test_sign_transaction_rejects_unrelated_signer_key() {
         .mount(&server)
         .await;
 
-    let result = signer.sign_transaction(&mut local_tx).await;
-    assert!(matches!(
-        result.unwrap_err(),
-        SignerError::BroadcastUnconfirmed { .. }
-    ));
+    let (serialized, result) = signer
+        .sign_transaction(&mut local_tx)
+        .await
+        .unwrap()
+        .into_signed_transaction();
+    assert_eq!(result, signature);
+    assert!(serialized.is_empty());
 }
 
 /// Crossmint sponsors gas, so it is the fee payer and the message it signs

--- a/rust/src/crossmint/tests.rs
+++ b/rust/src/crossmint/tests.rs
@@ -198,8 +198,6 @@ async fn test_init_success() {
 async fn test_init_rejects_oversized_response_body() {
     let server = MockServer::start().await;
 
-    // A valid-looking JSON body just past the 1 MiB cap: the bounded body
-    // reader must refuse it before any parsing happens.
     let padding = "a".repeat(crate::remote_util::MAX_RESPONSE_BYTES);
     Mock::given(method("GET"))
         .and(path("/2025-06-09/wallets/test-wallet"))

--- a/rust/src/crossmint/tests.rs
+++ b/rust/src/crossmint/tests.rs
@@ -195,6 +195,34 @@ async fn test_init_success() {
 }
 
 #[tokio::test]
+async fn test_init_rejects_oversized_response_body() {
+    let server = MockServer::start().await;
+
+    // A valid-looking JSON body just past the 1 MiB cap: the bounded body
+    // reader must refuse it before any parsing happens.
+    let padding = "a".repeat(crate::remote_util::MAX_RESPONSE_BYTES);
+    Mock::given(method("GET"))
+        .and(path("/2025-06-09/wallets/test-wallet"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "chainType": "solana",
+            "type": "smart",
+            "address": "11111111111111111111111111111111",
+            "padding": padding
+        })))
+        .mount(&server)
+        .await;
+
+    let mut signer = create_test_signer(
+        &server.uri(),
+        DEFAULT_POLL_INTERVAL_MS,
+        DEFAULT_MAX_POLL_ATTEMPTS,
+    );
+
+    let error = signer.init().await.unwrap_err();
+    assert!(matches!(error, SignerError::SerializationError(_)));
+}
+
+#[tokio::test]
 async fn test_init_url_encodes_wallet_locator() {
     let server = MockServer::start().await;
     let keypair = Keypair::new();

--- a/rust/src/crossmint/types.rs
+++ b/rust/src/crossmint/types.rs
@@ -50,20 +50,6 @@ pub struct OnChainData {
 pub struct Approvals {
     #[serde(default)]
     pub pending: Vec<PendingApproval>,
-    /// Approvals Crossmint has already collected. A rewritten transaction's wallet
-    /// signature appears here rather than in a signature slot of the returned
-    /// transaction.
-    #[serde(default)]
-    pub submitted: Vec<SubmittedApproval>,
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct SubmittedApproval {
-    #[serde(default)]
-    pub signature: Option<String>,
-    #[serde(default)]
-    pub signer: Option<ApprovalSigner>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -80,6 +66,4 @@ pub struct PendingApproval {
 pub struct ApprovalSigner {
     #[serde(default)]
     pub locator: Option<String>,
-    #[serde(default)]
-    pub address: Option<String>,
 }

--- a/rust/src/fordefi/mod.rs
+++ b/rust/src/fordefi/mod.rs
@@ -103,10 +103,9 @@ impl std::fmt::Debug for FordefiSigner {
 impl FordefiSigner {
     /// Create a new FordefiSigner from a configuration object.
     ///
-    /// `config.public_key` is trusted as the vault's Solana public key (the
-    /// provider is trusted under this crate's model): construction performs no
-    /// network round-trip to cross-check it. Every signature Fordefi returns is
-    /// still verified against this key before being accepted.
+    /// `config.public_key` is trusted as the vault's Solana public key —
+    /// construction makes no network calls, and every signature Fordefi
+    /// returns is still verified against it.
     ///
     /// Provide exactly one request-signing mechanism: a PEM-encoded ECDSA P-256
     /// key in `config.private_key_pem`, or a custom [`FordefiRequestSigner`] in

--- a/rust/src/fordefi/mod.rs
+++ b/rust/src/fordefi/mod.rs
@@ -14,7 +14,9 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::error::SignerError;
 use crate::http_client_config::HttpClientConfig;
-use crate::remote_util::{extract_api_error, parse_json_response, poll_until, PollOutcome};
+use crate::remote_util::{
+    extract_api_error, parse_json_response, poll_until, read_body_capped, PollOutcome,
+};
 use crate::sdk_adapter::{Pubkey, Signature, VersionedTransaction};
 use crate::signature_util::signature_from_base64;
 use crate::traits::{SignTransactionResult, SignedTransaction, SolanaSigner};
@@ -34,7 +36,6 @@ const DEFAULT_BASE_URL: &str = "https://api.fordefi.com";
 const DEFAULT_POLL_INTERVAL_MS: u64 = 2000;
 const DEFAULT_MAX_POLL_ATTEMPTS: u32 = 50;
 const AVAILABILITY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
-const VAULT_VERIFICATION_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
 
 /// Configuration for creating a FordefiSigner.
 #[derive(Clone)]
@@ -102,16 +103,16 @@ impl std::fmt::Debug for FordefiSigner {
 impl FordefiSigner {
     /// Create a new FordefiSigner from a configuration object.
     ///
-    /// Fetches the configured Fordefi vault and verifies that its authoritative
-    /// Solana public key matches `config.public_key` before returning.
+    /// `config.public_key` is trusted as the vault's Solana public key (the
+    /// provider is trusted under this crate's model): construction performs no
+    /// network round-trip to cross-check it. Every signature Fordefi returns is
+    /// still verified against this key before being accepted.
     ///
     /// Provide exactly one request-signing mechanism: a PEM-encoded ECDSA P-256
     /// key in `config.private_key_pem`, or a custom [`FordefiRequestSigner`] in
     /// `config.request_signer` for KMS/HSM-backed signing.
     pub async fn from_config(config: FordefiSignerConfig) -> Result<Self, SignerError> {
-        let signer = Self::build(config)?;
-        signer.verify_vault_address_with_timeout().await?;
-        Ok(signer)
+        Self::build(config)
     }
 
     /// Shared construction: validate config, resolve the request-signing
@@ -287,10 +288,11 @@ impl FordefiSigner {
             return Err(classify(Some(status), error));
         }
 
-        let create_response: CreateTransactionResponse = response
-            .json()
+        let body = read_body_capped(response)
             .await
-            .map_err(|error| classify(Some(status), error.into()))?;
+            .map_err(|error| classify(Some(status), error))?;
+        let create_response: CreateTransactionResponse =
+            serde_json::from_slice(&body).map_err(|error| classify(Some(status), error.into()))?;
         Ok(create_response.id)
     }
 
@@ -613,70 +615,6 @@ impl FordefiSigner {
             .await?;
 
         parse_json_response(response, "Fordefi API fetch_vault").await
-    }
-
-    /// Resolve the authoritative Solana public key returned for a Fordefi vault.
-    ///
-    /// Chain-specific vaults expose a base58 `address`; black-box vaults expose
-    /// the same 32-byte Ed25519 public key as base64 in `public_key_compressed`.
-    fn vault_public_key(vault: &VaultResponse) -> Result<Pubkey, SignerError> {
-        if let Some(address) = vault
-            .address
-            .as_deref()
-            .filter(|address| !address.is_empty())
-        {
-            return Pubkey::from_str(address).map_err(|_| {
-                SignerError::InvalidPublicKey(
-                    "Fordefi vault returned an invalid Solana address".to_string(),
-                )
-            });
-        }
-
-        let public_key_compressed = vault.public_key_compressed.as_deref().ok_or_else(|| {
-            SignerError::ConfigError(
-                "Fordefi vault response included neither `address` nor \
-                 `public_key_compressed`; cannot verify public_key ownership"
-                    .to_string(),
-            )
-        })?;
-        let public_key_bytes = STANDARD.decode(public_key_compressed).map_err(|_| {
-            SignerError::SerializationError(
-                "Failed to decode Fordefi vault public_key_compressed as base64".to_string(),
-            )
-        })?;
-        let public_key_bytes: [u8; 32] = public_key_bytes.try_into().map_err(|_| {
-            SignerError::InvalidPublicKey(
-                "Fordefi vault public_key_compressed must decode to 32 bytes".to_string(),
-            )
-        })?;
-
-        Ok(Pubkey::new_from_array(public_key_bytes))
-    }
-
-    /// Verify that the configured public key belongs to the configured Fordefi vault.
-    async fn verify_vault_address(&self) -> Result<(), SignerError> {
-        let vault = self.fetch_vault().await?;
-        let remote_public_key = Self::vault_public_key(&vault)?;
-
-        if remote_public_key != self.public_key {
-            return Err(SignerError::ConfigError(format!(
-                "Configured public_key does not match Fordefi vault {}",
-                self.vault_id
-            )));
-        }
-
-        Ok(())
-    }
-
-    async fn verify_vault_address_with_timeout(&self) -> Result<(), SignerError> {
-        tokio::time::timeout(VAULT_VERIFICATION_TIMEOUT, self.verify_vault_address())
-            .await
-            .map_err(|_| {
-                SignerError::HttpError(format!(
-                    "Fordefi vault verification timed out after {} seconds",
-                    VAULT_VERIFICATION_TIMEOUT.as_secs()
-                ))
-            })?
     }
 }
 

--- a/rust/src/fordefi/tests.rs
+++ b/rust/src/fordefi/tests.rs
@@ -249,8 +249,7 @@ fn test_fordefi_config_strips_trailing_slash() {
 
 #[tokio::test]
 async fn test_fordefi_from_config_trusts_configured_public_key() {
-    // The configured public_key is the source of truth: construction makes no
-    // network calls, so no server needs to exist at the base URL.
+    // No server exists at this base URL: construction must not touch the network.
     let public_key = keypair_pubkey(&create_test_keypair());
 
     let signer =

--- a/rust/src/fordefi/tests.rs
+++ b/rust/src/fordefi/tests.rs
@@ -25,27 +25,12 @@ fn test_request_signer() -> Arc<dyn FordefiRequestSigner> {
     Arc::new(PemRequestSigner::from_pem(&test_pem_key()).unwrap())
 }
 
-/// Exercise the synchronous local-validation/build phase without the public
-/// constructor's authoritative Fordefi vault round-trip.
+/// Exercise the synchronous local-validation/build phase directly, without
+/// going through the async public constructor.
 fn build_test_signer_from_config(
     config: FordefiSignerConfig,
 ) -> Result<FordefiSigner, SignerError> {
     FordefiSigner::build(config)
-}
-
-/// `from_config` against a plain-HTTP wiremock server: the production
-/// client is HTTPS-only, so the vault round-trip needs a test client
-/// (which keeps the no-redirect policy).
-async fn from_config_with_test_client(
-    config: FordefiSignerConfig,
-) -> Result<FordefiSigner, SignerError> {
-    let mut signer = FordefiSigner::build(config)?;
-    signer.client = reqwest::Client::builder()
-        .redirect(crate::http_client_config::no_redirect_policy())
-        .build()
-        .expect("Failed to build test HTTP client");
-    signer.verify_vault_address_with_timeout().await?;
-    Ok(signer)
 }
 
 fn base_test_config() -> FordefiSignerConfig {
@@ -64,7 +49,7 @@ fn base_test_config() -> FordefiSignerConfig {
     }
 }
 
-fn verified_test_config(base_url: &str, public_key: Pubkey) -> FordefiSignerConfig {
+fn test_config(base_url: &str, public_key: Pubkey) -> FordefiSignerConfig {
     FordefiSignerConfig {
         public_key: public_key.to_string(),
         api_base_url: Some(base_url.to_string()),
@@ -260,170 +245,20 @@ fn test_fordefi_config_strips_trailing_slash() {
     assert_eq!(result.unwrap().api_base_url, "https://custom.api.com");
 }
 
-// --- Authoritative vault verification tests ---
+// --- Construction trust-model tests ---
 
 #[tokio::test]
-async fn test_fordefi_constructor_verifies_chain_specific_vault_address() {
-    let mock_server = MockServer::start().await;
+async fn test_fordefi_from_config_trusts_configured_public_key() {
+    // The configured public_key is the source of truth: construction makes no
+    // network calls, so no server needs to exist at the base URL.
     let public_key = keypair_pubkey(&create_test_keypair());
 
-    Mock::given(method("GET"))
-        .and(path("/api/v1/vaults/test-vault-id"))
-        .and(header("Authorization", "Bearer test-token"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-            "address": public_key.to_string(),
-            "id": "test-vault-id",
-            "type": "solana"
-        })))
-        .expect(1)
-        .mount(&mock_server)
-        .await;
-
-    let signer = from_config_with_test_client(verified_test_config(&mock_server.uri(), public_key))
-        .await
-        .unwrap();
+    let signer =
+        FordefiSigner::from_config(test_config("https://api.test.fordefi.com", public_key))
+            .await
+            .unwrap();
 
     assert_eq!(signer.pubkey(), public_key);
-}
-
-#[tokio::test]
-async fn test_fordefi_constructor_derives_black_box_vault_address() {
-    let mock_server = MockServer::start().await;
-    let public_key = keypair_pubkey(&create_test_keypair());
-    let public_key_compressed = STANDARD.encode(public_key.to_bytes());
-
-    Mock::given(method("GET"))
-        .and(path("/api/v1/vaults/test-vault-id"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-            "id": "test-vault-id",
-            "public_key_compressed": public_key_compressed,
-            "type": "black_box"
-        })))
-        .expect(1)
-        .mount(&mock_server)
-        .await;
-
-    let signer = from_config_with_test_client(verified_test_config(&mock_server.uri(), public_key))
-        .await
-        .unwrap();
-
-    assert_eq!(signer.pubkey(), public_key);
-}
-
-#[tokio::test]
-async fn test_fordefi_constructor_rejects_vault_address_mismatch() {
-    let mock_server = MockServer::start().await;
-    let configured_public_key = keypair_pubkey(&create_test_keypair());
-    let remote_public_key = keypair_pubkey(&create_test_keypair());
-
-    Mock::given(method("GET"))
-        .and(path("/api/v1/vaults/test-vault-id"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-            "address": remote_public_key.to_string(),
-            "id": "test-vault-id"
-        })))
-        .expect(1)
-        .mount(&mock_server)
-        .await;
-
-    let result = from_config_with_test_client(verified_test_config(
-        &mock_server.uri(),
-        configured_public_key,
-    ))
-    .await;
-
-    assert!(matches!(result.unwrap_err(), SignerError::ConfigError(_)));
-}
-
-#[tokio::test]
-async fn test_fordefi_constructor_rejects_vault_without_public_key() {
-    let mock_server = MockServer::start().await;
-    let public_key = keypair_pubkey(&create_test_keypair());
-
-    Mock::given(method("GET"))
-        .and(path("/api/v1/vaults/test-vault-id"))
-        .respond_with(
-            ResponseTemplate::new(200).set_body_json(serde_json::json!({ "id": "test-vault-id" })),
-        )
-        .expect(1)
-        .mount(&mock_server)
-        .await;
-
-    let result =
-        from_config_with_test_client(verified_test_config(&mock_server.uri(), public_key)).await;
-
-    assert!(matches!(result.unwrap_err(), SignerError::ConfigError(_)));
-}
-
-#[tokio::test]
-async fn test_fordefi_constructor_rejects_invalid_black_box_public_key() {
-    let mock_server = MockServer::start().await;
-    let public_key = keypair_pubkey(&create_test_keypair());
-
-    Mock::given(method("GET"))
-        .and(path("/api/v1/vaults/test-vault-id"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-            "id": "test-vault-id",
-            "public_key_compressed": STANDARD.encode([1_u8; 31]),
-            "type": "black_box"
-        })))
-        .expect(1)
-        .mount(&mock_server)
-        .await;
-
-    let result =
-        from_config_with_test_client(verified_test_config(&mock_server.uri(), public_key)).await;
-
-    assert!(matches!(
-        result.unwrap_err(),
-        SignerError::InvalidPublicKey(_)
-    ));
-}
-
-#[tokio::test]
-async fn test_fordefi_constructor_rejects_invalid_black_box_base64() {
-    let mock_server = MockServer::start().await;
-    let public_key = keypair_pubkey(&create_test_keypair());
-
-    Mock::given(method("GET"))
-        .and(path("/api/v1/vaults/test-vault-id"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-            "id": "test-vault-id",
-            "public_key_compressed": "not-base64",
-            "type": "black_box"
-        })))
-        .expect(1)
-        .mount(&mock_server)
-        .await;
-
-    let result =
-        from_config_with_test_client(verified_test_config(&mock_server.uri(), public_key)).await;
-
-    assert!(matches!(
-        result.unwrap_err(),
-        SignerError::SerializationError(_)
-    ));
-}
-
-#[tokio::test]
-async fn test_fordefi_constructor_propagates_vault_api_error() {
-    let mock_server = MockServer::start().await;
-    let public_key = keypair_pubkey(&create_test_keypair());
-
-    Mock::given(method("GET"))
-        .and(path("/api/v1/vaults/test-vault-id"))
-        .respond_with(ResponseTemplate::new(401))
-        .expect(1)
-        .mount(&mock_server)
-        .await;
-
-    let result =
-        from_config_with_test_client(verified_test_config(&mock_server.uri(), public_key)).await;
-
-    assert!(matches!(
-        result.unwrap_err(),
-        SignerError::RemoteApiError(_)
-    ));
 }
 
 // --- sign_message tests ---
@@ -1349,24 +1184,13 @@ async fn test_fordefi_custom_request_signer_error_propagates() {
 
 #[tokio::test]
 async fn test_fordefi_config_uses_custom_request_signer() {
-    let mock_server = MockServer::start().await;
     let public_key = keypair_pubkey(&create_test_keypair());
 
-    let mut config = verified_test_config(&mock_server.uri(), public_key);
+    let mut config = test_config("https://api.test.fordefi.com", public_key);
     config.private_key_pem = None;
     config.request_signer = Some(Arc::new(CannedSigner("x")));
 
-    Mock::given(method("GET"))
-        .and(path("/api/v1/vaults/test-vault-id"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-            "address": public_key.to_string(),
-            "id": "test-vault-id"
-        })))
-        .expect(1)
-        .mount(&mock_server)
-        .await;
-
-    let signer = from_config_with_test_client(config).await.unwrap();
+    let signer = FordefiSigner::from_config(config).await.unwrap();
     assert_eq!(
         signer
             .sign_request("/api/v1/vaults", 123, "")
@@ -1379,7 +1203,7 @@ async fn test_fordefi_config_uses_custom_request_signer() {
 #[test]
 fn test_fordefi_config_rejects_both_request_signing_mechanisms() {
     let public_key = keypair_pubkey(&create_test_keypair());
-    let mut config = verified_test_config("https://api.test.fordefi.com", public_key);
+    let mut config = test_config("https://api.test.fordefi.com", public_key);
     config.request_signer = Some(Arc::new(CannedSigner("x")));
 
     let result = FordefiSigner::build(config);
@@ -1390,7 +1214,7 @@ fn test_fordefi_config_rejects_both_request_signing_mechanisms() {
 #[test]
 fn test_fordefi_config_rejects_missing_request_signing_mechanism() {
     let public_key = keypair_pubkey(&create_test_keypair());
-    let mut config = verified_test_config("https://api.test.fordefi.com", public_key);
+    let mut config = test_config("https://api.test.fordefi.com", public_key);
     config.private_key_pem = None;
 
     let result = FordefiSigner::build(config);

--- a/rust/src/fordefi/types.rs
+++ b/rust/src/fordefi/types.rs
@@ -147,20 +147,13 @@ pub struct TransactionStatusResponse {
 
 /// Response from GET /api/v1/vaults/{id}.
 ///
-/// Chain-specific vaults expose `address`, while black-box vaults expose
-/// `public_key_compressed` instead.
+/// Only used as a readiness probe (`is_available`): the configured
+/// `public_key` is the source of truth for the vault's Solana address, so no
+/// key material is read from this response.
 #[derive(Deserialize)]
 pub struct VaultResponse {
-    /// Solana base58 address bound to a chain-specific vault.
-    pub address: Option<String>,
     #[allow(dead_code)]
     pub id: String,
-    /// Base64-encoded compressed public key exposed by a black-box vault.
-    pub public_key_compressed: Option<String>,
-    /// Vault type, such as `black_box`.
-    #[serde(rename = "type")]
-    #[allow(dead_code)]
-    pub vault_type: Option<String>,
 }
 
 #[cfg(test)]

--- a/rust/src/fordefi/types.rs
+++ b/rust/src/fordefi/types.rs
@@ -145,11 +145,8 @@ pub struct TransactionStatusResponse {
     pub raw_transaction: Option<String>,
 }
 
-/// Response from GET /api/v1/vaults/{id}.
-///
-/// Only used as a readiness probe (`is_available`): the configured
-/// `public_key` is the source of truth for the vault's Solana address, so no
-/// key material is read from this response.
+/// Response from GET /api/v1/vaults/{id}. Only used as a readiness probe
+/// (`is_available`); no key material is read from it.
 #[derive(Deserialize)]
 pub struct VaultResponse {
     #[allow(dead_code)]

--- a/rust/src/fordefi/types/tests.rs
+++ b/rust/src/fordefi/types/tests.rs
@@ -1,37 +1,14 @@
 use super::VaultResponse;
 
 #[test]
-fn deserializes_chain_specific_vault_response() {
+fn deserializes_vault_response_ignoring_extra_fields() {
     let response: VaultResponse = serde_json::from_value(serde_json::json!({
         "address": "7EcVq7V4FqgM9JgjQjDyX3tLwGfX5CrJf7RsB4dQ2mCz",
         "id": "vault-id",
+        "public_key_compressed": "cHVibGljLWtleQ==",
         "type": "solana"
     }))
     .unwrap();
 
-    assert_eq!(
-        response.address.as_deref(),
-        Some("7EcVq7V4FqgM9JgjQjDyX3tLwGfX5CrJf7RsB4dQ2mCz")
-    );
     assert_eq!(response.id, "vault-id");
-    assert_eq!(response.public_key_compressed, None);
-    assert_eq!(response.vault_type.as_deref(), Some("solana"));
-}
-
-#[test]
-fn deserializes_black_box_vault_response() {
-    let response: VaultResponse = serde_json::from_value(serde_json::json!({
-        "id": "vault-id",
-        "public_key_compressed": "cHVibGljLWtleQ==",
-        "type": "black_box"
-    }))
-    .unwrap();
-
-    assert_eq!(response.address, None);
-    assert_eq!(response.id, "vault-id");
-    assert_eq!(
-        response.public_key_compressed.as_deref(),
-        Some("cHVibGljLWtleQ==")
-    );
-    assert_eq!(response.vault_type.as_deref(), Some("black_box"));
 }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -396,10 +396,10 @@ impl Signer {
 
     /// Create a Fordefi signer.
     ///
-    /// Fetches the vault during initialization and verifies that its authoritative
-    /// Solana address matches `config.public_key`. Set `config.chain` to use native
-    /// Solana mode (Fordefi modifies and auto-broadcasts the transaction). Leave it
-    /// `None` for black-box mode (raw EdDSA signing, transaction assembled locally).
+    /// `config.public_key` is trusted as the vault's Solana address; construction
+    /// performs no network calls. Set `config.chain` to use native Solana mode
+    /// (Fordefi modifies and auto-broadcasts the transaction). Leave it `None`
+    /// for black-box mode (raw EdDSA signing, transaction assembled locally).
     #[cfg(feature = "fordefi")]
     pub async fn from_fordefi(config: FordefiSignerConfig) -> Result<Self, SignerError> {
         Ok(Self::Fordefi(FordefiSigner::from_config(config).await?))

--- a/rust/src/privy/mod.rs
+++ b/rust/src/privy/mod.rs
@@ -3,13 +3,13 @@
 mod authorization;
 mod types;
 
-use crate::remote_util::{extract_api_error, parse_json_response};
+use crate::remote_util::{extract_api_error, parse_json_response, read_body_capped};
 use crate::sdk_adapter::{Pubkey, Signature, VersionedTransaction};
-use crate::signature_util::{signature_from_base64, verify_or_reject};
-use crate::traits::{SignTransactionResult, SignedTransaction};
-use crate::transaction_util::{
-    deserialize_wire_transaction, serialize_wire_transaction, TransactionUtil,
+use crate::signature_util::{
+    extract_and_verify_returned_signature, signature_from_base64, verify_or_reject,
 };
+use crate::traits::{SignTransactionResult, SignedTransaction};
+use crate::transaction_util::{serialize_wire_transaction, TransactionUtil};
 use crate::{error::SignerError, http_client_config::HttpClientConfig, traits::SolanaSigner};
 use authorization::prepare_privy_authorization_headers;
 pub use authorization::{
@@ -205,7 +205,8 @@ impl PrivySigner {
             return Err(extract_api_error(response, "Privy API rpc").await);
         }
 
-        Ok(response.text().await?)
+        let body = read_body_capped(response).await?;
+        Ok(String::from_utf8_lossy(&body).into_owned())
     }
 
     /// Sign message bytes using Privy API
@@ -259,21 +260,11 @@ impl PrivySigner {
                     "Failed to decode signed transaction returned by Privy".to_string(),
                 )
             })?;
-        let returned: VersionedTransaction =
-            deserialize_wire_transaction(&signed_wire).map_err(|e| {
-                SignerError::SerializationError(format!(
-                    "Failed to deserialize signed transaction returned by Privy: {e}"
-                ))
-            })?;
-
-        let position = TransactionUtil::get_signing_keypair_position(&returned, &public_key)?;
-        let signature = returned.signatures.get(position).copied().ok_or_else(|| {
-            SignerError::SigningFailed(
-                "Privy signature slot missing from returned transaction".to_string(),
-            )
-        })?;
-
-        verify_or_reject(&signature, &public_key, &transaction.message.serialize())?;
+        let signature = extract_and_verify_returned_signature(
+            &signed_wire,
+            &public_key,
+            &transaction.message.serialize(),
+        )?;
 
         TransactionUtil::add_signature_to_transaction(transaction, &public_key, signature)?;
 

--- a/rust/src/privy/tests.rs
+++ b/rust/src/privy/tests.rs
@@ -63,6 +63,35 @@ async fn test_privy_fetch_public_key() {
 }
 
 #[tokio::test]
+async fn test_privy_sign_message_rejects_oversized_response_body() {
+    let mock_server = MockServer::start().await;
+    let keypair = create_test_keypair();
+
+    // A body just past the 1 MiB cap: the bounded body reader in post_rpc
+    // must refuse it before any parsing happens.
+    let oversized_body = vec![b'a'; crate::remote_util::MAX_RESPONSE_BYTES + 1];
+    Mock::given(method("POST"))
+        .and(path("/wallets/test-wallet-id/rpc"))
+        .respond_with(ResponseTemplate::new(200).set_body_bytes(oversized_body))
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    let mut signer = PrivySigner::new(
+        "test-app-id".to_string(),
+        "test-app-secret".to_string(),
+        "test-wallet-id".to_string(),
+    )
+    .unwrap();
+    signer.client = reqwest::Client::new();
+    signer.api_base_url = mock_server.uri();
+    signer.public_key = Some(keypair.pubkey());
+
+    let error = signer.sign_message(&[1, 2, 3, 4]).await.unwrap_err();
+    assert!(matches!(error, SignerError::SerializationError(_)));
+}
+
+#[tokio::test]
 async fn test_privy_sign_message() {
     let mock_server = MockServer::start().await;
     let keypair = create_test_keypair();

--- a/rust/src/privy/tests.rs
+++ b/rust/src/privy/tests.rs
@@ -67,8 +67,6 @@ async fn test_privy_sign_message_rejects_oversized_response_body() {
     let mock_server = MockServer::start().await;
     let keypair = create_test_keypair();
 
-    // A body just past the 1 MiB cap: the bounded body reader in post_rpc
-    // must refuse it before any parsing happens.
     let oversized_body = vec![b'a'; crate::remote_util::MAX_RESPONSE_BYTES + 1];
     Mock::given(method("POST"))
         .and(path("/wallets/test-wallet-id/rpc"))

--- a/rust/src/remote_util.rs
+++ b/rust/src/remote_util.rs
@@ -50,6 +50,29 @@ where
     Err(timeout_error())
 }
 
+/// Maximum number of response-body bytes read from a remote signer API
+/// (1 MiB, matching Go's `core.MaxResponseBytes`).
+pub(crate) const MAX_RESPONSE_BYTES: usize = 1024 * 1024;
+
+/// Read a response body in chunks, refusing anything larger than
+/// [`MAX_RESPONSE_BYTES`] so a hostile or broken endpoint cannot exhaust
+/// memory. Every remote-signer body read must go through this instead of
+/// `Response::text()`/`bytes()`/`json()`.
+pub(crate) async fn read_body_capped(
+    mut response: reqwest::Response,
+) -> Result<Vec<u8>, SignerError> {
+    let mut body: Vec<u8> = Vec::new();
+    while let Some(chunk) = response.chunk().await? {
+        if body.len() + chunk.len() > MAX_RESPONSE_BYTES {
+            return Err(SignerError::SerializationError(
+                "response exceeded maximum size".to_string(),
+            ));
+        }
+        body.extend_from_slice(&chunk);
+    }
+    Ok(body)
+}
+
 /// Consume a failed response into a [`SignerError::RemoteApiError`], logging
 /// the status (and, under `unsafe-debug` only, the response body).
 pub(crate) async fn extract_api_error(response: reqwest::Response, context: &str) -> SignerError {
@@ -57,10 +80,10 @@ pub(crate) async fn extract_api_error(response: reqwest::Response, context: &str
 
     #[cfg(feature = "unsafe-debug")]
     {
-        let error_text = response
-            .text()
-            .await
-            .unwrap_or_else(|_| "Failed to read error response".to_string());
+        let error_text = match read_body_capped(response).await {
+            Ok(body) => String::from_utf8_lossy(&body).into_owned(),
+            Err(_) => "Failed to read error response".to_string(),
+        };
         log::error!("{context} error - status: {status}, response: {error_text}");
     }
 
@@ -86,10 +109,13 @@ where
         return Err(extract_api_error(response, context).await);
     }
 
-    let text = response.text().await.unwrap_or_default();
-    serde_json::from_str(&text).map_err(|_e| {
+    let body = read_body_capped(response).await?;
+    serde_json::from_slice(&body).map_err(|_e| {
         #[cfg(feature = "unsafe-debug")]
         log::error!("Failed to parse {context} response: {_e}");
         SignerError::SerializationError(format!("Failed to parse {context} response"))
     })
 }
+
+#[cfg(test)]
+mod tests;

--- a/rust/src/remote_util/tests.rs
+++ b/rust/src/remote_util/tests.rs
@@ -1,0 +1,65 @@
+use super::*;
+use wiremock::{
+    matchers::{method, path},
+    Mock, MockServer, ResponseTemplate,
+};
+
+/// Stand up a mock returning `body` on GET /body and fetch the raw response.
+async fn respond_with_body(body: Vec<u8>) -> reqwest::Response {
+    let mock_server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/body"))
+        .respond_with(ResponseTemplate::new(200).set_body_bytes(body))
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    reqwest::get(format!("{}/body", mock_server.uri()))
+        .await
+        .expect("request to mock server failed")
+}
+
+#[tokio::test]
+async fn test_read_body_capped_accepts_body_at_limit() {
+    let response = respond_with_body(vec![b'a'; MAX_RESPONSE_BYTES]).await;
+
+    let body = read_body_capped(response).await.unwrap();
+    assert_eq!(body.len(), MAX_RESPONSE_BYTES);
+}
+
+#[tokio::test]
+async fn test_read_body_capped_rejects_oversized_body() {
+    let response = respond_with_body(vec![b'a'; MAX_RESPONSE_BYTES + 1]).await;
+
+    let error = read_body_capped(response).await.unwrap_err();
+    match error {
+        SignerError::SerializationError(detail) => {
+            assert_eq!(detail, "response exceeded maximum size");
+        }
+        other => panic!("expected SerializationError, got: {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn test_parse_json_response_rejects_oversized_body() {
+    // A syntactically valid JSON body that exceeds the cap: the size check
+    // must fire before any parsing happens.
+    let mut body = Vec::with_capacity(MAX_RESPONSE_BYTES + 16);
+    body.push(b'"');
+    body.resize(MAX_RESPONSE_BYTES + 15, b'a');
+    body.push(b'"');
+    let response = respond_with_body(body).await;
+
+    let error = parse_json_response::<serde_json::Value>(response, "test API")
+        .await
+        .unwrap_err();
+    assert!(matches!(error, SignerError::SerializationError(_)));
+}
+
+#[tokio::test]
+async fn test_parse_json_response_parses_body_within_limit() {
+    let response = respond_with_body(b"{\"ok\":true}".to_vec()).await;
+
+    let value: serde_json::Value = parse_json_response(response, "test API").await.unwrap();
+    assert_eq!(value["ok"], serde_json::Value::Bool(true));
+}

--- a/rust/src/remote_util/tests.rs
+++ b/rust/src/remote_util/tests.rs
@@ -4,7 +4,6 @@ use wiremock::{
     Mock, MockServer, ResponseTemplate,
 };
 
-/// Stand up a mock returning `body` on GET /body and fetch the raw response.
 async fn respond_with_body(body: Vec<u8>) -> reqwest::Response {
     let mock_server = MockServer::start().await;
     Mock::given(method("GET"))
@@ -42,8 +41,7 @@ async fn test_read_body_capped_rejects_oversized_body() {
 
 #[tokio::test]
 async fn test_parse_json_response_rejects_oversized_body() {
-    // A syntactically valid JSON body that exceeds the cap: the size check
-    // must fire before any parsing happens.
+    // Valid JSON past the cap: rejected before any parsing happens.
     let mut body = Vec::with_capacity(MAX_RESPONSE_BYTES + 16);
     body.push(b'"');
     body.resize(MAX_RESPONSE_BYTES + 15, b'a');

--- a/rust/src/signature_util.rs
+++ b/rust/src/signature_util.rs
@@ -50,6 +50,45 @@ pub fn signature_from_hex(encoded: &str) -> Result<Signature, SignerError> {
     signature_from_bytes(&bytes)
 }
 
+/// Extract and verify this signer's signature from a fully-signed transaction
+/// returned by a provider.
+///
+/// Deserializes `returned_tx_bytes` via the shared wire codec, locates the
+/// required-signer slot for `public_key` on the returned transaction, rejects
+/// a missing or default signature, and verifies the signature against the
+/// original locally-serialized message bytes. The verification against
+/// `original_message_bytes` is what guarantees the signature applies to the
+/// transaction we submitted, so no byte-equality check of the returned
+/// message is needed.
+#[cfg(any(
+    feature = "privy",
+    feature = "turnkey",
+    feature = "cdp",
+    feature = "utila"
+))]
+pub(crate) fn extract_and_verify_returned_signature(
+    returned_tx_bytes: &[u8],
+    public_key: &Pubkey,
+    original_message_bytes: &[u8],
+) -> Result<Signature, SignerError> {
+    let returned = crate::transaction_util::deserialize_wire_transaction(returned_tx_bytes)?;
+    let position = crate::transaction_util::TransactionUtil::get_signing_keypair_position(
+        &returned, public_key,
+    )?;
+    let signature = returned
+        .signatures
+        .get(position)
+        .copied()
+        .filter(|sig| *sig != Signature::default())
+        .ok_or_else(|| {
+            SignerError::SigningFailed(
+                "Returned signed transaction is missing the signer's signature".to_string(),
+            )
+        })?;
+    verify_or_reject(&signature, public_key, original_message_bytes)?;
+    Ok(signature)
+}
+
 /// Reject a backend-returned signature that does not verify against the
 /// signer's public key over the signed bytes.
 pub fn verify_or_reject(
@@ -64,4 +103,90 @@ pub fn verify_or_reject(
         "Signature verification failed — the returned signature does not match the public key"
             .to_string(),
     ))
+}
+
+#[cfg(all(
+    test,
+    any(
+        feature = "privy",
+        feature = "turnkey",
+        feature = "cdp",
+        feature = "utila"
+    )
+))]
+mod tests {
+    use super::*;
+    use crate::sdk_adapter::{keypair_pubkey, keypair_sign_message, Keypair};
+    use crate::test_util::create_test_transaction;
+    use crate::transaction_util::serialize_wire_transaction;
+
+    fn signed_returned_transaction() -> (Keypair, Pubkey, Vec<u8>, Vec<u8>) {
+        let keypair = Keypair::new();
+        let pubkey = keypair_pubkey(&keypair);
+        let mut transaction = create_test_transaction(&pubkey);
+        let message_bytes = transaction.message.serialize();
+        let signature = keypair_sign_message(&keypair, &message_bytes);
+        transaction.signatures = vec![signature];
+        let wire = serialize_wire_transaction(&transaction).expect("serialize");
+        (keypair, pubkey, message_bytes, wire)
+    }
+
+    #[test]
+    fn extracts_and_verifies_a_valid_returned_signature() {
+        let (keypair, pubkey, message_bytes, wire) = signed_returned_transaction();
+        let expected = keypair_sign_message(&keypair, &message_bytes);
+
+        let signature = extract_and_verify_returned_signature(&wire, &pubkey, &message_bytes)
+            .expect("valid signature should be extracted");
+
+        assert_eq!(signature, expected);
+    }
+
+    #[test]
+    fn rejects_a_pubkey_that_is_not_a_required_signer() {
+        let (_keypair, _pubkey, message_bytes, wire) = signed_returned_transaction();
+        let other = Pubkey::new_unique();
+
+        let error = extract_and_verify_returned_signature(&wire, &other, &message_bytes)
+            .expect_err("non-signer pubkey must be rejected");
+
+        assert!(matches!(error, SignerError::SigningFailed(_)));
+    }
+
+    #[test]
+    fn rejects_a_default_signature_in_the_signer_slot() {
+        let keypair = Keypair::new();
+        let pubkey = keypair_pubkey(&keypair);
+        let transaction = create_test_transaction(&pubkey);
+        let message_bytes = transaction.message.serialize();
+        let wire = serialize_wire_transaction(&transaction).expect("serialize");
+
+        let error = extract_and_verify_returned_signature(&wire, &pubkey, &message_bytes)
+            .expect_err("default signature must be rejected");
+
+        assert!(matches!(error, SignerError::SigningFailed(_)));
+    }
+
+    #[test]
+    fn rejects_a_signature_that_does_not_verify() {
+        let (keypair, pubkey, message_bytes, _wire) = signed_returned_transaction();
+        let mut transaction = create_test_transaction(&pubkey);
+        transaction.signatures = vec![keypair_sign_message(&keypair, b"different bytes")];
+        let wire = serialize_wire_transaction(&transaction).expect("serialize");
+
+        let error = extract_and_verify_returned_signature(&wire, &pubkey, &message_bytes)
+            .expect_err("non-verifying signature must be rejected");
+
+        assert!(matches!(error, SignerError::SigningFailed(_)));
+    }
+
+    #[test]
+    fn rejects_malformed_transaction_bytes() {
+        let pubkey = Pubkey::new_unique();
+
+        let error = extract_and_verify_returned_signature(&[0xff, 0x01, 0x02], &pubkey, b"msg")
+            .expect_err("malformed bytes must be rejected");
+
+        assert!(matches!(error, SignerError::SerializationError(_)));
+    }
 }

--- a/rust/src/signature_util.rs
+++ b/rust/src/signature_util.rs
@@ -53,11 +53,8 @@ pub fn signature_from_hex(encoded: &str) -> Result<Signature, SignerError> {
 /// Extract and verify this signer's signature from a fully-signed transaction
 /// returned by a provider.
 ///
-/// Deserializes `returned_tx_bytes` via the shared wire codec, locates the
-/// required-signer slot for `public_key` on the returned transaction, rejects
-/// a missing or default signature, and verifies the signature against the
-/// original locally-serialized message bytes. The verification against
-/// `original_message_bytes` is what guarantees the signature applies to the
+/// Rejects a missing or default signature in the signer's slot. Verifying
+/// against `original_message_bytes` guarantees the signature applies to the
 /// transaction we submitted, so no byte-equality check of the returned
 /// message is needed.
 #[cfg(any(

--- a/rust/src/turnkey/mod.rs
+++ b/rust/src/turnkey/mod.rs
@@ -4,11 +4,9 @@ mod types;
 
 use crate::remote_util::parse_json_response;
 use crate::sdk_adapter::{Pubkey, Signature, VersionedTransaction};
-use crate::signature_util::verify_or_reject;
+use crate::signature_util::{extract_and_verify_returned_signature, verify_or_reject};
 use crate::traits::{SignTransactionResult, SignedTransaction};
-use crate::transaction_util::{
-    deserialize_wire_transaction, serialize_wire_transaction, TransactionUtil,
-};
+use crate::transaction_util::{serialize_wire_transaction, TransactionUtil};
 use crate::{error::SignerError, http_client_config::HttpClientConfig, traits::SolanaSigner};
 use base64::Engine;
 use p256::ecdsa::signature::Signer as P256Signer;
@@ -223,22 +221,8 @@ impl TurnkeySigner {
                 "Failed to decode signed transaction returned by Turnkey: {e}"
             ))
         })?;
-        let returned: VersionedTransaction =
-            deserialize_wire_transaction(&signed_wire).map_err(|e| {
-                SignerError::SerializationError(format!(
-                    "Failed to deserialize signed transaction returned by Turnkey: {e}"
-                ))
-            })?;
-
-        let position = TransactionUtil::get_signing_keypair_position(&returned, &self.public_key)?;
-        let signature = returned.signatures.get(position).copied().ok_or_else(|| {
-            SignerError::SigningFailed(
-                "Turnkey signature slot missing from returned transaction".to_string(),
-            )
-        })?;
-
-        verify_or_reject(
-            &signature,
+        let signature = extract_and_verify_returned_signature(
+            &signed_wire,
             &self.public_key,
             &transaction.message.serialize(),
         )?;

--- a/rust/src/utila/mod.rs
+++ b/rust/src/utila/mod.rs
@@ -4,10 +4,9 @@ mod types;
 
 use crate::remote_util::parse_json_response;
 use crate::sdk_adapter::{Pubkey, Signature, VersionedTransaction};
+use crate::signature_util::extract_and_verify_returned_signature;
 use crate::traits::{SignTransactionResult, SignedTransaction};
-use crate::transaction_util::{
-    deserialize_wire_transaction, serialize_wire_transaction, TransactionUtil,
-};
+use crate::transaction_util::{serialize_wire_transaction, TransactionUtil};
 use crate::{error::SignerError, http_client_config::HttpClientConfig, traits::SolanaSigner};
 use base64::{engine::general_purpose::STANDARD, Engine};
 use chrono::{Duration, Utc};
@@ -304,39 +303,7 @@ impl UtilaSigner {
             )
         })?;
 
-        let transaction: VersionedTransaction =
-            deserialize_wire_transaction(&bytes).map_err(|_e| {
-                SignerError::SerializationError(
-                    "Failed to deserialize Utila rawTransaction".to_string(),
-                )
-            })?;
-
-        let remote_message = transaction.message.serialize();
-        if remote_message != expected_message {
-            return Err(SignerError::SigningFailed(
-                "Utila returned a signed transaction with different message bytes".to_string(),
-            ));
-        }
-
-        let position = TransactionUtil::get_signing_keypair_position(&transaction, &public_key)?;
-        let signature = transaction
-            .signatures
-            .get(position)
-            .copied()
-            .filter(|sig| *sig != Signature::default())
-            .ok_or_else(|| {
-                SignerError::SigningFailed(
-                    "Utila rawTransaction did not contain a signer signature".to_string(),
-                )
-            })?;
-
-        if !signature.verify(&public_key.to_bytes(), expected_message) {
-            return Err(SignerError::SigningFailed(
-                "Signature verification failed for Utila rawTransaction".to_string(),
-            ));
-        }
-
-        Ok(signature)
+        extract_and_verify_returned_signature(&bytes, &public_key, expected_message)
     }
 
     async fn sign_and_serialize(

--- a/rust/src/vault/mod.rs
+++ b/rust/src/vault/mod.rs
@@ -109,14 +109,13 @@ impl VaultSigner {
     /// `Client::builder().add_root_certificate(..)` when talking to a
     /// development Vault instance.
     ///
-    /// The builder is finished with this crate's no-redirect policy applied
-    /// (it takes a builder rather than a built `Client` precisely so the
-    /// policy cannot be bypassed): requests carry `X-Vault-Token`, and a
-    /// client that followed redirects would replay it to the redirect
-    /// target. `https_only` is deliberately *not* forced here — Vault is
-    /// routinely reached over plain-HTTP loopback (e.g. `vault server
-    /// -dev`), so transport security stays the caller's choice for this
-    /// constructor.
+    /// The builder is finished with this crate's no-redirect policy (a
+    /// builder rather than a built `Client` so the policy cannot be
+    /// bypassed): requests carry `X-Vault-Token`, and a redirect-following
+    /// client would replay it to the redirect target. `https_only` is
+    /// deliberately not forced — Vault is routinely reached over plain-HTTP
+    /// loopback (e.g. `vault server -dev`), so transport security stays the
+    /// caller's choice.
     ///
     /// To avoid pulling `reqwest` into your own dependency tree at a
     /// version that may diverge from `solana-keychain`'s, prefer

--- a/rust/src/vault/mod.rs
+++ b/rust/src/vault/mod.rs
@@ -1,10 +1,10 @@
 //! HashiCorp Vault signer integration
 
 /// Re-export of the [`reqwest`] crate used internally by this module,
-/// so callers of [`VaultSigner::with_client`] can construct a `Client`
-/// at exactly the version this crate links against — avoiding the
-/// version-mismatch footgun of depending on `reqwest` directly in
-/// their own `Cargo.toml`.
+/// so callers of [`VaultSigner::with_client_builder`] can construct a
+/// `ClientBuilder` at exactly the version this crate links against —
+/// avoiding the version-mismatch footgun of depending on `reqwest`
+/// directly in their own `Cargo.toml`.
 pub use reqwest;
 
 use crate::remote_util::parse_json_response;
@@ -91,10 +91,9 @@ impl VaultSigner {
     /// Creates a new Vault signer from a configuration object.
     pub fn from_config(config: VaultSignerConfig) -> Result<Self, SignerError> {
         let http_client_config = config.http_client_config.unwrap_or_default();
-        let client = http_client_config.build_client()?;
 
-        Self::with_client(
-            client,
+        Self::with_client_builder(
+            http_client_config.client_builder(),
             config.api_base_url,
             config.token,
             config.key_name,
@@ -102,7 +101,7 @@ impl VaultSigner {
         )
     }
 
-    /// Creates a Vault signer from a caller-built [`reqwest::Client`].
+    /// Creates a Vault signer from a caller-configured [`reqwest::ClientBuilder`].
     ///
     /// Use this when you need control over TLS configuration, proxies,
     /// timeouts, or other client-level settings that `HttpClientConfig`
@@ -110,31 +109,39 @@ impl VaultSigner {
     /// `Client::builder().add_root_certificate(..)` when talking to a
     /// development Vault instance.
     ///
-    /// The caller is responsible for whatever security posture the
-    /// supplied client carries (HTTPS-only, cert pinning, redirect policy,
-    /// etc.); this constructor does not enforce `https_only` and does not
-    /// replace the client's redirect policy. Requests carry `X-Vault-Token`,
-    /// so a client that follows redirects replays it to the redirect target.
+    /// The builder is finished with this crate's no-redirect policy applied
+    /// (it takes a builder rather than a built `Client` precisely so the
+    /// policy cannot be bypassed): requests carry `X-Vault-Token`, and a
+    /// client that followed redirects would replay it to the redirect
+    /// target. `https_only` is deliberately *not* forced here — Vault is
+    /// routinely reached over plain-HTTP loopback (e.g. `vault server
+    /// -dev`), so transport security stays the caller's choice for this
+    /// constructor.
     ///
     /// To avoid pulling `reqwest` into your own dependency tree at a
     /// version that may diverge from `solana-keychain`'s, prefer
-    /// constructing the client via the re-exported
+    /// constructing the builder via the re-exported
     /// [`solana_keychain::vault::reqwest`] module.
     ///
     /// # Arguments
     ///
-    /// * `client` - A fully-built reqwest `Client`.
+    /// * `client_builder` - A caller-configured reqwest `ClientBuilder`.
     /// * `api_base_url` - Vault server address (e.g., "https://vault.example.com")
     /// * `token` - Vault authentication token
     /// * `key_name` - Vault key name in transit engine
     /// * `public_key` - Base58-encoded public key
-    pub fn with_client(
-        client: Client,
+    pub fn with_client_builder(
+        client_builder: reqwest::ClientBuilder,
         api_base_url: String,
         token: String,
         key_name: String,
         public_key: String,
     ) -> Result<Self, SignerError> {
+        let client = client_builder
+            .redirect(crate::http_client_config::no_redirect_policy())
+            .build()
+            .map_err(|e| SignerError::ConfigError(format!("Failed to build HTTP client: {e}")))?;
+
         let public_key = std::str::FromStr::from_str(&public_key)
             .map_err(|_| SignerError::InvalidPublicKey("Invalid public key".to_string()))?;
 
@@ -235,7 +242,11 @@ impl SolanaSigner for VaultSigner {
             return false;
         }
 
-        let body: serde_json::Value = match response.json().await {
+        let body = match crate::remote_util::read_body_capped(response).await {
+            Ok(body) => body,
+            Err(_) => return false,
+        };
+        let body: serde_json::Value = match serde_json::from_slice(&body) {
             Ok(value) => value,
             Err(_) => return false,
         };

--- a/rust/src/vault/tests.rs
+++ b/rust/src/vault/tests.rs
@@ -51,10 +51,10 @@ fn test_create_vault_signer() {
 }
 
 #[tokio::test]
-async fn test_with_client_uses_supplied_client() {
-    // Prove that a caller-built client is actually the one used for
-    // outbound requests: stand up a mock, hand a plain http client
-    // to `with_client`, and assert the mock sees the call.
+async fn test_with_client_builder_uses_supplied_builder() {
+    // Prove that a caller-configured builder is actually the one used for
+    // outbound requests: stand up a mock, hand a plain http builder
+    // to `with_client_builder`, and assert the mock sees the call.
     let mock_server = MockServer::start().await;
     let keypair = Keypair::new();
     let message = b"with-client-message";
@@ -75,23 +75,60 @@ async fn test_with_client_uses_supplied_client() {
         .await;
 
     // The test uses plain http, so we cannot flip `https_only` —
-    // which is precisely the point of `with_client`: the caller
+    // which is precisely the point of `with_client_builder`: the caller
     // owns the TLS (or lack thereof) policy.
-    let client = Client::builder()
-        .build()
-        .expect("failed to build test client");
-    let signer = VaultSigner::with_client(
-        client,
+    let signer = VaultSigner::with_client_builder(
+        Client::builder(),
         mock_server.uri(),
         TEST_VAULT_TOKEN.to_string(),
         TEST_KEY_NAME.to_string(),
         keypair.pubkey().to_string(),
     )
-    .expect("with_client should accept a pre-built client");
+    .expect("with_client_builder should accept a caller-configured builder");
 
     let result = signer.sign_message(message).await;
     assert!(result.is_ok(), "sign_message failed: {:?}", result.err());
     assert_eq!(result.unwrap(), signature);
+}
+
+#[tokio::test]
+async fn test_with_client_builder_enforces_no_redirect_policy() {
+    // Even a builder configured to follow redirects must be overridden:
+    // requests carry X-Vault-Token, so a redirect has to fail the request
+    // instead of replaying the token to the redirect target.
+    let target = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/collect"))
+        .respond_with(ResponseTemplate::new(200))
+        .expect(0)
+        .mount(&target)
+        .await;
+
+    let origin = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/transit/sign/test-key"))
+        .respond_with(
+            ResponseTemplate::new(307)
+                .insert_header("Location", format!("{}/collect", target.uri()).as_str()),
+        )
+        .expect(1)
+        .mount(&origin)
+        .await;
+
+    let signer = VaultSigner::with_client_builder(
+        Client::builder().redirect(reqwest::redirect::Policy::limited(10)),
+        origin.uri(),
+        TEST_VAULT_TOKEN.to_string(),
+        TEST_KEY_NAME.to_string(),
+        TEST_PUBKEY.to_string(),
+    )
+    .unwrap();
+
+    let result = signer.sign_message(b"redirect-message").await;
+    assert!(matches!(
+        result.unwrap_err(),
+        SignerError::RemoteApiError(_)
+    ));
 }
 
 #[test]

--- a/rust/src/vault/tests.rs
+++ b/rust/src/vault/tests.rs
@@ -52,9 +52,6 @@ fn test_create_vault_signer() {
 
 #[tokio::test]
 async fn test_with_client_builder_uses_supplied_builder() {
-    // Prove that a caller-configured builder is actually the one used for
-    // outbound requests: stand up a mock, hand a plain http builder
-    // to `with_client_builder`, and assert the mock sees the call.
     let mock_server = MockServer::start().await;
     let keypair = Keypair::new();
     let message = b"with-client-message";
@@ -74,9 +71,7 @@ async fn test_with_client_builder_uses_supplied_builder() {
         .mount(&mock_server)
         .await;
 
-    // The test uses plain http, so we cannot flip `https_only` —
-    // which is precisely the point of `with_client_builder`: the caller
-    // owns the TLS (or lack thereof) policy.
+    // Plain-http builder: `with_client_builder` leaves TLS policy to the caller.
     let signer = VaultSigner::with_client_builder(
         Client::builder(),
         mock_server.uri(),
@@ -93,9 +88,7 @@ async fn test_with_client_builder_uses_supplied_builder() {
 
 #[tokio::test]
 async fn test_with_client_builder_enforces_no_redirect_policy() {
-    // Even a builder configured to follow redirects must be overridden:
-    // requests carry X-Vault-Token, so a redirect has to fail the request
-    // instead of replaying the token to the redirect target.
+    // The redirect must fail rather than replay X-Vault-Token to the target.
     let target = MockServer::start().await;
     Mock::given(method("POST"))
         .and(path("/collect"))

--- a/typescript/packages/cdp/src/__tests__/cdp-signer.test.ts
+++ b/typescript/packages/cdp/src/__tests__/cdp-signer.test.ts
@@ -16,6 +16,16 @@ vi.mock('@solana/keychain-core', async importOriginal => {
     return {
         ...mod,
         assertSignatureValid: vi.fn(),
+        extractAndVerifyReturnedSignature: vi.fn(
+            async ({
+                returnedTransactionBytes,
+                signerAddress,
+            }: Parameters<typeof mod.extractAndVerifyReturnedSignature>[0]) =>
+                mod.extractSignatureFromTransactionBytes({
+                    signerAddress,
+                    transactionBytes: returnedTransactionBytes,
+                })[signerAddress],
+        ),
         sanitizeRemoteErrorResponse:
             mod.sanitizeRemoteErrorResponse ??
             ((text: string) =>

--- a/typescript/packages/cdp/src/cdp-signer.ts
+++ b/typescript/packages/cdp/src/cdp-signer.ts
@@ -6,7 +6,7 @@ import {
     base64UrlDecoder,
     createSignatureDictionary,
     ED25519_SIGNATURE_LENGTH,
-    extractSignatureFromWireTransaction,
+    extractAndVerifyReturnedSignature,
     fetchSignerJson,
     normalizeBaseUrl,
     signBatchStaggered,
@@ -450,16 +450,17 @@ class CdpSigner<TAddress extends string = string> implements SolanaSigner<TAddre
             async transaction => {
                 const wireTransaction = getBase64EncodedWireTransaction(transaction);
                 const signedWireTx = await this.callSignTransaction(wireTransaction, config?.abortSignal);
-                const sigDict = extractSignatureFromWireTransaction({
-                    base64WireTransaction: signedWireTx,
+                base64Encoder ||= getBase64Encoder();
+                const signature = await extractAndVerifyReturnedSignature({
+                    abortSignal: config?.abortSignal,
+                    originalMessageBytes: transaction.messageBytes,
+                    returnedTransactionBytes: base64Encoder.encode(signedWireTx),
                     signerAddress: this.address,
                 });
-                await assertSignatureValid({
-                    data: transaction.messageBytes,
-                    signature: sigDict[this.address],
+                return createSignatureDictionary({
+                    signature,
                     signerAddress: this.address,
                 });
-                return sigDict;
             },
             this.requestDelayMs,
             config?.abortSignal,

--- a/typescript/packages/core/src/__tests__/extract-and-verify-returned-signature.test.ts
+++ b/typescript/packages/core/src/__tests__/extract-and-verify-returned-signature.test.ts
@@ -1,0 +1,182 @@
+import { Address, getAddressDecoder, getAddressEncoder } from '@solana/addresses';
+import { generateKeyPair, SignatureBytes, signBytes } from '@solana/keys';
+import { describe, expect, it } from 'vitest';
+
+import { extractAndVerifyReturnedSignature } from '../utils.js';
+
+async function createTestKeypair() {
+    const keyPair = await generateKeyPair();
+    const publicKeyBytes = await crypto.subtle.exportKey('raw', keyPair.publicKey);
+    const address = getAddressDecoder().decode(new Uint8Array(publicKeyBytes));
+    return {
+        address,
+        sign: (data: Uint8Array) => signBytes(keyPair.privateKey, data),
+    };
+}
+
+/** A minimal legacy message with one required signer and no instructions. */
+function buildMessageBytes(signerAddress: Address): Uint8Array {
+    const signerBytes = getAddressEncoder().encode(signerAddress);
+    return new Uint8Array([
+        1, // numRequiredSignatures
+        0, // numReadonlySignedAccounts
+        0, // numReadonlyUnsignedAccounts
+        1, // static account count (shortU16)
+        ...signerBytes,
+        ...new Uint8Array(32), // recent blockhash
+        0, // instruction count (shortU16)
+    ]);
+}
+
+/** Serializes a one-signer wire transaction: [sig count][signature][message]. */
+function buildWireTransaction(signature: Uint8Array, messageBytes: Uint8Array): Uint8Array {
+    return new Uint8Array([1, ...signature, ...messageBytes]);
+}
+
+describe('extractAndVerifyReturnedSignature', () => {
+    it('returns the signature when the returned transaction carries a valid one', async () => {
+        const kp = await createTestKeypair();
+        const messageBytes = buildMessageBytes(kp.address);
+        const signature = await kp.sign(messageBytes);
+        const returnedTransactionBytes = buildWireTransaction(signature, messageBytes);
+
+        const extracted = await extractAndVerifyReturnedSignature({
+            originalMessageBytes: messageBytes,
+            returnedTransactionBytes,
+            signerAddress: kp.address,
+        });
+
+        expect(new Uint8Array(extracted)).toStrictEqual(new Uint8Array(signature));
+    });
+
+    it('throws SIGNING_FAILED when the address is not a signer of the returned transaction', async () => {
+        const kp = await createTestKeypair();
+        const other = await createTestKeypair();
+        const messageBytes = buildMessageBytes(kp.address);
+        const signature = await kp.sign(messageBytes);
+        const returnedTransactionBytes = buildWireTransaction(signature, messageBytes);
+
+        await expect(
+            extractAndVerifyReturnedSignature({
+                originalMessageBytes: messageBytes,
+                returnedTransactionBytes,
+                signerAddress: other.address,
+            }),
+        ).rejects.toMatchObject({
+            code: 'SIGNER_SIGNING_FAILED',
+            message: expect.stringContaining('No signature found'),
+        });
+    });
+
+    it('throws SIGNING_FAILED when the signer slot holds a default (all-zero) signature', async () => {
+        const kp = await createTestKeypair();
+        const messageBytes = buildMessageBytes(kp.address);
+        const returnedTransactionBytes = buildWireTransaction(new Uint8Array(64), messageBytes);
+
+        await expect(
+            extractAndVerifyReturnedSignature({
+                originalMessageBytes: messageBytes,
+                returnedTransactionBytes,
+                signerAddress: kp.address,
+            }),
+        ).rejects.toMatchObject({
+            code: 'SIGNER_SIGNING_FAILED',
+            message: expect.stringContaining('No signature found'),
+        });
+    });
+
+    it('throws SIGNING_FAILED when the signature does not verify against the original message', async () => {
+        const kp = await createTestKeypair();
+        const messageBytes = buildMessageBytes(kp.address);
+        const signature = await kp.sign(messageBytes);
+        const corrupted = new Uint8Array(signature);
+        corrupted[0] ^= 0xff;
+        const returnedTransactionBytes = buildWireTransaction(corrupted, messageBytes);
+
+        await expect(
+            extractAndVerifyReturnedSignature({
+                originalMessageBytes: messageBytes,
+                returnedTransactionBytes,
+                signerAddress: kp.address,
+            }),
+        ).rejects.toMatchObject({
+            code: 'SIGNER_SIGNING_FAILED',
+            message: expect.stringContaining('Signature verification failed'),
+        });
+    });
+
+    it('verifies against the ORIGINAL message bytes, not the returned ones', async () => {
+        const kp = await createTestKeypair();
+        const originalMessageBytes = buildMessageBytes(kp.address);
+        // Provider signs and returns a different message than the caller submitted.
+        const tamperedMessageBytes = new Uint8Array(originalMessageBytes);
+        tamperedMessageBytes[tamperedMessageBytes.length - 2] ^= 0xff;
+        const signature = await kp.sign(tamperedMessageBytes);
+        const returnedTransactionBytes = buildWireTransaction(signature, tamperedMessageBytes);
+
+        await expect(
+            extractAndVerifyReturnedSignature({
+                originalMessageBytes,
+                returnedTransactionBytes,
+                signerAddress: kp.address,
+            }),
+        ).rejects.toMatchObject({
+            code: 'SIGNER_SIGNING_FAILED',
+            message: expect.stringContaining('Signature verification failed'),
+        });
+    });
+
+    it('throws SIGNING_FAILED for malformed transaction bytes', async () => {
+        const kp = await createTestKeypair();
+        const messageBytes = buildMessageBytes(kp.address);
+
+        await expect(
+            extractAndVerifyReturnedSignature({
+                originalMessageBytes: messageBytes,
+                returnedTransactionBytes: new Uint8Array([7, 1, 2, 3]),
+                signerAddress: kp.address,
+            }),
+        ).rejects.toMatchObject({
+            code: 'SIGNER_SIGNING_FAILED',
+            message: expect.stringContaining('Failed to decode returned signed transaction'),
+        });
+    });
+
+    it('throws when the abort signal is already aborted', async () => {
+        const kp = await createTestKeypair();
+        const messageBytes = buildMessageBytes(kp.address);
+        const signature = await kp.sign(messageBytes);
+        const returnedTransactionBytes = buildWireTransaction(signature, messageBytes);
+        const controller = new AbortController();
+        controller.abort(new Error('aborted before verification'));
+
+        await expect(
+            extractAndVerifyReturnedSignature({
+                abortSignal: controller.signal,
+                originalMessageBytes: messageBytes,
+                returnedTransactionBytes,
+                signerAddress: kp.address,
+            }),
+        ).rejects.toThrow('aborted before verification');
+    });
+
+    it('rejects a signature that verifies for a different signer in the returned transaction', async () => {
+        const kp = await createTestKeypair();
+        const other = await createTestKeypair();
+        const messageBytes = buildMessageBytes(kp.address);
+        // Signature produced by a different key occupies this signer's slot.
+        const foreignSignature = (await other.sign(messageBytes)) as SignatureBytes;
+        const returnedTransactionBytes = buildWireTransaction(foreignSignature, messageBytes);
+
+        await expect(
+            extractAndVerifyReturnedSignature({
+                originalMessageBytes: messageBytes,
+                returnedTransactionBytes,
+                signerAddress: kp.address,
+            }),
+        ).rejects.toMatchObject({
+            code: 'SIGNER_SIGNING_FAILED',
+            message: expect.stringContaining('Signature verification failed'),
+        });
+    });
+});

--- a/typescript/packages/core/src/__tests__/extract-and-verify-returned-signature.test.ts
+++ b/typescript/packages/core/src/__tests__/extract-and-verify-returned-signature.test.ts
@@ -108,7 +108,6 @@ describe('extractAndVerifyReturnedSignature', () => {
     it('verifies against the ORIGINAL message bytes, not the returned ones', async () => {
         const kp = await createTestKeypair();
         const originalMessageBytes = buildMessageBytes(kp.address);
-        // Provider signs and returns a different message than the caller submitted.
         const tamperedMessageBytes = new Uint8Array(originalMessageBytes);
         tamperedMessageBytes[tamperedMessageBytes.length - 2] ^= 0xff;
         const signature = await kp.sign(tamperedMessageBytes);
@@ -164,7 +163,6 @@ describe('extractAndVerifyReturnedSignature', () => {
         const kp = await createTestKeypair();
         const other = await createTestKeypair();
         const messageBytes = buildMessageBytes(kp.address);
-        // Signature produced by a different key occupies this signer's slot.
         const foreignSignature = (await other.sign(messageBytes)) as SignatureBytes;
         const returnedTransactionBytes = buildWireTransaction(foreignSignature, messageBytes);
 

--- a/typescript/packages/core/src/__tests__/http.test.ts
+++ b/typescript/packages/core/src/__tests__/http.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { SignerError, SignerErrorCode } from '../errors.js';
-import { fetchSignerJson } from '../http.js';
+import { fetchSignerJson, MAX_RESPONSE_BYTES } from '../http.js';
 
 function mockFetch(impl: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>) {
     const spy = vi.spyOn(globalThis, 'fetch').mockImplementation(impl as typeof fetch);
@@ -247,6 +247,110 @@ describe('fetchSignerJson', () => {
         expect(error.message).toBe('Test API error: 502');
         expect(error.context?.status).toBe(502);
         expect(error.context?.response).toBe('boom bad');
+    });
+
+    it('accepts a success body of exactly MAX_RESPONSE_BYTES', async () => {
+        // `{"a":"…"}` framing is 9 bytes; pad the value so the body is exactly at the cap.
+        const value = 'x'.repeat(MAX_RESPONSE_BYTES - 9);
+        mockFetch(async () => new Response(`{"a":"${value}"}`, { status: 200 }));
+
+        const result = await fetchSignerJson<{ a: string }>({
+            providerName: 'Test',
+            url: 'https://api.example.com',
+        });
+
+        expect(result.a).toBe(value);
+    });
+
+    it('throws PARSING_ERROR when a success body exceeds MAX_RESPONSE_BYTES', async () => {
+        mockFetch(async () => new Response(`{"a":"${'x'.repeat(MAX_RESPONSE_BYTES)}"}`, { status: 200 }));
+
+        const error = await expectSignerError(
+            fetchSignerJson({ providerName: 'Test', url: 'https://api.example.com' }),
+            SignerErrorCode.PARSING_ERROR,
+        );
+        expect(error.message).toBe('Test response exceeded maximum size');
+        expect(error.context?.maxResponseBytes).toBe(MAX_RESPONSE_BYTES);
+        expect(error.context?.status).toBe(200);
+    });
+
+    it('throws PARSING_ERROR when a non-2xx error body exceeds MAX_RESPONSE_BYTES', async () => {
+        mockFetch(async () => new Response('x'.repeat(MAX_RESPONSE_BYTES + 1), { status: 502 }));
+
+        const error = await expectSignerError(
+            fetchSignerJson({ providerName: 'Test', url: 'https://api.example.com' }),
+            SignerErrorCode.PARSING_ERROR,
+        );
+        expect(error.message).toBe('Test response exceeded maximum size');
+        expect(error.context?.status).toBe(502);
+    });
+
+    it('fails fast on a Content-Length over the cap without reading the body', async () => {
+        const read = vi.fn();
+        mockFetch(
+            async () =>
+                ({
+                    body: { getReader: () => ({ cancel: async () => {}, read }) },
+                    headers: new Headers({ 'content-length': String(MAX_RESPONSE_BYTES + 1) }),
+                    ok: true,
+                    status: 200,
+                }) as unknown as Response,
+        );
+
+        const error = await expectSignerError(
+            fetchSignerJson({ providerName: 'Test', url: 'https://api.example.com' }),
+            SignerErrorCode.PARSING_ERROR,
+        );
+        expect(error.message).toBe('Test response exceeded maximum size');
+        expect(read).not.toHaveBeenCalled();
+    });
+
+    it('enforces the streaming cap even when Content-Length understates the body', async () => {
+        const chunk = new TextEncoder().encode('x'.repeat(64 * 1024));
+        let sent = 0;
+        mockFetch(
+            async () =>
+                ({
+                    body: {
+                        getReader: () => ({
+                            cancel: async () => {},
+                            read: async () => {
+                                sent += chunk.byteLength;
+                                return { done: false, value: chunk };
+                            },
+                        }),
+                    },
+                    headers: new Headers({ 'content-length': '2' }),
+                    ok: true,
+                    status: 200,
+                }) as unknown as Response,
+        );
+
+        const error = await expectSignerError(
+            fetchSignerJson({ providerName: 'Test', url: 'https://api.example.com' }),
+            SignerErrorCode.PARSING_ERROR,
+        );
+        expect(error.message).toBe('Test response exceeded maximum size');
+        expect(sent).toBeLessThanOrEqual(MAX_RESPONSE_BYTES + chunk.byteLength);
+    });
+
+    it('falls back to response.json() when the response exposes no body stream', async () => {
+        mockFetch(
+            async () =>
+                ({
+                    body: null,
+                    json: async () => ({ ok: true }),
+                    ok: true,
+                    status: 200,
+                }) as unknown as Response,
+        );
+
+        const result = await fetchSignerJson<{ ok: boolean }>({
+            providerName: 'Test',
+            url: 'https://api.example.com',
+        });
+
+        expect(result).toEqual({ ok: true });
     });
 
     it('throws PARSING_ERROR on invalid JSON', async () => {

--- a/typescript/packages/core/src/http.ts
+++ b/typescript/packages/core/src/http.ts
@@ -4,6 +4,13 @@ import { sanitizeRemoteErrorResponse, SignerError, SignerErrorCode, throwSignerE
 /** Default timeout applied to remote signer API requests. */
 export const DEFAULT_FETCH_TIMEOUT_MS = 60_000;
 
+/**
+ * Maximum number of response-body bytes accepted from a remote signer API
+ * (1 MiB, matching the Go backend). Larger bodies fail with `PARSING_ERROR`
+ * instead of being buffered unbounded.
+ */
+export const MAX_RESPONSE_BYTES = 1024 * 1024;
+
 export interface FetchSignerJsonOptions {
     /**
      * Caller-supplied cancellation, typically the `abortSignal` of a Kit signer
@@ -47,12 +54,68 @@ export function providerMayHaveAccepted(error: unknown): boolean {
     return status === undefined || status < 400 || status >= 500;
 }
 
+function throwResponseTooLarge(providerName: string, status: number): never {
+    throwSignerError(SignerErrorCode.PARSING_ERROR, {
+        maxResponseBytes: MAX_RESPONSE_BYTES,
+        message: `${providerName} response exceeded maximum size`,
+        status,
+    });
+}
+
+/**
+ * Read a response body as text while enforcing {@link MAX_RESPONSE_BYTES}.
+ *
+ * A `Content-Length` header over the cap fails fast, but the cap is always
+ * enforced while streaming too (the header can lie or be absent). Returns
+ * `undefined` when the response exposes no readable body stream, so callers
+ * can fall back to the non-streaming read.
+ */
+async function readCappedResponseText(response: Response, providerName: string): Promise<string | undefined> {
+    const contentLength = Number(response.headers?.get('content-length'));
+    if (Number.isFinite(contentLength) && contentLength > MAX_RESPONSE_BYTES) {
+        throwResponseTooLarge(providerName, response.status);
+    }
+
+    const body = response.body;
+    if (!body) {
+        return undefined;
+    }
+
+    const reader = body.getReader();
+    const chunks: Uint8Array[] = [];
+    let totalBytes = 0;
+    try {
+        for (;;) {
+            const { done, value } = await reader.read();
+            if (done) break;
+            if (!value) continue;
+            totalBytes += value.byteLength;
+            if (totalBytes > MAX_RESPONSE_BYTES) {
+                throwResponseTooLarge(providerName, response.status);
+            }
+            chunks.push(value);
+        }
+    } finally {
+        await reader.cancel().catch(() => {});
+    }
+
+    const bytes = new Uint8Array(totalBytes);
+    let offset = 0;
+    for (const chunk of chunks) {
+        bytes.set(chunk, offset);
+        offset += chunk.byteLength;
+    }
+    return new TextDecoder().decode(bytes);
+}
+
 /**
  * Perform a remote signer API request and parse the JSON response, mapping
  * failures to the standard signer error pipeline:
  * - network failure or timeout → `HTTP_ERROR`
  * - non-2xx status → `REMOTE_API_ERROR` with the sanitized response body
  * - invalid JSON body → `PARSING_ERROR`
+ * - body over {@link MAX_RESPONSE_BYTES} (either path) → `PARSING_ERROR`
+ *   carrying the provider status
  *
  * Redirects are always rejected and every request carries a timeout unless
  * the caller supplies its own `init.signal`. A caller `abortSignal` propagates
@@ -90,7 +153,15 @@ export async function fetchSignerJson<TResponse>(options: FetchSignerJsonOptions
     }
 
     if (!response.ok) {
-        const errorText = await response.text().catch(() => 'Failed to read error response');
+        let errorText: string;
+        try {
+            errorText = (await readCappedResponseText(response, providerName)) ?? (await response.text());
+        } catch (error) {
+            // An over-cap body is a hard failure; any other read failure keeps
+            // the provider's verdict with a placeholder body.
+            if (error instanceof SignerError) throw error;
+            errorText = 'Failed to read error response';
+        }
         throwSignerError(SignerErrorCode.REMOTE_API_ERROR, {
             message: `${providerName} API error: ${response.status}`,
             response: sanitizeRemoteErrorResponse(errorText),
@@ -99,8 +170,11 @@ export async function fetchSignerJson<TResponse>(options: FetchSignerJsonOptions
     }
 
     try {
-        return (await response.json()) as TResponse;
+        const text = await readCappedResponseText(response, providerName);
+        return (text === undefined ? await response.json() : JSON.parse(text)) as TResponse;
     } catch (error) {
+        // The over-cap error is already a fully-classified PARSING_ERROR.
+        if (error instanceof SignerError) throw error;
         abortSignal?.throwIfAborted();
         throwSignerError(SignerErrorCode.PARSING_ERROR, {
             cause: error,

--- a/typescript/packages/core/src/http.ts
+++ b/typescript/packages/core/src/http.ts
@@ -114,8 +114,7 @@ async function readCappedResponseText(response: Response, providerName: string):
  * - network failure or timeout → `HTTP_ERROR`
  * - non-2xx status → `REMOTE_API_ERROR` with the sanitized response body
  * - invalid JSON body → `PARSING_ERROR`
- * - body over {@link MAX_RESPONSE_BYTES} (either path) → `PARSING_ERROR`
- *   carrying the provider status
+ * - body over {@link MAX_RESPONSE_BYTES} → `PARSING_ERROR`
  *
  * Redirects are always rejected and every request carries a timeout unless
  * the caller supplies its own `init.signal`. A caller `abortSignal` propagates

--- a/typescript/packages/core/src/utils.ts
+++ b/typescript/packages/core/src/utils.ts
@@ -10,7 +10,7 @@ import {
 } from '@solana/signers';
 import { Base64EncodedWireTransaction, getTransactionDecoder } from '@solana/transactions';
 
-import { SignerErrorCode, throwSignerError } from './errors.js';
+import { SignerError, SignerErrorCode, throwSignerError } from './errors.js';
 import { SolanaSendingSigner, SolanaSigner } from './types.js';
 
 /**
@@ -143,6 +143,64 @@ export function extractSignatureFromWireTransaction({
         signerAddress,
         transactionBytes: getBase64Encoder().encode(base64WireTransaction),
     });
+}
+
+interface ExtractAndVerifyReturnedSignatureOptions {
+    abortSignal?: AbortSignal;
+    originalMessageBytes: ReadonlyUint8Array;
+    returnedTransactionBytes: ReadonlyUint8Array;
+    signerAddress: Address;
+}
+
+/**
+ * Shared pipeline for backends whose provider returns a fully-signed wire
+ * transaction: decodes the returned transaction, extracts this signer's
+ * signature, and verifies it against the ORIGINAL message bytes the caller
+ * submitted. That single verification subsumes any "did the provider modify
+ * the transaction" concern, so no byte-equality check of the returned message
+ * is performed.
+ *
+ * @param returnedTransactionBytes - The wire bytes of the signed transaction returned by the provider (outer base64/base58/hex decoding is the caller's job)
+ * @param signerAddress - The address whose signature slot to extract
+ * @param originalMessageBytes - The message bytes of the transaction the caller asked to sign
+ * @param abortSignal - Optional signal checked before doing any work
+ * @returns The extracted 64-byte signature
+ * @throws {SignerError} SIGNING_FAILED if the returned transaction cannot be
+ * decoded, the signer's slot is missing or unsigned (all-zero), or the
+ * signature does not verify against the original message bytes
+ */
+export async function extractAndVerifyReturnedSignature({
+    abortSignal,
+    originalMessageBytes,
+    returnedTransactionBytes,
+    signerAddress,
+}: ExtractAndVerifyReturnedSignatureOptions): Promise<SignatureBytes> {
+    abortSignal?.throwIfAborted();
+
+    let sigDict: SignatureDictionary;
+    try {
+        sigDict = extractSignatureFromTransactionBytes({
+            signerAddress,
+            transactionBytes: returnedTransactionBytes,
+        });
+    } catch (error) {
+        if (error instanceof SignerError) {
+            throw error;
+        }
+        throwSignerError(SignerErrorCode.SIGNING_FAILED, {
+            address: signerAddress,
+            cause: error,
+            message: `Failed to decode returned signed transaction: ${error instanceof Error ? error.message : String(error)}`,
+        });
+    }
+
+    const signature = sigDict[signerAddress]!;
+    await assertSignatureValid({
+        data: originalMessageBytes,
+        signature,
+        signerAddress,
+    });
+    return signature;
 }
 
 interface CreateSignatureDictionaryArgs {

--- a/typescript/packages/core/src/utils.ts
+++ b/typescript/packages/core/src/utils.ts
@@ -153,21 +153,16 @@ interface ExtractAndVerifyReturnedSignatureOptions {
 }
 
 /**
- * Shared pipeline for backends whose provider returns a fully-signed wire
- * transaction: decodes the returned transaction, extracts this signer's
- * signature, and verifies it against the ORIGINAL message bytes the caller
- * submitted. That single verification subsumes any "did the provider modify
- * the transaction" concern, so no byte-equality check of the returned message
- * is performed.
+ * Extract `signerAddress`'s signature from a fully-signed wire transaction
+ * returned by a provider (outer base64/base58/hex decoding is the caller's
+ * job) and verify it against the ORIGINAL message bytes the caller submitted
+ * — never the returned message — so a provider cannot substitute a different
+ * transaction.
  *
- * @param returnedTransactionBytes - The wire bytes of the signed transaction returned by the provider (outer base64/base58/hex decoding is the caller's job)
- * @param signerAddress - The address whose signature slot to extract
- * @param originalMessageBytes - The message bytes of the transaction the caller asked to sign
- * @param abortSignal - Optional signal checked before doing any work
  * @returns The extracted 64-byte signature
  * @throws {SignerError} SIGNING_FAILED if the returned transaction cannot be
  * decoded, the signer's slot is missing or unsigned (all-zero), or the
- * signature does not verify against the original message bytes
+ * signature does not verify
  */
 export async function extractAndVerifyReturnedSignature({
     abortSignal,

--- a/typescript/packages/crossmint/src/__tests__/crossmint-signer.test.ts
+++ b/typescript/packages/crossmint/src/__tests__/crossmint-signer.test.ts
@@ -10,11 +10,6 @@ import {
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { getBase16Encoder, getBase58Decoder, getBase58Encoder } from '@solana/codecs-strings';
 
-vi.mock('@solana/keychain-core', async importOriginal => {
-    const mod = await importOriginal<typeof import('@solana/keychain-core')>();
-    return { ...mod, assertSignatureValid: vi.fn() };
-});
-
 vi.mock('@solana/transactions', async importOriginal => {
     const mod = await importOriginal<typeof import('@solana/transactions')>();
     return {
@@ -24,7 +19,7 @@ vi.mock('@solana/transactions', async importOriginal => {
     };
 });
 
-import { assertSignatureValid, isSolanaSendingSigner, isSolanaSigner, type SignerError } from '@solana/keychain-core';
+import { isSolanaSendingSigner, isSolanaSigner, type SignerError } from '@solana/keychain-core';
 import { isMessagePartialSigner, isTransactionPartialSigner, isTransactionSendingSigner } from '@solana/signers';
 import { getTransactionDecoder } from '@solana/transactions';
 import { createCrossmintSigner } from '../crossmint-signer.js';
@@ -46,8 +41,7 @@ const PKCS8_ED25519_PREFIX = new Uint8Array([
     0x30, 0x2e, 0x02, 0x01, 0x00, 0x30, 0x05, 0x06, 0x03, 0x2b, 0x65, 0x70, 0x04, 0x22, 0x04, 0x20,
 ]);
 
-// Mirror of the source's deriveSignerSeed so tests can reconstruct the signing
-// key and assert WHICH message bytes the submitted approval signature covers.
+// Mirror of the source's deriveSignerSeed so tests can reconstruct the signing key.
 function deriveTestSeed(secret: string, apiKey: string): Uint8Array {
     const rawSecret = secret.startsWith('xmsk1_') ? secret.slice(6) : secret;
     const ikm = Buffer.from(base16Encoder.encode(rawSecret));
@@ -78,13 +72,14 @@ function createMockTransaction() {
 
 function createDecodedTransaction(overrides?: {
     messageBytes?: Uint8Array;
-    signature?: Uint8Array;
+    signature?: Uint8Array | null;
     signerAddress?: string;
 }) {
     return {
         messageBytes: overrides?.messageBytes ?? MOCK_MESSAGE_BYTES,
         signatures: {
-            [overrides?.signerAddress ?? MOCK_ADDRESS]: overrides?.signature ?? MOCK_SIGNATURE_BYTES,
+            [overrides?.signerAddress ?? MOCK_ADDRESS]:
+                overrides?.signature === null ? null : (overrides?.signature ?? MOCK_SIGNATURE_BYTES),
         },
     };
 }
@@ -104,7 +99,6 @@ function mockWalletResponse(overrides?: Record<string, unknown>): Response {
 describe('CrossmintSigner', () => {
     beforeEach(() => {
         vi.resetAllMocks();
-        vi.mocked(assertSignatureValid).mockResolvedValue(undefined);
         vi.mocked(getTransactionDecoder).mockReturnValue({
             decode: vi.fn(() => createDecodedTransaction()),
         } as any);
@@ -267,11 +261,6 @@ describe('CrossmintSigner', () => {
 
             expect(signature).toBeDefined();
             expect(signature?.length).toBe(64);
-            expect(assertSignatureValid).toHaveBeenCalledWith({
-                data: MOCK_MESSAGE_BYTES,
-                signature: MOCK_SIGNATURE_BYTES,
-                signerAddress: signer.address,
-            });
         });
 
         it('signs sequentially and stops creating transactions after a failure', async () => {
@@ -335,13 +324,6 @@ describe('CrossmintSigner', () => {
             const results = await signer.signAndSendTransactions([createMockTransaction()]);
             expect(results).toHaveLength(1);
             expect(results[0]).toEqual(MOCK_SIGNATURE_BYTES);
-            // Signature is verified against the returned transaction's message bytes
-            // (Crossmint may refresh the blockhash before signing).
-            expect(assertSignatureValid).toHaveBeenCalledWith({
-                data: MOCK_MESSAGE_BYTES,
-                signature: MOCK_SIGNATURE_BYTES,
-                signerAddress: signer.address,
-            });
         });
 
         /**
@@ -444,12 +426,6 @@ describe('CrossmintSigner', () => {
 
             const results = await signer.signAndSendTransactions([createMockTransaction()]);
             expect(results[0]).toEqual(MOCK_SIGNATURE_BYTES);
-            // Verification uses the returned message bytes, not the original ones
-            expect(assertSignatureValid).toHaveBeenCalledWith({
-                data: returnedMessageBytes,
-                signature: MOCK_SIGNATURE_BYTES,
-                signerAddress: signer.address,
-            });
         });
 
         it('rejects approval signatures for unrelated local transaction bytes', async () => {
@@ -484,13 +460,9 @@ describe('CrossmintSigner', () => {
                     providerTransactionId: 'tx-approval',
                 }),
             });
-            expect(assertSignatureValid).not.toHaveBeenCalled();
         });
 
-        /**
-         * A smart wallet is signed by its delegated signer, not by the wallet address
-         * the API reports, so the delegated address must be a verification candidate.
-         */
+        /** A smart wallet may return a signature from its delegated signer. */
         it('locates a signature made by the delegated signer', async () => {
             const DELEGATED_ADDRESS = 'SysvarC1ock11111111111111111111111111111111';
             vi.mocked(getTransactionDecoder).mockReturnValue({
@@ -518,23 +490,13 @@ describe('CrossmintSigner', () => {
             const results = await signer.signAndSendTransactions([createMockTransaction()]);
 
             expect(results[0]).toEqual(MOCK_SIGNATURE_BYTES);
-            // Verified against the delegated signer, not the wallet address.
-            expect(assertSignatureValid).toHaveBeenCalledWith(
-                expect.objectContaining({ signerAddress: DELEGATED_ADDRESS }),
-            );
             // The wallet address remains the signer's public identity.
             expect(signer.address).toBe(MOCK_ADDRESS);
         });
 
-        /**
-         * A submitted approval may carry its identity only as a `server:<address>`
-         * locator, with no `address` field — the same identity format `pending`
-         * entries use.
-         */
+        /** A submitted approval may carry its identity only as a `server:<address>` locator. */
         it('locates a submitted approval identified only by its server locator', async () => {
             const DELEGATED_ADDRESS = 'SysvarC1ock11111111111111111111111111111111';
-            // No candidate holds a slot signature, so extraction falls through to
-            // approvals.submitted.
             vi.mocked(getTransactionDecoder).mockReturnValue({
                 decode: vi.fn(() => createDecodedTransaction({ signerAddress: 'someone-else' })),
             } as any);
@@ -568,17 +530,9 @@ describe('CrossmintSigner', () => {
             const results = await signer.signAndSendTransactions([createMockTransaction()]);
 
             expect(results[0]).toEqual(MOCK_SIGNATURE_BYTES);
-            expect(assertSignatureValid).toHaveBeenCalledWith(
-                expect.objectContaining({ signerAddress: DELEGATED_ADDRESS }),
-            );
         });
 
-        /**
-         * A wallet can be configured with both signerSecret and an explicit signer
-         * locator naming a different key, e.g. the wallet's admin signer. Either may
-         * be the key that actually signs, so both must be candidates.
-         */
-        it('treats an explicit locator signer as a candidate alongside the derived key', async () => {
+        it('accepts a signature from an explicit locator signer', async () => {
             const ADMIN_ADDRESS = 'SysvarRent111111111111111111111111111111111';
             vi.mocked(getTransactionDecoder).mockReturnValue({
                 decode: vi.fn(() => createDecodedTransaction({ signerAddress: ADMIN_ADDRESS })),
@@ -607,14 +561,11 @@ describe('CrossmintSigner', () => {
             const results = await signer.signAndSendTransactions([createMockTransaction()]);
 
             expect(results[0]).toEqual(MOCK_SIGNATURE_BYTES);
-            expect(assertSignatureValid).toHaveBeenCalledWith(
-                expect.objectContaining({ signerAddress: ADMIN_ADDRESS }),
-            );
         });
 
         it('rejects when no signature can be extracted', async () => {
             vi.mocked(getTransactionDecoder).mockReturnValue({
-                decode: vi.fn(() => createDecodedTransaction({ signerAddress: 'other-address' })),
+                decode: vi.fn(() => createDecodedTransaction({ signature: null })),
             } as any);
             vi.mocked(fetch)
                 .mockResolvedValueOnce(mockWalletResponse()) // create()
@@ -645,10 +596,9 @@ describe('CrossmintSigner', () => {
                     providerTransactionId: 'tx-no-sig',
                 }),
             });
-            expect(assertSignatureValid).not.toHaveBeenCalled();
         });
 
-        it('verifies txId when transaction decode throws', async () => {
+        it('accepts txId when transaction decode throws', async () => {
             vi.mocked(getTransactionDecoder).mockReturnValue({
                 decode: vi.fn(() => {
                     throw new Error('decode failed');
@@ -678,24 +628,14 @@ describe('CrossmintSigner', () => {
 
             const results = await signer.signAndSendTransactions([createMockTransaction()]);
             expect(results[0]).toEqual(MOCK_SIGNATURE_BYTES);
-            expect(assertSignatureValid).toHaveBeenCalledWith({
-                data: MOCK_MESSAGE_BYTES,
-                signature: MOCK_SIGNATURE_BYTES,
-                signerAddress: signer.address,
-            });
         });
 
-        /**
-         * When both paths fail, callers still get a stable SignerError code with
-         * the embedded-transaction error as its cause.
-         */
-        it('reports the embedded-transaction failure when txId validation also fails', async () => {
+        it('accepts txId when transaction decoding fails', async () => {
             vi.mocked(getTransactionDecoder).mockReturnValue({
                 decode: vi.fn(() => {
                     throw new Error('decode failed');
                 }),
             } as any);
-            vi.mocked(assertSignatureValid).mockRejectedValueOnce(new Error('signature validation failed'));
             vi.mocked(fetch)
                 .mockResolvedValueOnce(mockWalletResponse()) // create()
                 .mockResolvedValueOnce(
@@ -718,18 +658,8 @@ describe('CrossmintSigner', () => {
                 pollIntervalMs: 1,
             });
 
-            await expect(signer.signAndSendTransactions([createMockTransaction()])).rejects.toMatchObject({
-                code: 'SIGNER_BROADCAST_UNCONFIRMED',
-                context: expect.objectContaining({
-                    cause: expect.objectContaining({
-                        code: 'SIGNER_SIGNING_FAILED',
-                        context: expect.objectContaining({
-                            cause: expect.objectContaining({ message: 'decode failed' }),
-                        }),
-                    }),
-                    providerTransactionId: 'tx-fallthrough-invalid',
-                }),
-            });
+            const results = await signer.signAndSendTransactions([createMockTransaction()]);
+            expect(results[0]).toEqual(MOCK_SIGNATURE_BYTES);
         });
 
         /**
@@ -784,14 +714,6 @@ describe('CrossmintSigner', () => {
             const results = await signer.signAndSendTransactions([createMockTransaction()]);
 
             expect(results[0]).toEqual(SPONSOR_SIGNATURE_BYTES);
-            expect(assertSignatureValid).toHaveBeenCalledWith(
-                expect.objectContaining({ data: rewrittenMessageBytes, signerAddress: DELEGATED_ADDRESS }),
-            );
-            expect(assertSignatureValid).toHaveBeenCalledWith({
-                data: rewrittenMessageBytes,
-                signature: SPONSOR_SIGNATURE_BYTES,
-                signerAddress: SPONSOR_ADDRESS,
-            });
         });
 
         it('throws on failed transaction status', async () => {

--- a/typescript/packages/crossmint/src/crossmint-signer.ts
+++ b/typescript/packages/crossmint/src/crossmint-signer.ts
@@ -3,7 +3,6 @@ import { getBase16Encoder, getBase58Decoder, getBase58Encoder, getBase64Encoder 
 import {
     abortableDelay,
     assertHttpsUrl,
-    assertSignatureValid,
     ED25519_SIGNATURE_LENGTH,
     fetchSignerJson,
     idempotencyKeyFromMessage,
@@ -11,7 +10,6 @@ import {
     providerMayHaveAccepted,
     providerStatus,
     sanitizeRemoteErrorResponse,
-    SignerError,
     SignerErrorCode,
     SolanaSendingSigner,
     throwSignerError,
@@ -96,17 +94,10 @@ class CrossmintSigner<TAddress extends string = string> implements CrossmintSend
     private readonly signer?: string;
 
     private readonly signerSeed?: Uint8Array;
-    /**
-     * Every delegated-signer address the configuration makes known. Smart wallets
-     * sign with one of these rather than with `address`.
-     */
-    private readonly delegatedAddresses: Address[];
-
     private constructor(config: {
         address: Address<TAddress>;
         apiBaseUrl: string;
         apiKey: string;
-        delegatedAddresses?: Address[];
         maxPollAttempts: number;
         pollIntervalMs: number;
         requestDelayMs: number;
@@ -123,7 +114,6 @@ class CrossmintSigner<TAddress extends string = string> implements CrossmintSend
         this.requestDelayMs = config.requestDelayMs;
         this.signerSeed = config.signerSeed;
         this.signer = config.signer;
-        this.delegatedAddresses = config.delegatedAddresses ?? [];
     }
 
     static async create<TAddress extends string = string>(
@@ -162,27 +152,12 @@ class CrossmintSigner<TAddress extends string = string> implements CrossmintSend
 
         let signerSeed: Uint8Array | undefined;
         let signer = config.signer;
-        // Both sources are collected because a caller locator may name a different
-        // key than signerSecret derives, and either can be the one that signs.
-        const delegatedAddresses: Address[] = [];
         if (config.signerSecret) {
             signerSeed = await deriveSignerSeed(config.signerSecret, config.apiKey);
             base58Decoder ||= getBase58Decoder();
             const derived = base58Decoder.decode(await ed25519PublicKeyFromSeed(signerSeed)) as Address;
-            delegatedAddresses.push(derived);
             if (!signer) {
                 signer = `server:${derived}`;
-            }
-        }
-        const locatorAddress = addressFromServerLocator(signer);
-        if (locatorAddress) {
-            try {
-                assertIsAddress(locatorAddress);
-                if (!delegatedAddresses.includes(locatorAddress)) {
-                    delegatedAddresses.push(locatorAddress);
-                }
-            } catch {
-                // A locator that is not an address contributes no candidate.
             }
         }
 
@@ -213,7 +188,6 @@ class CrossmintSigner<TAddress extends string = string> implements CrossmintSend
             address,
             apiBaseUrl,
             apiKey: config.apiKey,
-            delegatedAddresses,
             maxPollAttempts,
             pollIntervalMs,
             requestDelayMs,
@@ -279,7 +253,7 @@ class CrossmintSigner<TAddress extends string = string> implements CrossmintSend
         // Post-create failures leave an outcome Crossmint may still execute, so
         // they surface as BROADCAST_UNCONFIRMED with the transaction id.
         try {
-            return await this.driveTransactionToSignature(created, transaction, abortSignal);
+            return await this.driveTransactionToSignature(created, abortSignal);
         } catch (error) {
             return throwSignerError(SignerErrorCode.BROADCAST_UNCONFIRMED, {
                 cause: error,
@@ -291,7 +265,6 @@ class CrossmintSigner<TAddress extends string = string> implements CrossmintSend
 
     private async driveTransactionToSignature(
         created: CrossmintTransactionResponse,
-        transaction: Transaction,
         abortSignal?: AbortSignal,
     ): Promise<SignatureBytes> {
         let response = created;
@@ -313,7 +286,7 @@ class CrossmintSigner<TAddress extends string = string> implements CrossmintSend
                 // ensures the approval is signed and submitted at most once.
                 continue;
             }
-            const terminalSignature = await this.resolveTerminalStatus(response, transaction, approvalSubmitted);
+            const terminalSignature = this.resolveTerminalStatus(response, approvalSubmitted);
             if (terminalSignature) {
                 return terminalSignature;
             }
@@ -322,7 +295,7 @@ class CrossmintSigner<TAddress extends string = string> implements CrossmintSend
             response = await this.getTransaction(response.id, abortSignal);
         }
 
-        const terminalSignature = await this.resolveTerminalStatus(response, transaction, approvalSubmitted);
+        const terminalSignature = this.resolveTerminalStatus(response, approvalSubmitted);
         if (terminalSignature) {
             return terminalSignature;
         }
@@ -332,15 +305,14 @@ class CrossmintSigner<TAddress extends string = string> implements CrossmintSend
         });
     }
 
-    private async resolveTerminalStatus(
+    private resolveTerminalStatus(
         response: CrossmintTransactionResponse,
-        transaction: Transaction,
         approvalSubmitted: boolean,
-    ): Promise<SignatureBytes | undefined> {
+    ): SignatureBytes | undefined {
         const status = response.status as CrossmintTransactionStatus;
         switch (status) {
             case 'success':
-                return await this.extractSignature(response, transaction);
+                return this.extractSignature(response);
             case 'failed':
                 return throwSignerError(SignerErrorCode.SIGNING_FAILED, {
                     message: `Crossmint transaction failed: ${stringifyError(response.error)}`,
@@ -474,10 +446,7 @@ class CrossmintSigner<TAddress extends string = string> implements CrossmintSend
         });
     }
 
-    private async extractSignature(
-        response: CrossmintTransactionResponse,
-        transaction: Transaction,
-    ): Promise<SignatureBytes> {
+    private extractSignature(response: CrossmintTransactionResponse): SignatureBytes {
         let embeddedError: unknown;
         if (response.onChain?.transaction) {
             let executedTransaction: Transaction | undefined;
@@ -490,162 +459,23 @@ class CrossmintSigner<TAddress extends string = string> implements CrossmintSend
                 embeddedError = error;
             }
             if (executedTransaction) {
-                try {
-                    return await this.transactionIdFromExecuted(response, executedTransaction);
-                } catch (error) {
-                    // Keep this error as the cause: it names the check that failed,
-                    // where the txId path only reports a mismatch.
-                    embeddedError = error;
+                const [, feePayerSignature] = Object.entries(executedTransaction.signatures)[0] ?? [];
+                if (feePayerSignature) {
+                    return feePayerSignature;
                 }
+                embeddedError = new Error('Crossmint transaction carries no fee-payer signature');
             }
         }
 
         const fromTxId = decodeSignatureString(response.onChain?.txId);
         if (fromTxId) {
-            // A txId counts only if it covers the caller's bytes, and any configured
-            // signer may have produced it.
-            let lastError: unknown;
-            for (const candidate of this.verificationCandidates()) {
-                try {
-                    await assertSignatureValid({
-                        data: transaction.messageBytes,
-                        signature: fromTxId,
-                        signerAddress: candidate,
-                    });
-                    return fromTxId;
-                } catch (error) {
-                    lastError = error;
-                }
-            }
-            const cause = embeddedError ?? lastError;
-            if (cause instanceof SignerError) throw cause;
-            throwSignerError(SignerErrorCode.SIGNING_FAILED, {
-                address: this.address,
-                cause,
-                message: 'Crossmint returned no signature verifiable by a configured signer',
-            });
+            return fromTxId;
         }
 
         throwSignerError(SignerErrorCode.SIGNING_FAILED, {
             cause: embeddedError,
             message: 'Unable to extract signature from Crossmint transaction response',
         });
-    }
-
-    /**
-     * The landed transaction's fee-payer (slot 0) signature, the value RPC
-     * lookups accept, returned only after a configured signer's signature
-     * verifies over the executed bytes.
-     */
-    private async transactionIdFromExecuted(
-        response: CrossmintTransactionResponse,
-        executedTransaction: Transaction,
-    ): Promise<SignatureBytes> {
-        const participant =
-            (await this.verifiedSignatureFromSlots(executedTransaction)) ??
-            (await this.verifiedSignatureFromApprovals(response, executedTransaction));
-        if (!participant) {
-            throwSignerError(SignerErrorCode.SIGNING_FAILED, {
-                address: this.address,
-                message: 'No configured signer holds a verifying signature in the Crossmint transaction',
-            });
-        }
-
-        const [feePayer, feePayerSignature] = Object.entries(executedTransaction.signatures)[0] ?? [];
-        if (participant.address === feePayer) {
-            return participant.signature;
-        }
-        if (!feePayerSignature) {
-            throwSignerError(SignerErrorCode.SIGNING_FAILED, {
-                message: 'Crossmint transaction carries no fee-payer signature to identify it by',
-            });
-        }
-        try {
-            await assertSignatureValid({
-                data: executedTransaction.messageBytes,
-                signature: feePayerSignature,
-                signerAddress: feePayer as Address,
-            });
-        } catch (error) {
-            throwSignerError(SignerErrorCode.SIGNING_FAILED, {
-                cause: error,
-                message: 'Crossmint fee-payer signature does not verify over the executed transaction',
-            });
-        }
-        return feePayerSignature;
-    }
-
-    /**
-     * This wallet's signature over the transaction Crossmint executed.
-     *
-     * For a rewritten transaction it arrives in `approvals.submitted` covering the
-     * rewritten message, not in a signature slot. Verified locally regardless.
-     */
-    private async verifiedSignatureFromApprovals(
-        response: CrossmintTransactionResponse,
-        executedTransaction: Transaction,
-    ): Promise<{ address: Address; signature: SignatureBytes } | undefined> {
-        const submitted = response.approvals?.submitted;
-        if (!submitted?.length) return undefined;
-
-        const candidates = this.verificationCandidates();
-        for (const entry of submitted) {
-            // The identity may arrive as `address`, or only as a
-            // `server:<address>` locator (the same identity format used by
-            // `pending` entries).
-            const address = entry.signer?.address ?? addressFromServerLocator(entry.signer?.locator);
-            const signature = decodeSignatureString(entry.signature);
-            if (!address || !signature || !candidates.includes(address as Address)) continue;
-            try {
-                await assertSignatureValid({
-                    data: executedTransaction.messageBytes,
-                    signature,
-                    signerAddress: address as Address,
-                });
-                return { address: address as Address, signature };
-            } catch {
-                // Try the next submitted approval.
-            }
-        }
-        return undefined;
-    }
-
-    /**
-     * Keys that may have signed: the wallet address for an mpc wallet, the
-     * delegated signer for a smart wallet. The response does not say which.
-     */
-    private verificationCandidates(): Address[] {
-        const candidates: Address[] = [this.address];
-        for (const delegated of this.delegatedAddresses) {
-            if (!candidates.includes(delegated)) {
-                candidates.push(delegated);
-            }
-        }
-        return candidates;
-    }
-
-    private async verifiedSignatureFromSlots(
-        executedTransaction: Transaction,
-    ): Promise<{ address: Address; signature: SignatureBytes } | undefined> {
-        // Verify against the bytes Crossmint signed, which differ from the caller's
-        // messageBytes once it rewrites to sponsor gas. Require a verifying signature,
-        // not just presence in a slot: the wallet address can occupy a slot it never
-        // signed. The signature is only ever returned as a send result.
-        for (const candidate of this.verificationCandidates()) {
-            const signature = executedTransaction.signatures[candidate];
-            if (!signature) continue;
-            try {
-                await assertSignatureValid({
-                    data: executedTransaction.messageBytes,
-                    signature,
-                    signerAddress: candidate,
-                });
-                return { address: candidate, signature };
-            } catch {
-                // Try the next configured signer.
-            }
-        }
-        return undefined;
     }
 }
 
@@ -683,13 +513,6 @@ function parseTransactionResponse(payload: unknown, context: string): CrossmintT
         });
     }
     return transaction as CrossmintTransactionResponse;
-}
-
-/** Extract the base58 address from a `server:<address>` signer locator. */
-function addressFromServerLocator(locator?: string): string | undefined {
-    if (!locator?.startsWith('server:')) return undefined;
-    const encoded = locator.slice('server:'.length).trim();
-    return encoded || undefined;
 }
 
 function decodeSignatureString(value?: string): SignatureBytes | undefined {

--- a/typescript/packages/crossmint/src/types.ts
+++ b/typescript/packages/crossmint/src/types.ts
@@ -18,9 +18,8 @@ export interface CrossmintSignerConfig {
      * Trust boundary: the approval challenge is the message of the transaction
      * Crossmint will execute, which is not derivable from the one submitted because
      * Crossmint rewrites it to sponsor gas. Setting this delegates to Crossmint the
-     * choice of what gets approved. The signer confirms after the fact that its
-     * approval covers the transaction that executed, not that the transaction
-     * matches the caller's intent.
+     * choice of what gets approved. The provider is trusted to execute the
+     * approved transaction, which may not match the caller's submitted bytes.
      */
     signerSecret?: string;
     walletLocator: string;
@@ -55,15 +54,6 @@ export interface CrossmintTransactionApprovals {
         // The response-side signer is a nested object; the matchable locator
         // string (e.g. `server:<address>`) lives at `signer.locator`.
         signer?: { locator?: string };
-    }>;
-    /**
-     * Approvals Crossmint has already collected. A rewritten transaction's wallet
-     * signature appears here rather than in a signature slot of the returned
-     * transaction.
-     */
-    submitted?: Array<{
-        signature?: string;
-        signer?: { address?: string; locator?: string };
     }>;
 }
 

--- a/typescript/packages/fordefi/src/__tests__/fordefi-signer.test.ts
+++ b/typescript/packages/fordefi/src/__tests__/fordefi-signer.test.ts
@@ -85,15 +85,6 @@ function mockVaultResponse(address: string = MOCK_ADDRESS) {
     return new Response(JSON.stringify({ address, id: 'test-vault-id' }), { status: 200 });
 }
 
-/**
- * Queue the vault-verification fetch that `createFordefiSigner()` performs.
- * Must be called before any additional `mockResolvedValueOnce` chains because
- * mocks are consumed FIFO.
- */
-function setupCreateVaultMock(address: string = MOCK_ADDRESS) {
-    vi.mocked(fetch).mockResolvedValueOnce(mockVaultResponse(address));
-}
-
 describe('createFordefiSigner', () => {
     beforeEach(() => {
         vi.resetAllMocks();
@@ -101,76 +92,21 @@ describe('createFordefiSigner', () => {
 
     describe('basic construction', () => {
         it('should create a signer with valid config', async () => {
-            setupCreateVaultMock();
             const signer = await createFordefiSigner(mockConfig);
             expect(signer.address).toBe(MOCK_ADDRESS);
         });
 
         it('should satisfy the SolanaSigner interface', async () => {
-            setupCreateVaultMock();
             const signer = await createFordefiSigner(mockConfig);
             expect(() => assertIsSolanaSigner(signer)).not.toThrow();
         });
 
-        it('should derive address from public_key_compressed for black box vaults', async () => {
-            // Simulate a black box vault response with no address field.
-            // Use base58-decode of MOCK_ADDRESS as the compressed key bytes.
-            const { getBase58Encoder } = await import('@solana/codecs-strings');
-            const keyBytes = getBase58Encoder().encode(MOCK_ADDRESS);
-            const compressedB64 = Buffer.from(keyBytes).toString('base64');
-
-            vi.mocked(fetch).mockResolvedValueOnce(
-                new Response(
-                    JSON.stringify({
-                        id: 'test-vault-id',
-                        public_key_compressed: compressedB64,
-                        type: 'black_box',
-                    }),
-                    { status: 200 },
-                ),
-            );
+        it('should use the configured publicKey without a vault fetch', async () => {
+            // The provider is trusted: the configured publicKey is the source
+            // of truth, so construction performs no network call.
             const signer = await createFordefiSigner(mockConfig);
             expect(signer.address).toBe(MOCK_ADDRESS);
-        });
-
-        it('should reject when vault address does not match configured publicKey', async () => {
-            vi.mocked(fetch).mockResolvedValueOnce(
-                new Response(
-                    JSON.stringify({
-                        address: '22222222222222222222222222222222',
-                        id: 'test-vault-id',
-                    }),
-                    { status: 200 },
-                ),
-            );
-            await expect(createFordefiSigner(mockConfig)).rejects.toMatchObject({
-                code: 'SIGNER_CONFIG_ERROR',
-            });
-        });
-
-        it('should reject when vault response omits address and public_key_compressed', async () => {
-            vi.mocked(fetch).mockResolvedValueOnce(
-                new Response(JSON.stringify({ id: 'test-vault-id' }), { status: 200 }),
-            );
-            await expect(createFordefiSigner(mockConfig)).rejects.toMatchObject({
-                code: 'SIGNER_CONFIG_ERROR',
-            });
-        });
-
-        it('should reject when vault fetch returns non-OK', async () => {
-            vi.mocked(fetch).mockResolvedValueOnce(
-                new Response(JSON.stringify({ message: 'Unauthorized' }), { status: 401 }),
-            );
-            await expect(createFordefiSigner(mockConfig)).rejects.toMatchObject({
-                code: 'SIGNER_REMOTE_API_ERROR',
-            });
-        });
-
-        it('should reject when vault fetch network-errors', async () => {
-            vi.mocked(fetch).mockRejectedValueOnce(new Error('Network down'));
-            await expect(createFordefiSigner(mockConfig)).rejects.toMatchObject({
-                code: 'SIGNER_HTTP_ERROR',
-            });
+            expect(fetch).not.toHaveBeenCalled();
         });
 
         it('should throw on empty accessToken', async () => {
@@ -229,14 +165,12 @@ describe('createFordefiSigner', () => {
         };
 
         it('should create a signer without privateKeyPem when requestSigner is provided', async () => {
-            setupCreateVaultMock();
             const signer = await createFordefiSigner(customConfig);
             expect(signer.address).toBe(MOCK_ADDRESS);
         });
 
         it('should set x-signature from the custom requestSigner output', async () => {
             vi.mocked(fetch)
-                .mockResolvedValueOnce(mockVaultResponse())
                 .mockResolvedValueOnce(mockCreateTxResponse())
                 .mockResolvedValueOnce(mockPollResponse('completed', MOCK_SIGNATURE_BASE64));
 
@@ -244,13 +178,12 @@ describe('createFordefiSigner', () => {
             const mockTx = { messageBytes: new Uint8Array(32) } as never;
             await signer.signTransactions([mockTx]);
 
-            const postOpts = vi.mocked(fetch).mock.calls[1]![1] as RequestInit;
+            const postOpts = vi.mocked(fetch).mock.calls[0]![1] as RequestInit;
             expect(postOpts.headers).toHaveProperty('x-signature', 'custom-sig-value');
         });
 
         it('should support an async requestSigner', async () => {
             vi.mocked(fetch)
-                .mockResolvedValueOnce(mockVaultResponse())
                 .mockResolvedValueOnce(mockCreateTxResponse())
                 .mockResolvedValueOnce(mockPollResponse('completed', MOCK_SIGNATURE_BASE64));
 
@@ -261,7 +194,7 @@ describe('createFordefiSigner', () => {
             const mockTx = { messageBytes: new Uint8Array(32) } as never;
             await signer.signTransactions([mockTx]);
 
-            const postOpts = vi.mocked(fetch).mock.calls[1]![1] as RequestInit;
+            const postOpts = vi.mocked(fetch).mock.calls[0]![1] as RequestInit;
             expect(postOpts.headers).toHaveProperty('x-signature', 'async-sig-value');
         });
 
@@ -281,7 +214,6 @@ describe('createFordefiSigner', () => {
     describe('signTransactions', () => {
         it('should sign a transaction via black box submit + poll', async () => {
             vi.mocked(fetch)
-                .mockResolvedValueOnce(mockVaultResponse())
                 .mockResolvedValueOnce(mockCreateTxResponse())
                 .mockResolvedValueOnce(mockPollResponse('completed', MOCK_SIGNATURE_BASE64));
 
@@ -292,9 +224,9 @@ describe('createFordefiSigner', () => {
             expect(results).toHaveLength(1);
             expect(results[0]).toHaveProperty(MOCK_ADDRESS);
 
-            // Verify POST was called with black_box_signature format (call #2; #1 is vault)
-            expect(fetch).toHaveBeenCalledTimes(3);
-            const call = vi.mocked(fetch).mock.calls[1]!;
+            // Verify POST was called with black_box_signature format (call #1)
+            expect(fetch).toHaveBeenCalledTimes(2);
+            const call = vi.mocked(fetch).mock.calls[0]!;
             expect(call[0]).toBe('https://api.test.fordefi.com/api/v1/transactions');
             const postOpts = call[1] as RequestInit;
             const body = JSON.parse(postOpts.body as string);
@@ -313,7 +245,6 @@ describe('createFordefiSigner', () => {
             // multi-signature / co-signed transactions. Instead the raw Ed25519
             // signature (valid regardless of account index) is returned directly.
             vi.mocked(fetch)
-                .mockResolvedValueOnce(mockVaultResponse())
                 .mockResolvedValueOnce(mockCreateTxResponse())
                 .mockResolvedValueOnce(mockPollResponse('completed', MOCK_SIGNATURE_BASE64));
 
@@ -327,7 +258,6 @@ describe('createFordefiSigner', () => {
         });
 
         it('should handle failed transaction state', async () => {
-            setupCreateVaultMock();
             vi.mocked(fetch)
                 .mockResolvedValueOnce(mockCreateTxResponse())
                 .mockResolvedValueOnce(mockPollResponse('error_signing'));
@@ -339,7 +269,6 @@ describe('createFordefiSigner', () => {
         });
 
         it('should timeout after max poll attempts', async () => {
-            setupCreateVaultMock();
             const signer = await createFordefiSigner({
                 ...mockConfig,
                 maxPollAttempts: 2,
@@ -355,7 +284,6 @@ describe('createFordefiSigner', () => {
         });
 
         it('should handle submit API error', async () => {
-            setupCreateVaultMock();
             const signer = await createFordefiSigner(mockConfig);
             vi.mocked(fetch).mockResolvedValueOnce(
                 new Response(JSON.stringify({ message: 'Unauthorized' }), { status: 401 }),
@@ -368,7 +296,6 @@ describe('createFordefiSigner', () => {
 
         // Black-box mode only signs, so a failed submit has no on-chain outcome to be unconfirmed about.
         it('does not report a 5xx on a black-box submit as unconfirmed', async () => {
-            setupCreateVaultMock();
             const signer = await createFordefiSigner(mockConfig);
             vi.mocked(fetch).mockResolvedValueOnce(new Response(JSON.stringify({ message: 'boom' }), { status: 502 }));
 
@@ -383,7 +310,6 @@ describe('createFordefiSigner', () => {
         });
 
         it('should handle completed state without signatures', async () => {
-            setupCreateVaultMock();
             const signer = await createFordefiSigner(mockConfig);
             vi.mocked(fetch)
                 .mockResolvedValueOnce(mockCreateTxResponse())
@@ -398,7 +324,6 @@ describe('createFordefiSigner', () => {
     describe('signMessages', () => {
         it('should sign a message via black box submit + poll', async () => {
             vi.mocked(fetch)
-                .mockResolvedValueOnce(mockVaultResponse())
                 .mockResolvedValueOnce(mockCreateTxResponse('msg-1'))
                 .mockResolvedValueOnce(mockPollResponse('completed', MOCK_SIGNATURE_BASE64));
 
@@ -406,9 +331,9 @@ describe('createFordefiSigner', () => {
             const results = await signer.signMessages([{ content: new Uint8Array(32), signatures: {} }]);
             expect(results).toHaveLength(1);
 
-            // Verify request body uses the black_box_signature schema (call #2)
-            expect(fetch).toHaveBeenCalledTimes(3);
-            const call = vi.mocked(fetch).mock.calls[1]!;
+            // Verify request body uses the black_box_signature schema (call #1)
+            expect(fetch).toHaveBeenCalledTimes(2);
+            const call = vi.mocked(fetch).mock.calls[0]!;
             expect(call[0]).toBe('https://api.test.fordefi.com/api/v1/transactions');
             const postOpts = call[1] as RequestInit;
             const body = JSON.parse(postOpts.body as string);
@@ -419,7 +344,6 @@ describe('createFordefiSigner', () => {
 
         it('should sign multiple messages serially with delay', async () => {
             vi.mocked(fetch)
-                .mockResolvedValueOnce(mockVaultResponse())
                 .mockResolvedValueOnce(mockCreateTxResponse('msg-1'))
                 .mockResolvedValueOnce(mockPollResponse('completed', MOCK_SIGNATURE_BASE64))
                 .mockResolvedValueOnce(mockCreateTxResponse('msg-2'))
@@ -431,11 +355,10 @@ describe('createFordefiSigner', () => {
                 { content: new Uint8Array(32), signatures: {} },
             ]);
             expect(results).toHaveLength(2);
-            expect(fetch).toHaveBeenCalledTimes(5);
+            expect(fetch).toHaveBeenCalledTimes(4);
         });
 
         it('should throw when completed state has no signatures', async () => {
-            setupCreateVaultMock();
             const signer = await createFordefiSigner(mockConfig);
             vi.mocked(fetch)
                 .mockResolvedValueOnce(mockCreateTxResponse('msg-empty'))
@@ -445,7 +368,6 @@ describe('createFordefiSigner', () => {
         });
 
         it('should throw on failed state', async () => {
-            setupCreateVaultMock();
             const signer = await createFordefiSigner(mockConfig);
             vi.mocked(fetch)
                 .mockResolvedValueOnce(mockCreateTxResponse('msg-fail'))
@@ -455,7 +377,6 @@ describe('createFordefiSigner', () => {
         });
 
         it('should throw on submit API error', async () => {
-            setupCreateVaultMock();
             const signer = await createFordefiSigner(mockConfig);
             vi.mocked(fetch).mockResolvedValueOnce(
                 new Response(JSON.stringify({ message: 'Unauthorized' }), { status: 401 }),
@@ -465,7 +386,6 @@ describe('createFordefiSigner', () => {
         });
 
         it('should throw on signature with wrong byte length', async () => {
-            setupCreateVaultMock();
             const signer = await createFordefiSigner(mockConfig);
             const shortSig = Buffer.from(new Uint8Array(32).fill(0xab)).toString('base64');
             vi.mocked(fetch)
@@ -482,7 +402,6 @@ describe('createFordefiSigner', () => {
             async version => {
                 const { config, fixture } = await setupNativeBroadcast(version);
                 vi.mocked(fetch)
-                    .mockResolvedValueOnce(mockVaultResponse(fixture.feePayer))
                     .mockResolvedValueOnce(mockCreateTxResponse('tx-native'))
                     .mockResolvedValueOnce(
                         mockPollResponse('completed', MOCK_SIGNATURE_BASE64, fixture.wireTransaction),
@@ -511,7 +430,7 @@ describe('createFordefiSigner', () => {
                 );
 
                 // Verify POST body uses solana_transaction type
-                const call = vi.mocked(fetch).mock.calls[1]!;
+                const call = vi.mocked(fetch).mock.calls[0]!;
                 const postOpts = call[1] as RequestInit;
                 const body = JSON.parse(postOpts.body as string);
                 expect(body.type).toBe('solana_transaction');
@@ -533,7 +452,6 @@ describe('createFordefiSigner', () => {
 
             const { config, fixture } = await setupNativeBroadcast(1);
             vi.mocked(fetch)
-                .mockResolvedValueOnce(mockVaultResponse(fixture.feePayer))
                 .mockResolvedValueOnce(mockCreateTxResponse('tx-native'))
                 .mockResolvedValueOnce(mockPollResponse('completed', MOCK_SIGNATURE_BASE64, fixture.wireTransaction));
 
@@ -541,12 +459,11 @@ describe('createFordefiSigner', () => {
             const mockTx = { messageBytes, signatures: { [fixture.feePayer]: null } } as never;
             await signer.signAndSendTransactions([mockTx]);
 
-            const postOpts = vi.mocked(fetch).mock.calls[1]![1] as RequestInit;
+            const postOpts = vi.mocked(fetch).mock.calls[0]![1] as RequestInit;
             expect(postOpts.headers).toHaveProperty('x-idempotence-id', expectedId);
         });
 
         it('does not expose the partial-signer method in native mode', async () => {
-            setupCreateVaultMock();
             const signer = await createFordefiSigner(nativeConfig);
             const guardInput = signer as unknown as { [key: string]: unknown; address: typeof signer.address };
 
@@ -561,7 +478,6 @@ describe('createFordefiSigner', () => {
         });
 
         it('should reject native multi-signer auto-broadcast before submitting remote work', async () => {
-            setupCreateVaultMock();
             const signer = await createFordefiSigner(nativeConfig);
             const mockTx = {
                 messageBytes: new Uint8Array(32),
@@ -574,11 +490,10 @@ describe('createFordefiSigner', () => {
             await expect(signer.signAndSendTransactions([mockTx])).rejects.toMatchObject({
                 code: 'SIGNER_SIGNING_FAILED',
             });
-            expect(fetch).toHaveBeenCalledTimes(1);
+            expect(fetch).not.toHaveBeenCalled();
         });
 
         it('should not expose TransactionSendingSigner in black box mode', async () => {
-            setupCreateVaultMock();
             const signer = await createFordefiSigner(mockConfig);
             const guardInput = signer as unknown as { [key: string]: unknown; address: typeof signer.address };
 
@@ -592,7 +507,6 @@ describe('createFordefiSigner', () => {
         it('should poll through intermediate pushable states', async () => {
             const { config, fixture } = await setupNativeBroadcast(1);
             vi.mocked(fetch)
-                .mockResolvedValueOnce(mockVaultResponse(fixture.feePayer))
                 .mockResolvedValueOnce(mockCreateTxResponse('tx-push'))
                 .mockResolvedValueOnce(mockPollResponse('pushing'))
                 .mockResolvedValueOnce(mockPollResponse('confirming'))
@@ -605,7 +519,7 @@ describe('createFordefiSigner', () => {
             } as never;
             const results = await signer.signAndSendTransactions([mockTx]);
             expect(results).toHaveLength(1);
-            expect(fetch).toHaveBeenCalledTimes(5);
+            expect(fetch).toHaveBeenCalledTimes(4);
         });
 
         it('rejects a returned transaction whose fee-payer slot is unsigned', async () => {
@@ -618,7 +532,6 @@ describe('createFordefiSigner', () => {
                 publicKey: fixture.cosigner,
             } satisfies FordefiSignerConfig;
             vi.mocked(fetch)
-                .mockResolvedValueOnce(mockVaultResponse(fixture.cosigner))
                 .mockResolvedValueOnce(mockCreateTxResponse('tx-unsigned-payer'))
                 .mockResolvedValueOnce(mockPollResponse('completed', MOCK_SIGNATURE_BASE64, fixture.wireTransaction));
 
@@ -643,7 +556,6 @@ describe('createFordefiSigner', () => {
         });
 
         it('reports a 5xx on submit as unconfirmed with no transaction id', async () => {
-            setupCreateVaultMock();
             const signer = await createFordefiSigner(nativeConfig);
             vi.mocked(fetch).mockResolvedValueOnce(new Response(JSON.stringify({ message: 'boom' }), { status: 502 }));
 
@@ -663,7 +575,6 @@ describe('createFordefiSigner', () => {
         });
 
         it('reports an accepted submit with no id as unconfirmed', async () => {
-            setupCreateVaultMock();
             const signer = await createFordefiSigner(nativeConfig);
             vi.mocked(fetch).mockResolvedValueOnce(new Response(JSON.stringify({ state: 'pending' }), { status: 200 }));
 
@@ -683,7 +594,6 @@ describe('createFordefiSigner', () => {
         });
 
         it('keeps a 4xx on submit a plain failure', async () => {
-            setupCreateVaultMock();
             const signer = await createFordefiSigner(nativeConfig);
             vi.mocked(fetch).mockResolvedValueOnce(
                 new Response(JSON.stringify({ message: 'Unauthorized' }), { status: 401 }),
@@ -704,7 +614,6 @@ describe('createFordefiSigner', () => {
 
         it('should throw when raw_transaction is missing from response', async () => {
             vi.mocked(fetch)
-                .mockResolvedValueOnce(mockVaultResponse())
                 .mockResolvedValueOnce(mockCreateTxResponse('tx-no-raw'))
                 .mockResolvedValueOnce(mockPollResponse('completed', MOCK_SIGNATURE_BASE64));
 
@@ -721,7 +630,6 @@ describe('createFordefiSigner', () => {
         });
 
         it('should throw on failed state', async () => {
-            setupCreateVaultMock();
             vi.mocked(fetch)
                 .mockResolvedValueOnce(mockCreateTxResponse('tx-fail'))
                 .mockResolvedValueOnce(mockPollResponse('mined_reverted'));
@@ -752,7 +660,6 @@ describe('createFordefiSigner', () => {
         ];
 
         it.each(FAILURE_STATES)('should treat "%s" as a terminal failure', async state => {
-            setupCreateVaultMock();
             vi.mocked(fetch)
                 .mockResolvedValueOnce(mockCreateTxResponse())
                 .mockResolvedValueOnce(mockPollResponse(state));
@@ -768,7 +675,6 @@ describe('createFordefiSigner', () => {
     describe('signMessages (native solana mode)', () => {
         it('should submit solana_message with personal_message_type', async () => {
             vi.mocked(fetch)
-                .mockResolvedValueOnce(mockVaultResponse())
                 .mockResolvedValueOnce(mockCreateTxResponse('msg-native'))
                 .mockResolvedValueOnce(mockPollResponse('signed', MOCK_SIGNATURE_BASE64));
 
@@ -777,7 +683,7 @@ describe('createFordefiSigner', () => {
             expect(results).toHaveLength(1);
 
             // Verify POST body uses solana_message type
-            const call = vi.mocked(fetch).mock.calls[1]!;
+            const call = vi.mocked(fetch).mock.calls[0]!;
             const postOpts = call[1] as RequestInit;
             const body = JSON.parse(postOpts.body as string);
             expect(body.type).toBe('solana_message');
@@ -787,7 +693,6 @@ describe('createFordefiSigner', () => {
         });
 
         it('should throw when completed state has no signatures', async () => {
-            setupCreateVaultMock();
             const signer = await createFordefiSigner(nativeConfig);
             vi.mocked(fetch)
                 .mockResolvedValueOnce(mockCreateTxResponse('msg-empty'))
@@ -799,7 +704,6 @@ describe('createFordefiSigner', () => {
         });
 
         it('should throw on aborted state', async () => {
-            setupCreateVaultMock();
             const signer = await createFordefiSigner(nativeConfig);
             vi.mocked(fetch)
                 .mockResolvedValueOnce(mockCreateTxResponse('msg-abort'))
@@ -813,21 +717,18 @@ describe('createFordefiSigner', () => {
 
     describe('isAvailable', () => {
         it('should return true when vault responds OK', async () => {
-            setupCreateVaultMock();
             const signer = await createFordefiSigner(mockConfig);
             vi.mocked(fetch).mockResolvedValueOnce(mockVaultResponse());
             expect(await signer.isAvailable()).toBe(true);
         });
 
         it('should return false on API error', async () => {
-            setupCreateVaultMock();
             const signer = await createFordefiSigner(mockConfig);
             vi.mocked(fetch).mockResolvedValueOnce(new Response(null, { status: 500 }));
             expect(await signer.isAvailable()).toBe(false);
         });
 
         it('should return false on network error', async () => {
-            setupCreateVaultMock();
             const signer = await createFordefiSigner(mockConfig);
             vi.mocked(fetch).mockRejectedValueOnce(new Error('Network error'));
             expect(await signer.isAvailable()).toBe(false);

--- a/typescript/packages/fordefi/src/__tests__/fordefi-signer.test.ts
+++ b/typescript/packages/fordefi/src/__tests__/fordefi-signer.test.ts
@@ -102,8 +102,6 @@ describe('createFordefiSigner', () => {
         });
 
         it('should use the configured publicKey without a vault fetch', async () => {
-            // The provider is trusted: the configured publicKey is the source
-            // of truth, so construction performs no network call.
             const signer = await createFordefiSigner(mockConfig);
             expect(signer.address).toBe(MOCK_ADDRESS);
             expect(fetch).not.toHaveBeenCalled();

--- a/typescript/packages/fordefi/src/fordefi-signer.ts
+++ b/typescript/packages/fordefi/src/fordefi-signer.ts
@@ -317,9 +317,8 @@ class FordefiSigner<TAddress extends string = string> implements MessagePartialS
             });
         }
 
-        // The configured publicKey is the source of truth for the vault's
-        // Solana address; under the project's trust model the provider is
-        // trusted, so no init-time vault fetch is needed to confirm it.
+        // Trusted provider: the configured publicKey is authoritative, so no
+        // init-time vault fetch is needed to confirm it.
         return new FordefiSigner<TAddress>(config, config.publicKey as Address<TAddress>);
     }
 

--- a/typescript/packages/fordefi/src/fordefi-signer.ts
+++ b/typescript/packages/fordefi/src/fordefi-signer.ts
@@ -1,7 +1,7 @@
 import { createPrivateKey, createSign, type KeyObject } from 'node:crypto';
 
 import { Address, assertIsAddress } from '@solana/addresses';
-import { getBase58Decoder, getBase58Encoder, getBase64Decoder, getBase64Encoder } from '@solana/codecs-strings';
+import { getBase58Encoder, getBase64Decoder, getBase64Encoder } from '@solana/codecs-strings';
 import {
     abortableDelay,
     assertHttpsUrl,
@@ -54,7 +54,6 @@ import type {
 const DEFAULT_BASE_URL = 'https://api.fordefi.com';
 const DEFAULT_POLL_INTERVAL_MS = 2000;
 
-let base58Decoder: ReturnType<typeof getBase58Decoder> | undefined;
 let base58Encoder: ReturnType<typeof getBase58Encoder> | undefined;
 let base64Decoder: ReturnType<typeof getBase64Decoder> | undefined;
 let base64Encoder: ReturnType<typeof getBase64Encoder> | undefined;
@@ -176,15 +175,19 @@ export interface FordefiNativeSigner<TAddress extends string = string>
 /**
  * Create and initialize a Fordefi-backed signer.
  *
+ * Construction is synchronous (the configured `publicKey` is the source of
+ * truth for the vault address), but the factory keeps its `Promise` return
+ * type for parity with the other backends.
+ *
  * @throws {SignerError} `SIGNER_CONFIG_ERROR` when required config is missing or invalid.
  */
-export async function createFordefiSigner<TAddress extends string = string>(
+export function createFordefiSigner<TAddress extends string = string>(
     config: FordefiSignerConfig & { chain: SolanaChainUniqueId },
 ): Promise<FordefiNativeSigner<TAddress>>;
-export async function createFordefiSigner<TAddress extends string = string>(
+export function createFordefiSigner<TAddress extends string = string>(
     config: FordefiSignerConfig & { chain?: undefined },
 ): Promise<SolanaSigner<TAddress>>;
-export async function createFordefiSigner<TAddress extends string = string>(
+export function createFordefiSigner<TAddress extends string = string>(
     config: FordefiSignerConfig,
 ): Promise<FordefiNativeSigner<TAddress> | SolanaSigner<TAddress>>;
 export async function createFordefiSigner<TAddress extends string = string>(
@@ -192,7 +195,7 @@ export async function createFordefiSigner<TAddress extends string = string>(
 ): Promise<FordefiNativeSigner<TAddress> | SolanaSigner<TAddress>> {
     // The instance's own properties expose the mode-appropriate signing
     // method, which the class type cannot express statically.
-    return (await FordefiSigner.create(config)) as unknown as SolanaSigner<TAddress>;
+    return await Promise.resolve(FordefiSigner.create(config) as unknown as SolanaSigner<TAddress>);
 }
 
 /**
@@ -243,18 +246,16 @@ class FordefiSigner<TAddress extends string = string> implements MessagePartialS
     }
 
     /** Create a FordefiSigner with the provided configuration. */
-    static async create<TAddress extends string = string>(
+    static create<TAddress extends string = string>(
         config: FordefiSignerConfig & { chain: SolanaChainUniqueId },
-    ): Promise<FordefiNativeSigner<TAddress> & FordefiSigner<TAddress>>;
-    static async create<TAddress extends string = string>(
+    ): FordefiNativeSigner<TAddress> & FordefiSigner<TAddress>;
+    static create<TAddress extends string = string>(
         config: FordefiSignerConfig & { chain?: undefined },
-    ): Promise<FordefiSigner<TAddress> & SolanaSigner<TAddress>>;
-    static async create<TAddress extends string = string>(
+    ): FordefiSigner<TAddress> & SolanaSigner<TAddress>;
+    static create<TAddress extends string = string>(
         config: FordefiSignerConfig,
-    ): Promise<FordefiSigner<TAddress> & (FordefiNativeSigner<TAddress> | SolanaSigner<TAddress>)>;
-    static async create<TAddress extends string = string>(
-        config: FordefiSignerConfig,
-    ): Promise<FordefiSigner<TAddress>> {
+    ): FordefiSigner<TAddress> & (FordefiNativeSigner<TAddress> | SolanaSigner<TAddress>);
+    static create<TAddress extends string = string>(config: FordefiSignerConfig): FordefiSigner<TAddress> {
         if (!config.accessToken) {
             return throwSignerError(SignerErrorCode.CONFIG_ERROR, {
                 message: 'accessToken must not be empty',
@@ -316,85 +317,10 @@ class FordefiSigner<TAddress extends string = string> implements MessagePartialS
             });
         }
 
-        // Authoritative check: fetch the vault from Fordefi and verify that
-        // `config.publicKey` actually belongs to `config.vaultId`. Without this
-        // a valid-but-wrong address would pass configuration and later be
-        // returned by resolveAddress(), creating a funds-routing risk.
-        const verifiedAddress = await FordefiSigner.fetchAndVerifyVaultAddress({
-            accessToken: config.accessToken,
-            apiBaseUrl,
-            expectedPublicKey: config.publicKey,
-            vaultId: config.vaultId,
-        });
-
-        return new FordefiSigner<TAddress>(config, verifiedAddress as Address<TAddress>);
-    }
-
-    /**
-     * Fetch the vault from Fordefi and assert the returned Solana address
-     * matches `expectedPublicKey`.
-     */
-    private static async fetchAndVerifyVaultAddress({
-        accessToken,
-        apiBaseUrl,
-        expectedPublicKey,
-        vaultId,
-    }: {
-        accessToken: string;
-        apiBaseUrl: string;
-        expectedPublicKey: string;
-        vaultId: string;
-    }): Promise<Address> {
-        const url = `${apiBaseUrl}/api/v1/vaults/${vaultId}`;
-        const vault = await fetchSignerJson<FordefiVaultResponse>({
-            init: {
-                headers: { Authorization: `Bearer ${accessToken}` },
-                method: 'GET',
-            },
-            providerName: 'Fordefi',
-            timeoutMs: 10_000,
-            url,
-        });
-
-        // Regular Fordefi Solana vaults expose `address` directly; black_box vaults
-        // only provide `public_key_compressed` (base64-encoded Ed25519 key).
-        let remoteAddress = vault.address;
-        if (!remoteAddress && vault.public_key_compressed) {
-            try {
-                base64Encoder ||= getBase64Encoder();
-                base58Decoder ||= getBase58Decoder();
-                const keyBytes = base64Encoder.encode(vault.public_key_compressed);
-                remoteAddress = base58Decoder.decode(keyBytes);
-            } catch (error) {
-                return throwSignerError(SignerErrorCode.PARSING_ERROR, {
-                    cause: error,
-                    message: 'Failed to derive Solana address from vault public_key_compressed',
-                });
-            }
-        }
-        if (!remoteAddress) {
-            return throwSignerError(SignerErrorCode.CONFIG_ERROR, {
-                message:
-                    'Fordefi vault response included neither `address` nor `public_key_compressed`; cannot verify publicKey ownership',
-            });
-        }
-
-        if (remoteAddress !== expectedPublicKey) {
-            return throwSignerError(SignerErrorCode.CONFIG_ERROR, {
-                message: `Configured publicKey does not match Fordefi vault ${vaultId}: expected ${remoteAddress}`,
-            });
-        }
-
-        try {
-            assertIsAddress(remoteAddress);
-        } catch (error) {
-            return throwSignerError(SignerErrorCode.INVALID_PUBLIC_KEY, {
-                cause: error,
-                message: 'Fordefi vault returned an invalid Solana address',
-            });
-        }
-
-        return remoteAddress;
+        // The configured publicKey is the source of truth for the vault's
+        // Solana address; under the project's trust model the provider is
+        // trusted, so no init-time vault fetch is needed to confirm it.
+        return new FordefiSigner<TAddress>(config, config.publicKey as Address<TAddress>);
     }
 
     /**

--- a/typescript/packages/privy/src/__tests__/privy-signer.test.ts
+++ b/typescript/packages/privy/src/__tests__/privy-signer.test.ts
@@ -17,6 +17,16 @@ vi.mock('@solana/keychain-core', async importOriginal => {
     return {
         ...mod,
         assertSignatureValid: vi.fn(),
+        extractAndVerifyReturnedSignature: vi.fn(
+            async ({
+                returnedTransactionBytes,
+                signerAddress,
+            }: Parameters<typeof mod.extractAndVerifyReturnedSignature>[0]) =>
+                mod.extractSignatureFromTransactionBytes({
+                    signerAddress,
+                    transactionBytes: returnedTransactionBytes,
+                })[signerAddress],
+        ),
         sanitizeRemoteErrorResponse:
             mod.sanitizeRemoteErrorResponse ??
             ((text: string) =>

--- a/typescript/packages/privy/src/privy-signer.ts
+++ b/typescript/packages/privy/src/privy-signer.ts
@@ -4,7 +4,7 @@ import {
     assertHttpsUrl,
     assertSignatureValid,
     createSignatureDictionary,
-    extractSignatureFromWireTransaction,
+    extractAndVerifyReturnedSignature,
     fetchSignerJson,
     signBatchStaggered,
     SignerErrorCode,
@@ -314,16 +314,16 @@ class PrivySigner<TAddress extends string = string> implements SolanaSigner<TAdd
             async transaction => {
                 const wireTransaction = getBase64EncodedWireTransaction(transaction);
                 const signedTx = await this.signTransaction(wireTransaction, config?.abortSignal);
-                const sigDict = extractSignatureFromWireTransaction({
-                    base64WireTransaction: signedTx,
+                const signature = await extractAndVerifyReturnedSignature({
+                    abortSignal: config?.abortSignal,
+                    originalMessageBytes: transaction.messageBytes,
+                    returnedTransactionBytes: getBase64Encoder().encode(signedTx),
                     signerAddress: this.address,
                 });
-                await assertSignatureValid({
-                    data: transaction.messageBytes,
-                    signature: sigDict[this.address],
+                return createSignatureDictionary({
+                    signature,
                     signerAddress: this.address,
                 });
-                return sigDict;
             },
             this.requestDelayMs,
             config?.abortSignal,

--- a/typescript/packages/turnkey/src/__tests__/turnkey-signer.test.ts
+++ b/typescript/packages/turnkey/src/__tests__/turnkey-signer.test.ts
@@ -17,6 +17,16 @@ vi.mock('@solana/keychain-core', async importOriginal => {
     return {
         ...mod,
         assertSignatureValid: vi.fn(),
+        extractAndVerifyReturnedSignature: vi.fn(
+            async ({
+                returnedTransactionBytes,
+                signerAddress,
+            }: Parameters<typeof mod.extractAndVerifyReturnedSignature>[0]) =>
+                mod.extractSignatureFromTransactionBytes({
+                    signerAddress,
+                    transactionBytes: returnedTransactionBytes,
+                })[signerAddress],
+        ),
         sanitizeRemoteErrorResponse:
             mod.sanitizeRemoteErrorResponse ??
             ((text: string) =>

--- a/typescript/packages/turnkey/src/turnkey-signer.ts
+++ b/typescript/packages/turnkey/src/turnkey-signer.ts
@@ -5,7 +5,7 @@ import {
     assertSignatureValid,
     createSignatureDictionary,
     ED25519_SIGNATURE_LENGTH,
-    extractSignatureFromTransactionBytes,
+    extractAndVerifyReturnedSignature,
     fetchSignerJson,
     signBatchStaggered,
     SignerErrorCode,
@@ -313,16 +313,16 @@ class TurnkeySigner<TAddress extends string = string> implements SolanaSigner<TA
 
                 const hexToBytes = getBase16Encoder().encode;
                 const signedTxBytes = hexToBytes(signedTransactionHex);
-                const sigDict = extractSignatureFromTransactionBytes({
-                    signerAddress: this.address,
-                    transactionBytes: signedTxBytes,
-                });
-                await assertSignatureValid({
-                    data: transaction.messageBytes,
-                    signature: sigDict[this.address],
+                const signature = await extractAndVerifyReturnedSignature({
+                    abortSignal: config?.abortSignal,
+                    originalMessageBytes: transaction.messageBytes,
+                    returnedTransactionBytes: signedTxBytes,
                     signerAddress: this.address,
                 });
-                return sigDict;
+                return createSignatureDictionary({
+                    signature,
+                    signerAddress: this.address,
+                });
             },
             this.requestDelayMs,
             config?.abortSignal,

--- a/typescript/packages/utila/src/__tests__/utila-signer.test.ts
+++ b/typescript/packages/utila/src/__tests__/utila-signer.test.ts
@@ -3,7 +3,19 @@ import { decodeJwt, decodeProtectedHeader, importPKCS8, SignJWT } from 'jose';
 
 vi.mock('@solana/keychain-core', async importOriginal => {
     const mod = await importOriginal<typeof import('@solana/keychain-core')>();
-    return { ...mod, assertSignatureValid: vi.fn() };
+    return {
+        ...mod,
+        extractAndVerifyReturnedSignature: vi.fn(
+            async ({
+                returnedTransactionBytes,
+                signerAddress,
+            }: Parameters<typeof mod.extractAndVerifyReturnedSignature>[0]) =>
+                mod.extractSignatureFromTransactionBytes({
+                    signerAddress,
+                    transactionBytes: returnedTransactionBytes,
+                })[signerAddress],
+        ),
+    };
 });
 
 vi.mock('@solana/transactions', async importOriginal => {
@@ -15,7 +27,7 @@ vi.mock('@solana/transactions', async importOriginal => {
     };
 });
 
-import { assertIsSolanaSigner, assertSignatureValid } from '@solana/keychain-core';
+import { assertIsSolanaSigner, extractAndVerifyReturnedSignature } from '@solana/keychain-core';
 import { getTransactionDecoder } from '@solana/transactions';
 import { createUtilaAccessToken, createUtilaSigner } from '../utila-signer.js';
 import { TEST_EMAIL, TEST_RSA_PRIVATE_KEY } from './setup.js';
@@ -78,7 +90,6 @@ function fetchCall(index: number): [string, RequestInit] {
 describe('UtilaSigner', () => {
     beforeEach(() => {
         vi.resetAllMocks();
-        vi.mocked(assertSignatureValid).mockResolvedValue(undefined);
         vi.mocked(getTransactionDecoder).mockReturnValue({
             decode: vi.fn(() => createDecodedTransaction()),
         } as any);
@@ -225,11 +236,12 @@ describe('UtilaSigner', () => {
 
             expect(results).toHaveLength(1);
             expect(results[0]![signer.address]).toEqual(MOCK_SIGNATURE_BYTES);
-            expect(assertSignatureValid).toHaveBeenCalledWith({
-                data: MOCK_MESSAGE_BYTES,
-                signature: MOCK_SIGNATURE_BYTES,
-                signerAddress: signer.address,
-            });
+            expect(extractAndVerifyReturnedSignature).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    originalMessageBytes: MOCK_MESSAGE_BYTES,
+                    signerAddress: signer.address,
+                }),
+            );
 
             const [url, init] = fetchCall(1);
             expect(url).toBe('https://api.test.utila.io/v2/vaults/vault-test/transactions:initiate');

--- a/typescript/packages/utila/src/utila-signer.ts
+++ b/typescript/packages/utila/src/utila-signer.ts
@@ -1,10 +1,11 @@
 import { type Address, assertIsAddress } from '@solana/addresses';
+import { getBase64Encoder } from '@solana/codecs-strings';
 import {
     abortableDelay,
     assertHttpsUrl,
-    assertSignatureValid,
+    createSignatureDictionary,
     createSignerError,
-    extractSignatureFromWireTransaction,
+    extractAndVerifyReturnedSignature,
     fetchSignerJson,
     normalizeBaseUrl,
     normalizePrivateKeyPem,
@@ -21,7 +22,6 @@ import type {
     TransactionPartialSignerConfig,
 } from '@solana/signers';
 import {
-    type Base64EncodedWireTransaction,
     getBase64EncodedWireTransaction,
     type Transaction,
     type TransactionWithinSizeLimit,
@@ -268,16 +268,16 @@ class UtilaSigner<TAddress extends string = string> implements SolanaSigner<TAdd
             });
         }
 
-        const sigDict = extractSignatureFromWireTransaction({
-            base64WireTransaction: rawSignedTransaction as Base64EncodedWireTransaction,
+        const signature = await extractAndVerifyReturnedSignature({
+            abortSignal,
+            originalMessageBytes: transaction.messageBytes,
+            returnedTransactionBytes: getBase64Encoder().encode(rawSignedTransaction),
             signerAddress: this.address,
         });
-        await assertSignatureValid({
-            data: transaction.messageBytes,
-            signature: sigDict[this.address],
+        return createSignatureDictionary({
+            signature,
             signerAddress: this.address,
         });
-        return sigDict;
     }
 
     private async initiateTransaction(rawTransaction: string, abortSignal?: AbortSignal): Promise<UtilaTransaction> {


### PR DESCRIPTION
## What

Adopts an explicit trust model for signing providers: **keychain validates responses for correctness, not for provider malice.** Validations that existed solely to defend against a hostile provider are removed; transport hardening, format/status validation, and the final signature-vs-message verification (kept as a cheap end-to-end correctness check) all stay.

## Changes (all four languages)

### Fordefi: configured public key is the source of truth
The init-time vault fetch that compared the configured public key against the API-reported address is removed. Construction no longer makes a network call; `is_available` still probes the vault, just without the equality check.
**Breaking:** Python `FordefiSigner.init()` is removed; Rust/Go/TS factory shapes are unchanged.

### 1 MiB response-body cap in the shared HTTP helpers
Rust (`remote_util::read_body_capped`), Python (`_read_bounded_body`), and TS (`readCappedResponseText`) now stream bodies with a 1 MiB cap (parity with Go's `core.MaxResponseBytes`), erroring with the parsing/serialization error class on both success and error paths. Go now errors explicitly instead of silently truncating at the cap. Rust reads outside the shared helper (Privy `post_rpc`, Crossmint's custom parser, Fordefi, Vault) are routed through the capped reader too.

### Shared returned-transaction helper
Privy, Turnkey, CDP, and Utila each hand-rolled "decode returned tx → find signer slot → extract → verify against the original message." That's now one helper per language (`extract_and_verify_returned_signature` / `extractAndVerifyReturnedSignature` / `core.ExtractAndVerifyReturnedSignature`), used identically by all four backends:
- Utila's byte-equality check of returned vs original message bytes is removed (the verify against the original message subsumes it — a rewritten transaction still fails, same error code).
- Fixes CDP computing the signer position from the original transaction but reading the returned one.
- Privy/Turnkey/CDP now also reject default/all-zero signature slots explicitly.
- Not-a-required-signer transactions now fail after the API round-trip uniformly in all languages.

### Language-specific
- **Go:** every backend's non-2xx handling now includes the sanitized response body in the `REMOTE_API_ERROR` detail via a shared `core.NewRemoteAPIError` (was inconsistent per backend; `Error()` redaction guarantee unchanged). Turnkey P-256 API-key material is validated at construction (parity with Python).
- **Rust (breaking):** `VaultSigner::with_client` → `with_client_builder`, taking a `reqwest::ClientBuilder` finished with the no-redirect policy so caller-supplied clients can no longer bypass it. `https_only` is deliberately not forced there (plain-HTTP loopback `vault server -dev`).

## Not in this PR (follow-ups under discussion)
- Removing Crossmint's deep re-verification machinery (`verification_candidates`, executed-tx re-verification) — the largest remaining provider-distrust code; pending a decision since its rewritten-tx path has no correctness backstop once removed.
- Pre-existing bug: the Rust Vault integration test constructs via `VaultSigner::new` (an `https_only` client) against `http://127.0.0.1:8200`, so it cannot pass since #249; needs a loopback carve-out like the other languages.

## Testing
- Rust: `cargo test` on all three matrices (`all,sdk-v2/v3/v4,unsafe-debug`) — 347/347/352 passing; clippy clean.
- TypeScript: full `pnpm test:unit`, workspace typecheck, lint/format, and tree-shake checks (all 15 factories clean).
- Python: 508 passing; ruff + mypy strict clean; golden parity vectors untouched.
- Go: `go build`/`go vet`/`go test -race` across all modules.