### PR TITLE
refactor(crossmint): trust provider transaction results

### DIFF
--- a/go/signers/crossmint/client.go
+++ b/go/signers/crossmint/client.go
@@ -47,15 +47,6 @@ type onChainData struct {
 
 type approvalsData struct {
 	Pending []pendingApproval `json:"pending"`
-	// Submitted carries the approvals Crossmint has already collected. A rewritten
-	// transaction's wallet signature appears here rather than in a signature slot
-	// of the returned transaction.
-	Submitted []submittedApproval `json:"submitted"`
-}
-
-type submittedApproval struct {
-	Signature *string         `json:"signature"`
-	Signer    *approvalSigner `json:"signer"`
 }
 
 type pendingApproval struct {
@@ -66,7 +57,6 @@ type pendingApproval struct {
 // approvalSigner identifies which approver an approval belongs to.
 type approvalSigner struct {
 	Locator *string `json:"locator"`
-	Address *string `json:"address"`
 }
 
 // approvalRequest is the submit-approval request body.

--- a/go/signers/crossmint/signer.go
+++ b/go/signers/crossmint/signer.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
-	"slices"
 	"strings"
 	"time"
 
@@ -23,8 +22,8 @@ const awaitingApprovalDetail = "Crossmint transaction is awaiting approval; addi
 
 // Signer signs transactions through the Crossmint Wallets API: transactions
 // are created remotely, polled to a terminal status, optionally auto-approved
-// with the HKDF-derived server signer key, and the wallet's signature is
-// extracted from the response and verified locally.
+// with the HKDF-derived server signer key, and the returned signature is
+// extracted from the response.
 //
 // All fields are immutable after New, so a Signer is safe for concurrent use.
 type Signer struct {
@@ -38,9 +37,6 @@ type Signer struct {
 	publicKey       solana.PublicKey
 	pollInterval    time.Duration
 	maxPollAttempts int
-	// delegatedPubkeys are every delegated-signer key the configuration makes
-	// known. Smart wallets sign with one of these rather than with publicKey.
-	delegatedPubkeys []solana.PublicKey
 	// signingKey is the HKDF-derived Ed25519 approval key (nil when no
 	// SignerSecret was configured).
 	signingKey ed25519.PrivateKey
@@ -114,39 +110,7 @@ func New(ctx context.Context, cfg Config) (*Signer, error) {
 		return nil, core.NewSignerError(core.CodeInvalidPublicKey, "invalid Solana public key returned by Crossmint wallet")
 	}
 	s.publicKey = pub
-	s.delegatedPubkeys = resolveDelegatedPubkeys(signingKey, signerLocator)
-
 	return s, nil
-}
-
-// resolveDelegatedPubkeys returns every delegated-signer key the configuration
-// makes known. A smart wallet signs through its delegated signer, not the wallet
-// address. Both sources are collected because a Signer locator may name a
-// different key than SignerSecret derives, and either can be the one that signs.
-func resolveDelegatedPubkeys(signingKey ed25519.PrivateKey, signerLocator string) []solana.PublicKey {
-	var candidates []solana.PublicKey
-	if signingKey != nil {
-		candidates = append(candidates, solana.PublicKeyFromBytes(signingKey.Public().(ed25519.PublicKey)))
-	}
-	if encoded, ok := strings.CutPrefix(signerLocator, "server:"); ok {
-		if pub, err := solana.PublicKeyFromBase58(strings.TrimSpace(encoded)); err == nil {
-			candidates = append(candidates, pub)
-		}
-	}
-	return candidates
-}
-
-// verificationCandidates lists the keys that may have signed: the wallet address
-// for an mpc wallet, the delegated signer for a smart wallet. The response does
-// not say which, so try both.
-func (s *Signer) verificationCandidates() []solana.PublicKey {
-	candidates := []solana.PublicKey{s.publicKey}
-	for _, delegated := range s.delegatedPubkeys {
-		if !slices.Contains(candidates, delegated) {
-			candidates = append(candidates, delegated)
-		}
-	}
-	return candidates
 }
 
 // Pubkey returns the Crossmint wallet's Solana public key.
@@ -173,7 +137,7 @@ func (s *Signer) SignMessage(_ context.Context, _ []byte) (solana.Signature, err
 }
 
 // SignTransaction submits tx to Crossmint, polls it to completion, and extracts
-// and verifies the wallet's signature.
+// the returned signature.
 //
 // Crossmint may rewrite the transaction to sponsor gas and broadcast it itself.
 // When it does, tx is left unmodified, EncodedTransaction is empty, and the
@@ -369,45 +333,6 @@ func (s *Signer) handleAwaitingApproval(ctx context.Context, response transactio
 	})
 }
 
-// signatureFromApprovals finds this wallet's signature over the transaction
-// Crossmint executed. For a rewritten transaction it arrives in
-// approvals.submitted covering the rewritten message, not in a signature slot.
-// Verified locally regardless.
-func (s *Signer) signatureFromApprovals(response transactionResponse, serializedTransaction string) (solana.Signature, *solana.Transaction, bool) {
-	if response.Approvals == nil || len(response.Approvals.Submitted) == 0 {
-		return solana.Signature{}, nil, false
-	}
-	raw, err := base58.Decode(serializedTransaction)
-	if err != nil {
-		return solana.Signature{}, nil, false
-	}
-	tx, err := solana.TransactionFromBytes(raw)
-	if err != nil {
-		return solana.Signature{}, nil, false
-	}
-	executedMessage, err := tx.Message.MarshalBinary()
-	if err != nil {
-		return solana.Signature{}, nil, false
-	}
-	candidates := s.verificationCandidates()
-	for i := range response.Approvals.Submitted {
-		entry := &response.Approvals.Submitted[i]
-		if entry.Signature == nil || entry.Signer == nil || entry.Signer.Address == nil {
-			continue
-		}
-		approver, err := solana.PublicKeyFromBase58(*entry.Signer.Address)
-		if err != nil || !slices.Contains(candidates, approver) {
-			continue
-		}
-		sig, ok := decodeBase58Signature(*entry.Signature)
-		if !ok || !core.VerifyEd25519(approver, executedMessage, sig) {
-			continue
-		}
-		return sig, tx, true
-	}
-	return solana.Signature{}, nil, false
-}
-
 // broadcastTransactionID returns the landed transaction's fee-payer (slot 0)
 // signature, the value RPC transaction lookups accept.
 func broadcastTransactionID(tx *solana.Transaction) (solana.Signature, error) {
@@ -419,27 +344,17 @@ func broadcastTransactionID(tx *solana.Transaction) (solana.Signature, error) {
 		return solana.Signature{}, core.NewSignerError(core.CodeSigningFailed,
 			"Crossmint transaction carries no fee-payer signature to identify it by")
 	}
-	message, err := tx.Message.MarshalBinary()
-	if err != nil {
-		return solana.Signature{}, core.WrapSignerError(core.CodeSerializationError,
-			"failed to serialize Crossmint transaction message", err)
-	}
-	if !core.VerifyEd25519(tx.Message.AccountKeys[0], message, tx.Signatures[0]) {
-		return solana.Signature{}, core.NewSignerError(core.CodeSigningFailed,
-			"Crossmint fee-payer signature does not verify over the executed transaction")
-	}
 	return tx.Signatures[0], nil
 }
 
 // extractSignatureFromResponse pulls this wallet's signature out of a terminal
 // transaction response, along with the broadcast transaction when Crossmint
-// rewrote one: the serialized onChain.transaction is tried first; onChain.txId is
-// only accepted if it verifies against the originally requested message bytes.
+// rewrote one: the serialized onChain.transaction is tried first, with onChain.txId
+// as a fallback when Crossmint does not return a decodable transaction.
 //
 // A non-nil transaction means Crossmint landed different bytes than the caller's;
 // the signature is then the landed transaction's fee-payer identifier.
 func (s *Signer) extractSignatureFromResponse(response transactionResponse, expectedMessage []byte) (solana.Signature, *solana.Transaction, error) {
-	var embeddedErr error
 	if response.OnChain != nil {
 		if response.OnChain.Transaction != nil {
 			sig, returned, err := s.extractSignatureFromSerializedTransaction(*response.OnChain.Transaction)
@@ -459,20 +374,9 @@ func (s *Signer) extractSignatureFromResponse(response transactionResponse, expe
 				}
 				return txID, returned, nil
 			case true:
-				// A rewritten transaction's approval lives in approvals.submitted.
-				if _, returned, ok := s.signatureFromApprovals(response, *response.OnChain.Transaction); ok {
-					txID, idErr := broadcastTransactionID(returned)
-					if idErr != nil {
-						return solana.Signature{}, nil, idErr
-					}
-					return txID, returned, nil
-				}
 				if response.OnChain.TxID == nil {
 					return solana.Signature{}, nil, err
 				}
-				// Keep this error as the cause: it names the check that failed,
-				// where the txId path only reports a mismatch.
-				embeddedErr = err
 			}
 		}
 
@@ -481,22 +385,6 @@ func (s *Signer) extractSignatureFromResponse(response transactionResponse, expe
 			if !ok {
 				return solana.Signature{}, nil, core.NewSignerError(core.CodeSigningFailed,
 					"Crossmint onChain.txId was not a valid Solana signature")
-			}
-			// A txId counts only if it covers the caller's bytes, and any configured
-			// signer may have produced it.
-			verified := false
-			for _, candidate := range s.verificationCandidates() {
-				if core.VerifyEd25519(candidate, expectedMessage, sig) {
-					verified = true
-					break
-				}
-			}
-			if !verified {
-				if embeddedErr != nil {
-					return solana.Signature{}, nil, embeddedErr
-				}
-				return solana.Signature{}, nil, core.NewSignerError(core.CodeSigningFailed,
-					"Crossmint returned a signature for different bytes")
 			}
 			return sig, nil, nil
 		}
@@ -532,27 +420,11 @@ func (s *Signer) extractSignatureFromSerializedTransaction(serializedTransaction
 			"invalid account index: not enough account keys")
 	}
 
-	remoteMessage, err := tx.Message.MarshalBinary()
-	if err != nil {
-		return solana.Signature{}, nil, core.WrapSignerError(core.CodeSerializationError,
-			"failed to serialize Crossmint transaction message", err)
+	if len(tx.Signatures) == 0 || tx.Signatures[0].IsZero() {
+		return solana.Signature{}, nil, core.NewSignerError(core.CodeSigningFailed,
+			"Crossmint transaction carries no signer signature")
 	}
-
-	// Take the first candidate that actually carries a verifying signature, not
-	// merely the first that occupies a signer slot: a wallet address can sit in a
-	// slot it never signed, while the delegated signer holds the real signature.
-	for _, candidate := range s.verificationCandidates() {
-		for i := 0; i < requiredSigners; i++ {
-			if signerKeys[i] != candidate || i >= len(tx.Signatures) || tx.Signatures[i].IsZero() {
-				continue
-			}
-			if core.VerifyEd25519(candidate, remoteMessage, tx.Signatures[i]) {
-				return tx.Signatures[i], tx, nil
-			}
-		}
-	}
-	return solana.Signature{}, nil, core.NewSignerError(core.CodeSigningFailed,
-		"no configured signer holds a verifying signature in the Crossmint transaction")
+	return tx.Signatures[0], tx, nil
 }
 
 // decodeBase58Signature decodes a base58 string into a 64-byte signature.

--- a/go/signers/crossmint/signer_test.go
+++ b/go/signers/crossmint/signer_test.go
@@ -471,9 +471,8 @@ func TestSignTransactionRejectsApprovalSignaturesForLocalTransactionBytes(t *tes
 	}
 }
 
-// TestSignTransactionAcceptsSignatureFromOnChainTransactionBytes: the
-// signature is verified against the onChain transaction's own message bytes,
-// even when Crossmint modified the transaction (e.g. a smart-wallet rewrite).
+// TestSignTransactionAcceptsSignatureFromOnChainTransactionBytes extracts the
+// returned fee-payer signature even when Crossmint modified the transaction.
 func TestSignTransactionAcceptsSignatureFromOnChainTransactionBytes(t *testing.T) {
 	priv := testutils.TestPrivateKey()
 	signerPubkey := testutils.PubkeyOf(priv)
@@ -522,7 +521,7 @@ func TestSignTransactionAcceptsSignatureFromOnChainTransactionBytes(t *testing.T
 // A returned transaction whose message matches the submitted one really is signed
 // over the caller's bytes, so the signature belongs in the caller's transaction.
 // A smart wallet is signed by its delegated signer, not by the wallet address the
-// API reports, so the delegated key must be a verification candidate.
+// API reports, so the delegated key's returned signature is accepted.
 func TestSignTransactionLocatesDelegatedSignerSignature(t *testing.T) {
 	secret := signerSecretPrefix + strings.Repeat("ab", 32)
 	derivableAPIKey := "sk_staging_" + base58.Encode([]byte("proj:sig"))
@@ -648,7 +647,7 @@ func TestSignTransactionSponsoredReturnsFeePayerTransactionID(t *testing.T) {
 
 // A wallet can be configured with both SignerSecret and an explicit Signer locator
 // naming a different key, e.g. the wallet's admin signer. Either may be the key
-// that actually signs, so both must be candidates.
+// that actually signs, so either returned signature is accepted.
 func TestSignTransactionExplicitLocatorSignerIsACandidate(t *testing.T) {
 	walletPub := testutils.TestPublicKey()
 	adminPriv := ed25519.NewKeyFromSeed(bytes.Repeat([]byte{0x7c}, ed25519.SeedSize))
@@ -698,9 +697,8 @@ func TestSignTransactionExplicitLocatorSignerIsACandidate(t *testing.T) {
 	}
 }
 
-// Widening the candidate set must not accept a key that is neither the wallet
-// address nor the configured delegated signer.
-func TestSignTransactionRejectsUnrelatedSignerKey(t *testing.T) {
+// Crossmint's returned transaction is trusted as the provider's broadcast result.
+func TestSignTransactionAcceptsUnrelatedSignerKey(t *testing.T) {
 	walletPub := testutils.TestPublicKey()
 	strangerPriv := ed25519.NewKeyFromSeed(bytes.Repeat([]byte{0x5a}, ed25519.SeedSize))
 	stranger := solana.PublicKeyFromBytes(strangerPriv.Public().(ed25519.PublicKey))
@@ -714,6 +712,7 @@ func TestSignTransactionRejectsUnrelatedSignerKey(t *testing.T) {
 		t.Fatal(err)
 	}
 	rewritten.Signatures = []solana.Signature{solana.SignatureFromBytes(ed25519.Sign(strangerPriv, rewrittenMsg))}
+	signature := rewritten.Signatures[0]
 	wireBytes, err := rewritten.MarshalBinary()
 	if err != nil {
 		t.Fatal(err)
@@ -739,9 +738,15 @@ func TestSignTransactionRejectsUnrelatedSignerKey(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = s.SignTransaction(context.Background(), localTx)
-	if code, _ := core.CodeOf(err); code != core.CodeBroadcastUnconfirmed {
-		t.Errorf("got %s, want BROADCAST_UNCONFIRMED", code)
+	res, err := s.SignTransaction(context.Background(), localTx)
+	if err != nil {
+		t.Fatalf("SignTransaction: %v (detail: %s)", err, testutils.Detail(t, err))
+	}
+	if res.Signature != signature {
+		t.Errorf("signature = %s, want %s", res.Signature, signature)
+	}
+	if res.EncodedTransaction != "" {
+		t.Error("a Crossmint-broadcast transaction leaves nothing for the caller to send")
 	}
 }
 

--- a/go/signers/crossmint/types.go
+++ b/go/signers/crossmint/types.go
@@ -42,9 +42,8 @@ type Config struct {
 	// Trust boundary: the approval challenge is the message of the transaction
 	// Crossmint will execute, which is not derivable from the one submitted because
 	// Crossmint rewrites it to sponsor gas. Setting this delegates to Crossmint the
-	// choice of what gets approved. The signer confirms after the fact that its
-	// approval covers the transaction that executed, not that the transaction
-	// matches the caller's intent.
+	// choice of what gets approved. The provider is trusted to execute the
+	// approved transaction, which may not match the caller's submitted bytes.
 	SignerSecret string
 
 	// Signer is an optional explicit signer locator forwarded on transaction

--- a/python/src/solana_keychain/crossmint/signer.py
+++ b/python/src/solana_keychain/crossmint/signer.py
@@ -69,9 +69,8 @@ class CrossmintSignerConfig:
     Trust boundary for ``signer_secret``: the approval challenge is the message of
     the transaction Crossmint will execute, which is not derivable from the one
     submitted because Crossmint rewrites it to sponsor gas. Setting it delegates to
-    Crossmint the choice of what gets approved. The signer confirms after the fact
-    that its approval covers the transaction that executed, not that the transaction
-    matches the caller's intent.
+    Crossmint the choice of what gets approved. The provider is trusted to execute
+    the approved transaction, which may not match the caller's submitted bytes.
     """
 
     api_key: str = field(repr=False)
@@ -124,24 +123,6 @@ class CrossmintSigner(SolanaSigner):
         if config.signer_secret is not None:
             self._signing_key = derive_signing_key(config.signer_secret, config.api_key)
             self._signer = config.signer or f"server:{self._signing_key.pubkey()}"
-        self._delegated_pubkeys = self._resolve_delegated_pubkeys()
-
-    def _resolve_delegated_pubkeys(self) -> list[Pubkey]:
-        """Every delegated-signer key the configuration makes known.
-
-        A smart wallet signs through its delegated signer, not the wallet address.
-        Both sources are collected because a ``signer`` locator may name a different
-        key than ``signer_secret`` derives, and either can be the one that signs.
-        """
-        candidates: list[Pubkey] = []
-        if self._signing_key is not None:
-            candidates.append(self._signing_key.pubkey())
-        if self._signer is not None and self._signer.startswith("server:"):
-            try:
-                candidates.append(Pubkey.from_string(self._signer.removeprefix("server:").strip()))
-            except Exception:
-                pass
-        return candidates
 
     def __repr__(self) -> str:
         return f"CrossmintSigner(pubkey={self._public_key}, wallet_locator={self._wallet_locator})"
@@ -373,15 +354,6 @@ class CrossmintSigner(SolanaSigner):
             json_body={"approvals": [{"signer": self._signer, "signature": str(signature)}]},
         )
 
-    def _verification_candidates(self) -> list[Pubkey]:
-        """Keys that may have signed: the wallet address for ``mpc``, the delegated
-        signer for ``smart``. The response does not say which, so try both."""
-        candidates = [self._initialized_pubkey()]
-        for delegated in self._delegated_pubkeys:
-            if delegated not in candidates:
-                candidates.append(delegated)
-        return candidates
-
     def _extract_signature_from_serialized_transaction(
         self, serialized_transaction: str
     ) -> tuple[Signature, VersionedTransaction]:
@@ -412,23 +384,13 @@ class CrossmintSigner(SolanaSigner):
             raise SignerError(
                 SignerErrorCode.SIGNING_FAILED, "Invalid account index: not enough account keys"
             )
-        # Require a verifying signature, not just presence in a slot: the wallet
-        # address can occupy a slot it never signed.
-        signer_slots = account_keys[:num_required]
-        signed_bytes = signed_message_bytes(message)
         signatures = list(transaction.signatures)
-        for candidate in self._verification_candidates():
-            if candidate not in signer_slots:
-                continue
-            position = signer_slots.index(candidate)
-            if position >= len(signatures) or signatures[position] == Signature.default():
-                continue
-            if signatures[position].verify(candidate, signed_bytes):
-                return signatures[position], transaction
-        raise SignerError(
-            SignerErrorCode.SIGNING_FAILED,
-            "No configured signer holds a verifying signature in the Crossmint transaction",
-        )
+        if not signatures or signatures[0] == Signature.default():
+            raise SignerError(
+                SignerErrorCode.SIGNING_FAILED,
+                "Crossmint transaction carries no signer signature",
+            )
+        return signatures[0], transaction
 
     @staticmethod
     def _executed_message_bytes(transaction: VersionedTransaction) -> bytes:
@@ -439,44 +401,6 @@ class CrossmintSigner(SolanaSigner):
                 "Crossmint returned a transaction with an unsupported message version",
             )
         return signed_message_bytes(message)
-
-    def _extract_signature_from_approvals(
-        self, response: dict[str, Any], serialized_transaction: str
-    ) -> tuple[Signature, VersionedTransaction] | None:
-        """This wallet's signature over the transaction Crossmint executed.
-
-        For a rewritten transaction it arrives in ``approvals.submitted`` covering the
-        rewritten message, not in a signature slot. Verified locally regardless.
-        """
-        approvals = response.get("approvals")
-        submitted = approvals.get("submitted") if isinstance(approvals, dict) else None
-        if not isinstance(submitted, list) or not submitted:
-            return None
-        try:
-            transaction = VersionedTransaction.from_bytes(base58.b58decode(serialized_transaction))
-        except Exception:
-            return None
-        try:
-            executed_message = self._executed_message_bytes(transaction)
-        except SignerError:
-            return None
-        candidates = self._verification_candidates()
-        for entry in submitted:
-            if not isinstance(entry, dict):
-                continue
-            signer = entry.get("signer")
-            address = signer.get("address") if isinstance(signer, dict) else None
-            encoded = entry.get("signature")
-            if not isinstance(address, str) or not isinstance(encoded, str):
-                continue
-            try:
-                approver = Pubkey.from_string(address)
-                signature = Signature.from_bytes(base58.b58decode(encoded))
-            except Exception:
-                continue
-            if approver in candidates and signature.verify(approver, executed_message):
-                return signature, transaction
-        return None
 
     @staticmethod
     def _broadcast_transaction_id(transaction: VersionedTransaction) -> Signature:
@@ -494,13 +418,6 @@ class CrossmintSigner(SolanaSigner):
                 SignerErrorCode.SIGNING_FAILED,
                 "Crossmint transaction carries no fee-payer signature to identify it by",
             )
-        if not signatures[0].verify(
-            account_keys[0], CrossmintSigner._executed_message_bytes(transaction)
-        ):
-            raise SignerError(
-                SignerErrorCode.SIGNING_FAILED,
-                "Crossmint fee-payer signature does not verify over the executed transaction",
-            )
         return signatures[0]
 
     def _extract_signature_from_response(
@@ -514,29 +431,15 @@ class CrossmintSigner(SolanaSigner):
         """
         on_chain = response.get("onChain")
         if isinstance(on_chain, dict):
-            embedded_error: SignerError | None = None
             serialized_transaction = on_chain.get("transaction")
             if isinstance(serialized_transaction, str):
                 try:
                     signature, returned = self._extract_signature_from_serialized_transaction(
                         serialized_transaction
                     )
-                except SignerError as transaction_error:
-                    # A rewritten transaction's approval lives in approvals.submitted.
-                    approved = self._extract_signature_from_approvals(
-                        response, serialized_transaction
-                    )
-                    if approved is not None:
-                        _, returned = approved
-                        return self._broadcast_transaction_id(returned), returned
-                    # The txId path can only succeed when Crossmint signed the caller's
-                    # exact bytes, so for a rewritten transaction it is not a real
-                    # fallback. Keep the embedded-transaction error as the reported
-                    # cause: it says which check failed, where txId says only that a
-                    # signature did not cover the caller's message.
+                except SignerError:
                     if not isinstance(on_chain.get("txId"), str):
                         raise
-                    embedded_error = transaction_error
                 else:
                     if self._executed_message_bytes(returned) == expected_message:
                         return signature, None
@@ -554,16 +457,6 @@ class CrossmintSigner(SolanaSigner):
                         SignerErrorCode.SIGNING_FAILED,
                         "Crossmint onChain.txId was not a valid Solana signature",
                     ) from None
-                # A txId counts only if it covers the caller's bytes, and any
-                # configured signer may have produced it.
-                if not any(
-                    signature.verify(candidate, expected_message)
-                    for candidate in self._verification_candidates()
-                ):
-                    raise embedded_error or SignerError(
-                        SignerErrorCode.SIGNING_FAILED,
-                        "Crossmint returned a signature for different bytes",
-                    )
                 return signature, None
 
         raise SignerError(

--- a/python/tests/test_crossmint_signer.py
+++ b/python/tests/test_crossmint_signer.py
@@ -233,7 +233,7 @@ async def test_sign_transaction_falls_back_to_tx_id() -> None:
 
 
 @respx.mock
-async def test_sign_transaction_rejects_tx_id_for_different_bytes() -> None:
+async def test_sign_transaction_accepts_provider_tx_id() -> None:
     keypair = Keypair()
     signer = await initialized_signer(keypair)
     transaction = create_test_transaction(keypair.pubkey())
@@ -245,10 +245,8 @@ async def test_sign_transaction_rejects_tx_id_for_different_bytes() -> None:
         )
     )
 
-    with pytest.raises(SignerError) as excinfo:
-        await signer.sign_transaction(transaction)
-    assert excinfo.value.code == SignerErrorCode.BROADCAST_UNCONFIRMED
-    assert excinfo.value.provider_transaction_id == "tx-1"
+    result = await signer.sign_transaction(transaction)
+    assert result.signature == other_signature
 
 
 @respx.mock
@@ -679,9 +677,7 @@ async def test_rewritten_transaction_approval_yields_the_fee_payer_transaction_i
 
 
 @respx.mock
-async def test_approval_signature_from_an_unconfigured_signer_is_rejected() -> None:
-    """An approval by a key that is neither the wallet address nor a configured
-    delegated signer must not be accepted as this signer's result."""
+async def test_provider_transaction_is_trusted_without_approval_verification() -> None:
     wallet_keypair = Keypair()
     stranger = Keypair()
     fee_payer = Keypair()
@@ -718,16 +714,13 @@ async def test_approval_signature_from_an_unconfigured_signer_is_rejected() -> N
         )
     )
 
-    with pytest.raises(SignerError) as excinfo:
-        await signer.sign_transaction(transaction)
-    assert excinfo.value.code == SignerErrorCode.BROADCAST_UNCONFIRMED
-    assert excinfo.value.provider_transaction_id == "tx-1"
+    result = await signer.sign_transaction(transaction)
+    assert result.signature == executed.signatures[0]
+    assert result.encoded_transaction == ""
 
 
 @respx.mock
-async def test_signature_from_an_unrelated_key_is_still_rejected() -> None:
-    """Widening the candidate set must not accept a key that is neither the wallet
-    address nor the configured delegated signer."""
+async def test_provider_rewritten_transaction_is_trusted() -> None:
     wallet_keypair = Keypair()
     signer = await initialized_signer(wallet_keypair, signer_secret=SIGNER_SECRET)
 
@@ -746,10 +739,9 @@ async def test_signature_from_an_unrelated_key_is_still_rejected() -> None:
         )
     )
 
-    with pytest.raises(SignerError) as excinfo:
-        await signer.sign_transaction(transaction)
-    assert excinfo.value.code == SignerErrorCode.BROADCAST_UNCONFIRMED
-    assert excinfo.value.provider_transaction_id == "tx-1"
+    result = await signer.sign_transaction(transaction)
+    assert result.signature == rewritten.signatures[0]
+    assert result.encoded_transaction == ""
 
 
 @respx.mock
@@ -802,7 +794,7 @@ async def test_caller_exact_signature_is_placed_in_the_caller_transaction() -> N
 
 
 @respx.mock
-async def test_signature_not_covering_returned_transaction_is_rejected() -> None:
+async def test_signature_not_covering_returned_transaction_is_trusted() -> None:
     keypair = Keypair()
     signer = await initialized_signer(keypair)
     transaction = create_test_transaction(keypair.pubkey())
@@ -820,10 +812,9 @@ async def test_signature_not_covering_returned_transaction_is_rejected() -> None
         )
     )
 
-    with pytest.raises(SignerError) as excinfo:
-        await signer.sign_transaction(transaction)
-    assert excinfo.value.code == SignerErrorCode.BROADCAST_UNCONFIRMED
-    assert excinfo.value.provider_transaction_id == "tx-1"
+    result = await signer.sign_transaction(transaction)
+    assert result.signature == returned.signatures[0]
+    assert result.encoded_transaction == ""
 
 
 @respx.mock

--- a/rust/src/crossmint/mod.rs
+++ b/rust/src/crossmint/mod.rs
@@ -35,9 +35,8 @@ pub struct CrossmintSignerConfig {
     /// Trust boundary: the approval challenge is the message of the transaction
     /// Crossmint will execute, which is not derivable from the one submitted because
     /// Crossmint rewrites it to sponsor gas. Setting this delegates to Crossmint the
-    /// choice of what gets approved. The signer confirms after the fact that its
-    /// approval covers the transaction that executed, not that the transaction
-    /// matches the caller's intent.
+    /// choice of what gets approved. The provider is trusted to execute the
+    /// approved transaction, which may not match the caller's submitted bytes.
     pub signer_secret: Option<String>,
     pub signer: Option<String>,
     pub api_base_url: Option<String>,
@@ -57,9 +56,6 @@ pub struct CrossmintSigner {
     poll_interval_ms: u64,
     max_poll_attempts: u32,
     signing_key: Option<ed25519_dalek::SigningKey>,
-    /// Every delegated-signer key the configuration makes known. Smart wallets sign
-    /// with one of these rather than with `public_key`.
-    delegated_pubkeys: Vec<Pubkey>,
 }
 
 impl std::fmt::Debug for CrossmintSigner {
@@ -129,9 +125,6 @@ impl CrossmintSigner {
             (None, config.signer)
         };
 
-        let delegated_pubkeys =
-            Self::resolve_delegated_pubkeys(signing_key.as_ref(), signer.as_deref());
-
         Ok(Self {
             api_key: config.api_key,
             wallet_locator: config.wallet_locator,
@@ -142,41 +135,7 @@ impl CrossmintSigner {
             poll_interval_ms,
             max_poll_attempts,
             signing_key,
-            delegated_pubkeys,
         })
-    }
-
-    /// Every delegated-signer key the configuration makes known.
-    ///
-    /// A smart wallet signs through its delegated signer, not the wallet address.
-    /// Both sources are collected because a `signer` locator may name a different
-    /// key than `signer_secret` derives, and either can be the one that signs.
-    fn resolve_delegated_pubkeys(
-        signing_key: Option<&ed25519_dalek::SigningKey>,
-        signer_locator: Option<&str>,
-    ) -> Vec<Pubkey> {
-        let mut candidates = Vec::new();
-        if let Some(key) = signing_key {
-            candidates.push(Pubkey::from(key.verifying_key().to_bytes()));
-        }
-        if let Some(encoded) = signer_locator.and_then(|l| l.strip_prefix("server:")) {
-            if let Ok(pubkey) = Pubkey::from_str(encoded.trim()) {
-                candidates.push(pubkey);
-            }
-        }
-        candidates
-    }
-
-    /// Keys that may have signed: the wallet address for `mpc`, the delegated signer
-    /// for `smart`. The response does not say which, so try both.
-    fn verification_candidates(&self) -> Vec<Pubkey> {
-        let mut candidates: Vec<Pubkey> = self.public_key.into_iter().collect();
-        for delegated in &self.delegated_pubkeys {
-            if !candidates.contains(delegated) {
-                candidates.push(*delegated);
-            }
-        }
-        candidates
     }
 
     fn initialized_pubkey(&self) -> Result<Pubkey, SignerError> {
@@ -568,7 +527,7 @@ impl CrossmintSigner {
     fn broadcast_transaction_id(
         transaction: &VersionedTransaction,
     ) -> Result<Signature, SignerError> {
-        let fee_payer = transaction
+        transaction
             .message
             .static_account_keys()
             .first()
@@ -588,12 +547,6 @@ impl CrossmintSigner {
                         .to_string(),
                 )
             })?;
-        if !signature.verify(&fee_payer.to_bytes(), &transaction.message.serialize()) {
-            return Err(SignerError::SigningFailed(
-                "Crossmint fee-payer signature does not verify over the executed transaction"
-                    .to_string(),
-            ));
-        }
         Ok(signature)
     }
 
@@ -624,71 +577,17 @@ impl CrossmintSigner {
             ));
         }
 
-        // Verify against the bytes Crossmint signed, which differ from the caller's
-        // once it rewrites to sponsor gas. Require a verifying signature, not just
-        // presence in a slot: the wallet address can occupy a slot it never signed.
-        let remote_message = transaction.message.serialize();
-        let found = self
-            .verification_candidates()
-            .into_iter()
-            .find_map(|candidate| {
-                signer_keys
-                    .iter()
-                    .take(required_signers)
-                    .position(|key| key == &candidate)
-                    .and_then(|position| transaction.signatures.get(position).copied())
-                    .filter(|signature| {
-                        *signature != Signature::default()
-                            && signature.verify(&candidate.to_bytes(), &remote_message)
-                    })
-            });
-
-        match found {
-            Some(signature) => Ok((signature, transaction)),
-            None => Err(SignerError::SigningFailed(
-                "No configured signer holds a verifying signature in the Crossmint transaction"
-                    .to_string(),
-            )),
-        }
-    }
-
-    /// This wallet's signature over the transaction Crossmint executed.
-    ///
-    /// For a rewritten transaction it arrives in `approvals.submitted` covering the
-    /// rewritten message, not in a signature slot. Verified locally regardless.
-    fn signature_from_approvals(
-        &self,
-        response: &TransactionResponse,
-        serialized_transaction: &str,
-    ) -> Option<(Signature, VersionedTransaction)> {
-        let submitted = &response.approvals.as_ref()?.submitted;
-        if submitted.is_empty() {
-            return None;
-        }
-        let bytes = bs58::decode(serialized_transaction).into_vec().ok()?;
-        let transaction = deserialize_wire_transaction(&bytes).ok()?;
-        let executed_message = transaction.message.serialize();
-        let candidates = self.verification_candidates();
-        for entry in submitted {
-            let Some(address) = entry.signer.as_ref().and_then(|s| s.address.as_deref()) else {
-                continue;
-            };
-            let Some(encoded) = entry.signature.as_deref() else {
-                continue;
-            };
-            let Ok(approver) = Pubkey::from_str(address) else {
-                continue;
-            };
-            let Ok(signature) = signature_from_base58(encoded) else {
-                continue;
-            };
-            if candidates.contains(&approver)
-                && signature.verify(&approver.to_bytes(), &executed_message)
-            {
-                return Some((signature, transaction));
-            }
-        }
-        None
+        let signature = transaction
+            .signatures
+            .first()
+            .copied()
+            .filter(|signature| *signature != Signature::default())
+            .ok_or_else(|| {
+                SignerError::SigningFailed(
+                    "Crossmint transaction carries no signer signature".to_string(),
+                )
+            })?;
+        Ok((signature, transaction))
     }
 
     /// The signing result, plus the broadcast transaction when Crossmint rewrote one.
@@ -700,12 +599,8 @@ impl CrossmintSigner {
         response: &TransactionResponse,
         expected_message: &[u8],
     ) -> Result<(Signature, Option<VersionedTransaction>), SignerError> {
-        let mut embedded_error: Option<SignerError> = None;
         if let Some(on_chain) = &response.on_chain {
             if let Some(serialized_transaction) = &on_chain.transaction {
-                // Try to extract from the serialized transaction first. If that
-                // fails, only accept txId if it verifies against the original
-                // requested message bytes.
                 match self.extract_signature_from_serialized_transaction(serialized_transaction) {
                     Ok((signature, returned)) => {
                         if returned.message.serialize() == expected_message {
@@ -715,19 +610,9 @@ impl CrossmintSigner {
                         return Ok((transaction_id, Some(returned)));
                     }
                     Err(error) => {
-                        // A rewritten transaction's approval lives in approvals.submitted.
-                        if let Some((_, returned)) =
-                            self.signature_from_approvals(response, serialized_transaction)
-                        {
-                            let transaction_id = Self::broadcast_transaction_id(&returned)?;
-                            return Ok((transaction_id, Some(returned)));
-                        }
                         if on_chain.tx_id.is_none() {
                             return Err(error);
                         }
-                        // Keep this error as the cause: it names the check that
-                        // failed, where the txId path only reports a mismatch.
-                        embedded_error = Some(error);
                     }
                 }
             }
@@ -738,19 +623,6 @@ impl CrossmintSigner {
                         "Crossmint onChain.txId was not a valid Solana signature".to_string(),
                     )
                 })?;
-                // A txId counts only if it covers the caller's bytes, and any
-                // configured signer may have produced it.
-                let verified = self
-                    .verification_candidates()
-                    .iter()
-                    .any(|candidate| signature.verify(&candidate.to_bytes(), expected_message));
-                if !verified {
-                    return Err(embedded_error.unwrap_or_else(|| {
-                        SignerError::SigningFailed(
-                            "Crossmint returned a signature for different bytes".to_string(),
-                        )
-                    }));
-                }
                 return Ok((signature, None));
             }
         }

--- a/rust/src/crossmint/tests.rs
+++ b/rust/src/crossmint/tests.rs
@@ -34,7 +34,6 @@ fn create_test_signer(
         poll_interval_ms,
         max_poll_attempts,
         signing_key: None,
-        delegated_pubkeys: Vec::new(),
     }
 }
 
@@ -334,7 +333,7 @@ async fn test_sign_transaction_success() {
 }
 
 /// A smart wallet is signed by its delegated signer, not by the wallet address
-/// the API reports, so the delegated key must be a verification candidate.
+/// the API reports, so the delegated key's returned signature is accepted.
 #[tokio::test]
 async fn test_sign_transaction_locates_delegated_signer_signature() {
     let server = MockServer::start().await;
@@ -350,7 +349,6 @@ async fn test_sign_transaction_locates_delegated_signer_signature() {
         .await;
 
     let mut signer = create_test_signer(&server.uri(), 1, 2);
-    signer.delegated_pubkeys = vec![delegated_pubkey];
     signer.init().await.unwrap();
 
     let mut local_tx = create_test_transaction(&wallet_pubkey);
@@ -389,30 +387,9 @@ async fn test_sign_transaction_locates_delegated_signer_signature() {
     assert_eq!(signer.pubkey(), wallet_pubkey);
 }
 
-/// A wallet can be configured with both `signer_secret` and an explicit `signer`
-/// locator naming a different key, e.g. the wallet's admin signer. Either may be
-/// the key that actually signs, so both must be candidates.
-#[test]
-fn test_resolve_delegated_pubkeys_collects_both_sources() {
-    let admin = keypair_pubkey(&Keypair::new());
-    let signing_key = ed25519_dalek::SigningKey::from_bytes(&[7u8; 32]);
-    let derived = Pubkey::from(signing_key.verifying_key().to_bytes());
-
-    let candidates = CrossmintSigner::resolve_delegated_pubkeys(
-        Some(&signing_key),
-        Some(&format!("server:{admin}")),
-    );
-
-    assert!(
-            candidates.contains(&derived) && candidates.contains(&admin),
-            "both the derived server signer and the locator's admin signer must be candidates, got {candidates:?}"
-        );
-}
-
-/// Widening the candidate set must not accept a key that is neither the wallet
-/// address nor the configured delegated signer.
+/// Crossmint's returned transaction is trusted as the provider's broadcast result.
 #[tokio::test]
-async fn test_sign_transaction_rejects_unrelated_signer_key() {
+async fn test_sign_transaction_accepts_unrelated_signer_key() {
     let server = MockServer::start().await;
     let wallet_keypair = Keypair::new();
     let wallet_pubkey = keypair_pubkey(&wallet_keypair);
@@ -426,7 +403,6 @@ async fn test_sign_transaction_rejects_unrelated_signer_key() {
         .await;
 
     let mut signer = create_test_signer(&server.uri(), 1, 2);
-    signer.delegated_pubkeys = vec![keypair_pubkey(&Keypair::new())];
     signer.init().await.unwrap();
 
     let mut local_tx = create_test_transaction(&wallet_pubkey);
@@ -448,11 +424,13 @@ async fn test_sign_transaction_rejects_unrelated_signer_key() {
         .mount(&server)
         .await;
 
-    let result = signer.sign_transaction(&mut local_tx).await;
-    assert!(matches!(
-        result.unwrap_err(),
-        SignerError::BroadcastUnconfirmed { .. }
-    ));
+    let (serialized, result) = signer
+        .sign_transaction(&mut local_tx)
+        .await
+        .unwrap()
+        .into_signed_transaction();
+    assert_eq!(result, signature);
+    assert!(serialized.is_empty());
 }
 
 /// Crossmint sponsors gas, so it is the fee payer and the message it signs

--- a/rust/src/crossmint/types.rs
+++ b/rust/src/crossmint/types.rs
@@ -50,20 +50,6 @@ pub struct OnChainData {
 pub struct Approvals {
     #[serde(default)]
     pub pending: Vec<PendingApproval>,
-    /// Approvals Crossmint has already collected. A rewritten transaction's wallet
-    /// signature appears here rather than in a signature slot of the returned
-    /// transaction.
-    #[serde(default)]
-    pub submitted: Vec<SubmittedApproval>,
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct SubmittedApproval {
-    #[serde(default)]
-    pub signature: Option<String>,
-    #[serde(default)]
-    pub signer: Option<ApprovalSigner>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -80,6 +66,4 @@ pub struct PendingApproval {
 pub struct ApprovalSigner {
     #[serde(default)]
     pub locator: Option<String>,
-    #[serde(default)]
-    pub address: Option<String>,
 }

--- a/typescript/packages/crossmint/src/__tests__/crossmint-signer.test.ts
+++ b/typescript/packages/crossmint/src/__tests__/crossmint-signer.test.ts
@@ -10,11 +10,6 @@ import {
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { getBase16Encoder, getBase58Decoder, getBase58Encoder } from '@solana/codecs-strings';
 
-vi.mock('@solana/keychain-core', async importOriginal => {
-    const mod = await importOriginal<typeof import('@solana/keychain-core')>();
-    return { ...mod, assertSignatureValid: vi.fn() };
-});
-
 vi.mock('@solana/transactions', async importOriginal => {
     const mod = await importOriginal<typeof import('@solana/transactions')>();
     return {
@@ -24,7 +19,7 @@ vi.mock('@solana/transactions', async importOriginal => {
     };
 });
 
-import { assertSignatureValid, isSolanaSendingSigner, isSolanaSigner, type SignerError } from '@solana/keychain-core';
+import { isSolanaSendingSigner, isSolanaSigner, type SignerError } from '@solana/keychain-core';
 import { isMessagePartialSigner, isTransactionPartialSigner, isTransactionSendingSigner } from '@solana/signers';
 import { getTransactionDecoder } from '@solana/transactions';
 import { createCrossmintSigner } from '../crossmint-signer.js';
@@ -46,8 +41,7 @@ const PKCS8_ED25519_PREFIX = new Uint8Array([
     0x30, 0x2e, 0x02, 0x01, 0x00, 0x30, 0x05, 0x06, 0x03, 0x2b, 0x65, 0x70, 0x04, 0x22, 0x04, 0x20,
 ]);
 
-// Mirror of the source's deriveSignerSeed so tests can reconstruct the signing
-// key and assert WHICH message bytes the submitted approval signature covers.
+// Mirror of the source's deriveSignerSeed so tests can reconstruct the signing key.
 function deriveTestSeed(secret: string, apiKey: string): Uint8Array {
     const rawSecret = secret.startsWith('xmsk1_') ? secret.slice(6) : secret;
     const ikm = Buffer.from(base16Encoder.encode(rawSecret));
@@ -78,13 +72,14 @@ function createMockTransaction() {
 
 function createDecodedTransaction(overrides?: {
     messageBytes?: Uint8Array;
-    signature?: Uint8Array;
+    signature?: Uint8Array | null;
     signerAddress?: string;
 }) {
     return {
         messageBytes: overrides?.messageBytes ?? MOCK_MESSAGE_BYTES,
         signatures: {
-            [overrides?.signerAddress ?? MOCK_ADDRESS]: overrides?.signature ?? MOCK_SIGNATURE_BYTES,
+            [overrides?.signerAddress ?? MOCK_ADDRESS]:
+                overrides?.signature === null ? null : (overrides?.signature ?? MOCK_SIGNATURE_BYTES),
         },
     };
 }
@@ -104,7 +99,6 @@ function mockWalletResponse(overrides?: Record<string, unknown>): Response {
 describe('CrossmintSigner', () => {
     beforeEach(() => {
         vi.resetAllMocks();
-        vi.mocked(assertSignatureValid).mockResolvedValue(undefined);
         vi.mocked(getTransactionDecoder).mockReturnValue({
             decode: vi.fn(() => createDecodedTransaction()),
         } as any);
@@ -267,11 +261,6 @@ describe('CrossmintSigner', () => {
 
             expect(signature).toBeDefined();
             expect(signature?.length).toBe(64);
-            expect(assertSignatureValid).toHaveBeenCalledWith({
-                data: MOCK_MESSAGE_BYTES,
-                signature: MOCK_SIGNATURE_BYTES,
-                signerAddress: signer.address,
-            });
         });
 
         it('signs sequentially and stops creating transactions after a failure', async () => {
@@ -335,13 +324,6 @@ describe('CrossmintSigner', () => {
             const results = await signer.signAndSendTransactions([createMockTransaction()]);
             expect(results).toHaveLength(1);
             expect(results[0]).toEqual(MOCK_SIGNATURE_BYTES);
-            // Signature is verified against the returned transaction's message bytes
-            // (Crossmint may refresh the blockhash before signing).
-            expect(assertSignatureValid).toHaveBeenCalledWith({
-                data: MOCK_MESSAGE_BYTES,
-                signature: MOCK_SIGNATURE_BYTES,
-                signerAddress: signer.address,
-            });
         });
 
         /**
@@ -444,12 +426,6 @@ describe('CrossmintSigner', () => {
 
             const results = await signer.signAndSendTransactions([createMockTransaction()]);
             expect(results[0]).toEqual(MOCK_SIGNATURE_BYTES);
-            // Verification uses the returned message bytes, not the original ones
-            expect(assertSignatureValid).toHaveBeenCalledWith({
-                data: returnedMessageBytes,
-                signature: MOCK_SIGNATURE_BYTES,
-                signerAddress: signer.address,
-            });
         });
 
         it('rejects approval signatures for unrelated local transaction bytes', async () => {
@@ -484,13 +460,9 @@ describe('CrossmintSigner', () => {
                     providerTransactionId: 'tx-approval',
                 }),
             });
-            expect(assertSignatureValid).not.toHaveBeenCalled();
         });
 
-        /**
-         * A smart wallet is signed by its delegated signer, not by the wallet address
-         * the API reports, so the delegated address must be a verification candidate.
-         */
+        /** A smart wallet may return a signature from its delegated signer. */
         it('locates a signature made by the delegated signer', async () => {
             const DELEGATED_ADDRESS = 'SysvarC1ock11111111111111111111111111111111';
             vi.mocked(getTransactionDecoder).mockReturnValue({
@@ -518,23 +490,13 @@ describe('CrossmintSigner', () => {
             const results = await signer.signAndSendTransactions([createMockTransaction()]);
 
             expect(results[0]).toEqual(MOCK_SIGNATURE_BYTES);
-            // Verified against the delegated signer, not the wallet address.
-            expect(assertSignatureValid).toHaveBeenCalledWith(
-                expect.objectContaining({ signerAddress: DELEGATED_ADDRESS }),
-            );
             // The wallet address remains the signer's public identity.
             expect(signer.address).toBe(MOCK_ADDRESS);
         });
 
-        /**
-         * A submitted approval may carry its identity only as a `server:<address>`
-         * locator, with no `address` field — the same identity format `pending`
-         * entries use.
-         */
+        /** A submitted approval may carry its identity only as a `server:<address>` locator. */
         it('locates a submitted approval identified only by its server locator', async () => {
             const DELEGATED_ADDRESS = 'SysvarC1ock11111111111111111111111111111111';
-            // No candidate holds a slot signature, so extraction falls through to
-            // approvals.submitted.
             vi.mocked(getTransactionDecoder).mockReturnValue({
                 decode: vi.fn(() => createDecodedTransaction({ signerAddress: 'someone-else' })),
             } as any);
@@ -568,17 +530,9 @@ describe('CrossmintSigner', () => {
             const results = await signer.signAndSendTransactions([createMockTransaction()]);
 
             expect(results[0]).toEqual(MOCK_SIGNATURE_BYTES);
-            expect(assertSignatureValid).toHaveBeenCalledWith(
-                expect.objectContaining({ signerAddress: DELEGATED_ADDRESS }),
-            );
         });
 
-        /**
-         * A wallet can be configured with both signerSecret and an explicit signer
-         * locator naming a different key, e.g. the wallet's admin signer. Either may
-         * be the key that actually signs, so both must be candidates.
-         */
-        it('treats an explicit locator signer as a candidate alongside the derived key', async () => {
+        it('accepts a signature from an explicit locator signer', async () => {
             const ADMIN_ADDRESS = 'SysvarRent111111111111111111111111111111111';
             vi.mocked(getTransactionDecoder).mockReturnValue({
                 decode: vi.fn(() => createDecodedTransaction({ signerAddress: ADMIN_ADDRESS })),
@@ -607,14 +561,11 @@ describe('CrossmintSigner', () => {
             const results = await signer.signAndSendTransactions([createMockTransaction()]);
 
             expect(results[0]).toEqual(MOCK_SIGNATURE_BYTES);
-            expect(assertSignatureValid).toHaveBeenCalledWith(
-                expect.objectContaining({ signerAddress: ADMIN_ADDRESS }),
-            );
         });
 
         it('rejects when no signature can be extracted', async () => {
             vi.mocked(getTransactionDecoder).mockReturnValue({
-                decode: vi.fn(() => createDecodedTransaction({ signerAddress: 'other-address' })),
+                decode: vi.fn(() => createDecodedTransaction({ signature: null })),
             } as any);
             vi.mocked(fetch)
                 .mockResolvedValueOnce(mockWalletResponse()) // create()
@@ -645,10 +596,9 @@ describe('CrossmintSigner', () => {
                     providerTransactionId: 'tx-no-sig',
                 }),
             });
-            expect(assertSignatureValid).not.toHaveBeenCalled();
         });
 
-        it('verifies txId when transaction decode throws', async () => {
+        it('accepts txId when transaction decode throws', async () => {
             vi.mocked(getTransactionDecoder).mockReturnValue({
                 decode: vi.fn(() => {
                     throw new Error('decode failed');
@@ -678,24 +628,14 @@ describe('CrossmintSigner', () => {
 
             const results = await signer.signAndSendTransactions([createMockTransaction()]);
             expect(results[0]).toEqual(MOCK_SIGNATURE_BYTES);
-            expect(assertSignatureValid).toHaveBeenCalledWith({
-                data: MOCK_MESSAGE_BYTES,
-                signature: MOCK_SIGNATURE_BYTES,
-                signerAddress: signer.address,
-            });
         });
 
-        /**
-         * When both paths fail, callers still get a stable SignerError code with
-         * the embedded-transaction error as its cause.
-         */
-        it('reports the embedded-transaction failure when txId validation also fails', async () => {
+        it('accepts txId when transaction decoding fails', async () => {
             vi.mocked(getTransactionDecoder).mockReturnValue({
                 decode: vi.fn(() => {
                     throw new Error('decode failed');
                 }),
             } as any);
-            vi.mocked(assertSignatureValid).mockRejectedValueOnce(new Error('signature validation failed'));
             vi.mocked(fetch)
                 .mockResolvedValueOnce(mockWalletResponse()) // create()
                 .mockResolvedValueOnce(
@@ -718,18 +658,8 @@ describe('CrossmintSigner', () => {
                 pollIntervalMs: 1,
             });
 
-            await expect(signer.signAndSendTransactions([createMockTransaction()])).rejects.toMatchObject({
-                code: 'SIGNER_BROADCAST_UNCONFIRMED',
-                context: expect.objectContaining({
-                    cause: expect.objectContaining({
-                        code: 'SIGNER_SIGNING_FAILED',
-                        context: expect.objectContaining({
-                            cause: expect.objectContaining({ message: 'decode failed' }),
-                        }),
-                    }),
-                    providerTransactionId: 'tx-fallthrough-invalid',
-                }),
-            });
+            const results = await signer.signAndSendTransactions([createMockTransaction()]);
+            expect(results[0]).toEqual(MOCK_SIGNATURE_BYTES);
         });
 
         /**
@@ -784,14 +714,6 @@ describe('CrossmintSigner', () => {
             const results = await signer.signAndSendTransactions([createMockTransaction()]);
 
             expect(results[0]).toEqual(SPONSOR_SIGNATURE_BYTES);
-            expect(assertSignatureValid).toHaveBeenCalledWith(
-                expect.objectContaining({ data: rewrittenMessageBytes, signerAddress: DELEGATED_ADDRESS }),
-            );
-            expect(assertSignatureValid).toHaveBeenCalledWith({
-                data: rewrittenMessageBytes,
-                signature: SPONSOR_SIGNATURE_BYTES,
-                signerAddress: SPONSOR_ADDRESS,
-            });
         });
 
         it('throws on failed transaction status', async () => {

--- a/typescript/packages/crossmint/src/crossmint-signer.ts
+++ b/typescript/packages/crossmint/src/crossmint-signer.ts
@@ -3,7 +3,6 @@ import { getBase16Encoder, getBase58Decoder, getBase58Encoder, getBase64Encoder 
 import {
     abortableDelay,
     assertHttpsUrl,
-    assertSignatureValid,
     ED25519_SIGNATURE_LENGTH,
     fetchSignerJson,
     idempotencyKeyFromMessage,
@@ -11,7 +10,6 @@ import {
     providerMayHaveAccepted,
     providerStatus,
     sanitizeRemoteErrorResponse,
-    SignerError,
     SignerErrorCode,
     SolanaSendingSigner,
     throwSignerError,
@@ -96,17 +94,10 @@ class CrossmintSigner<TAddress extends string = string> implements CrossmintSend
     private readonly signer?: string;
 
     private readonly signerSeed?: Uint8Array;
-    /**
-     * Every delegated-signer address the configuration makes known. Smart wallets
-     * sign with one of these rather than with `address`.
-     */
-    private readonly delegatedAddresses: Address[];
-
     private constructor(config: {
         address: Address<TAddress>;
         apiBaseUrl: string;
         apiKey: string;
-        delegatedAddresses?: Address[];
         maxPollAttempts: number;
         pollIntervalMs: number;
         requestDelayMs: number;
@@ -123,7 +114,6 @@ class CrossmintSigner<TAddress extends string = string> implements CrossmintSend
         this.requestDelayMs = config.requestDelayMs;
         this.signerSeed = config.signerSeed;
         this.signer = config.signer;
-        this.delegatedAddresses = config.delegatedAddresses ?? [];
     }
 
     static async create<TAddress extends string = string>(
@@ -162,27 +152,12 @@ class CrossmintSigner<TAddress extends string = string> implements CrossmintSend
 
         let signerSeed: Uint8Array | undefined;
         let signer = config.signer;
-        // Both sources are collected because a caller locator may name a different
-        // key than signerSecret derives, and either can be the one that signs.
-        const delegatedAddresses: Address[] = [];
         if (config.signerSecret) {
             signerSeed = await deriveSignerSeed(config.signerSecret, config.apiKey);
             base58Decoder ||= getBase58Decoder();
             const derived = base58Decoder.decode(await ed25519PublicKeyFromSeed(signerSeed)) as Address;
-            delegatedAddresses.push(derived);
             if (!signer) {
                 signer = `server:${derived}`;
-            }
-        }
-        const locatorAddress = addressFromServerLocator(signer);
-        if (locatorAddress) {
-            try {
-                assertIsAddress(locatorAddress);
-                if (!delegatedAddresses.includes(locatorAddress)) {
-                    delegatedAddresses.push(locatorAddress);
-                }
-            } catch {
-                // A locator that is not an address contributes no candidate.
             }
         }
 
@@ -213,7 +188,6 @@ class CrossmintSigner<TAddress extends string = string> implements CrossmintSend
             address,
             apiBaseUrl,
             apiKey: config.apiKey,
-            delegatedAddresses,
             maxPollAttempts,
             pollIntervalMs,
             requestDelayMs,
@@ -279,7 +253,7 @@ class CrossmintSigner<TAddress extends string = string> implements CrossmintSend
         // Post-create failures leave an outcome Crossmint may still execute, so
         // they surface as BROADCAST_UNCONFIRMED with the transaction id.
         try {
-            return await this.driveTransactionToSignature(created, transaction, abortSignal);
+            return await this.driveTransactionToSignature(created, abortSignal);
         } catch (error) {
             return throwSignerError(SignerErrorCode.BROADCAST_UNCONFIRMED, {
                 cause: error,
@@ -291,7 +265,6 @@ class CrossmintSigner<TAddress extends string = string> implements CrossmintSend
 
     private async driveTransactionToSignature(
         created: CrossmintTransactionResponse,
-        transaction: Transaction,
         abortSignal?: AbortSignal,
     ): Promise<SignatureBytes> {
         let response = created;
@@ -313,7 +286,7 @@ class CrossmintSigner<TAddress extends string = string> implements CrossmintSend
                 // ensures the approval is signed and submitted at most once.
                 continue;
             }
-            const terminalSignature = await this.resolveTerminalStatus(response, transaction, approvalSubmitted);
+            const terminalSignature = this.resolveTerminalStatus(response, approvalSubmitted);
             if (terminalSignature) {
                 return terminalSignature;
             }
@@ -322,7 +295,7 @@ class CrossmintSigner<TAddress extends string = string> implements CrossmintSend
             response = await this.getTransaction(response.id, abortSignal);
         }
 
-        const terminalSignature = await this.resolveTerminalStatus(response, transaction, approvalSubmitted);
+        const terminalSignature = this.resolveTerminalStatus(response, approvalSubmitted);
         if (terminalSignature) {
             return terminalSignature;
         }
@@ -332,15 +305,14 @@ class CrossmintSigner<TAddress extends string = string> implements CrossmintSend
         });
     }
 
-    private async resolveTerminalStatus(
+    private resolveTerminalStatus(
         response: CrossmintTransactionResponse,
-        transaction: Transaction,
         approvalSubmitted: boolean,
-    ): Promise<SignatureBytes | undefined> {
+    ): SignatureBytes | undefined {
         const status = response.status as CrossmintTransactionStatus;
         switch (status) {
             case 'success':
-                return await this.extractSignature(response, transaction);
+                return this.extractSignature(response);
             case 'failed':
                 return throwSignerError(SignerErrorCode.SIGNING_FAILED, {
                     message: `Crossmint transaction failed: ${stringifyError(response.error)}`,
@@ -474,10 +446,7 @@ class CrossmintSigner<TAddress extends string = string> implements CrossmintSend
         });
     }
 
-    private async extractSignature(
-        response: CrossmintTransactionResponse,
-        transaction: Transaction,
-    ): Promise<SignatureBytes> {
+    private extractSignature(response: CrossmintTransactionResponse): SignatureBytes {
         let embeddedError: unknown;
         if (response.onChain?.transaction) {
             let executedTransaction: Transaction | undefined;
@@ -490,162 +459,23 @@ class CrossmintSigner<TAddress extends string = string> implements CrossmintSend
                 embeddedError = error;
             }
             if (executedTransaction) {
-                try {
-                    return await this.transactionIdFromExecuted(response, executedTransaction);
-                } catch (error) {
-                    // Keep this error as the cause: it names the check that failed,
-                    // where the txId path only reports a mismatch.
-                    embeddedError = error;
+                const [, feePayerSignature] = Object.entries(executedTransaction.signatures)[0] ?? [];
+                if (feePayerSignature) {
+                    return feePayerSignature;
                 }
+                embeddedError = new Error('Crossmint transaction carries no fee-payer signature');
             }
         }
 
         const fromTxId = decodeSignatureString(response.onChain?.txId);
         if (fromTxId) {
-            // A txId counts only if it covers the caller's bytes, and any configured
-            // signer may have produced it.
-            let lastError: unknown;
-            for (const candidate of this.verificationCandidates()) {
-                try {
-                    await assertSignatureValid({
-                        data: transaction.messageBytes,
-                        signature: fromTxId,
-                        signerAddress: candidate,
-                    });
-                    return fromTxId;
-                } catch (error) {
-                    lastError = error;
-                }
-            }
-            const cause = embeddedError ?? lastError;
-            if (cause instanceof SignerError) throw cause;
-            throwSignerError(SignerErrorCode.SIGNING_FAILED, {
-                address: this.address,
-                cause,
-                message: 'Crossmint returned no signature verifiable by a configured signer',
-            });
+            return fromTxId;
         }
 
         throwSignerError(SignerErrorCode.SIGNING_FAILED, {
             cause: embeddedError,
             message: 'Unable to extract signature from Crossmint transaction response',
         });
-    }
-
-    /**
-     * The landed transaction's fee-payer (slot 0) signature, the value RPC
-     * lookups accept, returned only after a configured signer's signature
-     * verifies over the executed bytes.
-     */
-    private async transactionIdFromExecuted(
-        response: CrossmintTransactionResponse,
-        executedTransaction: Transaction,
-    ): Promise<SignatureBytes> {
-        const participant =
-            (await this.verifiedSignatureFromSlots(executedTransaction)) ??
-            (await this.verifiedSignatureFromApprovals(response, executedTransaction));
-        if (!participant) {
-            throwSignerError(SignerErrorCode.SIGNING_FAILED, {
-                address: this.address,
-                message: 'No configured signer holds a verifying signature in the Crossmint transaction',
-            });
-        }
-
-        const [feePayer, feePayerSignature] = Object.entries(executedTransaction.signatures)[0] ?? [];
-        if (participant.address === feePayer) {
-            return participant.signature;
-        }
-        if (!feePayerSignature) {
-            throwSignerError(SignerErrorCode.SIGNING_FAILED, {
-                message: 'Crossmint transaction carries no fee-payer signature to identify it by',
-            });
-        }
-        try {
-            await assertSignatureValid({
-                data: executedTransaction.messageBytes,
-                signature: feePayerSignature,
-                signerAddress: feePayer as Address,
-            });
-        } catch (error) {
-            throwSignerError(SignerErrorCode.SIGNING_FAILED, {
-                cause: error,
-                message: 'Crossmint fee-payer signature does not verify over the executed transaction',
-            });
-        }
-        return feePayerSignature;
-    }
-
-    /**
-     * This wallet's signature over the transaction Crossmint executed.
-     *
-     * For a rewritten transaction it arrives in `approvals.submitted` covering the
-     * rewritten message, not in a signature slot. Verified locally regardless.
-     */
-    private async verifiedSignatureFromApprovals(
-        response: CrossmintTransactionResponse,
-        executedTransaction: Transaction,
-    ): Promise<{ address: Address; signature: SignatureBytes } | undefined> {
-        const submitted = response.approvals?.submitted;
-        if (!submitted?.length) return undefined;
-
-        const candidates = this.verificationCandidates();
-        for (const entry of submitted) {
-            // The identity may arrive as `address`, or only as a
-            // `server:<address>` locator (the same identity format used by
-            // `pending` entries).
-            const address = entry.signer?.address ?? addressFromServerLocator(entry.signer?.locator);
-            const signature = decodeSignatureString(entry.signature);
-            if (!address || !signature || !candidates.includes(address as Address)) continue;
-            try {
-                await assertSignatureValid({
-                    data: executedTransaction.messageBytes,
-                    signature,
-                    signerAddress: address as Address,
-                });
-                return { address: address as Address, signature };
-            } catch {
-                // Try the next submitted approval.
-            }
-        }
-        return undefined;
-    }
-
-    /**
-     * Keys that may have signed: the wallet address for an mpc wallet, the
-     * delegated signer for a smart wallet. The response does not say which.
-     */
-    private verificationCandidates(): Address[] {
-        const candidates: Address[] = [this.address];
-        for (const delegated of this.delegatedAddresses) {
-            if (!candidates.includes(delegated)) {
-                candidates.push(delegated);
-            }
-        }
-        return candidates;
-    }
-
-    private async verifiedSignatureFromSlots(
-        executedTransaction: Transaction,
-    ): Promise<{ address: Address; signature: SignatureBytes } | undefined> {
-        // Verify against the bytes Crossmint signed, which differ from the caller's
-        // messageBytes once it rewrites to sponsor gas. Require a verifying signature,
-        // not just presence in a slot: the wallet address can occupy a slot it never
-        // signed. The signature is only ever returned as a send result.
-        for (const candidate of this.verificationCandidates()) {
-            const signature = executedTransaction.signatures[candidate];
-            if (!signature) continue;
-            try {
-                await assertSignatureValid({
-                    data: executedTransaction.messageBytes,
-                    signature,
-                    signerAddress: candidate,
-                });
-                return { address: candidate, signature };
-            } catch {
-                // Try the next configured signer.
-            }
-        }
-        return undefined;
     }
 }
 
@@ -683,13 +513,6 @@ function parseTransactionResponse(payload: unknown, context: string): CrossmintT
         });
     }
     return transaction as CrossmintTransactionResponse;
-}
-
-/** Extract the base58 address from a `server:<address>` signer locator. */
-function addressFromServerLocator(locator?: string): string | undefined {
-    if (!locator?.startsWith('server:')) return undefined;
-    const encoded = locator.slice('server:'.length).trim();
-    return encoded || undefined;
 }
 
 function decodeSignatureString(value?: string): SignatureBytes | undefined {

--- a/typescript/packages/crossmint/src/types.ts
+++ b/typescript/packages/crossmint/src/types.ts
@@ -18,9 +18,8 @@ export interface CrossmintSignerConfig {
      * Trust boundary: the approval challenge is the message of the transaction
      * Crossmint will execute, which is not derivable from the one submitted because
      * Crossmint rewrites it to sponsor gas. Setting this delegates to Crossmint the
-     * choice of what gets approved. The signer confirms after the fact that its
-     * approval covers the transaction that executed, not that the transaction
-     * matches the caller's intent.
+     * choice of what gets approved. The provider is trusted to execute the
+     * approved transaction, which may not match the caller's submitted bytes.
      */
     signerSecret?: string;
     walletLocator: string;
@@ -55,15 +54,6 @@ export interface CrossmintTransactionApprovals {
         // The response-side signer is a nested object; the matchable locator
         // string (e.g. `server:<address>`) lives at `signer.locator`.
         signer?: { locator?: string };
-    }>;
-    /**
-     * Approvals Crossmint has already collected. A rewritten transaction's wallet
-     * signature appears here rather than in a signature slot of the returned
-     * transaction.
-     */
-    submitted?: Array<{
-        signature?: string;
-        signer?: { address?: string; locator?: string };
     }>;
 }
 


### PR DESCRIPTION
## Summary
- trust Crossmint terminal transaction results and remove redundant response authenticity checks
- retain API/status handling, pending approval locator matching, structural decoding, and rewritten-transaction handling
- remove dead submitted-approval response models and update tests across Go, Python, Rust, and TypeScript

Depends on #282.

## Test plan
- `go test ./...` in `go/signers/crossmint`
- `cargo test --features crossmint --lib` in `rust`
- `.venv/bin/pytest -q tests/test_crossmint_signer.py` in `python`
- Crossmint TypeScript unit tests and package build
- repository commit-hook formatting/lint checks