### PR TITLE
refactor(crossmint)!: make Crossmint a sending-only signer

### DIFF
--- a/go/README.md
+++ b/go/README.md
@@ -197,14 +197,16 @@ at runtime; the second is fixed per backend:
 |---------|----------------------------|-------------------|--------------------------|---------------|
 | memory, vault, privy, turnkey, awskms, fireblocks, gcpkms, dfns, para, openfort | not implemented | yes | not implemented | yes |
 | cdp | not implemented | yes | not implemented | UTF-8 payloads only, otherwise `CodeSerializationError` |
-| crossmint | `true` | yes | yes | `CodeSigningFailed` |
+| crossmint | `true` | `CodeSigningFailed` | yes | `CodeSigningFailed` |
 | utila | not implemented | yes | not implemented | `CodeSigningFailed` |
 | fordefi (black-box mode) | `false` | yes | `CodeSigningFailed` | yes |
 | fordefi (native mode) | `true` | `CodeSigningFailed` | yes | yes |
 
-Crossmint supports both: it decides per request whether to rewrite and broadcast
-the transaction or to sign the caller's exact bytes, and `SignTransaction`
-exposes that distinction through an empty `EncodedTransaction`.
+Crossmint executes every approved transaction server-side and exposes no
+sign-only API, so it offers `SignAndSendTransaction` only. It may rewrite the
+transaction to sponsor gas, in which case the returned signature identifies the
+transaction it landed rather than covering the caller's bytes; the caller's
+transaction is never modified.
 
 ### Sign and Send
 

--- a/go/signers/crossmint/integration_test.go
+++ b/go/signers/crossmint/integration_test.go
@@ -51,7 +51,7 @@ func TestIntegrationSignMessageNotSupported(t *testing.T) {
 // Signs a minimal empty-instruction transaction with a real blockhash: the
 // backend validates and finalizes the transaction server-side, so this stays
 // focused on remote signing behavior rather than balance/program execution.
-func TestIntegrationSignTransaction(t *testing.T) {
+func TestIntegrationSignAndSendTransaction(t *testing.T) {
 	s := integrationSigner(t)
 
 	rpcURL := os.Getenv("SOLANA_RPC_URL")
@@ -71,24 +71,14 @@ func TestIntegrationSignTransaction(t *testing.T) {
 		},
 	}
 
-	res, err := s.SignTransaction(context.Background(), tx)
+	sig, err := s.SignAndSendTransaction(context.Background(), tx)
 	if err != nil {
-		t.Fatalf("SignTransaction: %v", err)
+		t.Fatalf("SignAndSendTransaction: %v", err)
 	}
-	if len(res.Signature) != core.SignatureLength {
-		t.Fatalf("signature length = %d, want %d", len(res.Signature), core.SignatureLength)
+	if len(sig) != core.SignatureLength {
+		t.Fatalf("signature length = %d, want %d", len(sig), core.SignatureLength)
 	}
-	// Crossmint sponsors gas, so it rewrites the transaction, signs its own bytes
-	// and broadcasts server-side. The signature identifies what it landed and
-	// there is nothing left for the caller to send.
-	if res.EncodedTransaction != "" {
-		t.Error("a Crossmint-broadcast transaction leaves nothing for the caller to send")
-	}
-	for _, sig := range tx.Signatures {
-		if !sig.IsZero() {
-			t.Error("the caller's transaction must not carry a signature over other bytes")
-		}
-	}
+	assertCallerTransactionUntouched(t, tx)
 }
 
 func TestIntegrationIsAvailable(t *testing.T) {

--- a/go/signers/crossmint/signer.go
+++ b/go/signers/crossmint/signer.go
@@ -136,14 +136,20 @@ func (s *Signer) SignMessage(_ context.Context, _ []byte) (solana.Signature, err
 		"Crossmint sign_message is not supported for Solana wallets in this signer")
 }
 
-// SignTransaction submits tx to Crossmint, polls it to completion, and extracts
-// the returned signature.
+// SignTransaction is intentionally unsupported: Crossmint executes every
+// approved transaction server-side and exposes no sign-only API.
+func (s *Signer) SignTransaction(_ context.Context, _ *solana.Transaction) (core.SignedTransaction, error) {
+	return core.SignedTransaction{}, core.NewSignerError(core.CodeSigningFailed,
+		"Crossmint executes every transaction server-side; call SignAndSendTransaction instead")
+}
+
+// SignAndSendTransaction submits tx to Crossmint, polls it to completion, and
+// returns the signature identifying the transaction Crossmint landed.
 //
-// Crossmint may rewrite the transaction to sponsor gas and broadcast it itself.
-// When it does, tx is left unmodified, EncodedTransaction is empty, and the
-// returned signature is the landed transaction's fee-payer identifier, usable
-// with RPC transaction lookups. The wallet's own signature is added to tx only
-// when Crossmint signed it as given.
+// Crossmint may rewrite the transaction to sponsor gas, so the returned
+// signature does not necessarily cover the caller's bytes; it is the landed
+// transaction's identifier, usable with RPC transaction lookups. tx is never
+// modified.
 //
 // Not retry-safe: any failure after the create is accepted returns
 // CodeBroadcastUnconfirmed carrying the Crossmint transaction id; check that
@@ -153,70 +159,46 @@ func (s *Signer) SignMessage(_ context.Context, _ []byte) (solana.Signature, err
 // Each create carries an x-idempotency-key derived from the message bytes, so
 // replaying these exact bytes cannot create a second transaction; a rebuilt
 // transaction derives a different key and executes as a new transfer.
-func (s *Signer) SignTransaction(ctx context.Context, tx *solana.Transaction) (core.SignedTransaction, error) {
-	return s.executeManagedTransaction(ctx, tx)
-}
-
-func (s *Signer) executeManagedTransaction(ctx context.Context, tx *solana.Transaction) (core.SignedTransaction, error) {
+func (s *Signer) SignAndSendTransaction(ctx context.Context, tx *solana.Transaction) (solana.Signature, error) {
 	if s.publicKey.IsZero() {
-		return core.SignedTransaction{}, core.NewNotInitializedError("crossmint")
+		return solana.Signature{}, core.NewNotInitializedError("crossmint")
 	}
 
 	expectedMessage, err := tx.Message.MarshalBinary()
 	if err != nil {
-		return core.SignedTransaction{}, core.WrapSignerError(core.CodeSerializationError, "failed to serialize transaction message", err)
+		return solana.Signature{}, core.WrapSignerError(core.CodeSerializationError, "failed to serialize transaction message", err)
 	}
 	serialized, err := tx.MarshalBinary()
 	if err != nil {
-		return core.SignedTransaction{}, core.WrapSignerError(core.CodeSerializationError, "failed to serialize transaction", err)
+		return solana.Signature{}, core.WrapSignerError(core.CodeSerializationError, "failed to serialize transaction", err)
 	}
 
 	createResponse, err := s.createTransaction(ctx, base58.Encode(serialized), core.IdempotencyKeyFromMessage(expectedMessage))
 	if err != nil {
-		return core.SignedTransaction{}, err
+		return solana.Signature{}, err
 	}
 	// Post-create failures leave an outcome Crossmint may still execute, so
 	// they surface as CodeBroadcastUnconfirmed with the transaction id.
-	signed, err := s.finishManagedTransaction(ctx, tx, createResponse, expectedMessage)
+	sig, err := s.finishManagedTransaction(ctx, createResponse, expectedMessage)
 	if err != nil {
 		detail := err.Error()
 		var se *core.SignerError
 		if errors.As(err, &se) {
 			detail = se.Detail()
 		}
-		return core.SignedTransaction{}, core.NewBroadcastUnconfirmedError(createResponse.ID, detail)
+		return solana.Signature{}, core.NewBroadcastUnconfirmedError(createResponse.ID, detail)
 	}
-	return signed, nil
+	return sig, nil
 }
 
 // finishManagedTransaction polls a created transaction to a terminal status and
-// shapes the signing result from it.
-func (s *Signer) finishManagedTransaction(ctx context.Context, tx *solana.Transaction, createResponse transactionResponse, expectedMessage []byte) (core.SignedTransaction, error) {
+// extracts the signature identifying it.
+func (s *Signer) finishManagedTransaction(ctx context.Context, createResponse transactionResponse, expectedMessage []byte) (solana.Signature, error) {
 	finalResponse, err := s.pollTransaction(ctx, createResponse)
-	if err != nil {
-		return core.SignedTransaction{}, err
-	}
-	sig, broadcast, err := s.extractSignatureFromResponse(finalResponse, expectedMessage)
-	if err != nil {
-		return core.SignedTransaction{}, err
-	}
-
-	if broadcast != nil {
-		// Already landed, so complete regardless of the slots the returned copy
-		// shows filled, and nothing is left for the caller to send.
-		return core.SignedTransaction{Signature: sig, Completeness: core.Complete}, nil
-	}
-
-	return core.AttachSignature(tx, s.publicKey, sig)
-}
-
-// SignAndSendTransaction signs tx and lets Crossmint execute it.
-func (s *Signer) SignAndSendTransaction(ctx context.Context, tx *solana.Transaction) (solana.Signature, error) {
-	signed, err := s.executeManagedTransaction(ctx, tx)
 	if err != nil {
 		return solana.Signature{}, err
 	}
-	return signed.Signature, nil
+	return s.extractSignatureFromResponse(finalResponse, expectedMessage)
 }
 
 // IsAvailable reports whether the Crossmint wallet can be fetched within the
@@ -347,14 +329,15 @@ func broadcastTransactionID(tx *solana.Transaction) (solana.Signature, error) {
 	return tx.Signatures[0], nil
 }
 
-// extractSignatureFromResponse pulls this wallet's signature out of a terminal
-// transaction response, along with the broadcast transaction when Crossmint
-// rewrote one: the serialized onChain.transaction is tried first, with onChain.txId
-// as a fallback when Crossmint does not return a decodable transaction.
+// extractSignatureFromResponse pulls the signature identifying the transaction
+// Crossmint landed out of a terminal transaction response: the serialized
+// onChain.transaction is tried first, with onChain.txId as a fallback when
+// Crossmint does not return a decodable transaction.
 //
-// A non-nil transaction means Crossmint landed different bytes than the caller's;
-// the signature is then the landed transaction's fee-payer identifier.
-func (s *Signer) extractSignatureFromResponse(response transactionResponse, expectedMessage []byte) (solana.Signature, *solana.Transaction, error) {
+// When Crossmint landed different bytes than the caller's, the signature is the
+// landed transaction's fee-payer identifier rather than a signature over the
+// caller's message.
+func (s *Signer) extractSignatureFromResponse(response transactionResponse, expectedMessage []byte) (solana.Signature, error) {
 	if response.OnChain != nil {
 		if response.OnChain.Transaction != nil {
 			sig, returned, err := s.extractSignatureFromSerializedTransaction(*response.OnChain.Transaction)
@@ -362,20 +345,16 @@ func (s *Signer) extractSignatureFromResponse(response transactionResponse, expe
 			case err == nil:
 				returnedMessage, marshalErr := returned.Message.MarshalBinary()
 				if marshalErr != nil {
-					return solana.Signature{}, nil, core.WrapSignerError(core.CodeSerializationError,
+					return solana.Signature{}, core.WrapSignerError(core.CodeSerializationError,
 						"failed to serialize Crossmint transaction message", marshalErr)
 				}
 				if bytes.Equal(returnedMessage, expectedMessage) {
-					return sig, nil, nil
+					return sig, nil
 				}
-				txID, idErr := broadcastTransactionID(returned)
-				if idErr != nil {
-					return solana.Signature{}, nil, idErr
-				}
-				return txID, returned, nil
+				return broadcastTransactionID(returned)
 			case true:
 				if response.OnChain.TxID == nil {
-					return solana.Signature{}, nil, err
+					return solana.Signature{}, err
 				}
 			}
 		}
@@ -383,14 +362,14 @@ func (s *Signer) extractSignatureFromResponse(response transactionResponse, expe
 		if response.OnChain.TxID != nil {
 			sig, ok := decodeBase58Signature(*response.OnChain.TxID)
 			if !ok {
-				return solana.Signature{}, nil, core.NewSignerError(core.CodeSigningFailed,
+				return solana.Signature{}, core.NewSignerError(core.CodeSigningFailed,
 					"Crossmint onChain.txId was not a valid Solana signature")
 			}
-			return sig, nil, nil
+			return sig, nil
 		}
 	}
 
-	return solana.Signature{}, nil, core.NewSignerError(core.CodeSigningFailed,
+	return solana.Signature{}, core.NewSignerError(core.CodeSigningFailed,
 		"unable to extract signature from Crossmint transaction response")
 }
 

--- a/go/signers/crossmint/signer_test.go
+++ b/go/signers/crossmint/signer_test.go
@@ -94,6 +94,34 @@ func newTestSigner(t *testing.T, cfg Config) *Signer {
 	return s
 }
 
+func assertCallerTransactionUntouched(t *testing.T, tx *solana.Transaction) {
+	t.Helper()
+	for _, sig := range tx.Signatures {
+		if !sig.IsZero() {
+			t.Error("Crossmint broadcasts server-side, so the caller's transaction must stay unsigned")
+		}
+	}
+}
+
+// Crossmint has no sign-only API: an approved transaction is always executed
+// server-side, so a caller asking for signature-only work must be refused
+// rather than handed a transaction that has already landed.
+func TestSignTransactionIsRejected(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET "+testWalletPath, walletHandler(t, testAPIKey, testutils.TestPublicKey().String()))
+	srv := testutils.StartTLSServer(t, mux)
+	s := newTestSigner(t, baseConfig(srv))
+
+	tx, err := testutils.CreateTestTransaction(testutils.TestPublicKey())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = s.SignTransaction(context.Background(), tx)
+	testutils.AssertCode(t, err, core.CodeSigningFailed)
+	assertCallerTransactionUntouched(t, tx)
+}
+
 // TestBuildWalletsAPIURL: raw slashes, dot segments, pre-encoded traversal
 // sequences, and query/fragment metacharacters in a wallet locator must all
 // stay inside a single encoded path segment.
@@ -310,7 +338,7 @@ func TestSignMessageNotSupported(t *testing.T) {
 	}
 }
 
-func TestSignTransactionSuccess(t *testing.T) {
+func TestSignAndSendTransactionSuccess(t *testing.T) {
 	priv := testutils.TestPrivateKey()
 	signerPubkey := testutils.PubkeyOf(priv)
 
@@ -357,26 +385,14 @@ func TestSignTransactionSuccess(t *testing.T) {
 	srv := testutils.StartTLSServer(t, mux)
 
 	s := newTestSigner(t, baseConfig(srv))
-	res, err := s.SignTransaction(context.Background(), localTx)
+	sig, err := s.SignAndSendTransaction(context.Background(), localTx)
 	if err != nil {
-		t.Fatalf("SignTransaction: %v (detail: %s)", err, testutils.Detail(t, err))
+		t.Fatalf("SignAndSendTransaction: %v (detail: %s)", err, testutils.Detail(t, err))
 	}
-	if res.Signature != expectedSignature {
-		t.Errorf("signature = %s, want %s", res.Signature, expectedSignature)
+	if sig != expectedSignature {
+		t.Errorf("signature = %s, want %s", sig, expectedSignature)
 	}
-	if res.EncodedTransaction == "" {
-		t.Error("encoded transaction should not be empty")
-	}
-	if !res.IsComplete() {
-		t.Error("single-signer transaction should be Complete")
-	}
-	decoded, err := solana.TransactionFromBase64(res.EncodedTransaction)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if decoded.Signatures[0] != expectedSignature {
-		t.Error("encoded transaction signature mismatch at position 0")
-	}
+	assertCallerTransactionUntouched(t, localTx)
 }
 
 // createStatusSigner points a signer at a create endpoint answering status/body.
@@ -413,7 +429,7 @@ func TestCreateServerErrorIsUnconfirmedWithoutID(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = s.SignTransaction(context.Background(), tx)
+	_, err = s.SignAndSendTransaction(context.Background(), tx)
 	assertUnconfirmedWithoutID(t, err, http.StatusServiceUnavailable)
 }
 
@@ -423,7 +439,7 @@ func TestCreateAcceptedWithoutIDIsUnconfirmed(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = s.SignTransaction(context.Background(), tx)
+	_, err = s.SignAndSendTransaction(context.Background(), tx)
 	assertUnconfirmedWithoutID(t, err, 0)
 }
 
@@ -433,14 +449,14 @@ func TestCreateRejectionStaysPlainFailure(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = s.SignTransaction(context.Background(), tx)
+	_, err = s.SignAndSendTransaction(context.Background(), tx)
 	testutils.AssertCode(t, err, core.CodeRemoteAPIError)
 }
 
 // TestSignTransactionRejectsApprovalSignaturesForLocalTransactionBytes:
 // approval signatures (over Crossmint's internal payload) must never be used
 // as the transaction signature.
-func TestSignTransactionRejectsApprovalSignaturesForLocalTransactionBytes(t *testing.T) {
+func TestSignAndSendTransactionRejectsApprovalSignaturesForLocalTransactionBytes(t *testing.T) {
 	priv := testutils.TestPrivateKey()
 	signerPubkey := testutils.PubkeyOf(priv)
 
@@ -464,7 +480,7 @@ func TestSignTransactionRejectsApprovalSignaturesForLocalTransactionBytes(t *tes
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = s.SignTransaction(context.Background(), tx)
+	_, err = s.SignAndSendTransaction(context.Background(), tx)
 	testutils.AssertCode(t, err, core.CodeBroadcastUnconfirmed)
 	if detail := testutils.Detail(t, err); !strings.Contains(detail, "unable to extract signature") {
 		t.Errorf("detail = %q, want it to contain %q", detail, "unable to extract signature")
@@ -473,7 +489,7 @@ func TestSignTransactionRejectsApprovalSignaturesForLocalTransactionBytes(t *tes
 
 // TestSignTransactionAcceptsSignatureFromOnChainTransactionBytes extracts the
 // returned fee-payer signature even when Crossmint modified the transaction.
-func TestSignTransactionAcceptsSignatureFromOnChainTransactionBytes(t *testing.T) {
+func TestSignAndSendTransactionAcceptsSignatureFromOnChainTransactionBytes(t *testing.T) {
 	priv := testutils.TestPrivateKey()
 	signerPubkey := testutils.PubkeyOf(priv)
 
@@ -498,31 +514,24 @@ func TestSignTransactionAcceptsSignatureFromOnChainTransactionBytes(t *testing.T
 	if err != nil {
 		t.Fatal(err)
 	}
-	res, err := s.SignTransaction(context.Background(), localTx)
+	sig, err := s.SignAndSendTransaction(context.Background(), localTx)
 	if err != nil {
-		t.Fatalf("SignTransaction: %v (detail: %s)", err, testutils.Detail(t, err))
+		t.Fatalf("SignAndSendTransaction: %v (detail: %s)", err, testutils.Detail(t, err))
 	}
-	if res.Signature != remoteSignature {
-		t.Errorf("signature = %s, want %s", res.Signature, remoteSignature)
+	if sig != remoteSignature {
+		t.Errorf("signature = %s, want %s", sig, remoteSignature)
 	}
 	// Crossmint sponsors gas, so it is the fee payer and the message it signs
 	// differs from the caller's. Its signature must never be placed in the
 	// caller's transaction, which could not verify with it.
-	if res.EncodedTransaction != "" {
-		t.Error("a Crossmint-broadcast transaction leaves nothing for the caller to send")
-	}
-	for _, sig := range localTx.Signatures {
-		if !sig.IsZero() {
-			t.Error("the caller's transaction must not carry a signature over other bytes")
-		}
-	}
+	assertCallerTransactionUntouched(t, localTx)
 }
 
 // A returned transaction whose message matches the submitted one really is signed
 // over the caller's bytes, so the signature belongs in the caller's transaction.
 // A smart wallet is signed by its delegated signer, not by the wallet address the
 // API reports, so the delegated key's returned signature is accepted.
-func TestSignTransactionLocatesDelegatedSignerSignature(t *testing.T) {
+func TestSignAndSendTransactionLocatesDelegatedSignerSignature(t *testing.T) {
 	secret := signerSecretPrefix + strings.Repeat("ab", 32)
 	derivableAPIKey := "sk_staging_" + base58.Encode([]byte("proj:sig"))
 	delegatedPriv, err := deriveSigningKey(secret, derivableAPIKey)
@@ -569,12 +578,12 @@ func TestSignTransactionLocatesDelegatedSignerSignature(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	res, err := s.SignTransaction(context.Background(), localTx)
+	sig, err := s.SignAndSendTransaction(context.Background(), localTx)
 	if err != nil {
-		t.Fatalf("SignTransaction: %v (detail: %s)", err, testutils.Detail(t, err))
+		t.Fatalf("SignAndSendTransaction: %v (detail: %s)", err, testutils.Detail(t, err))
 	}
-	if res.Signature != expectedSignature {
-		t.Errorf("signature = %s, want %s", res.Signature, expectedSignature)
+	if sig != expectedSignature {
+		t.Errorf("signature = %s, want %s", sig, expectedSignature)
 	}
 	if !s.Pubkey().Equals(walletPub) {
 		t.Error("the wallet address remains the signer's public identity")
@@ -583,7 +592,7 @@ func TestSignTransactionLocatesDelegatedSignerSignature(t *testing.T) {
 
 // Under sponsorship the returned signature must be the sponsor fee-payer's
 // slot-0 signature, not the wallet's approval, so RPC lookups resolve.
-func TestSignTransactionSponsoredReturnsFeePayerTransactionID(t *testing.T) {
+func TestSignAndSendTransactionSponsoredReturnsFeePayerTransactionID(t *testing.T) {
 	secret := signerSecretPrefix + strings.Repeat("cd", 32)
 	derivableAPIKey := "sk_staging_" + base58.Encode([]byte("proj:sig"))
 	delegatedPriv, err := deriveSigningKey(secret, derivableAPIKey)
@@ -630,25 +639,23 @@ func TestSignTransactionSponsoredReturnsFeePayerTransactionID(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	res, err := s.SignTransaction(context.Background(), localTx)
+	sig, err := s.SignAndSendTransaction(context.Background(), localTx)
 	if err != nil {
-		t.Fatalf("SignTransaction: %v (detail: %s)", err, testutils.Detail(t, err))
+		t.Fatalf("SignAndSendTransaction: %v (detail: %s)", err, testutils.Detail(t, err))
 	}
-	if res.Signature != feePayerSignature {
-		t.Errorf("signature = %s, want fee payer %s", res.Signature, feePayerSignature)
+	if sig != feePayerSignature {
+		t.Errorf("signature = %s, want fee payer %s", sig, feePayerSignature)
 	}
-	if res.Signature == approvalSignature {
+	if sig == approvalSignature {
 		t.Error("the approval signature must not be returned as the transaction id")
 	}
-	if res.EncodedTransaction != "" {
-		t.Error("a Crossmint-broadcast transaction leaves nothing for the caller to send")
-	}
+	assertCallerTransactionUntouched(t, localTx)
 }
 
 // A wallet can be configured with both SignerSecret and an explicit Signer locator
 // naming a different key, e.g. the wallet's admin signer. Either may be the key
 // that actually signs, so either returned signature is accepted.
-func TestSignTransactionExplicitLocatorSignerIsACandidate(t *testing.T) {
+func TestSignAndSendTransactionExplicitLocatorSignerIsACandidate(t *testing.T) {
 	walletPub := testutils.TestPublicKey()
 	adminPriv := ed25519.NewKeyFromSeed(bytes.Repeat([]byte{0x7c}, ed25519.SeedSize))
 	admin := solana.PublicKeyFromBytes(adminPriv.Public().(ed25519.PublicKey))
@@ -688,17 +695,17 @@ func TestSignTransactionExplicitLocatorSignerIsACandidate(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	res, err := s.SignTransaction(context.Background(), localTx)
+	sig, err := s.SignAndSendTransaction(context.Background(), localTx)
 	if err != nil {
-		t.Fatalf("SignTransaction: %v (detail: %s)", err, testutils.Detail(t, err))
+		t.Fatalf("SignAndSendTransaction: %v (detail: %s)", err, testutils.Detail(t, err))
 	}
-	if res.Signature != expectedSignature {
-		t.Errorf("signature = %s, want %s", res.Signature, expectedSignature)
+	if sig != expectedSignature {
+		t.Errorf("signature = %s, want %s", sig, expectedSignature)
 	}
 }
 
 // Crossmint's returned transaction is trusted as the provider's broadcast result.
-func TestSignTransactionAcceptsUnrelatedSignerKey(t *testing.T) {
+func TestSignAndSendTransactionAcceptsUnrelatedSignerKey(t *testing.T) {
 	walletPub := testutils.TestPublicKey()
 	strangerPriv := ed25519.NewKeyFromSeed(bytes.Repeat([]byte{0x5a}, ed25519.SeedSize))
 	stranger := solana.PublicKeyFromBytes(strangerPriv.Public().(ed25519.PublicKey))
@@ -738,19 +745,17 @@ func TestSignTransactionAcceptsUnrelatedSignerKey(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	res, err := s.SignTransaction(context.Background(), localTx)
+	sig, err := s.SignAndSendTransaction(context.Background(), localTx)
 	if err != nil {
-		t.Fatalf("SignTransaction: %v (detail: %s)", err, testutils.Detail(t, err))
+		t.Fatalf("SignAndSendTransaction: %v (detail: %s)", err, testutils.Detail(t, err))
 	}
-	if res.Signature != signature {
-		t.Errorf("signature = %s, want %s", res.Signature, signature)
+	if sig != signature {
+		t.Errorf("signature = %s, want %s", sig, signature)
 	}
-	if res.EncodedTransaction != "" {
-		t.Error("a Crossmint-broadcast transaction leaves nothing for the caller to send")
-	}
+	assertCallerTransactionUntouched(t, localTx)
 }
 
-func TestSignTransactionUnrewrittenTransactionSignsCallerBytes(t *testing.T) {
+func TestSignAndSendTransactionUnrewrittenTransactionSignsCallerBytes(t *testing.T) {
 	priv := testutils.TestPrivateKey()
 	signerPubkey := testutils.PubkeyOf(priv)
 
@@ -776,19 +781,17 @@ func TestSignTransactionUnrewrittenTransactionSignsCallerBytes(t *testing.T) {
 	cfg.MaxPollAttempts = 1
 	s := newTestSigner(t, cfg)
 
-	res, err := s.SignTransaction(context.Background(), localTx)
+	sig, err := s.SignAndSendTransaction(context.Background(), localTx)
 	if err != nil {
-		t.Fatalf("SignTransaction: %v (detail: %s)", err, testutils.Detail(t, err))
+		t.Fatalf("SignAndSendTransaction: %v (detail: %s)", err, testutils.Detail(t, err))
 	}
-	if res.EncodedTransaction == "" {
-		t.Error("an unrewritten transaction is the caller's to broadcast")
+	if sig != expectedSignature {
+		t.Errorf("signature = %s, want %s", sig, expectedSignature)
 	}
-	if len(localTx.Signatures) == 0 || localTx.Signatures[0] != expectedSignature {
-		t.Error("the signature covers the caller's bytes and belongs in its transaction")
-	}
+	assertCallerTransactionUntouched(t, localTx)
 }
 
-func TestSignTransactionPrefersOnChainTransactionSignatureOverTxIDFallback(t *testing.T) {
+func TestSignAndSendTransactionPrefersOnChainTransactionSignatureOverTxIDFallback(t *testing.T) {
 	priv := testutils.TestPrivateKey()
 	signerPubkey := testutils.PubkeyOf(priv)
 
@@ -815,18 +818,18 @@ func TestSignTransactionPrefersOnChainTransactionSignatureOverTxIDFallback(t *te
 	if err != nil {
 		t.Fatal(err)
 	}
-	res, err := s.SignTransaction(context.Background(), localTx)
+	sig, err := s.SignAndSendTransaction(context.Background(), localTx)
 	if err != nil {
-		t.Fatalf("SignTransaction: %v (detail: %s)", err, testutils.Detail(t, err))
+		t.Fatalf("SignAndSendTransaction: %v (detail: %s)", err, testutils.Detail(t, err))
 	}
-	if res.Signature != remoteSignature {
-		t.Errorf("signature = %s, want %s", res.Signature, remoteSignature)
+	if sig != remoteSignature {
+		t.Errorf("signature = %s, want %s", sig, remoteSignature)
 	}
 }
 
 // TestSignTransactionAwaitingApproval: without a configured signer secret,
 // awaiting-approval is a terminal failure.
-func TestSignTransactionAwaitingApproval(t *testing.T) {
+func TestSignAndSendTransactionAwaitingApproval(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET "+testWalletPath, walletHandler(t, testAPIKey, testutils.TestPublicKey().String()))
 	mux.HandleFunc("POST "+testWalletPath+"/transactions", func(w http.ResponseWriter, _ *http.Request) {
@@ -840,7 +843,7 @@ func TestSignTransactionAwaitingApproval(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = s.SignTransaction(context.Background(), tx)
+	_, err = s.SignAndSendTransaction(context.Background(), tx)
 	testutils.AssertCode(t, err, core.CodeBroadcastUnconfirmed)
 	if detail := testutils.Detail(t, err); !strings.Contains(detail, "awaiting approval") {
 		t.Errorf("detail = %q, want it to contain %q", detail, "awaiting approval")
@@ -849,7 +852,7 @@ func TestSignTransactionAwaitingApproval(t *testing.T) {
 
 // TestSignTransactionSuccessOnLastPolledResponse: a success arriving on the
 // final poll attempt is still honored.
-func TestSignTransactionSuccessOnLastPolledResponse(t *testing.T) {
+func TestSignAndSendTransactionSuccessOnLastPolledResponse(t *testing.T) {
 	priv := testutils.TestPrivateKey()
 	signerPubkey := testutils.PubkeyOf(priv)
 
@@ -881,18 +884,18 @@ func TestSignTransactionSuccessOnLastPolledResponse(t *testing.T) {
 	cfg.MaxPollAttempts = 1
 	s := newTestSigner(t, cfg)
 
-	res, err := s.SignTransaction(context.Background(), tx)
+	sig, err := s.SignAndSendTransaction(context.Background(), tx)
 	if err != nil {
-		t.Fatalf("SignTransaction: %v (detail: %s)", err, testutils.Detail(t, err))
+		t.Fatalf("SignAndSendTransaction: %v (detail: %s)", err, testutils.Detail(t, err))
 	}
-	if res.Signature != expectedSignature {
-		t.Errorf("signature = %s, want %s", res.Signature, expectedSignature)
+	if sig != expectedSignature {
+		t.Errorf("signature = %s, want %s", sig, expectedSignature)
 	}
 }
 
 // TestSignTransactionFailedStatus covers the "failed" terminal status: the
 // remote error payload is surfaced (sanitized) in the SigningFailed detail.
-func TestSignTransactionFailedStatus(t *testing.T) {
+func TestSignAndSendTransactionFailedStatus(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET "+testWalletPath, walletHandler(t, testAPIKey, testutils.TestPublicKey().String()))
 	mux.HandleFunc("POST "+testWalletPath+"/transactions", func(w http.ResponseWriter, _ *http.Request) {
@@ -906,7 +909,7 @@ func TestSignTransactionFailedStatus(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = s.SignTransaction(context.Background(), tx)
+	_, err = s.SignAndSendTransaction(context.Background(), tx)
 	testutils.AssertCode(t, err, core.CodeBroadcastUnconfirmed)
 	detail := testutils.Detail(t, err)
 	if !strings.Contains(detail, "Crossmint transaction failed") || !strings.Contains(detail, "insufficient funds") {
@@ -915,7 +918,7 @@ func TestSignTransactionFailedStatus(t *testing.T) {
 }
 
 // TestSignTransactionPollingTimesOut covers the poll-exhaustion path.
-func TestSignTransactionPollingTimesOut(t *testing.T) {
+func TestSignAndSendTransactionPollingTimesOut(t *testing.T) {
 	pending := `{"id":"tx-123","status":"pending"}`
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET "+testWalletPath, walletHandler(t, testAPIKey, testutils.TestPublicKey().String()))
@@ -932,7 +935,7 @@ func TestSignTransactionPollingTimesOut(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = s.SignTransaction(context.Background(), tx)
+	_, err = s.SignAndSendTransaction(context.Background(), tx)
 	testutils.AssertCode(t, err, core.CodeBroadcastUnconfirmed)
 	if detail := testutils.Detail(t, err); !strings.Contains(detail, "polling timed out after 2 attempts") {
 		t.Errorf("detail = %q, want it to contain %q", detail, "polling timed out after 2 attempts")
@@ -973,7 +976,7 @@ func TestCreateTransactionRemoteAPIError(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			_, err = s.SignTransaction(context.Background(), tx)
+			_, err = s.SignAndSendTransaction(context.Background(), tx)
 			testutils.AssertCode(t, err, core.CodeRemoteAPIError)
 			if detail := testutils.Detail(t, err); !strings.Contains(detail, tc.wantIn) {
 				t.Errorf("detail = %q, want it to contain %q", detail, tc.wantIn)
@@ -1014,7 +1017,7 @@ func TestRemoteAPIErrorSanitizesHostileBody(t *testing.T) {
 // flow: HKDF key derivation from the signer secret + API key, the
 // "server:<pubkey>" locator, and approval submission for an awaiting-approval
 // transaction.
-func TestSignTransactionSubmitsApprovalWithDerivedKey(t *testing.T) {
+func TestSignAndSendTransactionSubmitsApprovalWithDerivedKey(t *testing.T) {
 	priv := testutils.TestPrivateKey()
 	signerPubkey := testutils.PubkeyOf(priv)
 
@@ -1089,12 +1092,12 @@ func TestSignTransactionSubmitsApprovalWithDerivedKey(t *testing.T) {
 	cfg.MaxPollAttempts = 3
 	s := newTestSigner(t, cfg)
 
-	res, err := s.SignTransaction(context.Background(), localTx)
+	sig, err := s.SignAndSendTransaction(context.Background(), localTx)
 	if err != nil {
-		t.Fatalf("SignTransaction: %v (detail: %s)", err, testutils.Detail(t, err))
+		t.Fatalf("SignAndSendTransaction: %v (detail: %s)", err, testutils.Detail(t, err))
 	}
-	if res.Signature != expectedSignature {
-		t.Errorf("signature = %s, want %s", res.Signature, expectedSignature)
+	if sig != expectedSignature {
+		t.Errorf("signature = %s, want %s", sig, expectedSignature)
 	}
 	if got := approvalCalls.Load(); got != 1 {
 		t.Errorf("approval endpoint called %d times, want 1", got)
@@ -1104,7 +1107,7 @@ func TestSignTransactionSubmitsApprovalWithDerivedKey(t *testing.T) {
 // TestSignTransactionAwaitingApprovalNoPendingMessage: with a derived signer
 // key and a pending challenge addressed to it but carrying no message, signing
 // fails.
-func TestSignTransactionAwaitingApprovalNoPendingMessage(t *testing.T) {
+func TestSignAndSendTransactionAwaitingApprovalNoPendingMessage(t *testing.T) {
 	apiKey := "sk_staging_" + base58.Encode([]byte("project-123:signature-data"))
 	secret := signerSecretPrefix + strings.Repeat("4d", 32)
 	derivedKey, err := deriveSigningKey(secret, apiKey)
@@ -1131,7 +1134,7 @@ func TestSignTransactionAwaitingApprovalNoPendingMessage(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = s.SignTransaction(context.Background(), tx)
+	_, err = s.SignAndSendTransaction(context.Background(), tx)
 	testutils.AssertCode(t, err, core.CodeBroadcastUnconfirmed)
 	if detail := testutils.Detail(t, err); !strings.Contains(detail, "no pending message found") {
 		t.Errorf("detail = %q, want it to contain %q", detail, "no pending message found")
@@ -1149,7 +1152,7 @@ func attachApprovalSigner(s *Signer, locator string, key ed25519.PrivateKey) {
 // when Crossmint acknowledges the approval but still reports awaiting-approval
 // (async registration), the signer must not re-submit; it keeps polling until
 // the transaction succeeds.
-func TestSignTransactionSubmitsApprovalOnceAndPollsAfterAsyncRegistration(t *testing.T) {
+func TestSignAndSendTransactionSubmitsApprovalOnceAndPollsAfterAsyncRegistration(t *testing.T) {
 	priv := testutils.TestPrivateKey()
 	signerPubkey := testutils.PubkeyOf(priv)
 	locator := "server:test-approver"
@@ -1193,12 +1196,12 @@ func TestSignTransactionSubmitsApprovalOnceAndPollsAfterAsyncRegistration(t *tes
 	s := newTestSigner(t, cfg)
 	attachApprovalSigner(s, locator, approvalKey)
 
-	res, err := s.SignTransaction(context.Background(), tx)
+	sig, err := s.SignAndSendTransaction(context.Background(), tx)
 	if err != nil {
-		t.Fatalf("SignTransaction: %v (detail: %s)", err, testutils.Detail(t, err))
+		t.Fatalf("SignAndSendTransaction: %v (detail: %s)", err, testutils.Detail(t, err))
 	}
-	if res.Signature != expectedSignature {
-		t.Errorf("signature = %s, want %s", res.Signature, expectedSignature)
+	if sig != expectedSignature {
+		t.Errorf("signature = %s, want %s", sig, expectedSignature)
 	}
 	if got := approvalCalls.Load(); got != 1 {
 		t.Errorf("approval endpoint called %d times, want 1", got)
@@ -1208,7 +1211,7 @@ func TestSignTransactionSubmitsApprovalOnceAndPollsAfterAsyncRegistration(t *tes
 // TestSignTransactionSelectsPendingApprovalMatchingSignerLocator: on a
 // multi-approver wallet only the pending challenge addressed to this signer's
 // locator is signed, never pending[0].
-func TestSignTransactionSelectsPendingApprovalMatchingSignerLocator(t *testing.T) {
+func TestSignAndSendTransactionSelectsPendingApprovalMatchingSignerLocator(t *testing.T) {
 	priv := testutils.TestPrivateKey()
 	signerPubkey := testutils.PubkeyOf(priv)
 	locator := "server:test-approver"
@@ -1271,12 +1274,12 @@ func TestSignTransactionSelectsPendingApprovalMatchingSignerLocator(t *testing.T
 	s := newTestSigner(t, cfg)
 	attachApprovalSigner(s, locator, approvalKey)
 
-	res, err := s.SignTransaction(context.Background(), tx)
+	sig, err := s.SignAndSendTransaction(context.Background(), tx)
 	if err != nil {
-		t.Fatalf("SignTransaction: %v (detail: %s)", err, testutils.Detail(t, err))
+		t.Fatalf("SignAndSendTransaction: %v (detail: %s)", err, testutils.Detail(t, err))
 	}
-	if res.Signature != expectedTxSignature {
-		t.Errorf("signature = %s, want %s", res.Signature, expectedTxSignature)
+	if sig != expectedTxSignature {
+		t.Errorf("signature = %s, want %s", sig, expectedTxSignature)
 	}
 	if got := approvalCalls.Load(); got != 1 {
 		t.Errorf("approval endpoint called %d times, want 1", got)
@@ -1399,7 +1402,7 @@ func TestStringDoesNotLeakSecrets(t *testing.T) {
 // An unsigned transaction is serialized as a zero placeholder signature per
 // required signer followed by the message bytes; the transaction posted to
 // Crossmint must use exactly that wire encoding.
-func TestSignTransactionSendsPlaceholderSignatures(t *testing.T) {
+func TestSignAndSendTransactionSendsPlaceholderSignatures(t *testing.T) {
 	priv := testutils.TestPrivateKey()
 	signerPubkey := testutils.PubkeyOf(priv)
 
@@ -1435,8 +1438,8 @@ func TestSignTransactionSendsPlaceholderSignatures(t *testing.T) {
 	srv := testutils.StartTLSServer(t, mux)
 
 	s := newTestSigner(t, baseConfig(srv))
-	if _, err := s.SignTransaction(context.Background(), localTx); err != nil {
-		t.Fatalf("SignTransaction: %v (detail: %s)", err, testutils.Detail(t, err))
+	if _, err := s.SignAndSendTransaction(context.Background(), localTx); err != nil {
+		t.Fatalf("SignAndSendTransaction: %v (detail: %s)", err, testutils.Detail(t, err))
 	}
 
 	posted, err := base58.Decode(postedB58)

--- a/python/README.md
+++ b/python/README.md
@@ -145,14 +145,16 @@ runtime; the second is fixed per backend:
 |---------|---------------------------|--------------------|-----------------------------|----------------|
 | memory, vault, privy, turnkey, aws-kms, fireblocks, gcp-kms, dfns, para, openfort | False | yes | `SIGNING_FAILED` | yes |
 | cdp | False | yes | `SIGNING_FAILED` | UTF-8 payloads only, otherwise `SERIALIZATION_ERROR` |
-| crossmint | True | yes | yes | `SIGNING_FAILED` |
+| crossmint | True | `SIGNING_FAILED` | yes | `SIGNING_FAILED` |
 | utila | False | yes | `SIGNING_FAILED` | `SIGNING_FAILED` |
 | fordefi (black-box mode) | False | yes | `SIGNING_FAILED` | yes |
 | fordefi (native mode) | True | `SIGNING_FAILED` | yes | yes |
 
-Crossmint supports both: it decides per request whether to rewrite and broadcast
-the transaction or to sign the caller's exact bytes, and `sign_transaction`
-exposes that distinction through an empty ``encoded_transaction``.
+Crossmint executes every approved transaction server-side and exposes no
+sign-only API, so it offers `sign_and_send_transaction` only. It may rewrite the
+transaction to sponsor gas, in which case the returned signature identifies the
+transaction it landed rather than covering the caller's bytes; the caller's
+transaction is never modified.
 
 ### Sign and Send
 

--- a/python/src/solana_keychain/crossmint/signer.py
+++ b/python/src/solana_keychain/crossmint/signer.py
@@ -30,10 +30,7 @@ from solana_keychain.core.signer import (
 )
 from solana_keychain.core.transaction_util import (
     ED25519_SIGNATURE_LENGTH,
-    add_signature_to_transaction,
-    classify_signed_transaction,
     idempotency_key_from_message,
-    serialize_transaction,
     signed_message_bytes,
 )
 from solana_keychain.crossmint.derive import derive_signing_key
@@ -422,12 +419,12 @@ class CrossmintSigner(SolanaSigner):
 
     def _extract_signature_from_response(
         self, response: dict[str, Any], expected_message: bytes
-    ) -> tuple[Signature, VersionedTransaction | None]:
-        """The signing result, plus the broadcast transaction when Crossmint rewrote one.
+    ) -> Signature:
+        """The signature identifying the transaction Crossmint landed.
 
-        A non-``None`` transaction means Crossmint changed the message before
-        signing and broadcast the result server-side; the signature is then the
-        landed transaction's fee-payer identifier.
+        When Crossmint changed the message before signing, this is the landed
+        transaction's fee-payer identifier rather than a signature over the
+        caller's message.
         """
         on_chain = response.get("onChain")
         if isinstance(on_chain, dict):
@@ -442,8 +439,8 @@ class CrossmintSigner(SolanaSigner):
                         raise
                 else:
                     if self._executed_message_bytes(returned) == expected_message:
-                        return signature, None
-                    return self._broadcast_transaction_id(returned), returned
+                        return signature
+                    return self._broadcast_transaction_id(returned)
 
             tx_id = on_chain.get("txId")
             if isinstance(tx_id, str):
@@ -457,7 +454,7 @@ class CrossmintSigner(SolanaSigner):
                         SignerErrorCode.SIGNING_FAILED,
                         "Crossmint onChain.txId was not a valid Solana signature",
                     ) from None
-                return signature, None
+                return signature
 
         raise SignerError(
             SignerErrorCode.SIGNING_FAILED,
@@ -465,32 +462,14 @@ class CrossmintSigner(SolanaSigner):
         )
 
     async def sign_transaction(self, transaction: VersionedTransaction) -> SignedTransaction:
-        """Sign ``transaction`` through Crossmint's managed wallet flow.
+        raise SignerError(
+            SignerErrorCode.SIGNING_FAILED,
+            "Crossmint executes every transaction server-side; "
+            "call sign_and_send_transaction instead",
+        )
 
-        Crossmint may rewrite the transaction (it sponsors gas, so it becomes the
-        fee payer) and broadcast it itself. When it does, ``transaction`` is left
-        unmodified and ``encoded_transaction`` is empty: the returned signature is
-        the landed transaction's fee-payer signature, usable with RPC transaction
-        lookups, and it does not cover the caller's message. Only when Crossmint
-        signs the caller's exact bytes is the signature placed in ``transaction``.
-
-        Not retry-safe: any failure after the create is accepted raises
-        ``BROADCAST_UNCONFIRMED`` carrying ``provider_transaction_id``; check
-        that transaction with Crossmint before retrying. A create that fails
-        without a usable response raises ``BROADCAST_UNCONFIRMED`` with no
-        ``provider_transaction_id``.
-
-        Each create carries an ``x-idempotency-key`` derived from the message
-        bytes, so replaying these exact bytes cannot create a second
-        transaction; a rebuilt transaction derives a different key and executes
-        as a new transfer.
-        """
-        return await self._execute_managed_transaction(transaction)
-
-    async def _execute_managed_transaction(
-        self, transaction: VersionedTransaction
-    ) -> SignedTransaction:
-        public_key = self._initialized_pubkey()
+    async def _execute_managed_transaction(self, transaction: VersionedTransaction) -> Signature:
+        self._initialized_pubkey()
         expected_message = signed_message_bytes(transaction.message)
         transaction_b58 = base58.b58encode(bytes(transaction)).decode("ascii")
 
@@ -501,9 +480,7 @@ class CrossmintSigner(SolanaSigner):
         # Post-create failures leave an outcome Crossmint may still execute, so
         # they surface as BROADCAST_UNCONFIRMED with the transaction id.
         try:
-            return await self._finish_managed_transaction(
-                create_response, transaction, expected_message, public_key
-            )
+            return await self._finish_managed_transaction(create_response, expected_message)
         except asyncio.CancelledError as error:
             # Awaiting a cancelled task strips the raised instance, so the id is
             # also logged; the re-raise must stay a CancelledError for asyncio.
@@ -523,32 +500,31 @@ class CrossmintSigner(SolanaSigner):
             ) from None
 
     async def _finish_managed_transaction(
-        self,
-        create_response: dict[str, Any],
-        transaction: VersionedTransaction,
-        expected_message: bytes,
-        public_key: Pubkey,
-    ) -> SignedTransaction:
+        self, create_response: dict[str, Any], expected_message: bytes
+    ) -> Signature:
         final_response = await self._poll_transaction(create_response)
-        signature, broadcast_transaction = self._extract_signature_from_response(
-            final_response, expected_message
-        )
-
-        if broadcast_transaction is not None:
-            # Crossmint has already landed this transaction, so the operation is
-            # finished whether or not the copy it returns shows every signature
-            # slot filled, and there is nothing left for the caller to send.
-            return SignedTransaction(encoded_transaction="", signature=signature, is_complete=True)
-
-        add_signature_to_transaction(transaction, public_key, signature)
-        return classify_signed_transaction(
-            transaction, serialize_transaction(transaction), signature
-        )
+        return self._extract_signature_from_response(final_response, expected_message)
 
     async def sign_and_send_transaction(self, transaction: VersionedTransaction) -> Signature:
-        """Sign ``transaction`` and let Crossmint execute it."""
-        signed = await self._execute_managed_transaction(transaction)
-        return signed.signature
+        """Submit ``transaction`` through Crossmint's managed wallet flow.
+
+        Crossmint may rewrite the transaction (it sponsors gas, so it becomes the
+        fee payer), in which case the returned signature identifies the landed
+        transaction rather than covering the caller's message. ``transaction`` is
+        never modified.
+
+        Not retry-safe: any failure after the create is accepted raises
+        ``BROADCAST_UNCONFIRMED`` carrying ``provider_transaction_id``; check
+        that transaction with Crossmint before retrying. A create that fails
+        without a usable response raises ``BROADCAST_UNCONFIRMED`` with no
+        ``provider_transaction_id``.
+
+        Each create carries an ``x-idempotency-key`` derived from the message
+        bytes, so replaying these exact bytes cannot create a second
+        transaction; a rebuilt transaction derives a different key and executes
+        as a new transfer.
+        """
+        return await self._execute_managed_transaction(transaction)
 
     async def sign_message(self, message: bytes) -> Signature:
         raise SignerError(

--- a/python/tests/integration/conftest.py
+++ b/python/tests/integration/conftest.py
@@ -101,26 +101,31 @@ async def fetch_latest_blockhash() -> Hash:
     return Hash.from_string(response.json()["result"]["value"]["blockhash"])
 
 
-async def assert_transaction_roundtrip(
-    signer: SolanaSigner, *, signs_caller_bytes: bool = True
-) -> None:
+async def _unsigned_transaction(signer: SolanaSigner) -> VersionedTransaction:
+    message = Message.new_with_blockhash([], signer.pubkey, await fetch_latest_blockhash())
+    return VersionedTransaction.from_legacy(Transaction.new_unsigned(message))
+
+
+async def assert_transaction_roundtrip(signer: SolanaSigner) -> None:
     """An instruction-free transaction keeps this focused on remote signing rather
     than balances or program execution.
-
-    ``signs_caller_bytes=False`` for broadcast-managed services that rewrite the
-    transaction before signing and broadcast it themselves: their signature covers
-    their own bytes, so only its shape can be checked, and there is nothing left
-    for the caller to send. Each signer verifies the signature against the bytes it
-    actually covers internally.
     """
-    message = Message.new_with_blockhash([], signer.pubkey, await fetch_latest_blockhash())
-    transaction = VersionedTransaction.from_legacy(Transaction.new_unsigned(message))
+    transaction = await _unsigned_transaction(signer)
     result = await signer.sign_transaction(transaction)
 
     assert result.is_complete
     assert len(bytes(result.signature)) == 64
-    if signs_caller_bytes:
-        assert Transaction.from_bytes(base64.b64decode(result.encoded_transaction))
-        assert result.signature.verify(signer.pubkey, signed_message_bytes(transaction.message))
-    else:
-        assert result.encoded_transaction == ""
+    assert Transaction.from_bytes(base64.b64decode(result.encoded_transaction))
+    assert result.signature.verify(signer.pubkey, signed_message_bytes(transaction.message))
+
+
+async def assert_send_transaction_roundtrip(signer: SolanaSigner) -> None:
+    """Broadcast-managed services rewrite the transaction before signing and
+    execute it themselves, so the returned signature covers their bytes rather
+    than the caller's and only its shape can be checked. Each signer verifies the
+    signature against the bytes it actually covers internally.
+    """
+    transaction = await _unsigned_transaction(signer)
+    signature = await signer.sign_and_send_transaction(transaction)
+
+    assert len(bytes(signature)) == 64

--- a/python/tests/integration/test_live_signers.py
+++ b/python/tests/integration/test_live_signers.py
@@ -14,6 +14,7 @@ import pytest
 from solana_keychain.core.signer import SolanaSigner
 from tests.integration.conftest import (
     assert_message_roundtrip,
+    assert_send_transaction_roundtrip,
     assert_transaction_roundtrip,
     optional_env,
     require_env,
@@ -282,18 +283,23 @@ async def test_live_sign_message(backend: str) -> None:
     await assert_message_roundtrip(signer)
 
 
-# Broadcast-managed services rewrite the transaction before signing, so their
-# signature covers their bytes rather than the caller's.
-_REWRITES_TRANSACTION = frozenset({"crossmint"})
+# Broadcast-managed services execute the transaction themselves and expose no
+# sign-only path.
+_BROADCAST_MANAGED = frozenset({"crossmint"})
 
 
-@pytest.mark.parametrize("backend", sorted(_ALL_BACKENDS))
+@pytest.mark.parametrize("backend", sorted(_ALL_BACKENDS.keys() - _BROADCAST_MANAGED))
 async def test_live_sign_transaction(backend: str) -> None:
     _skip_unless_selected(backend)
     signer = await _ALL_BACKENDS[backend]()
-    await assert_transaction_roundtrip(
-        signer, signs_caller_bytes=backend not in _REWRITES_TRANSACTION
-    )
+    await assert_transaction_roundtrip(signer)
+
+
+@pytest.mark.parametrize("backend", sorted(_BROADCAST_MANAGED))
+async def test_live_sign_and_send_transaction(backend: str) -> None:
+    _skip_unless_selected(backend)
+    signer = await _ALL_BACKENDS[backend]()
+    await assert_send_transaction_roundtrip(signer)
 
 
 @pytest.mark.parametrize("backend", sorted(_ALL_BACKENDS))

--- a/python/tests/test_crossmint_signer.py
+++ b/python/tests/test_crossmint_signer.py
@@ -11,6 +11,7 @@ import pytest
 import respx
 from solders.keypair import Keypair
 from solders.signature import Signature
+from solders.transaction import VersionedTransaction
 
 from solana_keychain import SignerError, SignerErrorCode
 from solana_keychain.core import signed_message_bytes
@@ -29,6 +30,12 @@ WALLET_LOCATOR = "email:user@test.com:solana"
 ENCODED_LOCATOR = "email%3Auser%40test.com%3Asolana"
 WALLET_URL = f"{API_BASE_URL}/2025-06-09/wallets/{ENCODED_LOCATOR}"
 TRANSACTIONS_URL = f"{WALLET_URL}/transactions"
+
+
+def assert_caller_transaction_untouched(transaction: VersionedTransaction) -> None:
+    assert all(signature == Signature.default() for signature in transaction.signatures), (
+        "Crossmint broadcasts server-side, so the caller's transaction must stay unsigned"
+    )
 
 
 def make_signer(**overrides: Any) -> CrossmintSigner:
@@ -174,15 +181,30 @@ async def test_sign_message_is_unsupported() -> None:
     assert excinfo.value.code == SignerErrorCode.SIGNING_FAILED
 
 
-async def test_uninitialized_sign_transaction_raises_not_initialized() -> None:
+async def test_uninitialized_sign_and_send_transaction_raises_not_initialized() -> None:
     signer = make_signer()
     with pytest.raises(SignerError) as excinfo:
-        await signer.sign_transaction(create_test_transaction(Keypair().pubkey()))
+        await signer.sign_and_send_transaction(create_test_transaction(Keypair().pubkey()))
     assert excinfo.value.code == SignerErrorCode.NOT_INITIALIZED
 
 
 @respx.mock
-async def test_sign_transaction_success_from_embedded_transaction() -> None:
+async def test_sign_transaction_is_rejected() -> None:
+    """Crossmint has no sign-only API: an approved transaction is always executed
+    server-side, so a caller asking for signature-only work must be refused rather
+    than handed a transaction that has already landed."""
+    keypair = Keypair()
+    signer = await initialized_signer(keypair)
+    transaction = create_test_transaction(keypair.pubkey())
+
+    with pytest.raises(SignerError) as excinfo:
+        await signer.sign_transaction(transaction)
+    assert excinfo.value.code == SignerErrorCode.SIGNING_FAILED
+    assert_caller_transaction_untouched(transaction)
+
+
+@respx.mock
+async def test_sign_and_send_transaction_success_from_embedded_transaction() -> None:
     keypair = Keypair()
     signer = await initialized_signer(keypair)
     transaction = create_test_transaction(keypair.pubkey())
@@ -200,10 +222,9 @@ async def test_sign_transaction_success_from_embedded_transaction() -> None:
         )
     )
 
-    result = await signer.sign_transaction(transaction)
+    signature = await signer.sign_and_send_transaction(transaction)
 
-    assert result.is_complete
-    assert result.signature == expected_signature
+    assert signature == expected_signature
     create_body = json.loads(respx.calls[1].request.content)
     assert "signer" not in create_body["params"]
     assert base58.b58decode(create_body["params"]["transaction"]) == unsigned_bytes
@@ -216,7 +237,7 @@ async def test_sign_transaction_success_from_embedded_transaction() -> None:
 
 
 @respx.mock
-async def test_sign_transaction_falls_back_to_tx_id() -> None:
+async def test_sign_and_send_transaction_falls_back_to_tx_id() -> None:
     keypair = Keypair()
     signer = await initialized_signer(keypair)
     transaction = create_test_transaction(keypair.pubkey())
@@ -228,12 +249,12 @@ async def test_sign_transaction_falls_back_to_tx_id() -> None:
         )
     )
 
-    result = await signer.sign_transaction(transaction)
-    assert result.signature == signature
+    signature = await signer.sign_and_send_transaction(transaction)
+    assert signature == signature
 
 
 @respx.mock
-async def test_sign_transaction_accepts_provider_tx_id() -> None:
+async def test_sign_and_send_transaction_accepts_provider_tx_id() -> None:
     keypair = Keypair()
     signer = await initialized_signer(keypair)
     transaction = create_test_transaction(keypair.pubkey())
@@ -245,25 +266,25 @@ async def test_sign_transaction_accepts_provider_tx_id() -> None:
         )
     )
 
-    result = await signer.sign_transaction(transaction)
-    assert result.signature == other_signature
+    signature = await signer.sign_and_send_transaction(transaction)
+    assert signature == other_signature
 
 
 @respx.mock
-async def test_sign_transaction_failed_status() -> None:
+async def test_sign_and_send_transaction_failed_status() -> None:
     keypair = Keypair()
     signer = await initialized_signer(keypair)
     respx.post(TRANSACTIONS_URL).mock(
         return_value=httpx.Response(200, json=tx_response("failed", error={"reason": "boom"}))
     )
     with pytest.raises(SignerError) as excinfo:
-        await signer.sign_transaction(create_test_transaction(keypair.pubkey()))
+        await signer.sign_and_send_transaction(create_test_transaction(keypair.pubkey()))
     assert excinfo.value.code == SignerErrorCode.BROADCAST_UNCONFIRMED
     assert excinfo.value.provider_transaction_id == "tx-1"
 
 
 @respx.mock
-async def test_sign_transaction_polling_timeout() -> None:
+async def test_sign_and_send_transaction_polling_timeout() -> None:
     keypair = Keypair()
     signer = await initialized_signer(keypair, max_poll_attempts=2)
     respx.post(TRANSACTIONS_URL).mock(return_value=httpx.Response(200, json=tx_response("pending")))
@@ -271,7 +292,7 @@ async def test_sign_transaction_polling_timeout() -> None:
         return_value=httpx.Response(200, json=tx_response("pending"))
     )
     with pytest.raises(SignerError) as excinfo:
-        await signer.sign_transaction(create_test_transaction(keypair.pubkey()))
+        await signer.sign_and_send_transaction(create_test_transaction(keypair.pubkey()))
     assert excinfo.value.code == SignerErrorCode.BROADCAST_UNCONFIRMED
     assert excinfo.value.provider_transaction_id == "tx-1"
 
@@ -284,7 +305,7 @@ async def test_create_server_error_is_unconfirmed_without_a_transaction_id() -> 
         return_value=httpx.Response(503, json={"error": "service unavailable"})
     )
     with pytest.raises(SignerError) as excinfo:
-        await signer.sign_transaction(create_test_transaction(keypair.pubkey()))
+        await signer.sign_and_send_transaction(create_test_transaction(keypair.pubkey()))
     assert excinfo.value.code == SignerErrorCode.BROADCAST_UNCONFIRMED
     assert excinfo.value.provider_transaction_id is None
     assert excinfo.value.status_code == 503
@@ -296,7 +317,7 @@ async def test_create_accepted_without_an_id_is_unconfirmed() -> None:
     signer = await initialized_signer(keypair)
     respx.post(TRANSACTIONS_URL).mock(return_value=httpx.Response(200, json={"status": "pending"}))
     with pytest.raises(SignerError) as excinfo:
-        await signer.sign_transaction(create_test_transaction(keypair.pubkey()))
+        await signer.sign_and_send_transaction(create_test_transaction(keypair.pubkey()))
     assert excinfo.value.code == SignerErrorCode.BROADCAST_UNCONFIRMED
     assert excinfo.value.provider_transaction_id is None
     assert excinfo.value.status_code is None
@@ -310,7 +331,7 @@ async def test_create_rejected_by_crossmint_stays_a_plain_failure() -> None:
         return_value=httpx.Response(400, json={"error": "invalid transaction"})
     )
     with pytest.raises(SignerError) as excinfo:
-        await signer.sign_transaction(create_test_transaction(keypair.pubkey()))
+        await signer.sign_and_send_transaction(create_test_transaction(keypair.pubkey()))
     assert excinfo.value.code == SignerErrorCode.REMOTE_API_ERROR
 
 
@@ -333,7 +354,7 @@ async def test_cancellation_during_create_warns_without_a_transaction_id(
 
     async def run() -> None:
         try:
-            await signer.sign_transaction(create_test_transaction(keypair.pubkey()))
+            await signer.sign_and_send_transaction(create_test_transaction(keypair.pubkey()))
         except asyncio.CancelledError as error:
             observed.append(str(error))
             raise
@@ -370,7 +391,7 @@ async def test_cancellation_after_create_carries_the_transaction_id(
 
     async def run() -> None:
         try:
-            await signer.sign_transaction(create_test_transaction(keypair.pubkey()))
+            await signer.sign_and_send_transaction(create_test_transaction(keypair.pubkey()))
         except asyncio.CancelledError as error:
             observed.append(str(error))
             raise
@@ -393,7 +414,7 @@ async def test_awaiting_approval_without_signer_key_fails() -> None:
         return_value=httpx.Response(200, json=tx_response("awaiting-approval"))
     )
     with pytest.raises(SignerError) as excinfo:
-        await signer.sign_transaction(create_test_transaction(keypair.pubkey()))
+        await signer.sign_and_send_transaction(create_test_transaction(keypair.pubkey()))
     assert excinfo.value.code == SignerErrorCode.BROADCAST_UNCONFIRMED
     assert excinfo.value.provider_transaction_id == "tx-1"
 
@@ -438,9 +459,9 @@ async def test_awaiting_approval_signs_only_our_pending_entry() -> None:
         )
     )
 
-    result = await signer.sign_transaction(transaction)
+    signature = await signer.sign_and_send_transaction(transaction)
 
-    assert result.signature == expected_signature
+    assert signature == expected_signature
     approval_body = json.loads(respx.calls[2].request.content)
     approval = approval_body["approvals"][0]
     assert approval["signer"] == locator
@@ -462,7 +483,7 @@ async def test_awaiting_approval_with_no_matching_entry_fails() -> None:
         )
     )
     with pytest.raises(SignerError) as excinfo:
-        await signer.sign_transaction(create_test_transaction(keypair.pubkey()))
+        await signer.sign_and_send_transaction(create_test_transaction(keypair.pubkey()))
     assert excinfo.value.code == SignerErrorCode.BROADCAST_UNCONFIRMED
     assert excinfo.value.provider_transaction_id == "tx-1"
 
@@ -491,11 +512,9 @@ async def test_rewritten_transaction_is_reported_as_a_broadcast_result() -> None
         )
     )
 
-    result = await signer.sign_transaction(transaction)
+    signature = await signer.sign_and_send_transaction(transaction)
 
-    assert result.signature == expected_signature
-    assert result.is_complete
-    assert result.encoded_transaction == ""
+    assert signature == expected_signature
     assert all(sig == Signature.default() for sig in transaction.signatures)
     assert not expected_signature.verify(
         keypair.pubkey(), signed_message_bytes(transaction.message)
@@ -526,10 +545,9 @@ async def test_delegated_signer_signature_is_located_and_verified() -> None:
         )
     )
 
-    result = await signer.sign_transaction(transaction)
+    signature = await signer.sign_and_send_transaction(transaction)
 
-    assert result.signature == expected_signature
-    assert result.encoded_transaction == ""
+    assert signature == expected_signature
     # The wallet address is still the signer's public identity.
     assert signer.pubkey == wallet_keypair.pubkey()
 
@@ -562,10 +580,9 @@ async def test_explicit_locator_signer_is_a_candidate_alongside_the_derived_key(
         )
     )
 
-    result = await signer.sign_transaction(transaction)
+    signature = await signer.sign_and_send_transaction(transaction)
 
-    assert result.signature == expected_signature
-    assert result.encoded_transaction == ""
+    assert signature == expected_signature
 
 
 @respx.mock
@@ -594,10 +611,9 @@ async def test_wallet_address_in_an_unsigned_slot_does_not_shadow_the_delegated_
         )
     )
 
-    result = await signer.sign_transaction(transaction)
+    signature = await signer.sign_and_send_transaction(transaction)
 
-    assert result.signature == expected_signature
-    assert result.encoded_transaction == ""
+    assert signature == expected_signature
 
 
 @respx.mock
@@ -618,9 +634,9 @@ async def test_tx_id_signed_by_the_delegated_signer_is_accepted() -> None:
         )
     )
 
-    result = await signer.sign_transaction(transaction)
+    signature = await signer.sign_and_send_transaction(transaction)
 
-    assert result.signature == expected_signature
+    assert signature == expected_signature
 
 
 @respx.mock
@@ -668,11 +684,10 @@ async def test_rewritten_transaction_approval_yields_the_fee_payer_transaction_i
         )
     )
 
-    result = await signer.sign_transaction(transaction)
+    signature = await signer.sign_and_send_transaction(transaction)
 
-    assert result.signature == fee_payer_signature
-    assert result.signature != approval_signature
-    assert result.encoded_transaction == ""
+    assert signature == fee_payer_signature
+    assert signature != approval_signature
     assert all(sig == Signature.default() for sig in transaction.signatures)
 
 
@@ -714,9 +729,8 @@ async def test_provider_transaction_is_trusted_without_approval_verification() -
         )
     )
 
-    result = await signer.sign_transaction(transaction)
-    assert result.signature == executed.signatures[0]
-    assert result.encoded_transaction == ""
+    signature = await signer.sign_and_send_transaction(transaction)
+    assert signature == executed.signatures[0]
 
 
 @respx.mock
@@ -739,13 +753,12 @@ async def test_provider_rewritten_transaction_is_trusted() -> None:
         )
     )
 
-    result = await signer.sign_transaction(transaction)
-    assert result.signature == rewritten.signatures[0]
-    assert result.encoded_transaction == ""
+    signature = await signer.sign_and_send_transaction(transaction)
+    assert signature == rewritten.signatures[0]
 
 
 @respx.mock
-async def test_unrewritten_returned_transaction_is_placed_in_the_caller_transaction() -> None:
+async def test_unrewritten_returned_transaction_is_not_placed_in_the_caller_transaction() -> None:
     """When Crossmint returns the submitted message unchanged, the signature does
     cover the caller's bytes, so it belongs in the caller's transaction."""
     keypair = Keypair()
@@ -763,17 +776,16 @@ async def test_unrewritten_returned_transaction_is_placed_in_the_caller_transact
         )
     )
 
-    result = await signer.sign_transaction(transaction)
+    signature = await signer.sign_and_send_transaction(transaction)
 
-    assert result.signature == expected_signature
-    assert result.encoded_transaction
-    assert list(transaction.signatures) == [expected_signature]
+    assert signature == expected_signature
+    assert_caller_transaction_untouched(transaction)
 
 
 @respx.mock
-async def test_caller_exact_signature_is_placed_in_the_caller_transaction() -> None:
-    """When Crossmint signs the submitted bytes unchanged, the signature belongs
-    in the caller's transaction and the caller can broadcast it."""
+async def test_caller_exact_signature_is_returned_without_touching_the_transaction() -> None:
+    """Even when Crossmint signs the submitted bytes unchanged, it has already
+    executed them, so the caller's transaction is left alone."""
     keypair = Keypair()
     signer = await initialized_signer(keypair)
     transaction = create_test_transaction(keypair.pubkey())
@@ -785,12 +797,10 @@ async def test_caller_exact_signature_is_placed_in_the_caller_transaction() -> N
         )
     )
 
-    result = await signer.sign_transaction(transaction)
+    signature = await signer.sign_and_send_transaction(transaction)
 
-    assert result.signature == expected_signature
-    assert result.encoded_transaction
-    assert list(transaction.signatures) == [expected_signature]
-    assert expected_signature.verify(keypair.pubkey(), signed_message_bytes(transaction.message))
+    assert signature == expected_signature
+    assert_caller_transaction_untouched(transaction)
 
 
 @respx.mock
@@ -812,9 +822,8 @@ async def test_signature_not_covering_returned_transaction_is_trusted() -> None:
         )
     )
 
-    result = await signer.sign_transaction(transaction)
-    assert result.signature == returned.signatures[0]
-    assert result.encoded_transaction == ""
+    signature = await signer.sign_and_send_transaction(transaction)
+    assert signature == returned.signatures[0]
 
 
 @respx.mock
@@ -830,7 +839,7 @@ async def test_embedded_transaction_without_signer_signature_falls_through() -> 
         )
     )
     with pytest.raises(SignerError) as excinfo:
-        await signer.sign_transaction(transaction)
+        await signer.sign_and_send_transaction(transaction)
     assert excinfo.value.code == SignerErrorCode.BROADCAST_UNCONFIRMED
     assert excinfo.value.provider_transaction_id == "tx-1"
 

--- a/rust/README.md
+++ b/rust/README.md
@@ -331,14 +331,16 @@ runtime; the second is fixed per backend:
 |---------|-----------------------------|--------------------|-----------------------------|----------------|
 | memory, vault, privy, turnkey, aws-kms, fireblocks, gcp-kms, dfns, para, openfort | `false` | yes | `SigningFailed` | yes |
 | cdp | `false` | yes | `SigningFailed` | UTF-8 payloads only, otherwise `SerializationError` |
-| crossmint | `true` | yes | yes | `SigningFailed` |
+| crossmint | `true` | `SigningFailed` | yes | `SigningFailed` |
 | utila | `false` | yes | `SigningFailed` | `SigningFailed` |
 | fordefi (black-box mode) | `false` | yes | `SigningFailed` | yes |
 | fordefi (native mode) | `true` | `SigningFailed` | yes | yes |
 
-Crossmint supports both: it decides per request whether to rewrite and broadcast
-the transaction or to sign the caller's exact bytes, and `sign_transaction`
-exposes that distinction through an empty encoded transaction.
+Crossmint executes every approved transaction server-side and exposes no
+sign-only API, so it offers `sign_and_send_transaction` only. It may rewrite the
+transaction to sponsor gas, in which case the returned signature identifies the
+transaction it landed rather than covering the caller's bytes; the caller's
+transaction is never modified.
 
 ### Sign and Send
 

--- a/rust/src/crossmint/mod.rs
+++ b/rust/src/crossmint/mod.rs
@@ -8,7 +8,7 @@ use crate::signature_util::signature_from_base58;
 use crate::traits::SignTransactionResult;
 use crate::transaction_util::{
     deserialize_wire_transaction, idempotency_key_from_message, serialize_wire_transaction,
-    unconfirmed_unless_rejected, TransactionUtil,
+    unconfirmed_unless_rejected,
 };
 use crate::{error::SignerError, http_client_config::HttpClientConfig, traits::SolanaSigner};
 use std::fmt::Write;
@@ -590,24 +590,24 @@ impl CrossmintSigner {
         Ok((signature, transaction))
     }
 
-    /// The signing result, plus the broadcast transaction when Crossmint rewrote one.
+    /// The signature identifying the transaction Crossmint landed.
     ///
-    /// `Some` means Crossmint landed different bytes than the caller's; the
-    /// signature is then the landed transaction's fee-payer identifier.
+    /// When Crossmint landed different bytes than the caller's, this is the
+    /// landed transaction's fee-payer identifier rather than a signature over
+    /// the caller's message.
     fn extract_signature_from_response(
         &self,
         response: &TransactionResponse,
         expected_message: &[u8],
-    ) -> Result<(Signature, Option<VersionedTransaction>), SignerError> {
+    ) -> Result<Signature, SignerError> {
         if let Some(on_chain) = &response.on_chain {
             if let Some(serialized_transaction) = &on_chain.transaction {
                 match self.extract_signature_from_serialized_transaction(serialized_transaction) {
                     Ok((signature, returned)) => {
                         if returned.message.serialize() == expected_message {
-                            return Ok((signature, None));
+                            return Ok(signature);
                         }
-                        let transaction_id = Self::broadcast_transaction_id(&returned)?;
-                        return Ok((transaction_id, Some(returned)));
+                        return Self::broadcast_transaction_id(&returned);
                     }
                     Err(error) => {
                         if on_chain.tx_id.is_none() {
@@ -623,7 +623,7 @@ impl CrossmintSigner {
                         "Crossmint onChain.txId was not a valid Solana signature".to_string(),
                     )
                 })?;
-                return Ok((signature, None));
+                return Ok(signature);
             }
         }
 
@@ -632,13 +632,13 @@ impl CrossmintSigner {
         ))
     }
 
-    /// Sign `transaction` through Crossmint's managed wallet flow.
+    /// Submit `transaction` through Crossmint's managed wallet flow and return the
+    /// signature identifying the transaction Crossmint landed.
     ///
-    /// Crossmint may rewrite the transaction to sponsor gas and broadcast it itself.
-    /// When it does, `transaction` is left unmodified, the returned serialized
-    /// transaction is empty, and the returned signature is the landed transaction's
-    /// fee-payer identifier, usable with RPC transaction lookups. The wallet's own
-    /// signature is placed in `transaction` only when Crossmint signed it as given.
+    /// Crossmint may rewrite the transaction to sponsor gas, so the returned
+    /// signature does not necessarily cover the caller's bytes; it is the landed
+    /// transaction's identifier, usable with RPC transaction lookups.
+    /// `transaction` is never modified.
     ///
     /// Not retry-safe: any failure after the create is accepted returns
     /// [`SignerError::BroadcastUnconfirmed`] carrying the Crossmint transaction id;
@@ -649,11 +649,11 @@ impl CrossmintSigner {
     /// so replaying these exact bytes cannot create a second transaction; a
     /// rebuilt transaction derives a different key and executes as a new
     /// transfer.
-    async fn sign_and_serialize(
+    async fn execute_managed_transaction(
         &self,
-        transaction: &mut VersionedTransaction,
-    ) -> Result<SignTransactionResult, SignerError> {
-        let public_key = self.initialized_pubkey()?;
+        transaction: &VersionedTransaction,
+    ) -> Result<Signature, SignerError> {
+        self.initialized_pubkey()?;
 
         let expected_message = transaction.message.serialize();
         let serialized = serialize_wire_transaction(transaction)?;
@@ -666,37 +666,20 @@ impl CrossmintSigner {
         let provider_tx_id = create_response.id.clone();
         // Post-create failures leave an outcome Crossmint may still execute, so
         // they surface as BroadcastUnconfirmed with the transaction id.
-        let (signature, broadcast) = self
-            .finish_managed_transaction(create_response, &expected_message)
+        self.finish_managed_transaction(create_response, &expected_message)
             .await
             .map_err(|error| SignerError::BroadcastUnconfirmed {
                 provider_tx_id: Some(provider_tx_id),
                 provider_status: None,
                 detail: error.detail_string(),
-            })?;
-
-        if broadcast.is_some() {
-            // Already landed, so complete regardless of the slots the returned copy
-            // shows filled, and nothing is left for the caller to send.
-            return Ok(SignTransactionResult::Complete((String::new(), signature)));
-        }
-
-        TransactionUtil::add_signature_to_transaction(transaction, &public_key, signature)?;
-
-        Ok(TransactionUtil::classify_signed_transaction(
-            transaction,
-            (
-                TransactionUtil::serialize_transaction(transaction)?,
-                signature,
-            ),
-        ))
+            })
     }
 
     async fn finish_managed_transaction(
         &self,
         create_response: TransactionResponse,
         expected_message: &[u8],
-    ) -> Result<(Signature, Option<VersionedTransaction>), SignerError> {
+    ) -> Result<Signature, SignerError> {
         let final_response = self.poll_transaction(create_response).await?;
         self.extract_signature_from_response(&final_response, expected_message)
     }
@@ -720,17 +703,19 @@ impl SolanaSigner for CrossmintSigner {
 
     async fn sign_transaction(
         &self,
-        tx: &mut VersionedTransaction,
+        _tx: &mut VersionedTransaction,
     ) -> Result<SignTransactionResult, SignerError> {
-        self.sign_and_serialize(tx).await
+        Err(SignerError::SigningFailed(
+            "Crossmint executes every transaction server-side; call sign_and_send_transaction instead"
+                .to_string(),
+        ))
     }
 
     async fn sign_and_send_transaction(
         &self,
         tx: &mut VersionedTransaction,
     ) -> Result<Signature, SignerError> {
-        let (_, signature) = self.sign_and_serialize(tx).await?.into_signed_transaction();
-        Ok(signature)
+        self.execute_managed_transaction(tx).await
     }
 
     async fn sign_message(&self, _message: &[u8]) -> Result<Signature, SignerError> {

--- a/rust/src/crossmint/tests.rs
+++ b/rust/src/crossmint/tests.rs
@@ -1,10 +1,18 @@
 use super::*;
 use crate::sdk_adapter::{keypair_pubkey, keypair_sign_message, Keypair};
 use crate::test_util::{create_test_transaction, create_test_transaction_with_recipient};
+use crate::transaction_util::TransactionUtil;
 use wiremock::{
     matchers::{header, method, path},
     Mock, MockServer, ResponseTemplate,
 };
+
+fn assert_caller_transaction_untouched(tx: &VersionedTransaction) {
+    assert!(
+        tx.signatures.iter().all(|s| *s == Signature::default()),
+        "Crossmint broadcasts server-side, so the caller's transaction must stay unsigned"
+    );
+}
 
 fn wallet_response(address: &str) -> ResponseTemplate {
     ResponseTemplate::new(200).set_body_json(serde_json::json!({
@@ -51,6 +59,23 @@ fn create_url_builder_test_signer(wallet_locator: &str) -> CrossmintSigner {
 fn test_broadcasts_transactions() {
     let signer = create_test_signer("https://example.com", 1, 1);
     assert!(signer.broadcasts_transactions());
+}
+
+/// Crossmint has no sign-only API: an approved transaction is always executed
+/// server-side, so a caller asking for signature-only work must be refused
+/// rather than handed a transaction that has already landed.
+#[tokio::test]
+async fn test_sign_transaction_is_rejected() {
+    let keypair = Keypair::new();
+    let signer_pubkey = keypair_pubkey(&keypair);
+    let mut signer = create_test_signer("https://example.com", 1, 1);
+    signer.public_key = Some(signer_pubkey);
+    let mut tx = create_test_transaction(&signer_pubkey);
+
+    let error = signer.sign_transaction(&mut tx).await.unwrap_err();
+
+    assert!(matches!(error, SignerError::SigningFailed(_)));
+    assert_caller_transaction_untouched(&tx);
 }
 
 fn build_url_and_path(wallet_locator: &str, segments: &[&str]) -> (String, String) {
@@ -273,7 +298,7 @@ async fn test_sign_message_not_supported() {
 }
 
 #[tokio::test]
-async fn test_sign_transaction_success() {
+async fn test_sign_and_send_transaction_success() {
     let server = MockServer::start().await;
     let keypair = Keypair::new();
     let signer_pubkey = keypair_pubkey(&keypair);
@@ -322,20 +347,19 @@ async fn test_sign_transaction_success() {
         .mount(&server)
         .await;
 
-    let (_serialized, signature) = signer
-        .sign_transaction(&mut local_tx)
+    let signature = signer
+        .sign_and_send_transaction(&mut local_tx)
         .await
-        .unwrap()
-        .into_signed_transaction();
+        .unwrap();
 
     assert_eq!(signature, expected_signature);
-    assert!(!_serialized.is_empty());
+    assert_caller_transaction_untouched(&local_tx);
 }
 
 /// A smart wallet is signed by its delegated signer, not by the wallet address
 /// the API reports, so the delegated key's returned signature is accepted.
 #[tokio::test]
-async fn test_sign_transaction_locates_delegated_signer_signature() {
+async fn test_sign_and_send_transaction_locates_delegated_signer_signature() {
     let server = MockServer::start().await;
     let wallet_keypair = Keypair::new();
     let wallet_pubkey = keypair_pubkey(&wallet_keypair);
@@ -375,21 +399,20 @@ async fn test_sign_transaction_locates_delegated_signer_signature() {
         .mount(&server)
         .await;
 
-    let (serialized, signature) = signer
-        .sign_transaction(&mut local_tx)
+    let signature = signer
+        .sign_and_send_transaction(&mut local_tx)
         .await
-        .unwrap()
-        .into_signed_transaction();
+        .unwrap();
 
     assert_eq!(signature, expected_signature);
-    assert!(serialized.is_empty());
+    assert_caller_transaction_untouched(&local_tx);
     // The wallet address remains the signer's public identity.
     assert_eq!(signer.pubkey(), wallet_pubkey);
 }
 
 /// Crossmint's returned transaction is trusted as the provider's broadcast result.
 #[tokio::test]
-async fn test_sign_transaction_accepts_unrelated_signer_key() {
+async fn test_sign_and_send_transaction_accepts_unrelated_signer_key() {
     let server = MockServer::start().await;
     let wallet_keypair = Keypair::new();
     let wallet_pubkey = keypair_pubkey(&wallet_keypair);
@@ -424,20 +447,19 @@ async fn test_sign_transaction_accepts_unrelated_signer_key() {
         .mount(&server)
         .await;
 
-    let (serialized, result) = signer
-        .sign_transaction(&mut local_tx)
+    let result = signer
+        .sign_and_send_transaction(&mut local_tx)
         .await
-        .unwrap()
-        .into_signed_transaction();
+        .unwrap();
     assert_eq!(result, signature);
-    assert!(serialized.is_empty());
+    assert_caller_transaction_untouched(&local_tx);
 }
 
 /// Crossmint sponsors gas, so it is the fee payer and the message it signs
 /// differs from the caller's. Its signature must never be placed in the
 /// caller's transaction, which could not verify with it.
 #[tokio::test]
-async fn test_sign_transaction_rewritten_is_reported_as_a_broadcast_result() {
+async fn test_sign_and_send_transaction_rewritten_is_reported_as_a_broadcast_result() {
     let server = MockServer::start().await;
     let keypair = Keypair::new();
     let signer_pubkey = keypair_pubkey(&keypair);
@@ -481,28 +503,19 @@ async fn test_sign_transaction_rewritten_is_reported_as_a_broadcast_result() {
         .mount(&server)
         .await;
 
-    let result = signer.sign_transaction(&mut local_tx).await.unwrap();
-    assert!(matches!(result, SignTransactionResult::Complete(_)));
-    let (serialized, signature) = result.into_signed_transaction();
+    let signature = signer
+        .sign_and_send_transaction(&mut local_tx)
+        .await
+        .unwrap();
 
     assert_eq!(signature, expected_signature);
-    assert!(
-        serialized.is_empty(),
-        "a Crossmint-broadcast transaction leaves nothing for the caller to send"
-    );
-    assert!(
-        local_tx
-            .signatures
-            .iter()
-            .all(|s| *s == Signature::default()),
-        "the caller's transaction must not carry a signature over other bytes"
-    );
+    assert_caller_transaction_untouched(&local_tx);
 }
 
 /// Under sponsorship the returned signature must be the sponsor fee-payer's
 /// slot-0 signature, not the wallet's approval, so RPC lookups resolve.
 #[tokio::test]
-async fn test_sign_transaction_sponsored_returns_fee_payer_transaction_id() {
+async fn test_sign_and_send_transaction_sponsored_returns_fee_payer_transaction_id() {
     let server = MockServer::start().await;
     let wallet_keypair = Keypair::new();
     let wallet_pubkey = keypair_pubkey(&wallet_keypair);
@@ -550,25 +563,20 @@ async fn test_sign_transaction_sponsored_returns_fee_payer_transaction_id() {
     signer.init().await.unwrap();
 
     let mut local_tx = create_test_transaction(&wallet_pubkey);
-    let (serialized, signature) = signer
-        .sign_transaction(&mut local_tx)
+    let signature = signer
+        .sign_and_send_transaction(&mut local_tx)
         .await
-        .unwrap()
-        .into_signed_transaction();
+        .unwrap();
 
     assert_eq!(signature, sponsor_signature);
     assert_ne!(signature, approval_signature);
-    assert!(serialized.is_empty());
-    assert!(local_tx
-        .signatures
-        .iter()
-        .all(|s| *s == Signature::default()));
+    assert_caller_transaction_untouched(&local_tx);
 }
 
 /// A quorum entry carrying neither a top-level address nor signature must not
 /// end the scan: the wallet's approval can follow it.
 #[tokio::test]
-async fn test_sign_transaction_skips_submitted_approvals_without_an_address() {
+async fn test_sign_and_send_transaction_skips_submitted_approvals_without_an_address() {
     let server = MockServer::start().await;
     let wallet_keypair = Keypair::new();
     let wallet_pubkey = keypair_pubkey(&wallet_keypair);
@@ -619,18 +627,17 @@ async fn test_sign_transaction_skips_submitted_approvals_without_an_address() {
     signer.init().await.unwrap();
 
     let mut local_tx = create_test_transaction(&wallet_pubkey);
-    let (serialized, signature) = signer
-        .sign_transaction(&mut local_tx)
+    let signature = signer
+        .sign_and_send_transaction(&mut local_tx)
         .await
-        .unwrap()
-        .into_signed_transaction();
+        .unwrap();
 
     assert_eq!(signature, sponsor_signature);
-    assert!(serialized.is_empty());
+    assert_caller_transaction_untouched(&local_tx);
 }
 
 #[tokio::test]
-async fn test_sign_transaction_rejects_approval_signatures_for_local_transaction_bytes() {
+async fn test_sign_and_send_transaction_rejects_approval_signatures_for_local_transaction_bytes() {
     let server = MockServer::start().await;
     let wallet_keypair = Keypair::new();
     let signer_address = keypair_pubkey(&wallet_keypair).to_string();
@@ -665,7 +672,7 @@ async fn test_sign_transaction_rejects_approval_signatures_for_local_transaction
     signer.init().await.unwrap();
 
     let mut tx = create_test_transaction(&signer.pubkey());
-    let result = signer.sign_transaction(&mut tx).await;
+    let result = signer.sign_and_send_transaction(&mut tx).await;
 
     assert!(result.is_err());
     match result.unwrap_err() {
@@ -707,7 +714,7 @@ async fn test_create_server_error_is_unconfirmed_without_a_transaction_id() {
     signer.init().await.unwrap();
     let mut tx = create_test_transaction(&signer.pubkey());
 
-    match signer.sign_transaction(&mut tx).await.unwrap_err() {
+    match signer.sign_and_send_transaction(&mut tx).await.unwrap_err() {
         SignerError::BroadcastUnconfirmed {
             provider_tx_id,
             provider_status,
@@ -743,7 +750,7 @@ async fn test_create_accepted_without_an_id_is_unconfirmed() {
     signer.init().await.unwrap();
     let mut tx = create_test_transaction(&signer.pubkey());
 
-    match signer.sign_transaction(&mut tx).await.unwrap_err() {
+    match signer.sign_and_send_transaction(&mut tx).await.unwrap_err() {
         SignerError::BroadcastUnconfirmed {
             provider_tx_id,
             provider_status,
@@ -779,14 +786,14 @@ async fn test_create_rejected_by_crossmint_stays_a_plain_failure() {
     signer.init().await.unwrap();
     let mut tx = create_test_transaction(&signer.pubkey());
 
-    match signer.sign_transaction(&mut tx).await.unwrap_err() {
+    match signer.sign_and_send_transaction(&mut tx).await.unwrap_err() {
         SignerError::RemoteApiError(_) => {}
         other => panic!("Expected RemoteApiError, got: {:?}", other),
     }
 }
 
 #[tokio::test]
-async fn test_sign_transaction_accepts_signature_from_on_chain_transaction_bytes() {
+async fn test_sign_and_send_transaction_accepts_signature_from_on_chain_transaction_bytes() {
     let server = MockServer::start().await;
     let wallet_keypair = Keypair::new();
     let signer_pubkey = keypair_pubkey(&wallet_keypair);
@@ -824,16 +831,16 @@ async fn test_sign_transaction_accepts_signature_from_on_chain_transaction_bytes
     signer.init().await.unwrap();
 
     let mut local_tx = create_test_transaction(&signer_pubkey);
-    let (_serialized, signature) = signer
-        .sign_transaction(&mut local_tx)
+    let signature = signer
+        .sign_and_send_transaction(&mut local_tx)
         .await
-        .unwrap()
-        .into_signed_transaction();
+        .unwrap();
     assert_eq!(signature, remote_signature);
 }
 
 #[tokio::test]
-async fn test_sign_transaction_prefers_on_chain_transaction_signature_over_txid_fallback() {
+async fn test_sign_and_send_transaction_prefers_on_chain_transaction_signature_over_txid_fallback()
+{
     let server = MockServer::start().await;
     let keypair = Keypair::new();
     let signer_pubkey = keypair_pubkey(&keypair);
@@ -876,16 +883,15 @@ async fn test_sign_transaction_prefers_on_chain_transaction_signature_over_txid_
     signer.init().await.unwrap();
 
     let mut local_tx = create_test_transaction(&signer_pubkey);
-    let (_serialized, signature) = signer
-        .sign_transaction(&mut local_tx)
+    let signature = signer
+        .sign_and_send_transaction(&mut local_tx)
         .await
-        .unwrap()
-        .into_signed_transaction();
+        .unwrap();
     assert_eq!(signature, remote_sig);
 }
 
 #[tokio::test]
-async fn test_sign_transaction_awaiting_approval() {
+async fn test_sign_and_send_transaction_awaiting_approval() {
     let server = MockServer::start().await;
     let keypair = Keypair::new();
     let signer_address = keypair_pubkey(&keypair).to_string();
@@ -913,7 +919,7 @@ async fn test_sign_transaction_awaiting_approval() {
     signer.init().await.unwrap();
 
     let mut tx = create_test_transaction(&signer.pubkey());
-    let result = signer.sign_transaction(&mut tx).await;
+    let result = signer.sign_and_send_transaction(&mut tx).await;
 
     assert!(result.is_err());
     match result.unwrap_err() {
@@ -938,7 +944,7 @@ fn attach_approval_signer(
 }
 
 #[tokio::test]
-async fn test_sign_transaction_submits_approval_once_and_polls_after_async_registration() {
+async fn test_sign_and_send_transaction_submits_approval_once_and_polls_after_async_registration() {
     let server = MockServer::start().await;
     let keypair = Keypair::new();
     let signer_pubkey = keypair_pubkey(&keypair);
@@ -999,16 +1005,12 @@ async fn test_sign_transaction_submits_approval_once_and_polls_after_async_regis
         .mount(&server)
         .await;
 
-    let (_serialized, signature) = signer
-        .sign_transaction(&mut tx)
-        .await
-        .unwrap()
-        .into_signed_transaction();
+    let signature = signer.sign_and_send_transaction(&mut tx).await.unwrap();
     assert_eq!(signature, expected_signature);
 }
 
 #[tokio::test]
-async fn test_sign_transaction_selects_pending_approval_matching_signer_locator() {
+async fn test_sign_and_send_transaction_selects_pending_approval_matching_signer_locator() {
     use ed25519_dalek::Signer as _;
     use wiremock::matchers::body_string_contains;
 
@@ -1072,16 +1074,12 @@ async fn test_sign_transaction_selects_pending_approval_matching_signer_locator(
         .mount(&server)
         .await;
 
-    let (_serialized, signature) = signer
-        .sign_transaction(&mut tx)
-        .await
-        .unwrap()
-        .into_signed_transaction();
+    let signature = signer.sign_and_send_transaction(&mut tx).await.unwrap();
     assert_eq!(signature, expected_tx_signature);
 }
 
 #[tokio::test]
-async fn test_sign_transaction_success_on_last_polled_response() {
+async fn test_sign_and_send_transaction_success_on_last_polled_response() {
     let server = MockServer::start().await;
     let keypair = Keypair::new();
     let signer_pubkey = keypair_pubkey(&keypair);
@@ -1128,10 +1126,6 @@ async fn test_sign_transaction_success_on_last_polled_response() {
     let mut signer = create_test_signer(&server.uri(), 1, 1);
     signer.init().await.unwrap();
 
-    let (_serialized, signature) = signer
-        .sign_transaction(&mut tx)
-        .await
-        .unwrap()
-        .into_signed_transaction();
+    let signature = signer.sign_and_send_transaction(&mut tx).await.unwrap();
     assert_eq!(signature, expected_signature);
 }

--- a/rust/src/tests/test_crossmint_integration.rs
+++ b/rust/src/tests/test_crossmint_integration.rs
@@ -66,7 +66,7 @@ mod tests {
 
     #[tokio::test]
     #[cfg(feature = "integration-tests")]
-    async fn test_crossmint_sign_transaction() {
+    async fn test_crossmint_sign_and_send_transaction() {
         let signer = get_signer().await;
 
         let rpc_url = env::var("SOLANA_RPC_URL")
@@ -81,21 +81,13 @@ mod tests {
         message.recent_blockhash = latest_blockhash;
         let mut transaction: VersionedTransaction = Transaction::new_unsigned(message).into();
 
-        let (base64_txn, signature) = signer
-            .sign_transaction(&mut transaction)
+        let signature = signer
+            .sign_and_send_transaction(&mut transaction)
             .await
-            .expect("Failed to sign transaction with Crossmint")
-            .into_signed_transaction();
+            .expect("Failed to sign and send transaction with Crossmint");
 
         assert_eq!(signature.as_ref().len(), 64, "Signature should be 64 bytes");
 
-        // Crossmint sponsors gas, so it rewrites the transaction, signs its own
-        // bytes and broadcasts server-side. The signature identifies what it
-        // landed and there is nothing left for the caller to send.
-        assert!(
-            base64_txn.is_empty(),
-            "a Crossmint-broadcast transaction leaves nothing for the caller to send"
-        );
         assert!(
             transaction
                 .signatures


### PR DESCRIPTION
## Problem

Crossmint's Wallets API has no sign-only path. Creating a transaction and approving it always causes Crossmint to execute it server-side ([create-transaction](https://docs.crossmint.com/api-reference/wallets/create-transaction): "Transaction will be automatically broadcast once it has all necessary approvals"); there is no `signOnly` parameter, and Solana wallets are routed through `/transactions` rather than the EVM-only `/signatures` endpoint.

Despite that, `sign_transaction` submitted, polled and returned. A caller asking to sign got a transaction that had already landed, signalled only by an empty encoded transaction. Two concrete consequences:

- Callers could not distinguish "signed, yours to broadcast" from "already on chain", and re-sending was a duplicate.
- In the `onChain.txId` fallback branch the signature was placed into the caller's transaction even though it identifies the landed transaction and does not necessarily cover the caller's message.

## Change

Crossmint becomes sending-only in Rust, Python and Go:

- `sign_transaction` / `SignTransaction` rejects with a signing failure, matching what Fordefi native mode already did.
- `sign_and_send_transaction` / `SignAndSendTransaction` owns the managed flow and returns the signature identifying the landed transaction.
- The caller's transaction is never mutated, and the empty-encoded-transaction convention is gone.
- `broadcasts_transactions()` / `BroadcastsTransactions()` stays `true`, so the existing send helpers and batch-signing guards dispatch unchanged.
- Rewritten-transaction handling, `BROADCAST_UNCONFIRMED` reconciliation and idempotency-key behavior are unchanged.

TypeScript needed no change: `CrossmintSigner` already implements `SolanaSendingSigner` and exposes no `signTransactions`. This brings the other three languages to that shape.

No trait or interface split: the existing capability flag already discriminates, and splitting would break Rust's `Signer` enum, Go's `core.Signer` factory return type and the Python ABC without buying enforcement that survives those unified surfaces.

## Tests

- New per-language test asserting `sign_transaction` is rejected and leaves the caller's transaction unsigned.
- Existing managed-flow tests moved to `sign_and_send_transaction`; every success path now also asserts the caller's transaction stays unsigned.
- Integration tests split: broadcast-managed backends exercise the send path, everything else keeps the sign path.

`just rust-test` (sdk-v2/v3/v4), full Python suite (514 passed), all Go modules, `just rust-fmt` and `just py-fmt` clean.

## Breaking change

`sign_transaction` / `SignTransaction` on the Crossmint signer now fails. Callers move to `sign_and_send_transaction` / `SignAndSendTransaction`, which returns a bare signature rather than a signed-transaction shape and leaves the caller's transaction unsigned.