### PR TITLE
docs: add a security model, tighten signer requirements, trim CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,138 +1,47 @@
 # CLAUDE.md
 
-Guidance for Claude Code working in this repo.
+One `SolanaSigner` contract over 14 backends in Rust, TypeScript, Python and Go, kept at cross-language parity: Memory, Vault, Privy, Turnkey, AWS KMS, Fireblocks, GCP KMS, Dfns, Crossmint, CDP, Para, Openfort, Utila, Fordefi.
 
-## Project Overview
+Layout: `rust/` (feature-gated crate), `typescript/` (pnpm monorepo, one package per backend plus `core` and the `keychain` umbrella), `python/` (single `solana-keychain` package, src layout), `go/` (one module per backend plus `core`, no umbrella). Adding a backend: [docs/ADDING_SIGNERS.md](docs/ADDING_SIGNERS.md).
 
-`solana-keychain` is a Rust + TypeScript + Python + Go library providing a unified `SolanaSigner` interface across thirteen backends, with full cross-language parity:
+## Commands
 
-Memory · Vault · Privy · Turnkey · AWS KMS · Fireblocks · GCP KMS · Dfns · Crossmint · CDP · Para · Openfort · Utila
+Always use `just`, never raw `cargo`/`pnpm`/`pytest`/`go test`: the recipes encode flags those get wrong. `just` with no args lists every recipe.
 
-## Repo Layout
+- `just build` / `test` / `fmt` / `test-integration` cover all four languages. `just <rust|ts|py|go>-*` scopes to one.
+- `just rust-test` runs the `sdk-v2`, `sdk-v3` and `sdk-v4` matrices. `cargo test --all-features` fails: the SDK features are mutually exclusive.
+- `just ts-treeshake` after touching TS exports; every package and the umbrella must stay tree-shakable.
+- Integration recipes spawn their own local `vault server -dev` and load `.env`. Never start Vault or pass secrets yourself.
+- Releases go through the [`release`](.claude/skills/release/SKILL.md) and [`complete-release`](.claude/skills/complete-release/SKILL.md) skills; CI wiring for a forked backend PR through [`add-signer-ci`](.claude/skills/add-signer-ci/SKILL.md). Check version consistency across **all** crates and packages.
 
-- `rust/` — Rust crate, feature-gated per backend. See [rust/README.md](rust/README.md).
-- `typescript/` — pnpm monorepo, one package per backend plus core/keychain umbrella. See [typescript/README.md](typescript/README.md).
-- `python/` — Python package (`solana-keychain`). See [python/README.md](python/README.md).
-- `docs/ADDING_SIGNERS.md` — full guide for adding a new backend (Rust + TS + CI).
-- `audits/AUDIT_STATUS.md` — audited-through commit and unaudited delta.
-- `justfile` — top-level dev commands. Prefer these over raw `cargo`/`pnpm` since they encode the right flags (e.g., `just rust-test` runs the `sdk-v2`, `sdk-v3`, and `sdk-v4` matrices — `cargo test --all-features` fails because the SDK features are mutually exclusive).
+## Security standing
 
-### Common commands
+Consumer-facing summary in [docs/SECURITY_MODEL.md](docs/SECURITY_MODEL.md); keep it in sync when a change alters the signing or sending shapes. Keychain is a signing adapter. It validates the signing hop, not the caller's intent: no simulation, no transaction-content checks, no policy engine, no key custody.
 
-Always prefer `just` recipes. They encode the right flags (e.g., `just rust-test` runs the `sdk-v2`, `sdk-v3`, and `sdk-v4` matrices — `cargo test --all-features` fails because the SDK features are mutually exclusive). Run `just` with no args to list every recipe.
+- **Signature binding.** A provider-returned signature is verified with ed25519 against locally computed message bytes at the signer's required position. Mismatch fails; it is never attached.
+- **Trusted-provider model.** Where a provider rewrites the transaction (Crossmint gas sponsorship, Fordefi native mode), the returned signature covers *its* bytes, not the caller's, and is not diffable. Crossmint's `SignerSecret` auto-approval delegates the choice of what gets approved to Crossmint.
+- **Broadcast-managed signers** (Crossmint, Fordefi native mode) never mutate the caller's transaction, and a failure does not mean nothing landed. `BROADCAST_UNCONFIRMED` carries a provider transaction id only when the create was accepted; without one, recovery rests on the message-derived idempotency key, which makes a byte-identical resend safe and a rebuilt transaction a new transfer.
+- **Redacted errors.** `SignerError` messages, `Debug`/`repr`, and sanitized remote bodies must never carry key material or raw provider responses. Callers match stable codes.
+- **Redirects always rejected**, timeouts always set, HTTPS enforced on configured base URLs. Two carve-outs: Vault allows plain-HTTP loopback for `vault server -dev`, and the KMS backends use their vendor SDK's transport. Signing before `init()` fails rather than using the zero address.
+- **Pinned wire format.** Golden vectors freeze the serialized bytes; never regenerate them to make a suite pass.
+- Rust zeroizes intermediate key buffers. Go and Python cannot: treat the whole process memory as sensitive with local-key backends.
+- Audit covers Rust and TypeScript through one commit; Python and Go are entirely unaudited. See [audits/AUDIT_STATUS.md](audits/AUDIT_STATUS.md).
 
-```bash
-just build              # rust-build + ts-build
-just test               # unit tests (rust + ts)
-just test-integration   # spins up local Vault, runs integration tests (both sides)
-just test-all           # test + test-integration
-just fmt                # cargo fmt/clippy + pnpm lint:fix/format
-```
+## Cross-language gotchas
 
-Per-side recipes (use these to scope work to one language):
+- **`init()` before use** for Privy, Fireblocks, Dfns, Crossmint, Para, Openfort. The `Signer::from_*` (Rust) and `await createXSigner(...)` / `create_keychain_signer(...)` factories do it for you; direct construction skips it.
+- **Crossmint is sending-only.** `sign_and_send_transaction` / `signAndSendTransactions` only; the sign-only entry point fails, and `signMessages` is unsupported. In TS it implements `SolanaSendingSigner` and deliberately exposes no `signTransactions`, because Kit classifies signers by duck-typed method presence, so it is excluded from `@solana/keychain-kit-plugin` at the type level.
+- **CDP** accepts UTF-8 message payloads only.
+- **Turnkey** response `r,s` must be left-padded to 32 bytes each before concatenation.
+- **GCP KMS** uses PureEdDSA with `EC_SIGN_ED25519`.
+- **Serialization** goes through the language's transaction helper, never `bincode`/`MarshalBinary` directly (`sdk-v4` needs `wincode` for v1; Python has `signed_message_bytes()` for the bytes a signature covers, never hand-roll the version prefix).
+- **v1 transactions** require Rust `sdk-v4` and solana-go v2; they are unrepresentable under `sdk-v2`/`sdk-v3`.
+- **Remote calls** go through the core HTTP helper (`fetchSignerJson`, `fetch_signer_json`, `core.NewHTTPClient`), which owns the error pipeline, sanitization, redirect rejection and timeouts. Batch signing uses the core staggered helper.
+- **Unit tests mock HTTP** (`wiremock`, `respx`, `httptest`); no live API calls. Integration suites are marker/tag-gated and skip themselves when unconfigured.
+- **Python extras:** the root `__init__.py` must never eagerly import a backend whose deps sit behind an optional extra, and such a backend must raise "install `solana-keychain[<extra>]`". New backends go in `keychain.py`'s `_BACKENDS` table.
+- **Adding a backend to TS** touches the umbrella in 7 places (including the treeshake script) plus `typescript-ci.yml` and `typescript-publish.yml`.
+- **No Go umbrella on purpose:** Go does not dead-code-eliminate across a runtime dispatch switch, so an umbrella would force every backend SDK into all consumers' builds.
 
-| Task | Rust | TypeScript | Python |
-| --- | --- | --- | --- |
-| Build | `just rust-build` | `just ts-build` | `just py-build` |
-| Unit tests | `just rust-test` | `just ts-test` | `just py-test` |
-| Format + lint | `just rust-fmt` | `just ts-fmt` | `just py-fmt` |
-| Integration tests | `just rust-test-integration` | `just ts-test-integration` | `just py-test-integration` |
-| Other | — | `just ts-treeshake` (verifies `@solana/keychain` umbrella + per-pkg tree-shakability) | — |
+## Branches
 
-Integration recipes auto-spawn a local `vault server -dev` and load `.env` from the repo root — do not run vault yourself or pass secrets via shell.
-
-For releases: `just release` (Rust), `just release-ts`, `just hotfix`, `just publish-ts`. See [RELEASING.md](RELEASING.md) for the full runbook (normal flow, partial-publish recovery, new-package onboarding, concurrency notes). Always check **all** crates/packages in the monorepo for version consistency.
-
-## Repo skills
-
-This repo ships Claude Code skills in [.claude/skills/](.claude/skills/) — invoke them whenever you're starting one of these workflows instead of reinventing the steps:
-
-| Skill | When to use |
-| --- | --- |
-| [`add-signer-ci`](.claude/skills/add-signer-ci/SKILL.md) | Wiring CI workflows for a new signing backend contributed via a fork PR. For the code itself see [docs/ADDING_SIGNERS.md](docs/ADDING_SIGNERS.md). |
-| [`release`](.claude/skills/release/SKILL.md) | Cutting a new Rust and/or TS release (PR-based flow, version bumps). |
-| [`complete-release`](.claude/skills/complete-release/SKILL.md) | Finalizing an approved release PR — merge, then trigger publish workflows from `main`. |
-
-## Rust
-
-Use `just rust-*` for the common workflows. For a single-backend slice (no `just` recipe), drop to cargo:
-
-```bash
-cd rust && cargo test --no-default-features --features <backend>,sdk-v2 <backend>::tests
-```
-
-Remember to also run `sdk-v3` and `sdk-v4` if your change touches SDK-version-sensitive code — `just rust-test` does all three for you.
-
-### Architecture
-
-- **Trait** ([rust/src/traits.rs](rust/src/traits.rs)): `SolanaSigner` with `pubkey()`, `sign_transaction()`, `sign_message()`, `is_available()`.
-- **Unified enum** ([rust/src/lib.rs](rust/src/lib.rs)): `Signer` enum wraps every backend, each variant `#[cfg(feature = "...")]`-gated. `Signer::from_<backend>(...)` constructors return a ready-to-use signer (calling `init()` internally where needed).
-- **Errors** ([rust/src/error.rs](rust/src/error.rs)): centralized `SignerError` via `thiserror`.
-
-Per-backend implementation details live in each module's source. See [rust/README.md](rust/README.md) for the supported-backend table and usage examples.
-
-### Feature flags
-
-One feature per backend (`memory` is default), `all` enables everything. At least one is required (enforced by `compile_error!` in `lib.rs`). SDK selection is mutually exclusive: `sdk-v2` (default), `sdk-v3`, or `sdk-v4` (solana-sdk 4.x).
-
-### Gotchas
-
-- **`init()` required before use:** `PrivySigner`, `FireblocksSigner`, `DfnsSigner`, `CrossmintSigner`, `ParaSigner`, `OpenfortSigner`. The others are ready after construction. The `Signer::from_*` factories handle `init()` for you.
-- **`sign_message` quirks:** `CrossmintSigner` returns `SigningFailed` (intentionally unsupported). `CdpSigner` only accepts UTF-8 payloads.
-- **Turnkey signature padding:** response `r,s` components must be left-padded to 32 bytes each before concatenation ([rust/src/turnkey/mod.rs](rust/src/turnkey/mod.rs)).
-- **GCP KMS:** PureEdDSA mode with `EC_SIGN_ED25519`.
-- **Transaction serialization:** go through `transaction_util::serialize_wire_transaction` / `deserialize_wire_transaction`, never `bincode` directly (`sdk-v4` needs `wincode` for v1).
-- **Transaction types:** `sign_transaction` takes a `VersionedTransaction` (legacy, v0 or v1). v1 messages exist only in the solana-sdk 4.x line, so v1 requires `sdk-v4` and is unrepresentable under `sdk-v2`/`sdk-v3`.
-- **Remote-signer tests** use `wiremock`; no live API calls in unit tests.
-
-## TypeScript
-
-Use `just ts-*` for build/test/fmt/treeshake. For a single-package slice (no `just` recipe), drop to pnpm:
-
-```bash
-cd typescript && pnpm install
-cd typescript && pnpm --filter @solana/keychain-<name> <script>   # e.g. test, build, typecheck
-cd typescript && pnpm typecheck                                    # workspace-wide
-```
-
-### Architecture
-
-- **Monorepo** ([typescript/](typescript/)): pnpm workspace, one package per backend plus `core` (interfaces) and `keychain` (umbrella factory).
-- **Interface** (`@solana/keychain-core`): every signer implements `SolanaSigner<TAddress>` — `address`, `signMessages()`, `signTransactions()`, `isAvailable()`. Compatible with `@solana/kit` and `@solana/signers`.
-- **Async factory pattern:** each package exports `async createXSigner(config)` returning a ready-to-use `SolanaSigner` (the factory awaits any `init()` internally — TS parity with Rust's `Signer::from_*`). The umbrella `@solana/keychain` exports `createKeychainSigner({ backend, ...config })` that dispatches to the per-backend factory.
-- **Package naming:** `@solana/keychain-<backend>` (e.g. `@solana/keychain-privy`, `@solana/keychain-aws-kms`).
-
-See [typescript/README.md](typescript/README.md) for the full package list and usage. When adding a backend, follow [docs/ADDING_SIGNERS.md](docs/ADDING_SIGNERS.md) — the umbrella package needs updates in 7 places (including the treeshake script).
-
-### Gotchas
-
-- **Async construction:** always `await createXSigner(...)` — direct class construction is deprecated and skips `init()`.
-- **Managed-broadcast backends (Crossmint, Fordefi native mode):** implement `SolanaSendingSigner` from core — `signAndSendTransactions()` only, with **no** `signTransactions`/`signMessages` (Crossmint) because Kit classifies signers by duck-typed method presence. They are excluded from `@solana/keychain-kit-plugin` at the type level.
-- **`signMessages` quirks (parity with Rust):** `CrossmintSigner` does not expose `signMessages` at all (Rust returns `SigningFailed`). `CdpSigner` requires UTF-8 message bytes.
-- **HTTPS enforced:** all `apiBaseUrl` config fields must reject non-HTTPS URLs — validate with `assertHttpsUrl()` from `@solana/keychain-core`.
-- **Remote API calls:** go through `fetchSignerJson()` from `@solana/keychain-core` — it owns the HTTP_ERROR/REMOTE_API_ERROR/PARSING_ERROR pipeline, response sanitization (`sanitizeRemoteErrorResponse()`), redirect rejection, and a default 60s timeout. Batch signing uses core `signBatchStaggered()` + `validateRequestDelayMs()`.
-- **Integration tests:** use `runSignerIntegrationTest` + per-package `setup.ts`; spun up via `just ts-test-integration` (loads `.env`, starts local Vault).
-- **Tree-shakability:** run `just ts-treeshake` after touching exports — every package and the umbrella must stay tree-shakable.
-- **Adding a backend:** the umbrella package, `typescript-ci.yml`, and `typescript-publish.yml` all need updates (see [docs/ADDING_SIGNERS.md](docs/ADDING_SIGNERS.md)).
-
-## Python
-
-Single package under [python/](python/) (PyPI `solana-keychain`, import `solana_keychain`), src layout, hatchling. The `just py-*` recipes bootstrap `python/.venv` automatically (plain venv + pip; `rm -rf python/.venv` to refresh after dependency changes). Tooling: pytest (+pytest-asyncio, auto mode), ruff (format + lint), mypy strict.
-
-### Architecture
-
-- **Contract** (`solana_keychain.core`): `SolanaSigner` ABC — `pubkey` property, async `sign_transaction()` / `sign_message()` / `is_available()`. `sign_transaction` takes a `VersionedTransaction` (legacy, v0 or v1) and returns `SignedTransaction` with `is_complete`. Use `signed_message_bytes()` for the bytes a signature covers; never hand-roll the version prefix.
-- **Errors**: `SignerError` with stable `code` values; `str()`/`repr()` only surface generic messages (detail is redacted and must never leak key material or raw remote responses).
-- **Serialization**: built on `solders`; golden wire-format vectors pinned in `python/tests/test_parity.py` — never regenerate them to make the suite pass.
-- **Remote API calls** go through `fetch_signer_json()` from `solana_keychain.core` — it owns the HTTP_ERROR/REMOTE_API_ERROR/PARSING_ERROR pipeline, response sanitization, redirect rejection, and a default 60s timeout. Base URLs must pass `assert_https_url()`. Unit tests mock HTTP with `respx`; no live API calls in unit tests.
-- **Backend imports/extras rules**: the root `__init__.py` must never eagerly import a backend whose dependencies live behind an optional extra (use lazy `__getattr__` or leave it to submodule imports), and such backends must raise a clear "install `solana-keychain[<extra>]`" error when imported without their extra. Backends with only base deps (`solders`, `httpx`) may be exported eagerly.
-- **Umbrella factory**: `create_keychain_signer(backend, config)` in `solana_keychain/keychain.py` dispatches by backend name with lazy imports; new backends must be added to its `_BACKENDS` table.
-- **Integration tests**: `python/tests/integration/`, gated by the `integration` pytest marker (excluded by default via `addopts`), env-var-driven with the same variable names as the other integration suites; each backend skips itself when unconfigured. `just py-test-integration` runs the local Vault flow.
-
-## Branch Workflow
-
-- `main` — integration branch (audited + unaudited).
-- `feat/*`, `fix/*`, `chore/*` — topic branches from `main`.
-- `hotfix/*` — urgent fixes from a deployed stable tag (use `just hotfix`).
-
-`just branch-info` prints the full guidance.
+`main` is the integration branch (audited plus unaudited). Topic branches are `feat/*`, `fix/*`, `chore/*` off `main`; urgent fixes are `hotfix/*` off a deployed stable tag via `just hotfix`. `just branch-info` prints the full guidance.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## Implementations
 
-This repository contains three implementations:
+This repository contains four implementations:
 
 ### [Rust](rust/)
 
@@ -31,6 +31,20 @@ Async signer library built on [`solders`](https://pypi.org/project/solders/) for
 - **Backends**: Memory, Vault, Privy, Turnkey, AWS KMS, Fireblocks, GCP KMS, Dfns, Para, CDP, Crossmint, Openfort, Utila, Fordefi
 - **Features**: Async/await, optional extras so heavy provider SDKs stay out of the base install, strict typing
 - [View Python Documentation →](python/README.md)
+
+### [Go](go/)
+
+Async-free signer library built on [`solana-go`](https://github.com/solana-foundation/solana-go), with one Go module per backend so your module graph contains only the backends you import.
+
+- **Backends**: Memory, Vault, Privy, Turnkey, AWS KMS, Fireblocks, GCP KMS, Dfns, Para, CDP, Crossmint, Openfort, Utila, Fordefi
+- **Features**: Per-backend modules, golden wire-format vectors, redacted errors matched by stable code
+- [View Go Documentation →](go/README.md)
+
+## Security Model
+
+`solana-keychain` is a signing adapter: it validates the signing hop, not what your transaction does. Backends come in two shapes, and only one of them signs the bytes you built. [docs/SECURITY_MODEL.md](docs/SECURITY_MODEL.md) is the short version, worth reading before putting a signer on a path that moves value.
+
+To report a vulnerability, follow [SECURITY.md](SECURITY.md) rather than opening an issue.
 
 ## Security Audit
 

--- a/docs/ADDING_SIGNERS.md
+++ b/docs/ADDING_SIGNERS.md
@@ -1092,8 +1092,36 @@ let decoded = STANDARD.decode(&api_response.signature).expect("decode failed");
 return Err(SignerError::RemoteApiError(format!("API error: {error_body}")));
 ```
 
-### Security Best Practices
+### Security Requirements
 
+These are not suggestions. Consumers pick a backend on the strength of them, so
+a new backend that skips one silently breaks what the rest of the library
+guarantees. If your provider makes one impossible, say so in the PR and in
+[SECURITY_MODEL.md](SECURITY_MODEL.md).
+
+- **Verify what the provider signed.** Compute the message bytes locally, and
+  verify the returned signature against them before attaching it. If the
+  provider returns a whole signed transaction, deserialize it, take the signature
+  at your signer's required-signer position, and verify that. A signature that
+  does not verify must fail, never be attached.
+- **Declare whether the provider broadcasts.** If it executes server-side,
+  implement the sending shape (`broadcasts_transactions` true,
+  `SolanaSendingSigner` in TypeScript, `core.TransactionBroadcaster` in Go) and
+  return the signature that identifies the landed transaction. If the provider
+  has no sign-only endpoint at all, make the backend sending-only: fail the
+  sign-only entry point rather than submitting behind the caller's back.
+- **Never mutate the caller's transaction with a signature that does not cover
+  it.** A provider that rewrites the transaction produces a signature over its
+  own bytes; leave the caller's transaction untouched.
+- **Report broadcast uncertainty as such.** A failure after submission may still
+  have landed. Surface `BROADCAST_UNCONFIRMED` rather than a generic error a
+  caller might blindly retry into a duplicate spend, and carry the provider
+  transaction id whenever you have one. If the create itself failed there is no
+  id to carry, so send a message-derived idempotency key on every create: that
+  is what makes a byte-identical resend safe.
+- **Never sign before init.** Hold the public key as an optional value and fail
+  with a config error if signing is attempted first; never fall back to the zero
+  address.
 - **Never log sensitive data** (private keys, API secrets, raw API responses)
 - **Use `Debug` impl that hides sensitive fields** — both `Debug` and `Display` on `SignerError` are redacted by default; do not rely on error messages containing details
 - **Validate all inputs** (public keys, signatures)

--- a/docs/SECURITY_MODEL.md
+++ b/docs/SECURITY_MODEL.md
@@ -1,0 +1,7 @@
+# Security Model
+
+`solana-keychain` validates the signing hop, never what a transaction does. Backends come in two shapes, and the difference matters before you put one on a path that moves value. Which shape a given backend has is in the signer-capabilities table of your language's README: [Rust](../rust/README.md#signer-capabilities), [TypeScript](../typescript/README.md#signer-capabilities), [Python](../python/README.md#signer-capabilities), [Go](../go/README.md#signer-capabilities).
+
+**Signing backends sign the bytes you built.** The signature the provider returns is verified against your locally computed message before it is used, so you end up with a transaction you can still inspect and broadcast yourself. See the memory or Vault example in the quick-start.
+
+**Sending backends sign bytes you never see.** The provider builds, rewrites (to sponsor gas) and broadcasts server-side, so the returned signature identifies the transaction that landed rather than covering the bytes you submitted, and there is nothing to verify it against. A failure may still have landed on chain, so reconcile before retrying. See Crossmint in the capabilities table and the sign-and-send section.

--- a/rust/README.md
+++ b/rust/README.md
@@ -495,4 +495,4 @@ just fmt
 
 ### Adding a New Signer Backend
 
-Interested in adding a new signer backend? Check out our [guide for adding new signers](docs/ADDING_SIGNERS.md). If you use [Claude Code](https://claude.ai/code), the repo includes an `add-signer-ci` skill that wires up the CI workflows.
+Interested in adding a new signer backend? Check out our [guide for adding new signers](../docs/ADDING_SIGNERS.md). If you use [Claude Code](https://claude.ai/code), the repo includes an `add-signer-ci` skill that wires up the CI workflows.


### PR DESCRIPTION
Rebased onto `main` now that #284 is merged. Audit standing is untouched: `audits/AUDIT_STATUS.md` is unchanged and every existing audit paragraph is byte-identical to `main`.

## Why

Backends come in two shapes and nothing said so where a consumer would look. A reader had no way to learn that a sending backend's signature identifies what landed rather than covering the bytes they submitted (#281). The only statement of that lived in a doc comment at `go/signers/crossmint/types.go:42`. The root README also claimed three implementations and omitted Go entirely.

## What changed

**`docs/SECURITY_MODEL.md`** (new, 3 lines): keychain validates the signing hop, never what a transaction does, then one line each for the two shapes.

- Signing backends sign the bytes you built, and the returned signature is verified against your locally computed message before use, so you keep a transaction you can inspect and broadcast yourself.
- Sending backends sign bytes you never see: the provider builds, rewrites to sponsor gas, and broadcasts, so the signature identifies what landed and there is nothing to verify it against. A failure may still have landed, so reconcile before retrying.

Each points at the signer-capabilities table and the quick-start in the reader's own language README rather than restating them.

**Root README**: gains the missing Go section and a short pointer to the above. No other README changes, so there is exactly one place to keep correct.

**`docs/ADDING_SIGNERS.md`**: "Security Best Practices" becomes "Security Requirements", with the obligations the sending shape creates. Verify what the provider signed. Declare whether it broadcasts, and go sending-only when the provider has no sign-only endpoint. Never attach a signature that does not cover the caller's bytes. Report broadcast uncertainty with a provider transaction id when one exists, and a message-derived idempotency key always, since a create that fails before returning an id leaves nothing else to reconcile against. Never sign before init.

**`CLAUDE.md`: 138 lines to 46.** Dropped the per-language command tables that `just` already lists, the architecture prose that reading `traits.rs`/`types.ts` answers, the package-naming convention, and a link to a `RELEASING.md` that does not exist. Kept the gotchas and added the security standing. Two stale facts corrected: the backend count said thirteen (it is 14, Fordefi was missing), and `just test`/`just build` were documented as rust+ts when they cover all four languages.

Also fixes a broken relative link to `ADDING_SIGNERS.md` in `rust/README.md`.

## Review feedback

Both Greptile P1s landed on an earlier, much longer draft and both were valid. The trimmed document no longer makes either claim, and the requirements list carries the corrected version:

- The blanket transport guarantee was wrong. `rust/src/vault/mod.rs:115` deliberately does not force `https_only` because `vault server -dev` is plain-HTTP loopback, the TypeScript and Python Vault signers allow the same, and `aws_kms`/`gcp_kms` reach their provider through the vendor SDK rather than this library's client.
- Reconciliation by provider transaction id assumed an id that can be absent: `rust/src/transaction_util.rs:32` raises `BROADCAST_UNCONFIRMED` with no id whenever the create fails with anything but a 4xx. The recovery path for that case is the message-derived idempotency key, present in all four languages for both Crossmint and Fordefi, which makes a byte-identical resend safe and a rebuilt transaction a new transfer. That is now what ADDING_SIGNERS requires.

Docs only, no code touched. Every relative link and anchor resolves.