### PR TITLE
feat(fordefi)!: native manual push mode for TypeScript

### DIFF
--- a/typescript/packages/fordefi/README.md
+++ b/typescript/packages/fordefi/README.md
@@ -10,13 +10,21 @@ npm install @solana/keychain-fordefi
 
 ## Signing Modes
 
-The signer supports two modes determined by whether `chain` is provided:
+The signer supports three modes, determined by `chain` and `pushMode`. Kit classifies signers by method presence, so each mode exposes exactly one transaction entry point and none of the others:
 
-### Native Solana mode (recommended for on-chain use)
+| Mode | Config | Shape | Entry point |
+|------|--------|-------|-------------|
+| Black box | `chain` unset | `FordefiBlackBoxSigner` | `signTransactions()` |
+| Native auto | `chain` set, `pushMode` omitted or `'auto'` | `FordefiNativeSigner` | `signAndSendTransactions()` |
+| Native manual | `chain` set, `pushMode: 'manual'` | `FordefiNativeManualSigner` | `modifyAndSignTransactions()` |
 
-Set `chain` to use Fordefi's native Solana transaction type. Fordefi may modify the transaction (e.g. updating the blockhash or adding compute budget instructions) and broadcasts it on-chain automatically (`push_mode: 'auto'`). Use this with a **Solana vault**.
+All three sign off-chain messages with `signMessages()`.
 
-> **Note:** Native mode is a Kit `TransactionSendingSigner` (`FordefiNativeSigner`, built on `SolanaSendingSigner` from `@solana/keychain-core`), because Fordefi may sign a different message than the one supplied by the caller and broadcasts it itself. Use `signAndSendTransactionMessageWithSigners()` or `signAndSendTransactions()`. Native instances expose **no** `signTransactions` — Kit classifies signers by method presence, so its absence is what routes the signer through Kit's sending flow — but message signing (`signMessages`) still works. Black-box instances are the mirror image: `signTransactions` and no `signAndSendTransactions`.
+### Native auto mode (recommended for on-chain use)
+
+Set `chain` to use Fordefi's native Solana transaction type. Fordefi may modify the transaction (e.g. updating the blockhash or adding compute budget instructions) and broadcasts it on-chain automatically. Use this with a **Solana vault**.
+
+> **Note:** Native auto mode is a Kit `TransactionSendingSigner` (`FordefiNativeSigner`, built on `SolanaSendingSigner` from `@solana/keychain-core`), because Fordefi may sign a different message than the one supplied by the caller and broadcasts it itself. Use `signAndSendTransactionMessageWithSigners()` or `signAndSendTransactions()`. Instances expose **no** `signTransactions`: Kit classifies signers by method presence, so its absence is what routes the signer through Kit's sending flow. Message signing (`signMessages`) still works. Black-box instances are the mirror image: `signTransactions` and no `signAndSendTransactions`.
 
 ```typescript
 import { createFordefiSigner } from '@solana/keychain-fordefi';
@@ -35,6 +43,36 @@ const transactionSignature = await signAndSendTransactionMessageWithSigners(tran
 ```
 
 Native auto-broadcast currently supports transactions whose only required signer is the configured Fordefi vault. Transactions requiring additional signers are rejected before submission until the integration forwards their partial signatures through Fordefi's `details.signatures` field.
+
+### Native manual mode
+
+Add `pushMode: 'manual'` to the native config. Fordefi still parses the transaction, so its policy engine and approval UI apply, but it signs **without** broadcasting: you own submission, and additional required signers are supported, which native auto rejects.
+
+Manual mode is a Kit `TransactionModifyingSigner` (`FordefiNativeManualSigner`, built on `SolanaModifyingSigner`). `modifyAndSignTransactions()` returns the transaction Fordefi signed, which **replaces** the one you submitted: continue from the returned value so every downstream signer signs the message the Fordefi signature covers.
+
+```typescript
+import { createFordefiSigner } from '@solana/keychain-fordefi';
+
+const signer = await createFordefiSigner({
+    accessToken: process.env.FORDEFI_ACCESS_TOKEN!,
+    vaultId: process.env.FORDEFI_VAULT_ID!,
+    privateKeyPem: fs.readFileSync('./secret/private.pem', 'utf8'),
+    publicKey: process.env.FORDEFI_PUBLIC_KEY!,
+    chain: 'solana_devnet',
+    pushMode: 'manual',
+});
+
+const [signedTransaction] = await signer.modifyAndSignTransactions([transaction]);
+await rpc.sendTransaction(getBase64EncodedWireTransaction(signedTransaction), { encoding: 'base64' }).send();
+```
+
+Requirements and caveats:
+
+- The Fordefi vault must be the transaction fee payer, and manual signing must run before any signature is applied. Both are checked before anything is submitted.
+- Fordefi may rewrite the message: at minimum the recent blockhash, and it manages the Compute Budget fee instructions, so a compute-unit limit or price you set yourself may not survive. What changed is **not** diffed, so inspect the result before broadcasting if its contents matter to you.
+- The returned signature is verified with ed25519 against the message Fordefi returned, at the vault's required-signer position. A mismatch fails and is never handed back.
+- Fordefi refreshes the blockhash but does not report its `lastValidBlockHeight`, so a refreshed lifetime carries Kit's `U64_MAX` placeholder; broadcast promptly rather than relying on local expiry detection.
+- The create carries an `x-idempotence-id` derived from the message bytes under a manual-specific namespace, so resending the same bytes reuses the Fordefi transaction instead of creating a second one, and cannot collide with an auto create that did broadcast them.
 
 ### Black box mode
 
@@ -59,6 +97,7 @@ const signer = await createFordefiSigner({
 | `requestSigner` | One of | Custom API-request signer (e.g. KMS/HSM). Provide exactly one of `privateKeyPem` or `requestSigner` |
 | `publicKey` | Yes | Solana public key of the vault (base58) |
 | `chain` | No | `'solana_mainnet'` or `'solana_devnet'` — enables native Solana mode |
+| `pushMode` | No | `'auto'` (default) or `'manual'`, i.e. whether Fordefi broadcasts. `'manual'` requires `chain` |
 | `fee` | No | Priority fee config for native mode (e.g. `{ type: 'custom', priority_fee: '1000' }`) |
 | `apiBaseUrl` | No | API base URL (default: `https://api.fordefi.com`) |
 | `pollIntervalMs` | No | Polling interval in ms (default: 2000) |

--- a/typescript/packages/fordefi/package.json
+++ b/typescript/packages/fordefi/package.json
@@ -48,6 +48,7 @@
         "@solana/codecs-strings": ">=8.0.0",
         "@solana/keys": ">=8.0.0",
         "@solana/signers": ">=8.0.0",
+        "@solana/transaction-messages": ">=8.0.0",
         "@solana/transactions": ">=8.0.0"
     },
     "publishConfig": {
@@ -59,6 +60,7 @@
         "@solana/keychain-test-utils": "workspace:*",
         "@solana/keys": "8.0.0",
         "@solana/signers": "8.0.0",
+        "@solana/transaction-messages": "8.0.0",
         "@solana/transactions": "8.0.0",
         "dotenv": "^17.4.2"
     }

--- a/typescript/packages/fordefi/package.json
+++ b/typescript/packages/fordefi/package.json
@@ -55,10 +55,12 @@
         "access": "public"
     },
     "devDependencies": {
+        "@solana-program/system": "^0.13.0",
         "@solana/addresses": "8.0.0",
         "@solana/codecs-strings": "8.0.0",
         "@solana/keychain-test-utils": "workspace:*",
         "@solana/keys": "8.0.0",
+        "@solana/kit": "8.0.0",
         "@solana/signers": "8.0.0",
         "@solana/transaction-messages": "8.0.0",
         "@solana/transactions": "8.0.0",

--- a/typescript/packages/fordefi/src/__tests__/fordefi-signer.integration.test.ts
+++ b/typescript/packages/fordefi/src/__tests__/fordefi-signer.integration.test.ts
@@ -1,13 +1,127 @@
-import { describe, it } from 'vitest';
+import { getTransferSolInstruction } from '@solana-program/system';
+import { assertSignatureValid } from '@solana/keychain-core';
 import { runSignerIntegrationTest } from '@solana/keychain-test-utils';
-import { getConfig } from './setup';
+import {
+    address,
+    appendTransactionMessageInstructions,
+    type Base64EncodedWireTransaction,
+    type Blockhash,
+    compileTransaction,
+    createTransactionMessage,
+    getBase58Decoder,
+    getBase64EncodedWireTransaction,
+    lamports,
+    pipe,
+    setTransactionMessageFeePayerSigner,
+    setTransactionMessageLifetimeUsingBlockhash,
+    signAndSendTransactionMessageWithSigners,
+    type TransactionSigner,
+} from '@solana/kit';
 import { config } from 'dotenv';
+import { describe, expect, it } from 'vitest';
+import { createFordefiSigner } from '../fordefi-signer';
+import type { SolanaChainUniqueId } from '../types';
+import { getConfig } from './setup';
 config();
 
 // Fordefi MPC signing can take tens of seconds end-to-end (submit + poll until
 // the co-signers finish), so we extend the per-test timeout well beyond the
 // vitest default of 30s.
 const TEST_TIMEOUT_MS = 120_000;
+
+const RPC_URL = process.env.SOLANA_RPC_URL ?? 'https://api.devnet.solana.com';
+const TRANSFER_LAMPORTS = lamports(1n);
+const CONFIRMATION_TIMEOUT_MS = 60_000;
+const CONFIRMATION_POLL_INTERVAL_MS = 2_000;
+
+async function callRpc<T>(method: string, params: unknown[]): Promise<T> {
+    const response = await fetch(RPC_URL, {
+        body: JSON.stringify({ id: 1, jsonrpc: '2.0', method, params }),
+        headers: { 'Content-Type': 'application/json' },
+        method: 'POST',
+    });
+    const json = (await response.json()) as { error?: unknown; result: T };
+    if (json.error) {
+        throw new Error(`${method} RPC error: ${JSON.stringify(json.error)}`);
+    }
+    return json.result;
+}
+
+async function getLatestBlockhash(): Promise<{ blockhash: Blockhash; lastValidBlockHeight: bigint }> {
+    const { value } = await callRpc<{ value: { blockhash: Blockhash; lastValidBlockHeight: number } }>(
+        'getLatestBlockhash',
+        [{ commitment: 'finalized' }],
+    );
+    return { blockhash: value.blockhash, lastValidBlockHeight: BigInt(value.lastValidBlockHeight) };
+}
+
+async function sendWireTransaction(wireTransaction: Base64EncodedWireTransaction): Promise<string> {
+    // Fordefi stamps the recent blockhash seconds before it signs, so a
+    // finalized-commitment preflight reports BlockhashNotFound and rejects the send.
+    return await callRpc<string>('sendTransaction', [
+        wireTransaction,
+        { encoding: 'base64', preflightCommitment: 'processed' },
+    ]);
+}
+
+async function confirmSignature(signature: string, rebroadcast?: Base64EncodedWireTransaction): Promise<void> {
+    const deadline = Date.now() + CONFIRMATION_TIMEOUT_MS;
+
+    while (Date.now() < deadline) {
+        const { value } = await callRpc<{ value: ({ confirmationStatus: string | null; err: unknown } | null)[] }>(
+            'getSignatureStatuses',
+            [[signature], { searchTransactionHistory: true }],
+        );
+        const status = value[0];
+
+        if (status) {
+            if (status.err) {
+                throw new Error(`Transaction failed on-chain: ${JSON.stringify(status.err)}`);
+            }
+            if (status.confirmationStatus === 'confirmed' || status.confirmationStatus === 'finalized') {
+                return;
+            }
+        }
+
+        if (rebroadcast) {
+            // A sent transaction can be dropped and never land, so resend it
+            // between polls while its blockhash is still valid.
+            await sendWireTransaction(rebroadcast).catch(() => undefined);
+        }
+        await new Promise(resolve => setTimeout(resolve, CONFIRMATION_POLL_INTERVAL_MS));
+    }
+
+    throw new Error(`Timed out waiting for confirmation of ${signature}`);
+}
+
+function nativeConfig() {
+    return {
+        accessToken: process.env.FORDEFI_ACCESS_TOKEN!,
+        apiBaseUrl: process.env.FORDEFI_API_BASE_URL,
+        chain: (process.env.FORDEFI_CHAIN ?? 'solana_devnet') as SolanaChainUniqueId,
+        maxPollAttempts: 110,
+        pollIntervalMs: 1000,
+        privateKeyPem: process.env.FORDEFI_PRIVATE_KEY_PEM!,
+        publicKey: process.env.FORDEFI_PUBLIC_KEY!,
+        vaultId: process.env.FORDEFI_VAULT_ID!,
+    };
+}
+
+async function buildUnsignedDevnetTransfer<TSigner extends TransactionSigner<string>>(feePayer: TSigner) {
+    const { blockhash, lastValidBlockHeight } = await getLatestBlockhash();
+    const destination = address(process.env.DEVNET_RECIPIENT ?? feePayer.address);
+
+    return pipe(
+        createTransactionMessage({ version: 0 }),
+        tx => setTransactionMessageFeePayerSigner(feePayer, tx),
+        tx => setTransactionMessageLifetimeUsingBlockhash({ blockhash, lastValidBlockHeight }, tx),
+        tx =>
+            appendTransactionMessageInstructions(
+                [getTransferSolInstruction({ amount: TRANSFER_LAMPORTS, destination, source: feePayer })],
+                tx,
+            ),
+    );
+}
 
 describe('FordefiSigner Integration', () => {
     it.skipIf(!process.env.FORDEFI_BB_VAULT_ID)(
@@ -28,6 +142,47 @@ describe('FordefiSigner Integration', () => {
         'simulates transactions with real API',
         async () => {
             await runSignerIntegrationTest(await getConfig(['simulateTransaction']));
+        },
+        TEST_TIMEOUT_MS,
+    );
+
+    it.skipIf(!process.env.FORDEFI_VAULT_ID)(
+        'native auto mode signs and broadcasts a devnet transfer',
+        async () => {
+            const signer = await createFordefiSigner({ ...nativeConfig(), pushMode: 'auto' as const });
+            const transactionMessage = await buildUnsignedDevnetTransfer(signer);
+
+            const signatureBytes = await signAndSendTransactionMessageWithSigners(transactionMessage);
+
+            expect(signatureBytes.byteLength).toBe(64);
+
+            await confirmSignature(getBase58Decoder().decode(signatureBytes));
+        },
+        TEST_TIMEOUT_MS,
+    );
+
+    it.skipIf(!process.env.FORDEFI_VAULT_ID)(
+        'native manual mode signs a devnet transfer the caller broadcasts',
+        async () => {
+            const signer = await createFordefiSigner({ ...nativeConfig(), pushMode: 'manual' as const });
+            const transactionMessage = await buildUnsignedDevnetTransfer(signer);
+
+            const signedTransactions = await signer.modifyAndSignTransactions([compileTransaction(transactionMessage)]);
+            expect(signedTransactions).toHaveLength(1);
+            const signedTransaction = signedTransactions[0]!;
+
+            const vaultSignature = signedTransaction.signatures[signer.address];
+            expect(vaultSignature?.byteLength).toBe(64);
+            await assertSignatureValid({
+                data: signedTransaction.messageBytes,
+                signature: vaultSignature!,
+                signerAddress: signer.address,
+            });
+
+            const wireTransaction = getBase64EncodedWireTransaction(signedTransaction);
+            const transactionSignature = await sendWireTransaction(wireTransaction);
+
+            await confirmSignature(transactionSignature, wireTransaction);
         },
         TEST_TIMEOUT_MS,
     );

--- a/typescript/packages/fordefi/src/__tests__/fordefi-signer.test.ts
+++ b/typescript/packages/fordefi/src/__tests__/fordefi-signer.test.ts
@@ -6,13 +6,14 @@ import {
     assertIsSolanaTransactionSigner,
     assertSignatureValid,
     isSolanaMessageSigner,
+    isSolanaModifyingSigner,
     isSolanaSendingSigner,
     isSolanaSigner,
     isSolanaTransactionSigner,
     type SignerError,
 } from '@solana/keychain-core';
 import { createCosignedWireTransaction, createSignedWireTransaction } from '@solana/keychain-test-utils';
-import { isTransactionPartialSigner, isTransactionSendingSigner } from '@solana/signers';
+import { isTransactionModifyingSigner, isTransactionPartialSigner, isTransactionSendingSigner } from '@solana/signers';
 
 vi.mock('@solana/keychain-core', async importOriginal => {
     const mod = await importOriginal<typeof import('@solana/keychain-core')>();
@@ -31,6 +32,7 @@ vi.mock('@solana/keychain-core', async importOriginal => {
 });
 
 import { createFordefiSigner, type FordefiSignerConfig } from '../fordefi-signer.js';
+import type { SolanaChainUniqueId } from '../types.js';
 
 // Mock fetch globally
 global.fetch = vi.fn();
@@ -44,7 +46,7 @@ const TEST_PEM = testPrivateKey.export({ type: 'sec1', format: 'pem' }) as strin
 const MOCK_SIGNATURE_BYTES = new Uint8Array(64).fill(0xab);
 const MOCK_SIGNATURE_BASE64 = Buffer.from(MOCK_SIGNATURE_BYTES).toString('base64');
 
-const mockConfig: FordefiSignerConfig & { chain?: undefined } = {
+const mockConfig: FordefiSignerConfig & { chain?: undefined; pushMode?: undefined } = {
     accessToken: 'test-token',
     apiBaseUrl: 'https://api.test.fordefi.com',
     privateKeyPem: TEST_PEM,
@@ -81,6 +83,31 @@ async function setupNativeBroadcast(version: 0 | 1) {
         publicKey: fixture.feePayer,
     } satisfies FordefiSignerConfig;
     return { config, fixture };
+}
+
+// Manual mode replaces the caller's transaction with real wire bytes, so the
+// response has to be a decodable transaction the vault signed.
+async function setupNativeManual(version: 0 | 1) {
+    const fixture = await createSignedWireTransaction(version);
+    const config = {
+        ...mockConfig,
+        chain: 'solana_mainnet',
+        publicKey: fixture.feePayer,
+        pushMode: 'manual',
+    } satisfies FordefiSignerConfig & { chain: SolanaChainUniqueId; pushMode: 'manual' };
+    return { config, fixture };
+}
+
+function unsignedManualTransaction(feePayer: string, messageBytes = new Uint8Array(32)) {
+    return { messageBytes, signatures: { [feePayer]: null } } as never;
+}
+
+function idempotencyKeyOf(input: Uint8Array) {
+    const digest = createHash('sha256').update(input).digest().subarray(0, 16);
+    digest[6] = (digest[6]! & 0x0f) | 0x40;
+    digest[8] = (digest[8]! & 0x3f) | 0x80;
+    const hex = digest.toString('hex');
+    return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20, 32)}`;
 }
 
 function mockVaultResponse(address: string = MOCK_ADDRESS) {
@@ -157,7 +184,7 @@ describe('createFordefiSigner', () => {
 
     describe('custom requestSigner', () => {
         // Config using a custom request signer instead of a PEM key.
-        const customConfig: FordefiSignerConfig & { chain?: undefined } = {
+        const customConfig: FordefiSignerConfig & { chain?: undefined; pushMode?: undefined } = {
             accessToken: 'test-token',
             apiBaseUrl: 'https://api.test.fordefi.com',
             publicKey: MOCK_ADDRESS,
@@ -646,6 +673,227 @@ describe('createFordefiSigner', () => {
                 code: 'SIGNER_BROADCAST_UNCONFIRMED',
                 context: expect.objectContaining({ providerTransactionId: 'tx-fail' }) as object,
             });
+        });
+    });
+
+    describe('modifyAndSignTransactions (native manual mode)', () => {
+        it.each([0, 1] as const)(
+            'should replace the caller transaction with the one Fordefi signed from a v%i envelope',
+            async version => {
+                const { config, fixture } = await setupNativeManual(version);
+                vi.mocked(fetch)
+                    .mockResolvedValueOnce(mockCreateTxResponse('tx-manual'))
+                    .mockResolvedValueOnce(mockPollResponse('signed', undefined, fixture.wireTransaction));
+
+                const signer = await createFordefiSigner(config);
+                const results = await signer.modifyAndSignTransactions([unsignedManualTransaction(fixture.feePayer)]);
+
+                expect(results).toHaveLength(1);
+                // Continuing from the caller's own bytes would leave downstream
+                // signers signing a message the Fordefi signature does not cover.
+                expect(results[0]!.messageBytes).toStrictEqual(fixture.messageBytes);
+                expect(results[0]!.signatures[fixture.feePayer]).toStrictEqual(fixture.signature);
+                expect(results[0]!.lifetimeConstraint).toBeDefined();
+
+                // The signature covers what Fordefi returned, not what was submitted.
+                expect(assertSignatureValid).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        data: fixture.messageBytes,
+                        signerAddress: fixture.feePayer,
+                    }),
+                );
+            },
+        );
+
+        it('should submit solana_transaction with push_mode manual', async () => {
+            const { config, fixture } = await setupNativeManual(0);
+            vi.mocked(fetch)
+                .mockResolvedValueOnce(mockCreateTxResponse('tx-manual'))
+                .mockResolvedValueOnce(mockPollResponse('signed', undefined, fixture.wireTransaction));
+
+            const signer = await createFordefiSigner(config);
+            await signer.modifyAndSignTransactions([unsignedManualTransaction(fixture.feePayer)]);
+
+            const postOpts = vi.mocked(fetch).mock.calls[0]![1] as RequestInit;
+            const body = JSON.parse(postOpts.body as string);
+            expect(body.type).toBe('solana_transaction');
+            expect(body.details.type).toBe('solana_serialized_transaction_message');
+            expect(body.details.push_mode).toBe('manual');
+        });
+
+        it('namespaces the x-idempotence-id so the same bytes cannot reuse an auto create', async () => {
+            const messageBytes = new Uint8Array(32).fill(0xab);
+            const { config, fixture } = await setupNativeManual(0);
+            vi.mocked(fetch)
+                .mockResolvedValueOnce(mockCreateTxResponse('tx-manual'))
+                .mockResolvedValueOnce(mockPollResponse('signed', undefined, fixture.wireTransaction));
+
+            const signer = await createFordefiSigner(config);
+            await signer.modifyAndSignTransactions([unsignedManualTransaction(fixture.feePayer, messageBytes)]);
+
+            const namespace = Buffer.from(`fordefi:solana:manual:solana_mainnet:${config.vaultId}:`, 'utf8');
+            const postOpts = vi.mocked(fetch).mock.calls[0]![1] as RequestInit;
+            expect(postOpts.headers).toHaveProperty(
+                'x-idempotence-id',
+                idempotencyKeyOf(Buffer.concat([namespace, Buffer.from(messageBytes)])),
+            );
+            expect(postOpts.headers).not.toHaveProperty('x-idempotence-id', idempotencyKeyOf(messageBytes));
+        });
+
+        it('exposes only the modifying method, so Kit cannot route it as a partial or sending signer', async () => {
+            const { config } = await setupNativeManual(0);
+            const signer = await createFordefiSigner(config);
+            const guardInput = signer as unknown as { [key: string]: unknown; address: typeof signer.address };
+
+            expect('signTransactions' in signer).toBe(false);
+            expect('signAndSendTransactions' in signer).toBe(false);
+            expect(isTransactionModifyingSigner(guardInput)).toBe(true);
+            expect(isTransactionPartialSigner(guardInput)).toBe(false);
+            expect(isTransactionSendingSigner(guardInput)).toBe(false);
+            expect(isSolanaSigner(guardInput)).toBe(true);
+            expect(isSolanaModifyingSigner(guardInput)).toBe(true);
+            expect(isSolanaTransactionSigner(guardInput)).toBe(false);
+            expect(isSolanaSendingSigner(guardInput)).toBe(false);
+            expect(isSolanaMessageSigner(guardInput)).toBe(true);
+        });
+
+        it('rejects a transaction the vault does not pay for before submitting remote work', async () => {
+            const { config, fixture } = await setupNativeManual(0);
+            const signer = await createFordefiSigner(config);
+            const mockTx = {
+                messageBytes: new Uint8Array(32),
+                signatures: { '22222222222222222222222222222222': null, [fixture.feePayer]: null },
+            } as never;
+
+            await expect(signer.modifyAndSignTransactions([mockTx])).rejects.toMatchObject({
+                code: 'SIGNER_SIGNING_FAILED',
+            });
+            expect(fetch).not.toHaveBeenCalled();
+        });
+
+        it('rejects an already-signed transaction, whose signatures the rewrite would invalidate', async () => {
+            const { config, fixture } = await setupNativeManual(0);
+            const signer = await createFordefiSigner(config);
+            const mockTx = {
+                messageBytes: new Uint8Array(32),
+                signatures: { [fixture.feePayer]: MOCK_SIGNATURE_BYTES },
+            } as never;
+
+            await expect(signer.modifyAndSignTransactions([mockTx])).rejects.toMatchObject({
+                code: 'SIGNER_SIGNING_FAILED',
+            });
+            expect(fetch).not.toHaveBeenCalled();
+        });
+
+        it('rejects a response without raw_transaction, having nothing to continue from', async () => {
+            const { config, fixture } = await setupNativeManual(0);
+            vi.mocked(fetch)
+                .mockResolvedValueOnce(mockCreateTxResponse('tx-manual'))
+                .mockResolvedValueOnce(mockPollResponse('signed', MOCK_SIGNATURE_BASE64));
+
+            const signer = await createFordefiSigner(config);
+            await expect(
+                signer.modifyAndSignTransactions([unsignedManualTransaction(fixture.feePayer)]),
+            ).rejects.toMatchObject({ code: 'SIGNER_SIGNING_FAILED' });
+        });
+
+        it('rejects a returned transaction that the configured vault did not sign', async () => {
+            const fixture = await createCosignedWireTransaction(0);
+            const config = {
+                ...mockConfig,
+                chain: 'solana_mainnet',
+                publicKey: fixture.feePayer,
+                pushMode: 'manual',
+            } satisfies FordefiSignerConfig & { chain: SolanaChainUniqueId; pushMode: 'manual' };
+            vi.mocked(fetch)
+                .mockResolvedValueOnce(mockCreateTxResponse('tx-manual'))
+                .mockResolvedValueOnce(mockPollResponse('signed', undefined, fixture.wireTransaction));
+
+            const signer = await createFordefiSigner(config);
+            await expect(
+                signer.modifyAndSignTransactions([unsignedManualTransaction(fixture.feePayer)]),
+            ).rejects.toMatchObject({ code: 'SIGNER_SIGNING_FAILED' });
+        });
+
+        it('leaves the caller transaction untouched when the returned signature does not verify', async () => {
+            const { config, fixture } = await setupNativeManual(0);
+            vi.mocked(fetch)
+                .mockResolvedValueOnce(mockCreateTxResponse('tx-manual'))
+                .mockResolvedValueOnce(mockPollResponse('signed', undefined, fixture.wireTransaction));
+            vi.mocked(assertSignatureValid).mockRejectedValueOnce(new Error('signature does not match'));
+
+            const signer = await createFordefiSigner(config);
+            const callerTransaction = unsignedManualTransaction(fixture.feePayer);
+            const before = structuredClone(callerTransaction);
+
+            await expect(signer.modifyAndSignTransactions([callerTransaction])).rejects.toThrow(
+                'signature does not match',
+            );
+            expect(callerTransaction).toStrictEqual(before);
+        });
+
+        it('does not leak the access token or the request key into a failure', async () => {
+            const { config, fixture } = await setupNativeManual(0);
+            vi.mocked(fetch).mockResolvedValueOnce(
+                new Response(JSON.stringify({ message: 'Unauthorized' }), { status: 401 }),
+            );
+
+            const signer = await createFordefiSigner(config);
+            const error = await signer.modifyAndSignTransactions([unsignedManualTransaction(fixture.feePayer)]).then(
+                () => {
+                    throw new Error('expected the submit failure to be reported');
+                },
+                (thrown: SignerError) => thrown,
+            );
+
+            const reported = `${error.message} ${JSON.stringify(error.context)} ${JSON.stringify(error)}`;
+            expect(reported).not.toContain(config.accessToken);
+            expect(reported).not.toContain(TEST_PEM);
+        });
+
+        it('keeps the caller lifetime when Fordefi did not refresh the blockhash', async () => {
+            const { config, fixture } = await setupNativeManual(0);
+            vi.mocked(fetch)
+                .mockResolvedValueOnce(mockCreateTxResponse('tx-manual'))
+                .mockResolvedValueOnce(mockPollResponse('signed', undefined, fixture.wireTransaction));
+
+            // Fordefi does not report a lastValidBlockHeight, so a surviving
+            // blockhash must not lose the caller's expiry height.
+            const lifetimeConstraint = { blockhash: '11111111111111111111111111111111', lastValidBlockHeight: 100n };
+            const signer = await createFordefiSigner(config);
+            const results = await signer.modifyAndSignTransactions([
+                {
+                    lifetimeConstraint,
+                    messageBytes: new Uint8Array(32),
+                    signatures: { [fixture.feePayer]: null },
+                } as never,
+            ]);
+
+            expect(results[0]!.lifetimeConstraint).toStrictEqual(lifetimeConstraint);
+        });
+
+        it('should reject pushMode manual without chain', async () => {
+            await expect(
+                createFordefiSigner({ ...mockConfig, pushMode: 'manual' } as FordefiSignerConfig),
+            ).rejects.toMatchObject({ code: 'SIGNER_CONFIG_ERROR' });
+        });
+
+        it('should reject an unrecognized pushMode rather than defaulting it to auto', async () => {
+            await expect(
+                createFordefiSigner({
+                    ...mockConfig,
+                    chain: 'solana_mainnet',
+                    pushMode: 'push',
+                } as unknown as FordefiSignerConfig),
+            ).rejects.toMatchObject({ code: 'SIGNER_CONFIG_ERROR' });
+        });
+
+        it('should still expose the sending method when pushMode is explicitly auto', async () => {
+            const signer = await createFordefiSigner({ ...nativeConfig, pushMode: 'auto' });
+            const guardInput = signer as unknown as { [key: string]: unknown; address: typeof signer.address };
+
+            expect(isTransactionSendingSigner(guardInput)).toBe(true);
+            expect(isTransactionModifyingSigner(guardInput)).toBe(false);
         });
     });
 

--- a/typescript/packages/fordefi/src/fordefi-signer.ts
+++ b/typescript/packages/fordefi/src/fordefi-signer.ts
@@ -1,7 +1,7 @@
 import { createPrivateKey, createSign, type KeyObject } from 'node:crypto';
 
 import { Address, assertIsAddress } from '@solana/addresses';
-import { getBase58Encoder, getBase64Decoder, getBase64Encoder } from '@solana/codecs-strings';
+import { getBase58Encoder, getBase64Decoder, getBase64Encoder, getUtf8Encoder } from '@solana/codecs-strings';
 import {
     abortableDelay,
     assertHttpsUrl,
@@ -16,6 +16,7 @@ import {
     signBatchStaggered,
     SignerErrorCode,
     SolanaMessageSigner,
+    SolanaModifyingSigner,
     SolanaSendingSigner,
     SolanaTransactionSigner,
     throwSignerError,
@@ -26,15 +27,20 @@ import {
     MessagePartialSignerConfig,
     SignableMessage,
     SignatureDictionary,
+    TransactionModifyingSigner,
+    TransactionModifyingSignerConfig,
     TransactionPartialSigner,
     TransactionPartialSignerConfig,
     TransactionSendingSigner,
     TransactionSendingSignerConfig,
 } from '@solana/signers';
+import { getCompiledTransactionMessageDecoder } from '@solana/transaction-messages';
 import {
+    assertIsTransactionWithinSizeLimit,
     Base64EncodedWireTransaction,
     getSignatureFromTransaction,
     getTransactionDecoder,
+    getTransactionLifetimeConstraintFromCompiledTransactionMessage,
     Transaction,
     TransactionWithinSizeLimit,
     TransactionWithLifetime,
@@ -43,6 +49,7 @@ import {
 import type {
     FordefiBlackBoxSignatureRequest,
     FordefiCreateTransactionResponse,
+    FordefiPushMode,
     FordefiSolanaFee,
     FordefiSolanaMessageRequest,
     FordefiSolanaTransactionRequest,
@@ -57,12 +64,15 @@ const DEFAULT_POLL_INTERVAL_MS = 2000;
 let base58Encoder: ReturnType<typeof getBase58Encoder> | undefined;
 let base64Decoder: ReturnType<typeof getBase64Decoder> | undefined;
 let base64Encoder: ReturnType<typeof getBase64Encoder> | undefined;
+let utf8Encoder: ReturnType<typeof getUtf8Encoder> | undefined;
 const DEFAULT_MAX_POLL_ATTEMPTS = 50;
 const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
 
+// An unrecognized value would otherwise fall through to auto and broadcast.
+const PUSH_MODES = new Set<string>(['auto', 'manual']);
 /** Terminal success states for pushable transactions (solana_transaction with push_mode auto). */
 const PUSHABLE_SUCCESS_STATES = new Set(['completed']);
-/** Terminal success states for non-pushable transactions (black_box_signature, solana_message). */
+/** Terminal success states for non-pushable transactions (black_box_signature, solana_message, native manual). */
 const NON_PUSHABLE_SUCCESS_STATES = new Set(['signed', 'completed']);
 /** Terminal failure states (all transaction types). Mirrors the Rust backend. */
 const FAILURE_STATES = new Set([
@@ -116,8 +126,8 @@ export interface FordefiSignerConfig {
     apiBaseUrl?: string;
     /**
      * Solana chain identifier. When set, uses native Solana API types
-     * (`solana_serialized_transaction_message` with `push_mode: 'auto'` for
-     * transactions, `solana_message` for messages) instead of `black_box_signature`.
+     * (`solana_serialized_transaction_message` for transactions,
+     * `solana_message` for messages) instead of `black_box_signature`.
      */
     chain?: SolanaChainUniqueId;
     /** Solana fee configuration for native mode transactions. Only used when `chain` is set. */
@@ -133,6 +143,11 @@ export interface FordefiSignerConfig {
     privateKeyPem?: string;
     /** Solana public key of the vault (base58) */
     publicKey: string;
+    /**
+     * Whether Fordefi broadcasts a native Solana transaction. Omitted is
+     * equivalent to `'auto'`; `'manual'` requires `chain`.
+     */
+    pushMode?: FordefiPushMode;
     /** Optional delay in ms between concurrent signing requests (default: 0) */
     requestDelayMs?: number;
     /**
@@ -151,15 +166,16 @@ export interface FordefiSignerConfig {
 }
 
 /**
- * Fordefi signer shape returned when `chain` enables native Solana mode.
+ * Fordefi signer shape returned when `chain` enables native Solana mode with
+ * `pushMode` omitted or `'auto'`.
  *
- * Native mode may replace the recent blockhash and fees before signing and
- * broadcasts with `push_mode: 'auto'`, so it must be used through Kit's
+ * Native auto mode may replace the recent blockhash and fees before signing and
+ * broadcasts the result itself, so it must be used through Kit's
  * {@link TransactionSendingSigner} flow rather than as a partial signer.
- * Native instances expose no `signTransactions` — Kit classifies signers by
- * duck-typed method presence — but do sign messages.
+ * Instances expose no `signTransactions`, because Kit classifies signers by
+ * duck-typed method presence, but do sign messages.
  *
- * Native mode is not retry-safe: any failure after Fordefi accepts the
+ * Native auto mode is not retry-safe: any failure after Fordefi accepts the
  * submission rejects with `BROADCAST_UNCONFIRMED` carrying
  * `context.providerTransactionId`; check that transaction with Fordefi before
  * retrying. A submission that fails without a usable response rejects with
@@ -171,6 +187,24 @@ export interface FordefiSignerConfig {
  */
 export interface FordefiNativeSigner<TAddress extends string = string>
     extends SolanaSendingSigner<TAddress>, SolanaMessageSigner<TAddress> {}
+
+/**
+ * Fordefi signer shape returned when `chain` is set and `pushMode` is
+ * `'manual'`.
+ *
+ * Fordefi rewrites the message (the recent blockhash, and the Compute Budget
+ * fee instructions it manages) and signs it without broadcasting, so
+ * `modifyAndSignTransactions()` returns the transaction Fordefi signed rather
+ * than signatures for the caller's own bytes. Continue from that transaction
+ * and never from the one you submitted: every downstream signer has to sign the
+ * message the Fordefi signature covers. What Fordefi changed is not diffed, so
+ * inspect the result before broadcasting it.
+ *
+ * Instances expose neither `signTransactions` nor `signAndSendTransactions`,
+ * and Fordefi must be the fee payer and sign before every downstream signer.
+ */
+export interface FordefiNativeManualSigner<TAddress extends string = string>
+    extends SolanaModifyingSigner<TAddress>, SolanaMessageSigner<TAddress> {}
 
 /**
  * Fordefi signer shape returned when `chain` is unset (black box mode).
@@ -191,17 +225,20 @@ export interface FordefiBlackBoxSigner<TAddress extends string = string>
  * @throws {SignerError} `SIGNER_CONFIG_ERROR` when required config is missing or invalid.
  */
 export function createFordefiSigner<TAddress extends string = string>(
-    config: FordefiSignerConfig & { chain: SolanaChainUniqueId },
+    config: FordefiSignerConfig & { chain: SolanaChainUniqueId; pushMode: 'manual' },
+): Promise<FordefiNativeManualSigner<TAddress>>;
+export function createFordefiSigner<TAddress extends string = string>(
+    config: FordefiSignerConfig & { chain: SolanaChainUniqueId; pushMode?: 'auto' },
 ): Promise<FordefiNativeSigner<TAddress>>;
 export function createFordefiSigner<TAddress extends string = string>(
     config: FordefiSignerConfig & { chain?: undefined },
 ): Promise<FordefiBlackBoxSigner<TAddress>>;
 export function createFordefiSigner<TAddress extends string = string>(
     config: FordefiSignerConfig,
-): Promise<FordefiBlackBoxSigner<TAddress> | FordefiNativeSigner<TAddress>>;
+): Promise<FordefiBlackBoxSigner<TAddress> | FordefiNativeManualSigner<TAddress> | FordefiNativeSigner<TAddress>>;
 export async function createFordefiSigner<TAddress extends string = string>(
     config: FordefiSignerConfig,
-): Promise<FordefiBlackBoxSigner<TAddress> | FordefiNativeSigner<TAddress>> {
+): Promise<FordefiBlackBoxSigner<TAddress> | FordefiNativeManualSigner<TAddress> | FordefiNativeSigner<TAddress>> {
     // The instance's own properties expose the mode-appropriate signing
     // method, which the class type cannot express statically.
     return await Promise.resolve(FordefiSigner.create(config) as unknown as FordefiBlackBoxSigner<TAddress>);
@@ -215,6 +252,7 @@ export async function createFordefiSigner<TAddress extends string = string>(
  */
 class FordefiSigner<TAddress extends string = string> implements SolanaMessageSigner<TAddress> {
     readonly address: Address<TAddress>;
+    declare modifyAndSignTransactions?: TransactionModifyingSigner<TAddress>['modifyAndSignTransactions'];
     declare signAndSendTransactions?: TransactionSendingSigner<TAddress>['signAndSendTransactions'];
     declare signTransactions?: TransactionPartialSigner<TAddress>['signTransactions'];
     private readonly accessToken: string;
@@ -223,6 +261,7 @@ class FordefiSigner<TAddress extends string = string> implements SolanaMessageSi
     private readonly fee?: FordefiSolanaFee;
     private readonly maxPollAttempts: number;
     private readonly pollIntervalMs: number;
+    private readonly pushMode: FordefiPushMode;
     private readonly requestSigner: FordefiRequestSigner;
     private readonly requestDelayMs: number;
     private readonly requestTimeoutMs: number;
@@ -235,6 +274,7 @@ class FordefiSigner<TAddress extends string = string> implements SolanaMessageSi
         this.fee = config.fee;
         this.maxPollAttempts = config.maxPollAttempts ?? DEFAULT_MAX_POLL_ATTEMPTS;
         this.pollIntervalMs = config.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+        this.pushMode = config.pushMode ?? 'auto';
         this.requestSigner = config.requestSigner ?? new PemRequestSigner(config.privateKeyPem ?? '');
         this.requestDelayMs = config.requestDelayMs ?? 0;
         this.requestTimeoutMs = config.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
@@ -243,11 +283,12 @@ class FordefiSigner<TAddress extends string = string> implements SolanaMessageSi
 
         // Kit classifies signers by duck-typed method presence, so each mode
         // exposes exactly the method it can honor as an own property: native
-        // mode rewrites and auto-broadcasts, so it is a sending signer and
-        // must not present a partial-signer method; black-box mode signs the
-        // caller's exact bytes, so it is a partial signer and must not
-        // present a sending method.
-        if (this.chain) {
+        // manual mode returns a rewritten transaction, native auto mode
+        // rewrites and broadcasts it, and black-box mode signs the caller's
+        // exact bytes.
+        if (this.chain && this.pushMode === 'manual') {
+            this.modifyAndSignTransactions = this.modifyAndSignNativeTransactions.bind(this);
+        } else if (this.chain) {
             this.signAndSendTransactions = this.signAndSendNativeTransactions.bind(this);
         } else {
             this.signTransactions = this.signBlackBoxTransactions.bind(this);
@@ -256,14 +297,18 @@ class FordefiSigner<TAddress extends string = string> implements SolanaMessageSi
 
     /** Create a FordefiSigner with the provided configuration. */
     static create<TAddress extends string = string>(
-        config: FordefiSignerConfig & { chain: SolanaChainUniqueId },
+        config: FordefiSignerConfig & { chain: SolanaChainUniqueId; pushMode: 'manual' },
+    ): FordefiNativeManualSigner<TAddress> & FordefiSigner<TAddress>;
+    static create<TAddress extends string = string>(
+        config: FordefiSignerConfig & { chain: SolanaChainUniqueId; pushMode?: 'auto' },
     ): FordefiNativeSigner<TAddress> & FordefiSigner<TAddress>;
     static create<TAddress extends string = string>(
         config: FordefiSignerConfig & { chain?: undefined },
     ): FordefiBlackBoxSigner<TAddress> & FordefiSigner<TAddress>;
     static create<TAddress extends string = string>(
         config: FordefiSignerConfig,
-    ): FordefiSigner<TAddress> & (FordefiBlackBoxSigner<TAddress> | FordefiNativeSigner<TAddress>);
+    ): FordefiSigner<TAddress> &
+        (FordefiBlackBoxSigner<TAddress> | FordefiNativeManualSigner<TAddress> | FordefiNativeSigner<TAddress>);
     static create<TAddress extends string = string>(config: FordefiSignerConfig): FordefiSigner<TAddress> {
         if (!config.accessToken) {
             return throwSignerError(SignerErrorCode.CONFIG_ERROR, {
@@ -292,6 +337,18 @@ class FordefiSigner<TAddress extends string = string> implements SolanaMessageSi
         if (!config.requestSigner && !config.privateKeyPem) {
             return throwSignerError(SignerErrorCode.CONFIG_ERROR, {
                 message: 'one of privateKeyPem or requestSigner must be provided',
+            });
+        }
+
+        if (config.pushMode !== undefined && !PUSH_MODES.has(config.pushMode)) {
+            return throwSignerError(SignerErrorCode.CONFIG_ERROR, {
+                message: "pushMode must be 'auto' or 'manual'",
+            });
+        }
+
+        if (config.pushMode === 'manual' && !config.chain) {
+            return throwSignerError(SignerErrorCode.CONFIG_ERROR, {
+                message: "pushMode 'manual' requires chain to enable Fordefi native Solana mode",
             });
         }
 
@@ -454,6 +511,135 @@ class FordefiSigner<TAddress extends string = string> implements SolanaMessageSi
     }
 
     /**
+     * Native manual path for Kit's TransactionModifyingSigner contract; attached
+     * as an own property only when `chain` is set and `pushMode` is `'manual'`.
+     *
+     * Fordefi rewrites the message before signing it and does not broadcast, so
+     * the returned transaction replaces the caller's. The rewrite itself is not
+     * diffed: the signature is verified against the bytes Fordefi returned, and
+     * those bytes are what the caller continues from.
+     */
+    private async modifyAndSignNativeTransactions(
+        transactions: readonly (Transaction | (Transaction & TransactionWithLifetime))[],
+        config?: TransactionModifyingSignerConfig,
+    ): Promise<readonly (Transaction & TransactionWithinSizeLimit & TransactionWithLifetime)[]> {
+        config?.abortSignal?.throwIfAborted();
+        return await signBatchStaggered(
+            transactions,
+            async transaction => {
+                config?.abortSignal?.throwIfAborted();
+                this.assertNativeManualTransactionSupported(transaction);
+
+                base64Decoder ||= getBase64Decoder();
+                const base64Data = base64Decoder.decode(transaction.messageBytes);
+                const txId = await this.submitSolanaTransaction(base64Data, 'manual', config?.abortSignal);
+                return await this.finishNativeManualSigning(txId, transaction, config?.abortSignal);
+            },
+            this.requestDelayMs,
+            config?.abortSignal,
+        );
+    }
+
+    /**
+     * Poll a submitted manual transaction to completion, verify the vault's
+     * signature against the message Fordefi returned, and hand back those bytes
+     * as a Kit transaction the caller can broadcast.
+     */
+    private async finishNativeManualSigning(
+        txId: string,
+        originalTransaction: Transaction | (Transaction & TransactionWithLifetime),
+        abortSignal?: AbortSignal,
+    ): Promise<Transaction & TransactionWithinSizeLimit & TransactionWithLifetime> {
+        const result = await this.pollForResult(txId, { pushable: false }, abortSignal);
+        if (!result.raw_transaction) {
+            return throwSignerError(SignerErrorCode.SIGNING_FAILED, {
+                message: 'Fordefi solana_transaction response missing raw_transaction',
+            });
+        }
+
+        let decodedTransaction: Transaction;
+        try {
+            base64Encoder ||= getBase64Encoder();
+            decodedTransaction = getTransactionDecoder().decode(base64Encoder.encode(result.raw_transaction));
+        } catch (error) {
+            return throwSignerError(SignerErrorCode.PARSING_ERROR, {
+                cause: error,
+                message: 'Failed to decode the Fordefi wire transaction',
+            });
+        }
+
+        const signerSignature = decodedTransaction.signatures[this.address];
+        if (!signerSignature) {
+            return throwSignerError(SignerErrorCode.SIGNING_FAILED, {
+                address: this.address,
+                message: 'Fordefi wire transaction did not contain the configured vault signature',
+            });
+        }
+
+        await assertSignatureValid({
+            data: decodedTransaction.messageBytes,
+            signature: signerSignature,
+            signerAddress: this.address,
+        });
+
+        const signedTransaction = Object.freeze({
+            ...decodedTransaction,
+            lifetimeConstraint: await this.readReturnedLifetime(originalTransaction, decodedTransaction),
+            signatures: Object.freeze(decodedTransaction.signatures),
+        });
+
+        try {
+            assertIsTransactionWithinSizeLimit(signedTransaction);
+        } catch (error) {
+            return throwSignerError(SignerErrorCode.SIGNING_FAILED, {
+                cause: error,
+                message: 'Fordefi wire transaction exceeds the Solana transaction size limit',
+            });
+        }
+
+        abortSignal?.throwIfAborted();
+        return signedTransaction;
+    }
+
+    /**
+     * Recover the lifetime of the returned transaction from its compiled
+     * message. Fordefi does not report the `lastValidBlockHeight` of a blockhash
+     * it refreshed, so Kit substitutes `U64_MAX`; the caller's own constraint is
+     * kept instead whenever the lifetime survived the rewrite.
+     */
+    private async readReturnedLifetime(
+        originalTransaction: Transaction | (Transaction & TransactionWithLifetime),
+        returnedTransaction: Transaction,
+    ): Promise<TransactionWithLifetime['lifetimeConstraint']> {
+        let returnedLifetime: TransactionWithLifetime['lifetimeConstraint'];
+        try {
+            const compiledMessage = getCompiledTransactionMessageDecoder().decode(returnedTransaction.messageBytes);
+            returnedLifetime = await getTransactionLifetimeConstraintFromCompiledTransactionMessage(compiledMessage);
+        } catch (error) {
+            return throwSignerError(SignerErrorCode.PARSING_ERROR, {
+                cause: error,
+                message: 'Failed to recover the lifetime of the Fordefi wire transaction',
+            });
+        }
+
+        if ('lifetimeConstraint' in originalTransaction) {
+            const originalLifetime = originalTransaction.lifetimeConstraint;
+            const lifetimeSurvived =
+                ('blockhash' in originalLifetime &&
+                    'blockhash' in returnedLifetime &&
+                    originalLifetime.blockhash === returnedLifetime.blockhash) ||
+                ('nonce' in originalLifetime &&
+                    'nonce' in returnedLifetime &&
+                    originalLifetime.nonce === returnedLifetime.nonce);
+            if (lifetimeSurvived) {
+                return originalLifetime;
+            }
+        }
+
+        return returnedLifetime;
+    }
+
+    /**
      * Native Solana transaction path for Kit's TransactionSendingSigner contract.
      *
      * Fordefi may replace the message lifetime and fees, then broadcasts the
@@ -483,7 +669,7 @@ class FordefiSigner<TAddress extends string = string> implements SolanaMessageSi
                 const base64Data = base64Decoder.decode(transaction.messageBytes);
                 let txId: string;
                 try {
-                    txId = await this.submitSolanaTransaction(base64Data, config?.abortSignal);
+                    txId = await this.submitSolanaTransaction(base64Data, 'auto', config?.abortSignal);
                 } catch (error) {
                     if (!providerMayHaveAccepted(error)) {
                         throw error;
@@ -583,6 +769,22 @@ class FordefiSigner<TAddress extends string = string> implements SolanaMessageSi
         }
     }
 
+    /** Fordefi may only rewrite a message the vault pays for and no one has signed yet. */
+    private assertNativeManualTransactionSupported(transaction: Transaction): void {
+        if (Object.keys(transaction.signatures)[0] !== this.address) {
+            throwSignerError(SignerErrorCode.SIGNING_FAILED, {
+                address: this.address,
+                message: 'Fordefi native manual signing requires the configured vault to be the transaction fee payer',
+            });
+        }
+        if (Object.values(transaction.signatures).some(signature => signature !== null)) {
+            throwSignerError(SignerErrorCode.SIGNING_FAILED, {
+                address: this.address,
+                message: 'Fordefi native manual signing must run before any transaction signatures are applied',
+            });
+        }
+    }
+
     /**
      * POST a transaction request to Fordefi and return the transaction ID.
      * Shared by all signing modes (black_box, solana_transaction, solana_message).
@@ -622,15 +824,20 @@ class FordefiSigner<TAddress extends string = string> implements SolanaMessageSi
     }
 
     /**
-     * Submit a native Solana serialized transaction message for signing + auto-push.
+     * Submit a native Solana serialized transaction message for signing, and for
+     * broadcasting when `pushMode` is `'auto'`.
      */
-    private async submitSolanaTransaction(base64Data: string, abortSignal?: AbortSignal): Promise<string> {
+    private async submitSolanaTransaction(
+        base64Data: string,
+        pushMode: FordefiPushMode,
+        abortSignal?: AbortSignal,
+    ): Promise<string> {
         const requestBody: FordefiSolanaTransactionRequest = {
             details: {
                 chain: this.chain!,
                 data: base64Data,
                 ...(this.fee ? { fee: this.fee } : {}),
-                push_mode: 'auto',
+                push_mode: pushMode,
                 type: 'solana_serialized_transaction_message',
             },
             sign_mode: 'auto',
@@ -639,11 +846,27 @@ class FordefiSigner<TAddress extends string = string> implements SolanaMessageSi
             vault_id: this.vaultId,
         };
         base64Encoder ||= getBase64Encoder();
+        const messageBytes = new Uint8Array(base64Encoder.encode(base64Data));
         return await this.submitTransaction(
             requestBody,
-            await idempotencyKeyFromMessage(base64Encoder.encode(base64Data)),
+            await idempotencyKeyFromMessage(
+                pushMode === 'manual' ? this.namespaceManualIdempotencyInput(messageBytes) : messageBytes,
+            ),
             abortSignal,
         );
+    }
+
+    /**
+     * Namespaced so the same bytes submitted for signing cannot collide with an
+     * earlier auto create that did broadcast them.
+     */
+    private namespaceManualIdempotencyInput(messageBytes: Uint8Array): Uint8Array {
+        utf8Encoder ||= getUtf8Encoder();
+        const namespace = utf8Encoder.encode(`fordefi:solana:manual:${this.chain!}:${this.vaultId}:`);
+        const namespaced = new Uint8Array(namespace.length + messageBytes.length);
+        namespaced.set(namespace);
+        namespaced.set(messageBytes, namespace.length);
+        return namespaced;
     }
 
     /**

--- a/typescript/packages/fordefi/src/index.ts
+++ b/typescript/packages/fordefi/src/index.ts
@@ -1,6 +1,7 @@
 export { createFordefiSigner } from './fordefi-signer.js';
 export type {
     FordefiBlackBoxSigner,
+    FordefiNativeManualSigner,
     FordefiNativeSigner,
     FordefiRequestSigner,
     FordefiSignerConfig,
@@ -9,6 +10,7 @@ export type {
     FordefiBlackBoxSignatureRequest,
     FordefiCreateTransactionResponse,
     FordefiErrorResponse,
+    FordefiPushMode,
     FordefiSolanaFee,
     FordefiSolanaMessageRequest,
     FordefiSolanaTransactionRequest,
@@ -20,6 +22,7 @@ export {
     assertIsSolanaSigner,
     assertIsSolanaTransactionSigner,
     isSolanaMessageSigner,
+    isSolanaModifyingSigner,
     isSolanaSendingSigner,
     isSolanaSigner,
     isSolanaTransactionSigner,

--- a/typescript/packages/fordefi/src/types.ts
+++ b/typescript/packages/fordefi/src/types.ts
@@ -30,17 +30,26 @@ export type FordefiSolanaFee =
     | { priority_level: 'high' | 'low' | 'medium'; type: 'priority' };
 
 /**
- * Request body for native Solana transaction signing via
- * `solana_serialized_transaction_message` with `push_mode: 'auto'`.
+ * Whether Fordefi broadcasts a native Solana transaction after signing it.
  *
- * Fordefi signs the serialized transaction message and pushes it on-chain.
+ * `auto` rewrites, signs and broadcasts; `manual` rewrites and signs, leaving
+ * the broadcast to the caller.
+ */
+export type FordefiPushMode = 'auto' | 'manual';
+
+/**
+ * Request body for native Solana transaction signing via
+ * `solana_serialized_transaction_message`.
+ *
+ * Fordefi signs the serialized transaction message and either pushes it
+ * on-chain or returns it for the caller to broadcast, per `details.push_mode`.
  */
 export interface FordefiSolanaTransactionRequest {
     details: {
         chain: SolanaChainUniqueId;
         data: string;
         fee?: FordefiSolanaFee;
-        push_mode: 'auto';
+        push_mode: FordefiPushMode;
         type: 'solana_serialized_transaction_message';
     };
     sign_mode: 'auto';

--- a/typescript/packages/keychain/src/create-keychain-signer.ts
+++ b/typescript/packages/keychain/src/create-keychain-signer.ts
@@ -6,7 +6,12 @@ import type {
 } from '@solana/keychain-core';
 import { SignerErrorCode, throwSignerError } from '@solana/keychain-core';
 import type { CrossmintSignerConfig } from '@solana/keychain-crossmint';
-import type { FordefiNativeSigner, FordefiSignerConfig, SolanaChainUniqueId } from '@solana/keychain-fordefi';
+import type {
+    FordefiNativeManualSigner,
+    FordefiNativeSigner,
+    FordefiSignerConfig,
+    SolanaChainUniqueId,
+} from '@solana/keychain-fordefi';
 import type { UtilaSignerConfig } from '@solana/keychain-utila';
 
 import type { KeychainSignerConfig } from './types.js';
@@ -37,7 +42,10 @@ export function createKeychainSigner(
     config: CrossmintSignerConfig & { backend: 'crossmint' },
 ): Promise<SolanaSendingSigner>;
 export function createKeychainSigner(
-    config: FordefiSignerConfig & { backend: 'fordefi'; chain: SolanaChainUniqueId },
+    config: FordefiSignerConfig & { backend: 'fordefi'; chain: SolanaChainUniqueId; pushMode: 'manual' },
+): Promise<FordefiNativeManualSigner>;
+export function createKeychainSigner(
+    config: FordefiSignerConfig & { backend: 'fordefi'; chain: SolanaChainUniqueId; pushMode?: 'auto' },
 ): Promise<FordefiNativeSigner>;
 export function createKeychainSigner(
     config: UtilaSignerConfig & { backend: 'utila' },

--- a/typescript/packages/keychain/src/index.ts
+++ b/typescript/packages/keychain/src/index.ts
@@ -9,7 +9,12 @@ export type { CdpSignerConfig } from '@solana/keychain-cdp';
 export type { CrossmintSignerConfig } from '@solana/keychain-crossmint';
 export type { DfnsSignerConfig } from '@solana/keychain-dfns';
 export type { FireblocksSignerConfig } from '@solana/keychain-fireblocks';
-export type { FordefiBlackBoxSigner, FordefiNativeSigner, FordefiSignerConfig } from '@solana/keychain-fordefi';
+export type {
+    FordefiBlackBoxSigner,
+    FordefiNativeManualSigner,
+    FordefiNativeSigner,
+    FordefiSignerConfig,
+} from '@solana/keychain-fordefi';
 export type { GcpKmsSignerConfig } from '@solana/keychain-gcp-kms';
 export type { MemorySignerConfig } from '@solana/keychain-memory';
 export type { OpenfortSignerConfig } from '@solana/keychain-openfort';

--- a/typescript/packages/kit-plugin/src/keychain-plugin.ts
+++ b/typescript/packages/kit-plugin/src/keychain-plugin.ts
@@ -9,12 +9,11 @@ import { extendClient } from '@solana/kit';
 
 /**
  * Backend configurations these plugins accept: every keychain backend except
- * the managed-broadcast ones — Crossmint, and Fordefi in native mode (`chain`
- * set). Those backends rewrite and broadcast transactions server-side, so
- * they expose `signAndSendTransactions` and no `signTransactions`, and cannot
- * serve as a client `payer` or `identity`: client send flows build, sign, and
- * broadcast themselves, and Kit routes a sending signer only through
- * `signAndSendTransactionMessageWithSigners()`. Create those signers with
+ * Crossmint and Fordefi in native mode (`chain` set). Those backends rewrite
+ * the transaction server-side, so they expose `signAndSendTransactions` or
+ * `modifyAndSignTransactions` and no `signTransactions`, and cannot serve as a
+ * client `payer` or `identity`: client send flows build, sign, and broadcast
+ * themselves against the message they compiled. Create those signers with
  * `createKeychainSigner()` and use that function directly instead.
  */
 export type KeychainKitPluginConfig =
@@ -22,17 +21,17 @@ export type KeychainKitPluginConfig =
     | (FordefiSignerConfig & { backend: 'fordefi'; chain?: undefined });
 
 /**
- * The managed-broadcast exclusion above only protects TypeScript callers, so
- * the config is also rejected at runtime — before `createKeychainSigner`
- * runs, since the excluded backends authenticate against their provider
- * during construction. The signer-shape assertion afterwards is the backstop
- * for any future backend whose factory returns a sending signer.
+ * The exclusion above only protects TypeScript callers, so the config is also
+ * rejected at runtime, before `createKeychainSigner` runs, since the excluded
+ * backends authenticate against their provider during construction. The
+ * signer-shape assertion afterwards is the backstop for any future backend
+ * whose factory returns a signer that is not a partial signer.
  */
 async function createPartialSigner(config: KeychainKitPluginConfig) {
     const { backend } = config as KeychainSignerConfig;
     if (backend === 'crossmint' || (backend === 'fordefi' && (config as { chain?: unknown }).chain !== undefined)) {
         throwSignerError(SignerErrorCode.CONFIG_ERROR, {
-            message: `The '${backend}' backend broadcasts transactions server-side and cannot serve as a Kit client payer/identity. Create it with createKeychainSigner() and use signAndSendTransaction() instead.`,
+            message: `The '${backend}' backend rewrites transactions server-side and cannot serve as a Kit client payer/identity. Create it with createKeychainSigner() and use signAndSendTransaction() instead.`,
         });
     }
     const signer = await createKeychainSigner(config);

--- a/typescript/pnpm-lock.yaml
+++ b/typescript/pnpm-lock.yaml
@@ -289,6 +289,9 @@ importers:
       '@solana/signers':
         specifier: 8.0.0
         version: 8.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/transaction-messages':
+        specifier: 8.0.0
+        version: 8.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/transactions':
         specifier: 8.0.0
         version: 8.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)

--- a/typescript/pnpm-lock.yaml
+++ b/typescript/pnpm-lock.yaml
@@ -274,6 +274,9 @@ importers:
         specifier: workspace:*
         version: link:../core
     devDependencies:
+      '@solana-program/system':
+        specifier: ^0.13.0
+        version: 0.13.0(@solana/kit@8.0.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10))
       '@solana/addresses':
         specifier: 8.0.0
         version: 8.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
@@ -286,6 +289,9 @@ importers:
       '@solana/keys':
         specifier: 8.0.0
         version: 8.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/kit':
+        specifier: 8.0.0
+        version: 8.0.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@solana/signers':
         specifier: 8.0.0
         version: 8.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)


### PR DESCRIPTION
TypeScript counterpart of #279, which lands the same mode in Rust. **Credit for the feature is entirely @hvbr1s'**; #271 carries the original TypeScript implementation and its review history. Stacked on #288 (`feat/ts-signer-union`), whose capability split provides `SolanaModifyingSigner`.

## What this adds

Fordefi's `push_mode: "manual"` alongside black box and native auto. Fordefi still parses the transaction, so its policy engine and approval UI apply, but it signs **without** broadcasting: the caller owns submission, and additional required signers are supported, which native auto rejects.

Kit classifies signers by duck-typed method presence, so each mode exposes exactly one transaction entry point as an own property and none of the others:

| Mode | Config | Shape | Entry point |
| --- | --- | --- | --- |
| Black box | `chain` unset | `FordefiBlackBoxSigner` | `signTransactions()` |
| Native auto | `chain` set, `pushMode` omitted or `'auto'` | `FordefiNativeSigner` | `signAndSendTransactions()` |
| Native manual (new) | `chain` set, `pushMode: 'manual'` | `FordefiNativeManualSigner` | `modifyAndSignTransactions()` |

All three still sign off-chain messages. The factory dispatches on config and rejects `pushMode: 'manual'` without `chain`, and an unrecognized `pushMode`, with `SIGNER_CONFIG_ERROR` before any network call, since an unvalidated value would otherwise fall through to auto and broadcast.

## Security shape

Fordefi may rewrite the message before signing it, at minimum the recent blockhash, and it manages the Compute Budget fee instructions. **That rewrite is not diffed.** Keychain validates the signing hop only, per the trusted-provider model in `docs/SECURITY_MODEL.md`:

- The returned signature is ed25519-verified against the message Fordefi returned, at the vault's required-signer position.
- The caller's transaction is replaced with those bytes, so it can never hold a message the signature does not cover; a verification failure leaves the caller's transaction untouched.
- Preconditions on the caller's own input still apply, checked before anything is submitted: the vault must be the fee payer and nothing may be signed yet.
- The create carries an `x-idempotence-id` derived from the message bytes under a manual-specific namespace, so a resend reuses the Fordefi transaction and cannot collide with an earlier auto create that did broadcast them.

Fordefi does not report the `lastValidBlockHeight` of a blockhash it refreshed, so the caller's own lifetime constraint is retained whenever the lifetime survived the rewrite, rather than degrading it to Kit's `U64_MAX` placeholder.

## Deviation from #271

#271 predates the reconciliation and carries a ~200-line returned-message diff validator plus a 0.1 SOL priority-fee cap. Neither exists in the Rust branch this ports (`c21087c`: the rewrite "is not diffed"), and transaction-content checks are explicitly outside what Keychain validates, so they are not ported. That also keeps `@solana-program/compute-budget` out of the package's dependencies. `@solana/transaction-messages` is added as a peer dependency for the compiled-message decoder used to recover the returned lifetime.

Touched outside `packages/fordefi` only where the new shape had to be threaded through: a manual overload on `createKeychainSigner`, the re-exported type on the umbrella, and the `kit-plugin` wording, whose exclusion already covered manual mode via `chain` but described it as broadcast-managed.

## Verification

- `just ts-build`: clean.
- `just ts-test`: 504 passed, up from 489. Fordefi: 78, up from 63.
- `just ts-treeshake`: every package and the umbrella fully tree-shakeable; all 15 signer factories tree-shake cleanly.
- `just ts-fmt`: lint and prettier clean.
- The new precondition, namespacing and lifetime-retention assertions were mutation-checked: each fails when its guard is removed.
