### PR TITLE
feat(fordefi)!: native manual push mode for Python

### DIFF
--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -7,7 +7,9 @@
 - thirteen-backend parity: Memory, Vault, Privy, Turnkey, AWS KMS, Fireblocks, GCP KMS, Dfns, Para, CDP, Crossmint, Openfort, Utila (#210, #211, #213–#221)
 - `create_keychain_signer()` umbrella factory with lazy per-backend imports, plus the env-gated live integration suite (#222)
 - Fordefi backend: `FordefiBlackBoxSigner` for raw signing and `FordefiNativeAutoSigner` for native Solana auto-broadcast, pluggable P-256 request signer, vault ownership verification (#227)
-- `sign_and_send_transaction()`: one call to get a transaction on chain, using the provider's broadcast for a `SendingSigner` and a caller-injected send function for a `TransactionSigner`
+- `SignedTransaction.transaction`: the authoritative signed transaction, so callers never have to know whether a backend signed the object they passed in
+- `sign_and_send_transaction()`: one call to get a transaction on chain, using the provider's broadcast for a `SendingSigner` and a caller-injected send function for a `TransactionSigner` or `ModifyingSigner`
+- `FordefiNativeManualSigner`: Fordefi's `push_mode: manual` as a `ModifyingSigner`, where Fordefi rewrites the blockhash and Compute Budget fee instructions and signs without broadcasting; the vault must be the fee payer of an as-yet-unsigned transaction, the returned signature is verified against the rewritten message at the vault's signer position, and the rewritten transaction comes back as `SignedTransaction.transaction`
 
 ### Bug Fixes
 

--- a/python/README.md
+++ b/python/README.md
@@ -82,6 +82,7 @@ async def main() -> None:
     #   result.encoded_transaction  # base64 wire transaction
     #   result.signature            # this signer's signature
     #   result.is_complete          # are all required signatures present?
+    #   result.transaction          # the authoritative signed transaction
 
 
 asyncio.run(main())
@@ -132,9 +133,8 @@ class TransactionSigner(SolanaSigner):
 
 
 class ModifyingSigner(SolanaSigner):
-    """The provider rewrites the transaction before signing it; continue from the
-    returned transaction, never from the bytes submitted. No backend currently
-    subclasses this."""
+    """The provider rewrites the transaction before signing it; continue from
+    `SignedTransaction.transaction`, never from the bytes submitted."""
 
     async def modify_and_sign_transaction(
         self, transaction: VersionedTransaction
@@ -148,9 +148,14 @@ class SendingSigner(SolanaSigner):
     async def sign_and_send_transaction(self, transaction: VersionedTransaction) -> Signature: ...
 ```
 
-`sign_transaction` signs the transaction in place and returns a
-`SignedTransaction(encoded_transaction, signature, is_complete)`; `is_complete`
-reports whether every required signature is present. Legacy, v0 and v1
+Both signing entry points return a
+`SignedTransaction(encoded_transaction, signature, is_complete, transaction)`;
+`is_complete` reports whether every required signature is present. A
+`TransactionSigner` signs the transaction in place and hands it back as
+`transaction`; a `ModifyingSigner` leaves the caller's object untouched, because
+solders messages are read-only, and hands back the provider's rewritten
+transaction instead. Only `transaction` is guaranteed to match
+`encoded_transaction` and the bytes `signature` covers. Legacy, v0 and v1
 transactions are all accepted.
 
 Errors are always `SignerError` with a stable `code`
@@ -169,7 +174,8 @@ whether it can sign arbitrary bytes is fixed per backend:
 | utila | `TransactionSigner` | `SIGNING_FAILED` |
 | crossmint | `SendingSigner` | `SIGNING_FAILED` |
 | fordefi black box (`FordefiBlackBoxSigner`) | `TransactionSigner` | yes |
-| fordefi native (`FordefiNativeAutoSigner`) | `SendingSigner` | yes |
+| fordefi native auto (`FordefiNativeAutoSigner`) | `SendingSigner` | yes |
+| fordefi native manual (`FordefiNativeManualSigner`) | `ModifyingSigner` | yes |
 
 Crossmint executes every approved transaction server-side and exposes no
 sign-only API, so it is a `SendingSigner` only. It may rewrite the
@@ -177,16 +183,74 @@ transaction to sponsor gas, in which case the returned signature identifies the
 transaction it landed rather than covering the caller's bytes; the caller's
 transaction is never modified.
 
-`create_fordefi_signer` picks the Fordefi type from `config.chain`: unset builds
-a `FordefiBlackBoxSigner`, a chain builds a `FordefiNativeAutoSigner`, and each
-type rejects a config meant for the other.
+### Fordefi signing modes
+
+`create_fordefi_signer` picks the Fordefi type from `config.chain` and
+`config.push_mode`, and each type rejects a config meant for another:
+
+| Config | Signer | Entry point |
+|--------|--------|-------------|
+| no `chain` | `FordefiBlackBoxSigner` | `sign_transaction` |
+| `chain`, `push_mode` unset or `"auto"` | `FordefiNativeAutoSigner` | `sign_and_send_transaction` |
+| `chain`, `push_mode="manual"` | `FordefiNativeManualSigner` | `modify_and_sign_transaction` |
+
+Black-box mode signs the caller's exact message bytes and leaves broadcasting to
+the caller. Native auto lets Fordefi update the blockhash and fees, then sign and
+broadcast; the caller's transaction is left untouched and the returned signature
+identifies what landed.
+
+Native manual lets Fordefi rewrite the recent blockhash and the Compute Budget
+fee instructions, then sign **without** broadcasting, so the caller broadcasts.
+The returned signature covers Fordefi's bytes, not the ones submitted, and the
+rewrite is not diffed against them: Fordefi is trusted for the rewrite. Inspect
+`result.transaction` before broadcasting it. Fordefi must be the fee payer and
+must sign before every downstream signer, so a transaction that is not vault-paid
+or already carries a signature is rejected before submitting.
+
+The signature is ed25519-verified against the returned transaction's own message
+at the vault's required-signer position; a signature that does not verify, or a
+returned transaction the vault does not sign, fails with `SIGNER_SIGNING_FAILED`
+and leaves the caller's transaction untouched.
+
+```python
+import os
+
+from solana_keychain.fordefi import FordefiSignerConfig, create_fordefi_signer
+
+signer = await create_fordefi_signer(
+    FordefiSignerConfig(
+        access_token=os.environ["FORDEFI_ACCESS_TOKEN"],
+        vault_id=os.environ["FORDEFI_VAULT_ID"],
+        public_key=os.environ["FORDEFI_PUBLIC_KEY"],
+        private_key_pem=os.environ["FORDEFI_PRIVATE_KEY_PEM"],
+        chain="solana_mainnet",
+        push_mode="manual",
+    )
+)
+
+result = await signer.modify_and_sign_transaction(transaction)
+if result.is_complete:
+    # Broadcast result.encoded_transaction through your RPC client.
+    pass
+else:
+    # Sign result.transaction with the downstream signers, reserialize, broadcast.
+    pass
+```
+
+Bound what Fordefi may spend through `config.fee`, for example
+`{"type": "custom", "priority_fee": "1000"}`; that request is what Fordefi
+honours, and the returned fee instructions are not checked against it locally.
+
+Fordefi normally refreshes the blockhash but does not return its exact
+`lastValidBlockHeight`, so broadcast manual results promptly rather than relying
+on a locally known block-height expiry.
 
 ### Sign and Send
 
 `sign_and_send_transaction` gets a transaction on chain with one call. A
-`SendingSigner` (Crossmint, Fordefi native) broadcasts through its provider and
-the send function is never called; a `TransactionSigner` signs and the send
-function broadcasts the base64-encoded result:
+`SendingSigner` (Crossmint, Fordefi native auto) broadcasts through its provider
+and the send function is never called; a `TransactionSigner` or `ModifyingSigner`
+signs and the send function broadcasts the base64-encoded result:
 
 ```python
 from solana_keychain import sign_and_send_transaction

--- a/python/src/solana_keychain/core/__init__.py
+++ b/python/src/solana_keychain/core/__init__.py
@@ -9,6 +9,7 @@ from solana_keychain.core.http import (
 from solana_keychain.core.send import SendTransactionFn, sign_and_send_transaction
 from solana_keychain.core.signature_util import (
     extract_and_verify_returned_signature,
+    extract_and_verify_rewritten_transaction,
     verify_returned_signature,
 )
 from solana_keychain.core.signer import (
@@ -44,6 +45,7 @@ __all__ = [
     "assert_https_url",
     "classify_signed_transaction",
     "extract_and_verify_returned_signature",
+    "extract_and_verify_rewritten_transaction",
     "fetch_signer_json",
     "get_signing_keypair_position",
     "has_all_required_signatures",

--- a/python/src/solana_keychain/core/send.py
+++ b/python/src/solana_keychain/core/send.py
@@ -6,7 +6,13 @@ from solders.signature import Signature
 from solders.transaction import VersionedTransaction
 
 from solana_keychain.core.errors import SignerError, SignerErrorCode
-from solana_keychain.core.signer import SendingSigner, SolanaSigner, TransactionSigner
+from solana_keychain.core.signer import (
+    ModifyingSigner,
+    SendingSigner,
+    SignedTransaction,
+    SolanaSigner,
+    TransactionSigner,
+)
 
 SendTransactionFn = Callable[[str], Awaitable[Signature]]
 """Broadcasts a base64-encoded wire transaction and returns its signature. The
@@ -21,13 +27,13 @@ async def sign_and_send_transaction(
     """Sign ``transaction`` and get it on chain with one call.
 
     A ``SendingSigner`` broadcasts through its provider and ``send_transaction``
-    is never called; a ``TransactionSigner`` signs and ``send_transaction``
-    broadcasts the encoded result.
+    is never called; a ``TransactionSigner`` or ``ModifyingSigner`` signs and
+    ``send_transaction`` broadcasts the encoded result.
 
-    Raises ``CONFIG_ERROR`` when a ``TransactionSigner`` is given no
+    Raises ``CONFIG_ERROR`` when a signing-only signer is given no
     ``send_transaction``, and ``SIGNING_FAILED`` when the sending signer returns
     no signature, the signed transaction is still missing signatures, or the
-    signer has neither capability.
+    signer has none of the three capabilities.
     """
     if isinstance(signer, SendingSigner):
         signature = await signer.sign_and_send_transaction(transaction)
@@ -38,7 +44,7 @@ async def sign_and_send_transaction(
             )
         return signature
 
-    if not isinstance(signer, TransactionSigner):
+    if not isinstance(signer, TransactionSigner | ModifyingSigner):
         raise SignerError(
             SignerErrorCode.SIGNING_FAILED,
             "this signer supports neither signing nor broadcasting transactions",
@@ -50,7 +56,11 @@ async def sign_and_send_transaction(
             "this signer cannot broadcast transactions; supply send_transaction to "
             "broadcast the signed one",
         )
-    signed = await signer.sign_transaction(transaction)
+    signed: SignedTransaction
+    if isinstance(signer, ModifyingSigner):
+        signed = await signer.modify_and_sign_transaction(transaction)
+    else:
+        signed = await signer.sign_transaction(transaction)
     if not signed.is_complete:
         raise SignerError(
             SignerErrorCode.SIGNING_FAILED,

--- a/python/src/solana_keychain/core/signature_util.py
+++ b/python/src/solana_keychain/core/signature_util.py
@@ -6,7 +6,10 @@ from solders.signature import Signature
 from solders.transaction import VersionedTransaction
 
 from solana_keychain.core.errors import SignerError, SignerErrorCode
-from solana_keychain.core.transaction_util import get_signing_keypair_position
+from solana_keychain.core.transaction_util import (
+    get_signing_keypair_position,
+    signed_message_bytes,
+)
 
 
 def verify_returned_signature(
@@ -22,6 +25,33 @@ def verify_returned_signature(
     return signature
 
 
+def _deserialize_returned_transaction(
+    returned_transaction_bytes: bytes, provider_name: str
+) -> VersionedTransaction:
+    try:
+        return VersionedTransaction.from_bytes(returned_transaction_bytes)
+    except Exception:
+        raise SignerError(
+            SignerErrorCode.SERIALIZATION_ERROR,
+            f"Failed to deserialize signed transaction returned by {provider_name}",
+        ) from None
+
+
+def _signature_at_signer_position(
+    transaction: VersionedTransaction, public_key: Pubkey, provider_name: str
+) -> Signature:
+    """Locate the signature by ``public_key``'s required-signer position rather
+    than assuming it occupies slot zero."""
+    position = get_signing_keypair_position(transaction, public_key)
+    signatures = transaction.signatures
+    if position >= len(signatures) or signatures[position] == Signature.default():
+        raise SignerError(
+            SignerErrorCode.SIGNING_FAILED,
+            f"{provider_name} returned a transaction without the signer's signature",
+        )
+    return signatures[position]
+
+
 def extract_and_verify_returned_signature(
     returned_transaction_bytes: bytes,
     public_key: Pubkey,
@@ -35,19 +65,23 @@ def extract_and_verify_returned_signature(
     ``original_message_bytes`` — never against the returned transaction's own
     message — so a provider cannot substitute a different transaction.
     """
-    try:
-        returned = VersionedTransaction.from_bytes(returned_transaction_bytes)
-    except Exception:
-        raise SignerError(
-            SignerErrorCode.SERIALIZATION_ERROR,
-            f"Failed to deserialize signed transaction returned by {provider_name}",
-        ) from None
+    returned = _deserialize_returned_transaction(returned_transaction_bytes, provider_name)
+    signature = _signature_at_signer_position(returned, public_key, provider_name)
+    return verify_returned_signature(signature, public_key, original_message_bytes)
 
-    position = get_signing_keypair_position(returned, public_key)
-    signatures = returned.signatures
-    if position >= len(signatures) or signatures[position] == Signature.default():
-        raise SignerError(
-            SignerErrorCode.SIGNING_FAILED,
-            f"{provider_name} returned a transaction without the signer's signature",
-        )
-    return verify_returned_signature(signatures[position], public_key, original_message_bytes)
+
+def extract_and_verify_rewritten_transaction(
+    returned_transaction_bytes: bytes, public_key: Pubkey, provider_name: str
+) -> tuple[VersionedTransaction, Signature]:
+    """Extract and verify ``public_key``'s signature from a wire transaction
+    ``provider_name`` rewrote before signing it.
+
+    The signature is verified against the returned transaction's own message,
+    because those are the bytes it covers. Both are handed back: the caller has
+    to continue from these, not from the ones it submitted, and the provider is
+    trusted for the rewrite itself.
+    """
+    returned = _deserialize_returned_transaction(returned_transaction_bytes, provider_name)
+    signature = _signature_at_signer_position(returned, public_key, provider_name)
+    verify_returned_signature(signature, public_key, signed_message_bytes(returned.message))
+    return returned, signature

--- a/python/src/solana_keychain/core/signer.py
+++ b/python/src/solana_keychain/core/signer.py
@@ -1,7 +1,7 @@
 """Core contract definitions for Solana signers."""
 
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TypeVar
 
 from solders.pubkey import Pubkey
@@ -31,11 +31,18 @@ class SignedTransaction:
     ``encoded_transaction`` is ``base64(bincode(tx))``. ``is_complete`` is True when
     every required signature slot is populated, False when other signers still need
     to sign.
+
+    ``transaction`` is the authoritative signed transaction. A ``TransactionSigner``
+    signs the caller's object and hands it back; a ``ModifyingSigner`` hands back the
+    provider's rewritten one, which ``solders`` cannot apply to the caller's object.
+    Only ``transaction`` is guaranteed to match ``encoded_transaction`` and the bytes
+    ``signature`` covers.
     """
 
     encoded_transaction: str
     signature: Signature
     is_complete: bool
+    transaction: VersionedTransaction = field(repr=False, compare=False)
 
 
 class SolanaSigner(ABC):
@@ -85,18 +92,18 @@ class ModifyingSigner(SolanaSigner):
 
     The returned signature covers the rewritten message, not the bytes the caller
     supplied, so any signatures collected beforehand are invalidated. Run a
-    modifying signer first and continue from the transaction it returns.
+    modifying signer first and continue from ``SignedTransaction.transaction``.
     """
 
     @abstractmethod
     async def modify_and_sign_transaction(
         self, transaction: VersionedTransaction
     ) -> SignedTransaction:
-        """Let the provider rewrite ``transaction``, sign the rewritten
-        transaction and replace ``transaction`` with it.
+        """Let the provider rewrite ``transaction`` and sign the rewritten one.
 
-        On success ``transaction`` holds the provider's rewritten transaction;
-        continue from it, never from the bytes submitted."""
+        ``transaction`` is left untouched, because a rewritten message cannot be
+        applied to it. Continue from ``SignedTransaction.transaction``, never from
+        the bytes submitted."""
 
 
 class SendingSigner(SolanaSigner):

--- a/python/src/solana_keychain/core/transaction_util.py
+++ b/python/src/solana_keychain/core/transaction_util.py
@@ -86,9 +86,14 @@ def has_all_required_signatures(transaction: VersionedTransaction) -> bool:
 def classify_signed_transaction(
     transaction: VersionedTransaction, encoded_transaction: str, signature: Signature
 ) -> SignedTransaction:
-    """Build a SignedTransaction marked complete or partial."""
+    """Build a SignedTransaction marked complete or partial.
+
+    Carries ``transaction`` through, so callers never have to know whether a
+    backend signed the object they passed in.
+    """
     return SignedTransaction(
         encoded_transaction=encoded_transaction,
         signature=signature,
         is_complete=has_all_required_signatures(transaction),
+        transaction=transaction,
     )

--- a/python/src/solana_keychain/fordefi/__init__.py
+++ b/python/src/solana_keychain/fordefi/__init__.py
@@ -2,6 +2,8 @@ from solana_keychain.fordefi.request_signer import FordefiRequestSigner, PemRequ
 from solana_keychain.fordefi.signer import (
     FordefiBlackBoxSigner,
     FordefiNativeAutoSigner,
+    FordefiNativeManualSigner,
+    FordefiPushMode,
     FordefiSignerConfig,
     create_fordefi_signer,
 )
@@ -9,6 +11,8 @@ from solana_keychain.fordefi.signer import (
 __all__ = [
     "FordefiBlackBoxSigner",
     "FordefiNativeAutoSigner",
+    "FordefiNativeManualSigner",
+    "FordefiPushMode",
     "FordefiRequestSigner",
     "FordefiSignerConfig",
     "PemRequestSigner",

--- a/python/src/solana_keychain/fordefi/signer.py
+++ b/python/src/solana_keychain/fordefi/signer.py
@@ -11,7 +11,7 @@ import json
 import logging
 import time
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, Literal
 from urllib.parse import quote
 
 import httpx
@@ -30,8 +30,12 @@ from solana_keychain.core.http import (
     provider_may_have_accepted,
 )
 from solana_keychain.core.poll import poll_attempts
-from solana_keychain.core.signature_util import verify_returned_signature
+from solana_keychain.core.signature_util import (
+    extract_and_verify_rewritten_transaction,
+    verify_returned_signature,
+)
 from solana_keychain.core.signer import (
+    ModifyingSigner,
     SendingSigner,
     SignedTransaction,
     SolanaSigner,
@@ -54,6 +58,8 @@ DEFAULT_API_BASE_URL = "https://api.fordefi.com"
 DEFAULT_POLL_INTERVAL_MS = 2000
 DEFAULT_MAX_POLL_ATTEMPTS = 50
 SUPPORTED_CHAINS = ("solana_devnet", "solana_mainnet")
+
+FordefiPushMode = Literal["auto", "manual"]
 
 _PUSHABLE_SUCCESS_STATES = frozenset({"completed"})
 _NON_PUSHABLE_SUCCESS_STATES = frozenset({"signed", "completed"})
@@ -83,10 +89,12 @@ class FordefiSignerConfig:
     key in ``private_key_pem``, or a custom ``FordefiRequestSigner`` in
     ``request_signer`` for KMS/HSM-backed request signing.
 
-    ``chain`` (``solana_devnet`` / ``solana_mainnet``) selects the signer type:
-    ``None`` builds a ``FordefiBlackBoxSigner``, a chain builds a
-    ``FordefiNativeAutoSigner`` using Fordefi's native Solana API types, where
-    transactions are signed and auto-broadcast by Fordefi and messages use
+    ``chain`` (``solana_devnet`` / ``solana_mainnet``) and ``push_mode`` select the
+    signer type: no ``chain`` builds a ``FordefiBlackBoxSigner``; a chain with
+    ``push_mode`` unset or ``auto`` builds a ``FordefiNativeAutoSigner``, where
+    Fordefi signs and broadcasts; a chain with ``push_mode="manual"`` builds a
+    ``FordefiNativeManualSigner``, where Fordefi signs without broadcasting.
+    Native modes use Fordefi's native Solana API types, so messages go through
     ``solana_message``.
 
     ``fee`` is the native-mode fee configuration passed through verbatim,
@@ -104,6 +112,7 @@ class FordefiSignerConfig:
     max_poll_attempts: int = DEFAULT_MAX_POLL_ATTEMPTS
     chain: str | None = None
     fee: dict[str, Any] | None = None
+    push_mode: FordefiPushMode | None = None
     http_client: httpx.AsyncClient | None = field(default=None, repr=False)
 
 
@@ -279,15 +288,17 @@ class FordefiBlackBoxSigner(_FordefiSignerBase, TransactionSigner):
 
     Signs the caller's exact message bytes via ``black_box_signature``; Fordefi
     does not broadcast, so the caller submits the returned encoded transaction
-    to an RPC. ``config.chain`` and ``config.fee`` must be unset; they select
-    ``FordefiNativeAutoSigner``.
+    to an RPC. ``config.chain``, ``config.fee``, ``config.push_mode`` and
+    ``config.max_priority_fee_lamports`` must be unset; they select a native
+    Solana signer.
     """
 
     def __init__(self, config: FordefiSignerConfig) -> None:
-        if config.chain is not None or config.fee is not None:
+        if config.chain is not None or config.fee is not None or config.push_mode is not None:
             raise SignerError(
                 SignerErrorCode.CONFIG_ERROR,
-                "chain and fee select native Solana mode; use FordefiNativeAutoSigner",
+                "chain, fee and push_mode select native Solana mode; use "
+                "FordefiNativeAutoSigner or FordefiNativeManualSigner",
             )
         super().__init__(config)
 
@@ -328,14 +339,10 @@ class FordefiBlackBoxSigner(_FordefiSignerBase, TransactionSigner):
         return signature
 
 
-class FordefiNativeAutoSigner(_FordefiSignerBase, SendingSigner):
-    """Signer backed by a regular Fordefi Solana vault.
+class _FordefiNativeSignerBase(_FordefiSignerBase):
+    """Shared native-mode plumbing: chain validation and the native request bodies."""
 
-    Uses Fordefi's native ``solana_transaction`` / ``solana_message`` API types
-    with ``push_mode: auto``: Fordefi replaces the blockhash (and optionally
-    fees), signs, and broadcasts on chain itself. ``config.chain`` must be set;
-    leave it unset for ``FordefiBlackBoxSigner``.
-    """
+    _push_mode: FordefiPushMode
 
     def __init__(self, config: FordefiSignerConfig) -> None:
         if config.chain is None:
@@ -357,7 +364,7 @@ class FordefiNativeAutoSigner(_FordefiSignerBase, SendingSigner):
             "type": "solana_serialized_transaction_message",
             "chain": self._chain,
             "data": base64.b64encode(data).decode("ascii"),
-            "push_mode": "auto",
+            "push_mode": self._push_mode,
         }
         if self._fee is not None:
             details["fee"] = self._fee
@@ -381,6 +388,33 @@ class FordefiNativeAutoSigner(_FordefiSignerBase, SendingSigner):
                 "raw_data": base64.b64encode(data).decode("ascii"),
             },
         }
+
+    async def sign_message(self, message: bytes) -> Signature:
+        transaction_id = await self._post_transaction(self._solana_message_request(message))
+        result = await self._poll_for_result(transaction_id, pushable=False)
+        signature = self._extract_signature(result)
+        verify_returned_signature(signature, self._public_key, message)
+        return signature
+
+
+class FordefiNativeAutoSigner(_FordefiNativeSignerBase, SendingSigner):
+    """Signer backed by a regular Fordefi Solana vault.
+
+    Uses Fordefi's native ``solana_transaction`` / ``solana_message`` API types
+    with ``push_mode: auto``: Fordefi replaces the blockhash (and optionally
+    fees), signs, and broadcasts on chain itself. ``config.chain`` must be set
+    and ``config.push_mode`` must be unset or ``auto``.
+    """
+
+    _push_mode: FordefiPushMode = "auto"
+
+    def __init__(self, config: FordefiSignerConfig) -> None:
+        if config.push_mode not in (None, "auto"):
+            raise SignerError(
+                SignerErrorCode.CONFIG_ERROR,
+                "push_mode must be auto here; use FordefiNativeManualSigner for manual",
+            )
+        super().__init__(config)
 
     async def sign_and_send_transaction(self, transaction: VersionedTransaction) -> Signature:
         """Sign ``transaction`` and let Fordefi broadcast it.
@@ -500,18 +534,101 @@ class FordefiNativeAutoSigner(_FordefiSignerBase, SendingSigner):
         )
         return classify_signed_transaction(returned, "", signature)
 
-    async def sign_message(self, message: bytes) -> Signature:
-        transaction_id = await self._post_transaction(self._solana_message_request(message))
+
+class FordefiNativeManualSigner(_FordefiNativeSignerBase, ModifyingSigner):
+    """Signer backed by a regular Fordefi Solana vault that does not broadcast.
+
+    Uses Fordefi's native ``solana_transaction`` / ``solana_message`` API types
+    with ``push_mode: manual``: Fordefi rewrites the blockhash and the Compute
+    Budget fee instructions and signs without broadcasting, so the caller
+    broadcasts the transaction Fordefi returned. ``config.chain`` must be set and
+    ``config.push_mode`` must be ``manual``.
+    """
+
+    _push_mode: FordefiPushMode = "manual"
+
+    def __init__(self, config: FordefiSignerConfig) -> None:
+        if config.push_mode != "manual":
+            raise SignerError(
+                SignerErrorCode.CONFIG_ERROR,
+                'push_mode must be "manual" here; use FordefiNativeAutoSigner for auto',
+            )
+        super().__init__(config)
+
+    async def modify_and_sign_transaction(
+        self, transaction: VersionedTransaction
+    ) -> SignedTransaction:
+        """Let Fordefi rewrite ``transaction`` and sign the rewrite.
+
+        Submits the unsigned message with ``push_mode: manual``. Fordefi rewrites
+        the blockhash and the Compute Budget fee instructions and signs without
+        broadcasting. The rewrite is not diffed against what was submitted, so
+        inspect ``SignedTransaction.transaction`` before broadcasting it; the
+        caller's ``transaction`` is left untouched and its bytes are not the ones
+        the returned signature covers.
+
+        Fordefi must be the transaction fee payer and must sign before every
+        downstream signer, so a transaction that is not vault-paid or already
+        carries a signature is rejected before submitting.
+
+        The create carries an ``x-idempotence-id`` derived from the message bytes
+        under a manual-specific namespace, so it can never reuse the id of an
+        auto create that did broadcast those same bytes.
+        """
+        self._require_unsigned_vault_paid_transaction(transaction)
+        message_data = signed_message_bytes(transaction.message)
+        transaction_id = await self._post_transaction(
+            self._solana_transaction_request(message_data),
+            idempotence_id=self._manual_idempotence_id(message_data),
+        )
         result = await self._poll_for_result(transaction_id, pushable=False)
-        signature = self._extract_signature(result)
-        verify_returned_signature(signature, self._public_key, message)
-        return signature
+        returned, signature = extract_and_verify_rewritten_transaction(
+            self._decode_raw_transaction(result), self._public_key, "Fordefi"
+        )
+        return classify_signed_transaction(returned, serialize_transaction(returned), signature)
+
+    def _manual_idempotence_id(self, message_data: bytes) -> str:
+        namespace = f"fordefi:solana:manual:{self._chain}:{self._vault_id}:".encode()
+        return idempotency_key_from_message(namespace + message_data)
+
+    def _require_unsigned_vault_paid_transaction(self, transaction: VersionedTransaction) -> None:
+        account_keys = transaction.message.account_keys
+        if not account_keys or account_keys[0] != self._public_key:
+            raise SignerError(
+                SignerErrorCode.SIGNING_FAILED,
+                "Fordefi native manual signing requires the configured vault to be "
+                "the transaction fee payer",
+            )
+        if any(signature != Signature.default() for signature in transaction.signatures):
+            raise SignerError(
+                SignerErrorCode.SIGNING_FAILED,
+                "Fordefi native manual signing must run before any transaction "
+                "signatures are applied",
+            )
+
+    @staticmethod
+    def _decode_raw_transaction(result: dict[str, Any]) -> bytes:
+        raw_transaction = result.get("raw_transaction")
+        if not isinstance(raw_transaction, str):
+            raise SignerError(
+                SignerErrorCode.SIGNING_FAILED,
+                "Fordefi solana_transaction response missing raw_transaction",
+            )
+        try:
+            return base64.b64decode(raw_transaction, validate=True)
+        except Exception:
+            raise SignerError(
+                SignerErrorCode.SERIALIZATION_ERROR, "Failed to decode raw_transaction base64"
+            ) from None
 
 
 async def create_fordefi_signer(
     config: FordefiSignerConfig,
-) -> FordefiBlackBoxSigner | FordefiNativeAutoSigner:
-    """Create a ready-to-use Fordefi signer, picked by ``config.chain``."""
+) -> FordefiBlackBoxSigner | FordefiNativeAutoSigner | FordefiNativeManualSigner:
+    """Create a ready-to-use Fordefi signer, picked by ``config.chain`` and
+    ``config.push_mode``."""
     if config.chain is None:
         return FordefiBlackBoxSigner(config)
+    if config.push_mode == "manual":
+        return FordefiNativeManualSigner(config)
     return FordefiNativeAutoSigner(config)

--- a/python/tests/integration/conftest.py
+++ b/python/tests/integration/conftest.py
@@ -10,13 +10,19 @@ do) to fail when the flow the run asked for never executed: the backend named by
 run. Skipping is only acceptable for backends the run did not ask for.
 """
 
+import asyncio
 import base64
+import contextlib
 import os
+import time
+from typing import Any
 
 import httpx
 import pytest
 from solders.hash import Hash
 from solders.message import Message
+from solders.pubkey import Pubkey
+from solders.system_program import TransferParams, transfer
 from solders.transaction import Transaction, VersionedTransaction
 
 from solana_keychain.core import signed_message_bytes
@@ -83,22 +89,73 @@ async def assert_message_roundtrip(signer: SolanaSigner) -> None:
     assert signature.verify(signer.pubkey, message)
 
 
-async def fetch_latest_blockhash() -> Hash:
-    """A live blockhash is required: services reject or silently replace a stale one,
-    and a replaced blockhash changes the message bytes the signature must cover."""
+async def rpc_call(method: str, params: list[Any]) -> Any:
     rpc_url = os.environ.get("SOLANA_RPC_URL", DEFAULT_RPC_URL)
     async with httpx.AsyncClient(timeout=30.0) as client:
         response = await client.post(
             rpc_url,
-            json={
-                "jsonrpc": "2.0",
-                "id": 1,
-                "method": "getLatestBlockhash",
-                "params": [{"commitment": "finalized"}],
-            },
+            json={"jsonrpc": "2.0", "id": 1, "method": method, "params": params},
         )
     response.raise_for_status()
-    return Hash.from_string(response.json()["result"]["value"]["blockhash"])
+    body = response.json()
+    if body.get("error"):
+        raise AssertionError(f"{method} RPC error: {body['error']}")
+    return body["result"]
+
+
+async def fetch_latest_blockhash() -> Hash:
+    """A live blockhash is required: services reject or silently replace a stale one,
+    and a replaced blockhash changes the message bytes the signature must cover."""
+    result = await rpc_call("getLatestBlockhash", [{"commitment": "finalized"}])
+    return Hash.from_string(result["value"]["blockhash"])
+
+
+async def unsigned_transfer(
+    payer: Pubkey, recipient: Pubkey, lamports: int
+) -> VersionedTransaction:
+    instruction = transfer(
+        TransferParams(from_pubkey=payer, to_pubkey=recipient, lamports=lamports)
+    )
+    message = Message.new_with_blockhash([instruction], payer, await fetch_latest_blockhash())
+    return VersionedTransaction.from_legacy(Transaction.new_unsigned(message))
+
+
+async def broadcast_transaction(encoded_transaction: str) -> str:
+    """Returns the transaction signature the cluster accepted."""
+    # Preflight defaults to finalized, which cannot yet see a blockhash stamped
+    # seconds ago and rejects the send as BlockhashNotFound.
+    signature = await rpc_call(
+        "sendTransaction",
+        [encoded_transaction, {"encoding": "base64", "preflightCommitment": "processed"}],
+    )
+    return str(signature)
+
+
+async def confirm_transaction(
+    signature: str, rebroadcast: str | None = None, timeout_seconds: float = 60.0
+) -> None:
+    """Poll until ``signature`` is confirmed. ``rebroadcast`` carries the encoded
+    transaction when the caller owns the broadcast, and is None when the provider
+    pushed it and the wire bytes are not available."""
+    deadline = time.monotonic() + timeout_seconds
+    while time.monotonic() < deadline:
+        status = (
+            await rpc_call(
+                "getSignatureStatuses", [[signature], {"searchTransactionHistory": True}]
+            )
+        )["value"][0]
+        if status is not None:
+            if status["err"] is not None:
+                raise AssertionError(f"transaction failed on chain: {status['err']}")
+            if status["confirmationStatus"] in ("confirmed", "finalized"):
+                return
+        if rebroadcast is not None:
+            # A sent transaction can be dropped before it lands, and only a resend
+            # while its blockhash is still valid gets it back into a block.
+            with contextlib.suppress(Exception):
+                await broadcast_transaction(rebroadcast)
+        await asyncio.sleep(2)
+    raise AssertionError(f"timed out waiting for confirmation of {signature}")
 
 
 async def _unsigned_transaction(signer: SolanaSigner) -> VersionedTransaction:

--- a/python/tests/integration/test_live_signers.py
+++ b/python/tests/integration/test_live_signers.py
@@ -8,17 +8,31 @@ substring-matches marker keywords, and every test here carries ``parametrize``.
 """
 
 import os
+from typing import TYPE_CHECKING
 
 import pytest
+from solders.pubkey import Pubkey
 
+from solana_keychain.core import signed_message_bytes
 from solana_keychain.core.signer import SolanaSigner
 from tests.integration.conftest import (
     assert_message_roundtrip,
     assert_send_transaction_roundtrip,
     assert_transaction_roundtrip,
+    broadcast_transaction,
+    confirm_transaction,
     optional_env,
     require_env,
+    unsigned_transfer,
 )
+
+if TYPE_CHECKING:
+    from solana_keychain.fordefi import (
+        FordefiNativeAutoSigner,
+        FordefiNativeManualSigner,
+        FordefiPushMode,
+        FordefiSignerConfig,
+    )
 
 pytestmark = pytest.mark.integration
 
@@ -148,6 +162,40 @@ async def make_fordefi_signer() -> SolanaSigner:
             api_base_url=optional_env("FORDEFI_API_BASE_URL") or DEFAULT_API_BASE_URL,
         )
     )
+
+
+def _native_fordefi_config(push_mode: "FordefiPushMode") -> "FordefiSignerConfig":
+    from solana_keychain.fordefi import FordefiSignerConfig
+    from solana_keychain.fordefi.signer import DEFAULT_API_BASE_URL
+
+    env = require_env(
+        "FORDEFI_ACCESS_TOKEN",
+        "FORDEFI_VAULT_ID",
+        "FORDEFI_PUBLIC_KEY",
+        "FORDEFI_PRIVATE_KEY_PEM",
+        "FORDEFI_CHAIN",
+    )
+    return FordefiSignerConfig(
+        access_token=env["FORDEFI_ACCESS_TOKEN"],
+        vault_id=env["FORDEFI_VAULT_ID"],
+        public_key=env["FORDEFI_PUBLIC_KEY"],
+        private_key_pem=env["FORDEFI_PRIVATE_KEY_PEM"],
+        chain=env["FORDEFI_CHAIN"],
+        push_mode=push_mode,
+        api_base_url=optional_env("FORDEFI_API_BASE_URL") or DEFAULT_API_BASE_URL,
+    )
+
+
+async def make_fordefi_native_auto_signer() -> "FordefiNativeAutoSigner":
+    from solana_keychain.fordefi import FordefiNativeAutoSigner
+
+    return FordefiNativeAutoSigner(_native_fordefi_config("auto"))
+
+
+async def make_fordefi_native_manual_signer() -> "FordefiNativeManualSigner":
+    from solana_keychain.fordefi import FordefiNativeManualSigner
+
+    return FordefiNativeManualSigner(_native_fordefi_config("manual"))
 
 
 async def make_cdp_signer() -> SolanaSigner:
@@ -307,3 +355,37 @@ async def test_live_is_available(backend: str) -> None:
     _skip_unless_selected(backend)
     signer = await _ALL_BACKENDS[backend]()
     assert await signer.is_available()
+
+
+def _devnet_recipient(payer: Pubkey) -> Pubkey:
+    recipient = optional_env("DEVNET_RECIPIENT")
+    return Pubkey.from_string(recipient) if recipient else payer
+
+
+@pytest.mark.parametrize("backend", ["fordefi"])
+async def test_live_fordefi_native_auto_sign_and_send(backend: str) -> None:
+    _skip_unless_selected(backend)
+    signer = await make_fordefi_native_auto_signer()
+    transaction = await unsigned_transfer(
+        signer.pubkey, _devnet_recipient(signer.pubkey), 100_000_000
+    )
+
+    signature = await signer.sign_and_send_transaction(transaction)
+
+    assert len(bytes(signature)) == 64
+    await confirm_transaction(str(signature))
+
+
+@pytest.mark.parametrize("backend", ["fordefi"])
+async def test_live_fordefi_native_manual_sign_and_broadcast(backend: str) -> None:
+    _skip_unless_selected(backend)
+    signer = await make_fordefi_native_manual_signer()
+    transaction = await unsigned_transfer(signer.pubkey, signer.pubkey, 1)
+
+    result = await signer.modify_and_sign_transaction(transaction)
+
+    assert result.is_complete
+    assert result.signature.verify(signer.pubkey, signed_message_bytes(result.transaction.message))
+
+    signature = await broadcast_transaction(result.encoded_transaction)
+    await confirm_transaction(signature, rebroadcast=result.encoded_transaction)

--- a/python/tests/test_fordefi_signer.py
+++ b/python/tests/test_fordefi_signer.py
@@ -16,20 +16,35 @@ from cryptography.hazmat.primitives.serialization import (
     NoEncryption,
     PrivateFormat,
 )
+from solders.hash import Hash
 from solders.keypair import Keypair
+from solders.message import Message, MessageV0, MessageV1
 from solders.signature import Signature
+from solders.transaction import VersionedTransaction
 
 from solana_keychain import SignerError, SignerErrorCode
-from solana_keychain.core import SendingSigner, TransactionSigner, signed_message_bytes
+from solana_keychain.core import (
+    ModifyingSigner,
+    SendingSigner,
+    TransactionSigner,
+    signed_message_bytes,
+)
+from solana_keychain.core.transaction_util import idempotency_key_from_message
 from solana_keychain.fordefi import (
     FordefiBlackBoxSigner,
     FordefiNativeAutoSigner,
+    FordefiNativeManualSigner,
     FordefiRequestSigner,
     FordefiSignerConfig,
     PemRequestSigner,
     create_fordefi_signer,
 )
-from tests.util import create_test_transaction, create_two_signer_transaction
+from tests.util import (
+    create_test_transaction,
+    create_test_v0_transaction,
+    create_test_v1_transaction,
+    create_two_signer_transaction,
+)
 
 API_BASE_URL = "https://fordefi.example.com"
 ACCESS_TOKEN = "test-access-token"
@@ -62,6 +77,12 @@ def make_black_box_signer(keypair: Keypair, **overrides: Any) -> FordefiBlackBox
 def make_native_signer(keypair: Keypair, **overrides: Any) -> FordefiNativeAutoSigner:
     overrides.setdefault("chain", "solana_devnet")
     return FordefiNativeAutoSigner(make_config(keypair, **overrides))
+
+
+def make_manual_signer(keypair: Keypair, **overrides: Any) -> FordefiNativeManualSigner:
+    overrides.setdefault("chain", "solana_devnet")
+    overrides.setdefault("push_mode", "manual")
+    return FordefiNativeManualSigner(make_config(keypair, **overrides))
 
 
 def mock_vault(body: dict[str, Any], status_code: int = 200) -> None:
@@ -99,16 +120,26 @@ def test_each_mode_exposes_exactly_one_transaction_capability() -> None:
     keypair = Keypair()
     black_box = make_black_box_signer(keypair)
     native = make_native_signer(keypair, chain="solana_mainnet")
+    manual = make_manual_signer(keypair, chain="solana_mainnet")
 
     assert isinstance(black_box, TransactionSigner)
-    assert not isinstance(black_box, SendingSigner)
+    assert not isinstance(black_box, SendingSigner | ModifyingSigner)
     assert isinstance(native, SendingSigner)
-    assert not isinstance(native, TransactionSigner)
+    assert not isinstance(native, TransactionSigner | ModifyingSigner)
+    assert isinstance(manual, ModifyingSigner)
+    assert not isinstance(manual, TransactionSigner | SendingSigner)
 
 
 def test_black_box_signer_rejects_a_native_config() -> None:
     with pytest.raises(SignerError) as excinfo:
         FordefiBlackBoxSigner(make_config(Keypair(), chain="solana_mainnet"))
+    assert excinfo.value.code == SignerErrorCode.CONFIG_ERROR
+
+
+def test_black_box_signer_rejects_a_push_mode() -> None:
+    """``push_mode`` is meaningless without a chain, so it must not be ignored."""
+    with pytest.raises(SignerError) as excinfo:
+        FordefiBlackBoxSigner(make_config(Keypair(), push_mode="auto"))
     assert excinfo.value.code == SignerErrorCode.CONFIG_ERROR
 
 
@@ -118,12 +149,38 @@ def test_native_signer_rejects_a_black_box_config() -> None:
     assert excinfo.value.code == SignerErrorCode.CONFIG_ERROR
 
 
-async def test_factory_picks_the_signer_type_from_chain() -> None:
+@pytest.mark.parametrize(
+    ("signer_type", "overrides"),
+    [
+        (FordefiNativeAutoSigner, {"chain": "solana_devnet", "push_mode": "manual"}),
+        (FordefiNativeManualSigner, {"chain": "solana_devnet"}),
+        (FordefiNativeManualSigner, {"chain": "solana_devnet", "push_mode": "auto"}),
+        (FordefiNativeManualSigner, {"push_mode": "manual"}),
+    ],
+)
+def test_native_signer_rejects_the_other_modes_config(
+    signer_type: type[FordefiNativeAutoSigner] | type[FordefiNativeManualSigner],
+    overrides: dict[str, Any],
+) -> None:
+    with pytest.raises(SignerError) as excinfo:
+        signer_type(make_config(Keypair(), **overrides))
+    assert excinfo.value.code == SignerErrorCode.CONFIG_ERROR
+
+
+async def test_factory_picks_the_signer_type_from_chain_and_push_mode() -> None:
     keypair = Keypair()
     black_box = await create_fordefi_signer(make_config(keypair))
     native = await create_fordefi_signer(make_config(keypair, chain="solana_devnet"))
+    auto = await create_fordefi_signer(
+        make_config(keypair, chain="solana_devnet", push_mode="auto")
+    )
+    manual = await create_fordefi_signer(
+        make_config(keypair, chain="solana_devnet", push_mode="manual")
+    )
     assert isinstance(black_box, FordefiBlackBoxSigner)
     assert isinstance(native, FordefiNativeAutoSigner)
+    assert isinstance(auto, FordefiNativeAutoSigner)
+    assert isinstance(manual, FordefiNativeManualSigner)
 
 
 @pytest.mark.parametrize("field", ["access_token", "vault_id", "public_key"])
@@ -583,6 +640,271 @@ async def test_sign_transaction_native_rejects_multi_signer_before_submitting() 
     assert not respx.calls
 
 
+def replace_blockhash(transaction: VersionedTransaction, blockhash: Hash) -> VersionedTransaction:
+    """Stand in for the rewrite Fordefi performs before signing."""
+    message = transaction.message
+    replaced: Message | MessageV0 | MessageV1
+    if isinstance(message, Message):
+        header = message.header
+        replaced = Message.new_with_compiled_instructions(
+            header.num_required_signatures,
+            header.num_readonly_signed_accounts,
+            header.num_readonly_unsigned_accounts,
+            message.account_keys,
+            blockhash,
+            message.instructions,
+        )
+    elif isinstance(message, MessageV0):
+        replaced = MessageV0(
+            message.header,
+            message.account_keys,
+            blockhash,
+            message.instructions,
+            message.address_table_lookups,
+        )
+    else:
+        replaced = MessageV1(
+            message.header,
+            message.config,
+            blockhash,
+            message.account_keys,
+            message.instructions,
+        )
+    return VersionedTransaction.populate(
+        replaced, [Signature.default()] * replaced.header.num_required_signatures
+    )
+
+
+def vault_signed_wire(
+    keypair: Keypair, transaction: VersionedTransaction, position: int = 0
+) -> tuple[str, Signature]:
+    signature = keypair.sign_message(signed_message_bytes(transaction.message))
+    signatures = list(transaction.signatures)
+    signatures[position] = signature
+    transaction.signatures = signatures
+    return base64.b64encode(bytes(transaction)).decode("ascii"), signature
+
+
+@respx.mock
+@pytest.mark.parametrize("version", ["legacy", "v0", "v1"])
+async def test_manual_signing_returns_the_transaction_fordefi_signed(version: str) -> None:
+    """Fordefi signed bytes it chose, so only its own transaction can be broadcast."""
+    keypair = Keypair()
+    fee = {"type": "priority", "priority_level": "high"}
+    signer = make_manual_signer(keypair, chain="solana_mainnet", fee=fee)
+    builders = {
+        "legacy": create_test_transaction,
+        "v0": create_test_v0_transaction,
+        "v1": create_test_v1_transaction,
+    }
+    transaction = builders[version](keypair.pubkey())
+    original_wire = bytes(transaction)
+    returned = replace_blockhash(transaction, Hash.new_unique())
+    raw_transaction, signature = vault_signed_wire(keypair, returned)
+    mock_sign_flow(
+        status_response("waiting_for_signing_trigger"),
+        status_response("signed", raw_transaction=raw_transaction),
+    )
+
+    result = await signer.modify_and_sign_transaction(transaction)
+
+    assert bytes(transaction) == original_wire, "the caller's transaction must stay untouched"
+    assert bytes(result.transaction) == bytes(returned)
+    assert base64.b64decode(result.encoded_transaction, validate=True) == bytes(returned)
+    assert result.signature == signature
+    assert result.is_complete
+    assert signature.verify(keypair.pubkey(), signed_message_bytes(result.transaction.message))
+
+    assert json.loads(respx.calls[0].request.content)["details"] == {
+        "type": "solana_serialized_transaction_message",
+        "chain": "solana_mainnet",
+        "data": base64.b64encode(signed_message_bytes(transaction.message)).decode("ascii"),
+        "push_mode": "manual",
+        "fee": fee,
+    }
+
+
+@respx.mock
+async def test_manual_idempotence_id_cannot_collide_with_an_auto_create() -> None:
+    """The same bytes under auto were broadcast, so the manual create must not
+    dedupe onto them."""
+    keypair = Keypair()
+    signer = make_manual_signer(keypair, chain="solana_mainnet")
+    transaction = create_test_transaction(keypair.pubkey())
+    message_data = signed_message_bytes(transaction.message)
+    raw_transaction, _ = vault_signed_wire(
+        keypair, replace_blockhash(transaction, Hash.new_unique())
+    )
+    mock_sign_flow(status_response("signed", raw_transaction=raw_transaction))
+
+    await signer.modify_and_sign_transaction(transaction)
+
+    namespaced = f"fordefi:solana:manual:solana_mainnet:{VAULT_ID}:".encode() + message_data
+    observed = respx.calls[0].request.headers["x-idempotence-id"]
+    assert observed == idempotency_key_from_message(namespaced)
+    assert observed != idempotency_key_from_message(message_data)
+
+
+@respx.mock
+async def test_manual_signing_returns_a_partial_multi_signer_transaction() -> None:
+    """Downstream signers have to sign the bytes Fordefi produced, not the
+    caller's, so the rewrite is what they must continue from."""
+    keypair = Keypair()
+    cosigner = Keypair()
+    signer = make_manual_signer(keypair)
+    transaction = create_two_signer_transaction(keypair.pubkey(), cosigner.pubkey())
+    returned = replace_blockhash(transaction, Hash.new_unique())
+    raw_transaction, vault_signature = vault_signed_wire(keypair, returned)
+    mock_sign_flow(status_response("signed", raw_transaction=raw_transaction))
+
+    result = await signer.modify_and_sign_transaction(transaction)
+
+    assert not result.is_complete
+    assert list(result.transaction.signatures) == [vault_signature, Signature.default()]
+    assert all(signature == Signature.default() for signature in transaction.signatures)
+
+
+@respx.mock
+async def test_manual_signing_finds_the_vault_signature_by_account_position() -> None:
+    """The vault pays the fee, but its signature slot is located by account
+    position rather than assumed to be slot zero."""
+    keypair = Keypair()
+    cosigner = Keypair()
+    signer = make_manual_signer(keypair)
+    transaction = create_two_signer_transaction(keypair.pubkey(), cosigner.pubkey())
+    returned = create_two_signer_transaction(cosigner.pubkey(), keypair.pubkey())
+    raw_transaction, vault_signature = vault_signed_wire(keypair, returned, position=1)
+    mock_sign_flow(status_response("signed", raw_transaction=raw_transaction))
+
+    result = await signer.modify_and_sign_transaction(transaction)
+
+    assert result.signature == vault_signature
+    assert list(result.transaction.signatures)[1] == vault_signature
+
+
+@respx.mock
+async def test_manual_signing_rejects_a_signature_over_other_bytes() -> None:
+    """An unverifiable signature must never reach the caller as a signed transaction."""
+    keypair = Keypair()
+    signer = make_manual_signer(keypair)
+    transaction = create_test_transaction(keypair.pubkey())
+    original_wire = bytes(transaction)
+    returned = replace_blockhash(transaction, Hash.new_unique())
+    returned.signatures = [Keypair().sign_message(signed_message_bytes(returned.message))]
+    mock_sign_flow(
+        status_response("signed", raw_transaction=base64.b64encode(bytes(returned)).decode("ascii"))
+    )
+
+    with pytest.raises(SignerError) as excinfo:
+        await signer.modify_and_sign_transaction(transaction)
+    assert excinfo.value.code == SignerErrorCode.SIGNING_FAILED
+    assert bytes(transaction) == original_wire
+
+
+@respx.mock
+async def test_manual_signing_rejects_an_empty_vault_signature_slot() -> None:
+    keypair = Keypair()
+    signer = make_manual_signer(keypair)
+    returned = replace_blockhash(create_test_transaction(keypair.pubkey()), Hash.new_unique())
+    mock_sign_flow(
+        status_response("signed", raw_transaction=base64.b64encode(bytes(returned)).decode("ascii"))
+    )
+
+    with pytest.raises(SignerError) as excinfo:
+        await signer.modify_and_sign_transaction(create_test_transaction(keypair.pubkey()))
+    assert excinfo.value.code == SignerErrorCode.SIGNING_FAILED
+
+
+@respx.mock
+async def test_manual_signing_rejects_a_transaction_the_vault_cannot_sign() -> None:
+    """A returned transaction with no slot for the vault carries no signature of ours."""
+    keypair = Keypair()
+    signer = make_manual_signer(keypair)
+    returned = create_test_transaction(Keypair().pubkey())
+    mock_sign_flow(
+        status_response("signed", raw_transaction=base64.b64encode(bytes(returned)).decode("ascii"))
+    )
+
+    with pytest.raises(SignerError) as excinfo:
+        await signer.modify_and_sign_transaction(create_test_transaction(keypair.pubkey()))
+    assert excinfo.value.code == SignerErrorCode.SIGNING_FAILED
+
+
+@respx.mock
+async def test_manual_signing_rejects_a_non_vault_fee_payer_before_submitting() -> None:
+    """Fordefi only rewrites transactions its own vault pays for."""
+    keypair = Keypair()
+    signer = make_manual_signer(keypair)
+
+    with pytest.raises(SignerError) as excinfo:
+        await signer.modify_and_sign_transaction(create_test_transaction(Keypair().pubkey()))
+    assert excinfo.value.code == SignerErrorCode.SIGNING_FAILED
+    assert not respx.calls
+
+
+@respx.mock
+async def test_manual_signing_rejects_a_presigned_transaction_before_submitting() -> None:
+    """Fordefi rewrites the message, which would silently void an existing signature."""
+    keypair = Keypair()
+    signer = make_manual_signer(keypair)
+    transaction = create_test_transaction(keypair.pubkey())
+    transaction.signatures = [keypair.sign_message(signed_message_bytes(transaction.message))]
+
+    with pytest.raises(SignerError) as excinfo:
+        await signer.modify_and_sign_transaction(transaction)
+    assert excinfo.value.code == SignerErrorCode.SIGNING_FAILED
+    assert not respx.calls
+
+
+@respx.mock
+@pytest.mark.parametrize(
+    ("raw_transaction", "error_code"),
+    [
+        (None, SignerErrorCode.SIGNING_FAILED),
+        ("not-base64!", SignerErrorCode.SERIALIZATION_ERROR),
+        (base64.b64encode(b"not a transaction").decode(), SignerErrorCode.SERIALIZATION_ERROR),
+    ],
+)
+async def test_manual_signing_rejects_an_unusable_wire_transaction(
+    raw_transaction: str | None, error_code: SignerErrorCode
+) -> None:
+    keypair = Keypair()
+    signer = make_manual_signer(keypair)
+    extra = {} if raw_transaction is None else {"raw_transaction": raw_transaction}
+    mock_sign_flow(status_response("signed", **extra))
+
+    with pytest.raises(SignerError) as excinfo:
+        await signer.modify_and_sign_transaction(create_test_transaction(keypair.pubkey()))
+    assert excinfo.value.code == error_code
+
+
+@respx.mock
+async def test_manual_signing_failure_is_never_broadcast_unconfirmed() -> None:
+    """Nothing is broadcast in manual mode, so a failure leaves no on-chain doubt."""
+    keypair = Keypair()
+    signer = make_manual_signer(keypair)
+    mock_sign_flow(status_response("error_signing"))
+
+    with pytest.raises(SignerError) as excinfo:
+        await signer.modify_and_sign_transaction(create_test_transaction(keypair.pubkey()))
+    assert excinfo.value.code == SignerErrorCode.SIGNING_FAILED
+    assert excinfo.value.provider_transaction_id is None
+
+
+@respx.mock
+async def test_manual_mode_signs_messages_through_solana_message() -> None:
+    keypair = Keypair()
+    message = b"manual-native-message"
+    signature = keypair.sign_message(message)
+    signer = make_manual_signer(keypair)
+    mock_sign_flow(status_response("signed", signatures=[{"data": signature_b64(signature)}]))
+
+    assert await signer.sign_message(message) == signature
+    body = json.loads(respx.calls[0].request.content)
+    assert body["type"] == "solana_message"
+    assert "push_mode" not in body["details"]
+
+
 @respx.mock
 async def test_is_available_success() -> None:
     mock_vault({"id": VAULT_ID})
@@ -623,7 +945,11 @@ def test_reprs_never_contain_secrets() -> None:
         private_key_pem=EC_PRIVATE_PEM,
         api_base_url=API_BASE_URL,
     )
-    signer = make_black_box_signer(keypair)
-    for text in (repr(config), repr(signer)):
+    signers = (
+        make_black_box_signer(keypair),
+        make_native_signer(keypair),
+        make_manual_signer(keypair),
+    )
+    for text in (repr(config), *(repr(signer) for signer in signers)):
         assert ACCESS_TOKEN not in text
         assert "PRIVATE KEY" not in text

--- a/python/tests/test_send.py
+++ b/python/tests/test_send.py
@@ -5,6 +5,7 @@ from solders.signature import Signature
 from solders.transaction import VersionedTransaction
 
 from solana_keychain.core import (
+    ModifyingSigner,
     SendingSigner,
     SignedTransaction,
     SignerError,
@@ -16,6 +17,7 @@ from solana_keychain.core import (
 from tests.util import create_test_transaction
 
 ENCODED = "encoded-transaction"
+REWRITTEN_ENCODED = "rewritten-transaction"
 SIGNATURE = Signature.from_bytes(bytes([7] * 64))
 
 
@@ -45,6 +47,23 @@ class StubTransactionSigner(_StubBase, TransactionSigner):
             encoded_transaction=ENCODED,
             signature=self._signature,
             is_complete=self._is_complete,
+            transaction=transaction,
+        )
+
+
+class StubModifyingSigner(_StubBase, ModifyingSigner):
+    def __init__(self, *, is_complete: bool = True) -> None:
+        super().__init__()
+        self._is_complete = is_complete
+
+    async def modify_and_sign_transaction(
+        self, transaction: VersionedTransaction
+    ) -> SignedTransaction:
+        return SignedTransaction(
+            encoded_transaction=REWRITTEN_ENCODED,
+            signature=self._signature,
+            is_complete=self._is_complete,
+            transaction=create_test_transaction(self.pubkey),
         )
 
 
@@ -84,6 +103,44 @@ async def test_sign_only_signer_broadcasts_the_encoded_transaction() -> None:
     )
     assert sent == [ENCODED]
     assert signature == broadcast_signature
+
+
+async def test_modifying_signer_broadcasts_the_rewritten_transaction() -> None:
+    """The provider rewrote the message, so only its own bytes can be broadcast."""
+    signer = StubModifyingSigner()
+    sent: list[str] = []
+    broadcast_signature = Signature.from_bytes(bytes([2] * 64))
+
+    async def send(encoded: str) -> Signature:
+        sent.append(encoded)
+        return broadcast_signature
+
+    signature = await sign_and_send_transaction(
+        signer, create_test_transaction(signer.pubkey), send
+    )
+    assert sent == [REWRITTEN_ENCODED]
+    assert signature == broadcast_signature
+
+
+async def test_modifying_signer_without_a_sender_is_rejected() -> None:
+    """A modifying signer does not broadcast either, so the hop is still required."""
+    signer = StubModifyingSigner()
+
+    with pytest.raises(SignerError) as excinfo:
+        await sign_and_send_transaction(signer, create_test_transaction(signer.pubkey))
+    assert excinfo.value.code == SignerErrorCode.CONFIG_ERROR
+
+
+async def test_partially_signed_rewrite_is_rejected_before_broadcast() -> None:
+    """A rewrite still awaiting downstream signers cannot land."""
+    signer = StubModifyingSigner(is_complete=False)
+
+    async def send(encoded: str) -> Signature:
+        raise AssertionError("send must not run for a partially signed rewrite")
+
+    with pytest.raises(SignerError) as excinfo:
+        await sign_and_send_transaction(signer, create_test_transaction(signer.pubkey), send)
+    assert excinfo.value.code == SignerErrorCode.SIGNING_FAILED
 
 
 async def test_missing_sender_is_rejected_before_signing() -> None:

--- a/python/tests/util.py
+++ b/python/tests/util.py
@@ -1,6 +1,6 @@
 from solders.hash import Hash
 from solders.instruction import AccountMeta, Instruction
-from solders.message import Message, MessageV1, TransactionConfig
+from solders.message import Message, MessageV0, MessageV1, TransactionConfig
 from solders.pubkey import Pubkey
 from solders.signature import Signature
 from solders.system_program import ID as SYSTEM_PROGRAM_ID
@@ -32,6 +32,15 @@ def create_test_transaction(
     instruction = _transfer_instruction(from_pubkey, to_pubkey)
     message = Message.new_with_blockhash([instruction], from_pubkey, Hash.default())
     return VersionedTransaction.from_legacy(Transaction.new_unsigned(message))
+
+
+def create_test_v0_transaction(
+    from_pubkey: Pubkey, to_pubkey: Pubkey | None = None
+) -> VersionedTransaction:
+    instruction = _transfer_instruction(from_pubkey, to_pubkey)
+    message = MessageV0.try_compile(from_pubkey, [instruction], [], Hash.default())
+    unsigned = [Signature.default()] * message.header.num_required_signatures
+    return VersionedTransaction.populate(message, unsigned)
 
 
 def create_test_v1_transaction(

--- a/typescript/packages/fordefi/README.md
+++ b/typescript/packages/fordefi/README.md
@@ -10,13 +10,21 @@ npm install @solana/keychain-fordefi
 
 ## Signing Modes
 
-The signer supports two modes determined by whether `chain` is provided:
+The signer supports three modes, determined by `chain` and `pushMode`. Kit classifies signers by method presence, so each mode exposes exactly one transaction entry point and none of the others:
 
-### Native Solana mode (recommended for on-chain use)
+| Mode | Config | Shape | Entry point |
+|------|--------|-------|-------------|
+| Black box | `chain` unset | `FordefiBlackBoxSigner` | `signTransactions()` |
+| Native auto | `chain` set, `pushMode` omitted or `'auto'` | `FordefiNativeSigner` | `signAndSendTransactions()` |
+| Native manual | `chain` set, `pushMode: 'manual'` | `FordefiNativeManualSigner` | `modifyAndSignTransactions()` |
 
-Set `chain` to use Fordefi's native Solana transaction type. Fordefi may modify the transaction (e.g. updating the blockhash or adding compute budget instructions) and broadcasts it on-chain automatically (`push_mode: 'auto'`). Use this with a **Solana vault**.
+All three sign off-chain messages with `signMessages()`.
 
-> **Note:** Native mode is a Kit `TransactionSendingSigner` (`FordefiNativeSigner`, built on `SolanaSendingSigner` from `@solana/keychain-core`), because Fordefi may sign a different message than the one supplied by the caller and broadcasts it itself. Use `signAndSendTransactionMessageWithSigners()` or `signAndSendTransactions()`. Native instances expose **no** `signTransactions` — Kit classifies signers by method presence, so its absence is what routes the signer through Kit's sending flow — but message signing (`signMessages`) still works. Black-box instances are the mirror image: `signTransactions` and no `signAndSendTransactions`.
+### Native auto mode (recommended for on-chain use)
+
+Set `chain` to use Fordefi's native Solana transaction type. Fordefi may modify the transaction (e.g. updating the blockhash or adding compute budget instructions) and broadcasts it on-chain automatically. Use this with a **Solana vault**.
+
+> **Note:** Native auto mode is a Kit `TransactionSendingSigner` (`FordefiNativeSigner`, built on `SolanaSendingSigner` from `@solana/keychain-core`), because Fordefi may sign a different message than the one supplied by the caller and broadcasts it itself. Use `signAndSendTransactionMessageWithSigners()` or `signAndSendTransactions()`. Instances expose **no** `signTransactions`: Kit classifies signers by method presence, so its absence is what routes the signer through Kit's sending flow. Message signing (`signMessages`) still works. Black-box instances are the mirror image: `signTransactions` and no `signAndSendTransactions`.
 
 ```typescript
 import { createFordefiSigner } from '@solana/keychain-fordefi';
@@ -35,6 +43,36 @@ const transactionSignature = await signAndSendTransactionMessageWithSigners(tran
 ```
 
 Native auto-broadcast currently supports transactions whose only required signer is the configured Fordefi vault. Transactions requiring additional signers are rejected before submission until the integration forwards their partial signatures through Fordefi's `details.signatures` field.
+
+### Native manual mode
+
+Add `pushMode: 'manual'` to the native config. Fordefi still parses the transaction, so its policy engine and approval UI apply, but it signs **without** broadcasting: you own submission, and additional required signers are supported, which native auto rejects.
+
+Manual mode is a Kit `TransactionModifyingSigner` (`FordefiNativeManualSigner`, built on `SolanaModifyingSigner`). `modifyAndSignTransactions()` returns the transaction Fordefi signed, which **replaces** the one you submitted: continue from the returned value so every downstream signer signs the message the Fordefi signature covers.
+
+```typescript
+import { createFordefiSigner } from '@solana/keychain-fordefi';
+
+const signer = await createFordefiSigner({
+    accessToken: process.env.FORDEFI_ACCESS_TOKEN!,
+    vaultId: process.env.FORDEFI_VAULT_ID!,
+    privateKeyPem: fs.readFileSync('./secret/private.pem', 'utf8'),
+    publicKey: process.env.FORDEFI_PUBLIC_KEY!,
+    chain: 'solana_devnet',
+    pushMode: 'manual',
+});
+
+const [signedTransaction] = await signer.modifyAndSignTransactions([transaction]);
+await rpc.sendTransaction(getBase64EncodedWireTransaction(signedTransaction), { encoding: 'base64' }).send();
+```
+
+Requirements and caveats:
+
+- The Fordefi vault must be the transaction fee payer, and manual signing must run before any signature is applied. Both are checked before anything is submitted.
+- Fordefi may rewrite the message: at minimum the recent blockhash, and it manages the Compute Budget fee instructions, so a compute-unit limit or price you set yourself may not survive. What changed is **not** diffed, so inspect the result before broadcasting if its contents matter to you.
+- The returned signature is verified with ed25519 against the message Fordefi returned, at the vault's required-signer position. A mismatch fails and is never handed back.
+- Fordefi refreshes the blockhash but does not report its `lastValidBlockHeight`, so a refreshed lifetime carries Kit's `U64_MAX` placeholder; broadcast promptly rather than relying on local expiry detection.
+- The create carries an `x-idempotence-id` derived from the message bytes under a manual-specific namespace, so resending the same bytes reuses the Fordefi transaction instead of creating a second one, and cannot collide with an auto create that did broadcast them.
 
 ### Black box mode
 
@@ -59,6 +97,7 @@ const signer = await createFordefiSigner({
 | `requestSigner` | One of | Custom API-request signer (e.g. KMS/HSM). Provide exactly one of `privateKeyPem` or `requestSigner` |
 | `publicKey` | Yes | Solana public key of the vault (base58) |
 | `chain` | No | `'solana_mainnet'` or `'solana_devnet'` — enables native Solana mode |
+| `pushMode` | No | `'auto'` (default) or `'manual'`, i.e. whether Fordefi broadcasts. `'manual'` requires `chain` |
 | `fee` | No | Priority fee config for native mode (e.g. `{ type: 'custom', priority_fee: '1000' }`) |
 | `apiBaseUrl` | No | API base URL (default: `https://api.fordefi.com`) |
 | `pollIntervalMs` | No | Polling interval in ms (default: 2000) |

--- a/typescript/packages/fordefi/package.json
+++ b/typescript/packages/fordefi/package.json
@@ -48,17 +48,21 @@
         "@solana/codecs-strings": ">=8.0.0",
         "@solana/keys": ">=8.0.0",
         "@solana/signers": ">=8.0.0",
+        "@solana/transaction-messages": ">=8.0.0",
         "@solana/transactions": ">=8.0.0"
     },
     "publishConfig": {
         "access": "public"
     },
     "devDependencies": {
+        "@solana-program/system": "^0.13.0",
         "@solana/addresses": "8.0.0",
         "@solana/codecs-strings": "8.0.0",
         "@solana/keychain-test-utils": "workspace:*",
         "@solana/keys": "8.0.0",
+        "@solana/kit": "8.0.0",
         "@solana/signers": "8.0.0",
+        "@solana/transaction-messages": "8.0.0",
         "@solana/transactions": "8.0.0",
         "dotenv": "^17.4.2"
     }

--- a/typescript/packages/fordefi/src/__tests__/fordefi-signer.integration.test.ts
+++ b/typescript/packages/fordefi/src/__tests__/fordefi-signer.integration.test.ts
@@ -1,13 +1,127 @@
-import { describe, it } from 'vitest';
+import { getTransferSolInstruction } from '@solana-program/system';
+import { assertSignatureValid } from '@solana/keychain-core';
 import { runSignerIntegrationTest } from '@solana/keychain-test-utils';
-import { getConfig } from './setup';
+import {
+    address,
+    appendTransactionMessageInstructions,
+    type Base64EncodedWireTransaction,
+    type Blockhash,
+    compileTransaction,
+    createTransactionMessage,
+    getBase58Decoder,
+    getBase64EncodedWireTransaction,
+    lamports,
+    pipe,
+    setTransactionMessageFeePayerSigner,
+    setTransactionMessageLifetimeUsingBlockhash,
+    signAndSendTransactionMessageWithSigners,
+    type TransactionSigner,
+} from '@solana/kit';
 import { config } from 'dotenv';
+import { describe, expect, it } from 'vitest';
+import { createFordefiSigner } from '../fordefi-signer';
+import type { SolanaChainUniqueId } from '../types';
+import { getConfig } from './setup';
 config();
 
 // Fordefi MPC signing can take tens of seconds end-to-end (submit + poll until
 // the co-signers finish), so we extend the per-test timeout well beyond the
 // vitest default of 30s.
 const TEST_TIMEOUT_MS = 120_000;
+
+const RPC_URL = process.env.SOLANA_RPC_URL ?? 'https://api.devnet.solana.com';
+const TRANSFER_LAMPORTS = lamports(1n);
+const CONFIRMATION_TIMEOUT_MS = 60_000;
+const CONFIRMATION_POLL_INTERVAL_MS = 2_000;
+
+async function callRpc<T>(method: string, params: unknown[]): Promise<T> {
+    const response = await fetch(RPC_URL, {
+        body: JSON.stringify({ id: 1, jsonrpc: '2.0', method, params }),
+        headers: { 'Content-Type': 'application/json' },
+        method: 'POST',
+    });
+    const json = (await response.json()) as { error?: unknown; result: T };
+    if (json.error) {
+        throw new Error(`${method} RPC error: ${JSON.stringify(json.error)}`);
+    }
+    return json.result;
+}
+
+async function getLatestBlockhash(): Promise<{ blockhash: Blockhash; lastValidBlockHeight: bigint }> {
+    const { value } = await callRpc<{ value: { blockhash: Blockhash; lastValidBlockHeight: number } }>(
+        'getLatestBlockhash',
+        [{ commitment: 'finalized' }],
+    );
+    return { blockhash: value.blockhash, lastValidBlockHeight: BigInt(value.lastValidBlockHeight) };
+}
+
+async function sendWireTransaction(wireTransaction: Base64EncodedWireTransaction): Promise<string> {
+    // Fordefi stamps the recent blockhash seconds before it signs, so a
+    // finalized-commitment preflight reports BlockhashNotFound and rejects the send.
+    return await callRpc<string>('sendTransaction', [
+        wireTransaction,
+        { encoding: 'base64', preflightCommitment: 'processed' },
+    ]);
+}
+
+async function confirmSignature(signature: string, rebroadcast?: Base64EncodedWireTransaction): Promise<void> {
+    const deadline = Date.now() + CONFIRMATION_TIMEOUT_MS;
+
+    while (Date.now() < deadline) {
+        const { value } = await callRpc<{ value: ({ confirmationStatus: string | null; err: unknown } | null)[] }>(
+            'getSignatureStatuses',
+            [[signature], { searchTransactionHistory: true }],
+        );
+        const status = value[0];
+
+        if (status) {
+            if (status.err) {
+                throw new Error(`Transaction failed on-chain: ${JSON.stringify(status.err)}`);
+            }
+            if (status.confirmationStatus === 'confirmed' || status.confirmationStatus === 'finalized') {
+                return;
+            }
+        }
+
+        if (rebroadcast) {
+            // A sent transaction can be dropped and never land, so resend it
+            // between polls while its blockhash is still valid.
+            await sendWireTransaction(rebroadcast).catch(() => undefined);
+        }
+        await new Promise(resolve => setTimeout(resolve, CONFIRMATION_POLL_INTERVAL_MS));
+    }
+
+    throw new Error(`Timed out waiting for confirmation of ${signature}`);
+}
+
+function nativeConfig() {
+    return {
+        accessToken: process.env.FORDEFI_ACCESS_TOKEN!,
+        apiBaseUrl: process.env.FORDEFI_API_BASE_URL,
+        chain: (process.env.FORDEFI_CHAIN ?? 'solana_devnet') as SolanaChainUniqueId,
+        maxPollAttempts: 110,
+        pollIntervalMs: 1000,
+        privateKeyPem: process.env.FORDEFI_PRIVATE_KEY_PEM!,
+        publicKey: process.env.FORDEFI_PUBLIC_KEY!,
+        vaultId: process.env.FORDEFI_VAULT_ID!,
+    };
+}
+
+async function buildUnsignedDevnetTransfer<TSigner extends TransactionSigner<string>>(feePayer: TSigner) {
+    const { blockhash, lastValidBlockHeight } = await getLatestBlockhash();
+    const destination = address(process.env.DEVNET_RECIPIENT ?? feePayer.address);
+
+    return pipe(
+        createTransactionMessage({ version: 0 }),
+        tx => setTransactionMessageFeePayerSigner(feePayer, tx),
+        tx => setTransactionMessageLifetimeUsingBlockhash({ blockhash, lastValidBlockHeight }, tx),
+        tx =>
+            appendTransactionMessageInstructions(
+                [getTransferSolInstruction({ amount: TRANSFER_LAMPORTS, destination, source: feePayer })],
+                tx,
+            ),
+    );
+}
 
 describe('FordefiSigner Integration', () => {
     it.skipIf(!process.env.FORDEFI_BB_VAULT_ID)(
@@ -28,6 +142,47 @@ describe('FordefiSigner Integration', () => {
         'simulates transactions with real API',
         async () => {
             await runSignerIntegrationTest(await getConfig(['simulateTransaction']));
+        },
+        TEST_TIMEOUT_MS,
+    );
+
+    it.skipIf(!process.env.FORDEFI_VAULT_ID)(
+        'native auto mode signs and broadcasts a devnet transfer',
+        async () => {
+            const signer = await createFordefiSigner({ ...nativeConfig(), pushMode: 'auto' as const });
+            const transactionMessage = await buildUnsignedDevnetTransfer(signer);
+
+            const signatureBytes = await signAndSendTransactionMessageWithSigners(transactionMessage);
+
+            expect(signatureBytes.byteLength).toBe(64);
+
+            await confirmSignature(getBase58Decoder().decode(signatureBytes));
+        },
+        TEST_TIMEOUT_MS,
+    );
+
+    it.skipIf(!process.env.FORDEFI_VAULT_ID)(
+        'native manual mode signs a devnet transfer the caller broadcasts',
+        async () => {
+            const signer = await createFordefiSigner({ ...nativeConfig(), pushMode: 'manual' as const });
+            const transactionMessage = await buildUnsignedDevnetTransfer(signer);
+
+            const signedTransactions = await signer.modifyAndSignTransactions([compileTransaction(transactionMessage)]);
+            expect(signedTransactions).toHaveLength(1);
+            const signedTransaction = signedTransactions[0]!;
+
+            const vaultSignature = signedTransaction.signatures[signer.address];
+            expect(vaultSignature?.byteLength).toBe(64);
+            await assertSignatureValid({
+                data: signedTransaction.messageBytes,
+                signature: vaultSignature!,
+                signerAddress: signer.address,
+            });
+
+            const wireTransaction = getBase64EncodedWireTransaction(signedTransaction);
+            const transactionSignature = await sendWireTransaction(wireTransaction);
+
+            await confirmSignature(transactionSignature, wireTransaction);
         },
         TEST_TIMEOUT_MS,
     );

--- a/typescript/packages/fordefi/src/__tests__/fordefi-signer.test.ts
+++ b/typescript/packages/fordefi/src/__tests__/fordefi-signer.test.ts
@@ -6,13 +6,14 @@ import {
     assertIsSolanaTransactionSigner,
     assertSignatureValid,
     isSolanaMessageSigner,
+    isSolanaModifyingSigner,
     isSolanaSendingSigner,
     isSolanaSigner,
     isSolanaTransactionSigner,
     type SignerError,
 } from '@solana/keychain-core';
 import { createCosignedWireTransaction, createSignedWireTransaction } from '@solana/keychain-test-utils';
-import { isTransactionPartialSigner, isTransactionSendingSigner } from '@solana/signers';
+import { isTransactionModifyingSigner, isTransactionPartialSigner, isTransactionSendingSigner } from '@solana/signers';
 
 vi.mock('@solana/keychain-core', async importOriginal => {
     const mod = await importOriginal<typeof import('@solana/keychain-core')>();
@@ -31,6 +32,7 @@ vi.mock('@solana/keychain-core', async importOriginal => {
 });
 
 import { createFordefiSigner, type FordefiSignerConfig } from '../fordefi-signer.js';
+import type { SolanaChainUniqueId } from '../types.js';
 
 // Mock fetch globally
 global.fetch = vi.fn();
@@ -44,7 +46,7 @@ const TEST_PEM = testPrivateKey.export({ type: 'sec1', format: 'pem' }) as strin
 const MOCK_SIGNATURE_BYTES = new Uint8Array(64).fill(0xab);
 const MOCK_SIGNATURE_BASE64 = Buffer.from(MOCK_SIGNATURE_BYTES).toString('base64');
 
-const mockConfig: FordefiSignerConfig & { chain?: undefined } = {
+const mockConfig: FordefiSignerConfig & { chain?: undefined; pushMode?: undefined } = {
     accessToken: 'test-token',
     apiBaseUrl: 'https://api.test.fordefi.com',
     privateKeyPem: TEST_PEM,
@@ -81,6 +83,31 @@ async function setupNativeBroadcast(version: 0 | 1) {
         publicKey: fixture.feePayer,
     } satisfies FordefiSignerConfig;
     return { config, fixture };
+}
+
+// Manual mode replaces the caller's transaction with real wire bytes, so the
+// response has to be a decodable transaction the vault signed.
+async function setupNativeManual(version: 0 | 1) {
+    const fixture = await createSignedWireTransaction(version);
+    const config = {
+        ...mockConfig,
+        chain: 'solana_mainnet',
+        publicKey: fixture.feePayer,
+        pushMode: 'manual',
+    } satisfies FordefiSignerConfig & { chain: SolanaChainUniqueId; pushMode: 'manual' };
+    return { config, fixture };
+}
+
+function unsignedManualTransaction(feePayer: string, messageBytes = new Uint8Array(32)) {
+    return { messageBytes, signatures: { [feePayer]: null } } as never;
+}
+
+function idempotencyKeyOf(input: Uint8Array) {
+    const digest = createHash('sha256').update(input).digest().subarray(0, 16);
+    digest[6] = (digest[6]! & 0x0f) | 0x40;
+    digest[8] = (digest[8]! & 0x3f) | 0x80;
+    const hex = digest.toString('hex');
+    return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20, 32)}`;
 }
 
 function mockVaultResponse(address: string = MOCK_ADDRESS) {
@@ -157,7 +184,7 @@ describe('createFordefiSigner', () => {
 
     describe('custom requestSigner', () => {
         // Config using a custom request signer instead of a PEM key.
-        const customConfig: FordefiSignerConfig & { chain?: undefined } = {
+        const customConfig: FordefiSignerConfig & { chain?: undefined; pushMode?: undefined } = {
             accessToken: 'test-token',
             apiBaseUrl: 'https://api.test.fordefi.com',
             publicKey: MOCK_ADDRESS,
@@ -646,6 +673,227 @@ describe('createFordefiSigner', () => {
                 code: 'SIGNER_BROADCAST_UNCONFIRMED',
                 context: expect.objectContaining({ providerTransactionId: 'tx-fail' }) as object,
             });
+        });
+    });
+
+    describe('modifyAndSignTransactions (native manual mode)', () => {
+        it.each([0, 1] as const)(
+            'should replace the caller transaction with the one Fordefi signed from a v%i envelope',
+            async version => {
+                const { config, fixture } = await setupNativeManual(version);
+                vi.mocked(fetch)
+                    .mockResolvedValueOnce(mockCreateTxResponse('tx-manual'))
+                    .mockResolvedValueOnce(mockPollResponse('signed', undefined, fixture.wireTransaction));
+
+                const signer = await createFordefiSigner(config);
+                const results = await signer.modifyAndSignTransactions([unsignedManualTransaction(fixture.feePayer)]);
+
+                expect(results).toHaveLength(1);
+                // Continuing from the caller's own bytes would leave downstream
+                // signers signing a message the Fordefi signature does not cover.
+                expect(results[0]!.messageBytes).toStrictEqual(fixture.messageBytes);
+                expect(results[0]!.signatures[fixture.feePayer]).toStrictEqual(fixture.signature);
+                expect(results[0]!.lifetimeConstraint).toBeDefined();
+
+                // The signature covers what Fordefi returned, not what was submitted.
+                expect(assertSignatureValid).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        data: fixture.messageBytes,
+                        signerAddress: fixture.feePayer,
+                    }),
+                );
+            },
+        );
+
+        it('should submit solana_transaction with push_mode manual', async () => {
+            const { config, fixture } = await setupNativeManual(0);
+            vi.mocked(fetch)
+                .mockResolvedValueOnce(mockCreateTxResponse('tx-manual'))
+                .mockResolvedValueOnce(mockPollResponse('signed', undefined, fixture.wireTransaction));
+
+            const signer = await createFordefiSigner(config);
+            await signer.modifyAndSignTransactions([unsignedManualTransaction(fixture.feePayer)]);
+
+            const postOpts = vi.mocked(fetch).mock.calls[0]![1] as RequestInit;
+            const body = JSON.parse(postOpts.body as string);
+            expect(body.type).toBe('solana_transaction');
+            expect(body.details.type).toBe('solana_serialized_transaction_message');
+            expect(body.details.push_mode).toBe('manual');
+        });
+
+        it('namespaces the x-idempotence-id so the same bytes cannot reuse an auto create', async () => {
+            const messageBytes = new Uint8Array(32).fill(0xab);
+            const { config, fixture } = await setupNativeManual(0);
+            vi.mocked(fetch)
+                .mockResolvedValueOnce(mockCreateTxResponse('tx-manual'))
+                .mockResolvedValueOnce(mockPollResponse('signed', undefined, fixture.wireTransaction));
+
+            const signer = await createFordefiSigner(config);
+            await signer.modifyAndSignTransactions([unsignedManualTransaction(fixture.feePayer, messageBytes)]);
+
+            const namespace = Buffer.from(`fordefi:solana:manual:solana_mainnet:${config.vaultId}:`, 'utf8');
+            const postOpts = vi.mocked(fetch).mock.calls[0]![1] as RequestInit;
+            expect(postOpts.headers).toHaveProperty(
+                'x-idempotence-id',
+                idempotencyKeyOf(Buffer.concat([namespace, Buffer.from(messageBytes)])),
+            );
+            expect(postOpts.headers).not.toHaveProperty('x-idempotence-id', idempotencyKeyOf(messageBytes));
+        });
+
+        it('exposes only the modifying method, so Kit cannot route it as a partial or sending signer', async () => {
+            const { config } = await setupNativeManual(0);
+            const signer = await createFordefiSigner(config);
+            const guardInput = signer as unknown as { [key: string]: unknown; address: typeof signer.address };
+
+            expect('signTransactions' in signer).toBe(false);
+            expect('signAndSendTransactions' in signer).toBe(false);
+            expect(isTransactionModifyingSigner(guardInput)).toBe(true);
+            expect(isTransactionPartialSigner(guardInput)).toBe(false);
+            expect(isTransactionSendingSigner(guardInput)).toBe(false);
+            expect(isSolanaSigner(guardInput)).toBe(true);
+            expect(isSolanaModifyingSigner(guardInput)).toBe(true);
+            expect(isSolanaTransactionSigner(guardInput)).toBe(false);
+            expect(isSolanaSendingSigner(guardInput)).toBe(false);
+            expect(isSolanaMessageSigner(guardInput)).toBe(true);
+        });
+
+        it('rejects a transaction the vault does not pay for before submitting remote work', async () => {
+            const { config, fixture } = await setupNativeManual(0);
+            const signer = await createFordefiSigner(config);
+            const mockTx = {
+                messageBytes: new Uint8Array(32),
+                signatures: { '22222222222222222222222222222222': null, [fixture.feePayer]: null },
+            } as never;
+
+            await expect(signer.modifyAndSignTransactions([mockTx])).rejects.toMatchObject({
+                code: 'SIGNER_SIGNING_FAILED',
+            });
+            expect(fetch).not.toHaveBeenCalled();
+        });
+
+        it('rejects an already-signed transaction, whose signatures the rewrite would invalidate', async () => {
+            const { config, fixture } = await setupNativeManual(0);
+            const signer = await createFordefiSigner(config);
+            const mockTx = {
+                messageBytes: new Uint8Array(32),
+                signatures: { [fixture.feePayer]: MOCK_SIGNATURE_BYTES },
+            } as never;
+
+            await expect(signer.modifyAndSignTransactions([mockTx])).rejects.toMatchObject({
+                code: 'SIGNER_SIGNING_FAILED',
+            });
+            expect(fetch).not.toHaveBeenCalled();
+        });
+
+        it('rejects a response without raw_transaction, having nothing to continue from', async () => {
+            const { config, fixture } = await setupNativeManual(0);
+            vi.mocked(fetch)
+                .mockResolvedValueOnce(mockCreateTxResponse('tx-manual'))
+                .mockResolvedValueOnce(mockPollResponse('signed', MOCK_SIGNATURE_BASE64));
+
+            const signer = await createFordefiSigner(config);
+            await expect(
+                signer.modifyAndSignTransactions([unsignedManualTransaction(fixture.feePayer)]),
+            ).rejects.toMatchObject({ code: 'SIGNER_SIGNING_FAILED' });
+        });
+
+        it('rejects a returned transaction that the configured vault did not sign', async () => {
+            const fixture = await createCosignedWireTransaction(0);
+            const config = {
+                ...mockConfig,
+                chain: 'solana_mainnet',
+                publicKey: fixture.feePayer,
+                pushMode: 'manual',
+            } satisfies FordefiSignerConfig & { chain: SolanaChainUniqueId; pushMode: 'manual' };
+            vi.mocked(fetch)
+                .mockResolvedValueOnce(mockCreateTxResponse('tx-manual'))
+                .mockResolvedValueOnce(mockPollResponse('signed', undefined, fixture.wireTransaction));
+
+            const signer = await createFordefiSigner(config);
+            await expect(
+                signer.modifyAndSignTransactions([unsignedManualTransaction(fixture.feePayer)]),
+            ).rejects.toMatchObject({ code: 'SIGNER_SIGNING_FAILED' });
+        });
+
+        it('leaves the caller transaction untouched when the returned signature does not verify', async () => {
+            const { config, fixture } = await setupNativeManual(0);
+            vi.mocked(fetch)
+                .mockResolvedValueOnce(mockCreateTxResponse('tx-manual'))
+                .mockResolvedValueOnce(mockPollResponse('signed', undefined, fixture.wireTransaction));
+            vi.mocked(assertSignatureValid).mockRejectedValueOnce(new Error('signature does not match'));
+
+            const signer = await createFordefiSigner(config);
+            const callerTransaction = unsignedManualTransaction(fixture.feePayer);
+            const before = structuredClone(callerTransaction);
+
+            await expect(signer.modifyAndSignTransactions([callerTransaction])).rejects.toThrow(
+                'signature does not match',
+            );
+            expect(callerTransaction).toStrictEqual(before);
+        });
+
+        it('does not leak the access token or the request key into a failure', async () => {
+            const { config, fixture } = await setupNativeManual(0);
+            vi.mocked(fetch).mockResolvedValueOnce(
+                new Response(JSON.stringify({ message: 'Unauthorized' }), { status: 401 }),
+            );
+
+            const signer = await createFordefiSigner(config);
+            const error = await signer.modifyAndSignTransactions([unsignedManualTransaction(fixture.feePayer)]).then(
+                () => {
+                    throw new Error('expected the submit failure to be reported');
+                },
+                (thrown: SignerError) => thrown,
+            );
+
+            const reported = `${error.message} ${JSON.stringify(error.context)} ${JSON.stringify(error)}`;
+            expect(reported).not.toContain(config.accessToken);
+            expect(reported).not.toContain(TEST_PEM);
+        });
+
+        it('keeps the caller lifetime when Fordefi did not refresh the blockhash', async () => {
+            const { config, fixture } = await setupNativeManual(0);
+            vi.mocked(fetch)
+                .mockResolvedValueOnce(mockCreateTxResponse('tx-manual'))
+                .mockResolvedValueOnce(mockPollResponse('signed', undefined, fixture.wireTransaction));
+
+            // Fordefi does not report a lastValidBlockHeight, so a surviving
+            // blockhash must not lose the caller's expiry height.
+            const lifetimeConstraint = { blockhash: '11111111111111111111111111111111', lastValidBlockHeight: 100n };
+            const signer = await createFordefiSigner(config);
+            const results = await signer.modifyAndSignTransactions([
+                {
+                    lifetimeConstraint,
+                    messageBytes: new Uint8Array(32),
+                    signatures: { [fixture.feePayer]: null },
+                } as never,
+            ]);
+
+            expect(results[0]!.lifetimeConstraint).toStrictEqual(lifetimeConstraint);
+        });
+
+        it('should reject pushMode manual without chain', async () => {
+            await expect(
+                createFordefiSigner({ ...mockConfig, pushMode: 'manual' } as FordefiSignerConfig),
+            ).rejects.toMatchObject({ code: 'SIGNER_CONFIG_ERROR' });
+        });
+
+        it('should reject an unrecognized pushMode rather than defaulting it to auto', async () => {
+            await expect(
+                createFordefiSigner({
+                    ...mockConfig,
+                    chain: 'solana_mainnet',
+                    pushMode: 'push',
+                } as unknown as FordefiSignerConfig),
+            ).rejects.toMatchObject({ code: 'SIGNER_CONFIG_ERROR' });
+        });
+
+        it('should still expose the sending method when pushMode is explicitly auto', async () => {
+            const signer = await createFordefiSigner({ ...nativeConfig, pushMode: 'auto' });
+            const guardInput = signer as unknown as { [key: string]: unknown; address: typeof signer.address };
+
+            expect(isTransactionSendingSigner(guardInput)).toBe(true);
+            expect(isTransactionModifyingSigner(guardInput)).toBe(false);
         });
     });
 

--- a/typescript/packages/fordefi/src/fordefi-signer.ts
+++ b/typescript/packages/fordefi/src/fordefi-signer.ts
@@ -1,7 +1,7 @@
 import { createPrivateKey, createSign, type KeyObject } from 'node:crypto';
 
 import { Address, assertIsAddress } from '@solana/addresses';
-import { getBase58Encoder, getBase64Decoder, getBase64Encoder } from '@solana/codecs-strings';
+import { getBase58Encoder, getBase64Decoder, getBase64Encoder, getUtf8Encoder } from '@solana/codecs-strings';
 import {
     abortableDelay,
     assertHttpsUrl,
@@ -16,6 +16,7 @@ import {
     signBatchStaggered,
     SignerErrorCode,
     SolanaMessageSigner,
+    SolanaModifyingSigner,
     SolanaSendingSigner,
     SolanaTransactionSigner,
     throwSignerError,
@@ -26,15 +27,20 @@ import {
     MessagePartialSignerConfig,
     SignableMessage,
     SignatureDictionary,
+    TransactionModifyingSigner,
+    TransactionModifyingSignerConfig,
     TransactionPartialSigner,
     TransactionPartialSignerConfig,
     TransactionSendingSigner,
     TransactionSendingSignerConfig,
 } from '@solana/signers';
+import { getCompiledTransactionMessageDecoder } from '@solana/transaction-messages';
 import {
+    assertIsTransactionWithinSizeLimit,
     Base64EncodedWireTransaction,
     getSignatureFromTransaction,
     getTransactionDecoder,
+    getTransactionLifetimeConstraintFromCompiledTransactionMessage,
     Transaction,
     TransactionWithinSizeLimit,
     TransactionWithLifetime,
@@ -43,6 +49,7 @@ import {
 import type {
     FordefiBlackBoxSignatureRequest,
     FordefiCreateTransactionResponse,
+    FordefiPushMode,
     FordefiSolanaFee,
     FordefiSolanaMessageRequest,
     FordefiSolanaTransactionRequest,
@@ -57,12 +64,15 @@ const DEFAULT_POLL_INTERVAL_MS = 2000;
 let base58Encoder: ReturnType<typeof getBase58Encoder> | undefined;
 let base64Decoder: ReturnType<typeof getBase64Decoder> | undefined;
 let base64Encoder: ReturnType<typeof getBase64Encoder> | undefined;
+let utf8Encoder: ReturnType<typeof getUtf8Encoder> | undefined;
 const DEFAULT_MAX_POLL_ATTEMPTS = 50;
 const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
 
+// An unrecognized value would otherwise fall through to auto and broadcast.
+const PUSH_MODES = new Set<string>(['auto', 'manual']);
 /** Terminal success states for pushable transactions (solana_transaction with push_mode auto). */
 const PUSHABLE_SUCCESS_STATES = new Set(['completed']);
-/** Terminal success states for non-pushable transactions (black_box_signature, solana_message). */
+/** Terminal success states for non-pushable transactions (black_box_signature, solana_message, native manual). */
 const NON_PUSHABLE_SUCCESS_STATES = new Set(['signed', 'completed']);
 /** Terminal failure states (all transaction types). Mirrors the Rust backend. */
 const FAILURE_STATES = new Set([
@@ -116,8 +126,8 @@ export interface FordefiSignerConfig {
     apiBaseUrl?: string;
     /**
      * Solana chain identifier. When set, uses native Solana API types
-     * (`solana_serialized_transaction_message` with `push_mode: 'auto'` for
-     * transactions, `solana_message` for messages) instead of `black_box_signature`.
+     * (`solana_serialized_transaction_message` for transactions,
+     * `solana_message` for messages) instead of `black_box_signature`.
      */
     chain?: SolanaChainUniqueId;
     /** Solana fee configuration for native mode transactions. Only used when `chain` is set. */
@@ -133,6 +143,11 @@ export interface FordefiSignerConfig {
     privateKeyPem?: string;
     /** Solana public key of the vault (base58) */
     publicKey: string;
+    /**
+     * Whether Fordefi broadcasts a native Solana transaction. Omitted is
+     * equivalent to `'auto'`; `'manual'` requires `chain`.
+     */
+    pushMode?: FordefiPushMode;
     /** Optional delay in ms between concurrent signing requests (default: 0) */
     requestDelayMs?: number;
     /**
@@ -151,15 +166,16 @@ export interface FordefiSignerConfig {
 }
 
 /**
- * Fordefi signer shape returned when `chain` enables native Solana mode.
+ * Fordefi signer shape returned when `chain` enables native Solana mode with
+ * `pushMode` omitted or `'auto'`.
  *
- * Native mode may replace the recent blockhash and fees before signing and
- * broadcasts with `push_mode: 'auto'`, so it must be used through Kit's
+ * Native auto mode may replace the recent blockhash and fees before signing and
+ * broadcasts the result itself, so it must be used through Kit's
  * {@link TransactionSendingSigner} flow rather than as a partial signer.
- * Native instances expose no `signTransactions` — Kit classifies signers by
- * duck-typed method presence — but do sign messages.
+ * Instances expose no `signTransactions`, because Kit classifies signers by
+ * duck-typed method presence, but do sign messages.
  *
- * Native mode is not retry-safe: any failure after Fordefi accepts the
+ * Native auto mode is not retry-safe: any failure after Fordefi accepts the
  * submission rejects with `BROADCAST_UNCONFIRMED` carrying
  * `context.providerTransactionId`; check that transaction with Fordefi before
  * retrying. A submission that fails without a usable response rejects with
@@ -171,6 +187,24 @@ export interface FordefiSignerConfig {
  */
 export interface FordefiNativeSigner<TAddress extends string = string>
     extends SolanaSendingSigner<TAddress>, SolanaMessageSigner<TAddress> {}
+
+/**
+ * Fordefi signer shape returned when `chain` is set and `pushMode` is
+ * `'manual'`.
+ *
+ * Fordefi rewrites the message (the recent blockhash, and the Compute Budget
+ * fee instructions it manages) and signs it without broadcasting, so
+ * `modifyAndSignTransactions()` returns the transaction Fordefi signed rather
+ * than signatures for the caller's own bytes. Continue from that transaction
+ * and never from the one you submitted: every downstream signer has to sign the
+ * message the Fordefi signature covers. What Fordefi changed is not diffed, so
+ * inspect the result before broadcasting it.
+ *
+ * Instances expose neither `signTransactions` nor `signAndSendTransactions`,
+ * and Fordefi must be the fee payer and sign before every downstream signer.
+ */
+export interface FordefiNativeManualSigner<TAddress extends string = string>
+    extends SolanaModifyingSigner<TAddress>, SolanaMessageSigner<TAddress> {}
 
 /**
  * Fordefi signer shape returned when `chain` is unset (black box mode).
@@ -191,17 +225,20 @@ export interface FordefiBlackBoxSigner<TAddress extends string = string>
  * @throws {SignerError} `SIGNER_CONFIG_ERROR` when required config is missing or invalid.
  */
 export function createFordefiSigner<TAddress extends string = string>(
-    config: FordefiSignerConfig & { chain: SolanaChainUniqueId },
+    config: FordefiSignerConfig & { chain: SolanaChainUniqueId; pushMode: 'manual' },
+): Promise<FordefiNativeManualSigner<TAddress>>;
+export function createFordefiSigner<TAddress extends string = string>(
+    config: FordefiSignerConfig & { chain: SolanaChainUniqueId; pushMode?: 'auto' },
 ): Promise<FordefiNativeSigner<TAddress>>;
 export function createFordefiSigner<TAddress extends string = string>(
     config: FordefiSignerConfig & { chain?: undefined },
 ): Promise<FordefiBlackBoxSigner<TAddress>>;
 export function createFordefiSigner<TAddress extends string = string>(
     config: FordefiSignerConfig,
-): Promise<FordefiBlackBoxSigner<TAddress> | FordefiNativeSigner<TAddress>>;
+): Promise<FordefiBlackBoxSigner<TAddress> | FordefiNativeManualSigner<TAddress> | FordefiNativeSigner<TAddress>>;
 export async function createFordefiSigner<TAddress extends string = string>(
     config: FordefiSignerConfig,
-): Promise<FordefiBlackBoxSigner<TAddress> | FordefiNativeSigner<TAddress>> {
+): Promise<FordefiBlackBoxSigner<TAddress> | FordefiNativeManualSigner<TAddress> | FordefiNativeSigner<TAddress>> {
     // The instance's own properties expose the mode-appropriate signing
     // method, which the class type cannot express statically.
     return await Promise.resolve(FordefiSigner.create(config) as unknown as FordefiBlackBoxSigner<TAddress>);
@@ -215,6 +252,7 @@ export async function createFordefiSigner<TAddress extends string = string>(
  */
 class FordefiSigner<TAddress extends string = string> implements SolanaMessageSigner<TAddress> {
     readonly address: Address<TAddress>;
+    declare modifyAndSignTransactions?: TransactionModifyingSigner<TAddress>['modifyAndSignTransactions'];
     declare signAndSendTransactions?: TransactionSendingSigner<TAddress>['signAndSendTransactions'];
     declare signTransactions?: TransactionPartialSigner<TAddress>['signTransactions'];
     private readonly accessToken: string;
@@ -223,6 +261,7 @@ class FordefiSigner<TAddress extends string = string> implements SolanaMessageSi
     private readonly fee?: FordefiSolanaFee;
     private readonly maxPollAttempts: number;
     private readonly pollIntervalMs: number;
+    private readonly pushMode: FordefiPushMode;
     private readonly requestSigner: FordefiRequestSigner;
     private readonly requestDelayMs: number;
     private readonly requestTimeoutMs: number;
@@ -235,6 +274,7 @@ class FordefiSigner<TAddress extends string = string> implements SolanaMessageSi
         this.fee = config.fee;
         this.maxPollAttempts = config.maxPollAttempts ?? DEFAULT_MAX_POLL_ATTEMPTS;
         this.pollIntervalMs = config.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+        this.pushMode = config.pushMode ?? 'auto';
         this.requestSigner = config.requestSigner ?? new PemRequestSigner(config.privateKeyPem ?? '');
         this.requestDelayMs = config.requestDelayMs ?? 0;
         this.requestTimeoutMs = config.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
@@ -243,11 +283,12 @@ class FordefiSigner<TAddress extends string = string> implements SolanaMessageSi
 
         // Kit classifies signers by duck-typed method presence, so each mode
         // exposes exactly the method it can honor as an own property: native
-        // mode rewrites and auto-broadcasts, so it is a sending signer and
-        // must not present a partial-signer method; black-box mode signs the
-        // caller's exact bytes, so it is a partial signer and must not
-        // present a sending method.
-        if (this.chain) {
+        // manual mode returns a rewritten transaction, native auto mode
+        // rewrites and broadcasts it, and black-box mode signs the caller's
+        // exact bytes.
+        if (this.chain && this.pushMode === 'manual') {
+            this.modifyAndSignTransactions = this.modifyAndSignNativeTransactions.bind(this);
+        } else if (this.chain) {
             this.signAndSendTransactions = this.signAndSendNativeTransactions.bind(this);
         } else {
             this.signTransactions = this.signBlackBoxTransactions.bind(this);
@@ -256,14 +297,18 @@ class FordefiSigner<TAddress extends string = string> implements SolanaMessageSi
 
     /** Create a FordefiSigner with the provided configuration. */
     static create<TAddress extends string = string>(
-        config: FordefiSignerConfig & { chain: SolanaChainUniqueId },
+        config: FordefiSignerConfig & { chain: SolanaChainUniqueId; pushMode: 'manual' },
+    ): FordefiNativeManualSigner<TAddress> & FordefiSigner<TAddress>;
+    static create<TAddress extends string = string>(
+        config: FordefiSignerConfig & { chain: SolanaChainUniqueId; pushMode?: 'auto' },
     ): FordefiNativeSigner<TAddress> & FordefiSigner<TAddress>;
     static create<TAddress extends string = string>(
         config: FordefiSignerConfig & { chain?: undefined },
     ): FordefiBlackBoxSigner<TAddress> & FordefiSigner<TAddress>;
     static create<TAddress extends string = string>(
         config: FordefiSignerConfig,
-    ): FordefiSigner<TAddress> & (FordefiBlackBoxSigner<TAddress> | FordefiNativeSigner<TAddress>);
+    ): FordefiSigner<TAddress> &
+        (FordefiBlackBoxSigner<TAddress> | FordefiNativeManualSigner<TAddress> | FordefiNativeSigner<TAddress>);
     static create<TAddress extends string = string>(config: FordefiSignerConfig): FordefiSigner<TAddress> {
         if (!config.accessToken) {
             return throwSignerError(SignerErrorCode.CONFIG_ERROR, {
@@ -292,6 +337,18 @@ class FordefiSigner<TAddress extends string = string> implements SolanaMessageSi
         if (!config.requestSigner && !config.privateKeyPem) {
             return throwSignerError(SignerErrorCode.CONFIG_ERROR, {
                 message: 'one of privateKeyPem or requestSigner must be provided',
+            });
+        }
+
+        if (config.pushMode !== undefined && !PUSH_MODES.has(config.pushMode)) {
+            return throwSignerError(SignerErrorCode.CONFIG_ERROR, {
+                message: "pushMode must be 'auto' or 'manual'",
+            });
+        }
+
+        if (config.pushMode === 'manual' && !config.chain) {
+            return throwSignerError(SignerErrorCode.CONFIG_ERROR, {
+                message: "pushMode 'manual' requires chain to enable Fordefi native Solana mode",
             });
         }
 
@@ -454,6 +511,135 @@ class FordefiSigner<TAddress extends string = string> implements SolanaMessageSi
     }
 
     /**
+     * Native manual path for Kit's TransactionModifyingSigner contract; attached
+     * as an own property only when `chain` is set and `pushMode` is `'manual'`.
+     *
+     * Fordefi rewrites the message before signing it and does not broadcast, so
+     * the returned transaction replaces the caller's. The rewrite itself is not
+     * diffed: the signature is verified against the bytes Fordefi returned, and
+     * those bytes are what the caller continues from.
+     */
+    private async modifyAndSignNativeTransactions(
+        transactions: readonly (Transaction | (Transaction & TransactionWithLifetime))[],
+        config?: TransactionModifyingSignerConfig,
+    ): Promise<readonly (Transaction & TransactionWithinSizeLimit & TransactionWithLifetime)[]> {
+        config?.abortSignal?.throwIfAborted();
+        return await signBatchStaggered(
+            transactions,
+            async transaction => {
+                config?.abortSignal?.throwIfAborted();
+                this.assertNativeManualTransactionSupported(transaction);
+
+                base64Decoder ||= getBase64Decoder();
+                const base64Data = base64Decoder.decode(transaction.messageBytes);
+                const txId = await this.submitSolanaTransaction(base64Data, 'manual', config?.abortSignal);
+                return await this.finishNativeManualSigning(txId, transaction, config?.abortSignal);
+            },
+            this.requestDelayMs,
+            config?.abortSignal,
+        );
+    }
+
+    /**
+     * Poll a submitted manual transaction to completion, verify the vault's
+     * signature against the message Fordefi returned, and hand back those bytes
+     * as a Kit transaction the caller can broadcast.
+     */
+    private async finishNativeManualSigning(
+        txId: string,
+        originalTransaction: Transaction | (Transaction & TransactionWithLifetime),
+        abortSignal?: AbortSignal,
+    ): Promise<Transaction & TransactionWithinSizeLimit & TransactionWithLifetime> {
+        const result = await this.pollForResult(txId, { pushable: false }, abortSignal);
+        if (!result.raw_transaction) {
+            return throwSignerError(SignerErrorCode.SIGNING_FAILED, {
+                message: 'Fordefi solana_transaction response missing raw_transaction',
+            });
+        }
+
+        let decodedTransaction: Transaction;
+        try {
+            base64Encoder ||= getBase64Encoder();
+            decodedTransaction = getTransactionDecoder().decode(base64Encoder.encode(result.raw_transaction));
+        } catch (error) {
+            return throwSignerError(SignerErrorCode.PARSING_ERROR, {
+                cause: error,
+                message: 'Failed to decode the Fordefi wire transaction',
+            });
+        }
+
+        const signerSignature = decodedTransaction.signatures[this.address];
+        if (!signerSignature) {
+            return throwSignerError(SignerErrorCode.SIGNING_FAILED, {
+                address: this.address,
+                message: 'Fordefi wire transaction did not contain the configured vault signature',
+            });
+        }
+
+        await assertSignatureValid({
+            data: decodedTransaction.messageBytes,
+            signature: signerSignature,
+            signerAddress: this.address,
+        });
+
+        const signedTransaction = Object.freeze({
+            ...decodedTransaction,
+            lifetimeConstraint: await this.readReturnedLifetime(originalTransaction, decodedTransaction),
+            signatures: Object.freeze(decodedTransaction.signatures),
+        });
+
+        try {
+            assertIsTransactionWithinSizeLimit(signedTransaction);
+        } catch (error) {
+            return throwSignerError(SignerErrorCode.SIGNING_FAILED, {
+                cause: error,
+                message: 'Fordefi wire transaction exceeds the Solana transaction size limit',
+            });
+        }
+
+        abortSignal?.throwIfAborted();
+        return signedTransaction;
+    }
+
+    /**
+     * Recover the lifetime of the returned transaction from its compiled
+     * message. Fordefi does not report the `lastValidBlockHeight` of a blockhash
+     * it refreshed, so Kit substitutes `U64_MAX`; the caller's own constraint is
+     * kept instead whenever the lifetime survived the rewrite.
+     */
+    private async readReturnedLifetime(
+        originalTransaction: Transaction | (Transaction & TransactionWithLifetime),
+        returnedTransaction: Transaction,
+    ): Promise<TransactionWithLifetime['lifetimeConstraint']> {
+        let returnedLifetime: TransactionWithLifetime['lifetimeConstraint'];
+        try {
+            const compiledMessage = getCompiledTransactionMessageDecoder().decode(returnedTransaction.messageBytes);
+            returnedLifetime = await getTransactionLifetimeConstraintFromCompiledTransactionMessage(compiledMessage);
+        } catch (error) {
+            return throwSignerError(SignerErrorCode.PARSING_ERROR, {
+                cause: error,
+                message: 'Failed to recover the lifetime of the Fordefi wire transaction',
+            });
+        }
+
+        if ('lifetimeConstraint' in originalTransaction) {
+            const originalLifetime = originalTransaction.lifetimeConstraint;
+            const lifetimeSurvived =
+                ('blockhash' in originalLifetime &&
+                    'blockhash' in returnedLifetime &&
+                    originalLifetime.blockhash === returnedLifetime.blockhash) ||
+                ('nonce' in originalLifetime &&
+                    'nonce' in returnedLifetime &&
+                    originalLifetime.nonce === returnedLifetime.nonce);
+            if (lifetimeSurvived) {
+                return originalLifetime;
+            }
+        }
+
+        return returnedLifetime;
+    }
+
+    /**
      * Native Solana transaction path for Kit's TransactionSendingSigner contract.
      *
      * Fordefi may replace the message lifetime and fees, then broadcasts the
@@ -483,7 +669,7 @@ class FordefiSigner<TAddress extends string = string> implements SolanaMessageSi
                 const base64Data = base64Decoder.decode(transaction.messageBytes);
                 let txId: string;
                 try {
-                    txId = await this.submitSolanaTransaction(base64Data, config?.abortSignal);
+                    txId = await this.submitSolanaTransaction(base64Data, 'auto', config?.abortSignal);
                 } catch (error) {
                     if (!providerMayHaveAccepted(error)) {
                         throw error;
@@ -583,6 +769,22 @@ class FordefiSigner<TAddress extends string = string> implements SolanaMessageSi
         }
     }
 
+    /** Fordefi may only rewrite a message the vault pays for and no one has signed yet. */
+    private assertNativeManualTransactionSupported(transaction: Transaction): void {
+        if (Object.keys(transaction.signatures)[0] !== this.address) {
+            throwSignerError(SignerErrorCode.SIGNING_FAILED, {
+                address: this.address,
+                message: 'Fordefi native manual signing requires the configured vault to be the transaction fee payer',
+            });
+        }
+        if (Object.values(transaction.signatures).some(signature => signature !== null)) {
+            throwSignerError(SignerErrorCode.SIGNING_FAILED, {
+                address: this.address,
+                message: 'Fordefi native manual signing must run before any transaction signatures are applied',
+            });
+        }
+    }
+
     /**
      * POST a transaction request to Fordefi and return the transaction ID.
      * Shared by all signing modes (black_box, solana_transaction, solana_message).
@@ -622,15 +824,20 @@ class FordefiSigner<TAddress extends string = string> implements SolanaMessageSi
     }
 
     /**
-     * Submit a native Solana serialized transaction message for signing + auto-push.
+     * Submit a native Solana serialized transaction message for signing, and for
+     * broadcasting when `pushMode` is `'auto'`.
      */
-    private async submitSolanaTransaction(base64Data: string, abortSignal?: AbortSignal): Promise<string> {
+    private async submitSolanaTransaction(
+        base64Data: string,
+        pushMode: FordefiPushMode,
+        abortSignal?: AbortSignal,
+    ): Promise<string> {
         const requestBody: FordefiSolanaTransactionRequest = {
             details: {
                 chain: this.chain!,
                 data: base64Data,
                 ...(this.fee ? { fee: this.fee } : {}),
-                push_mode: 'auto',
+                push_mode: pushMode,
                 type: 'solana_serialized_transaction_message',
             },
             sign_mode: 'auto',
@@ -639,11 +846,27 @@ class FordefiSigner<TAddress extends string = string> implements SolanaMessageSi
             vault_id: this.vaultId,
         };
         base64Encoder ||= getBase64Encoder();
+        const messageBytes = new Uint8Array(base64Encoder.encode(base64Data));
         return await this.submitTransaction(
             requestBody,
-            await idempotencyKeyFromMessage(base64Encoder.encode(base64Data)),
+            await idempotencyKeyFromMessage(
+                pushMode === 'manual' ? this.namespaceManualIdempotencyInput(messageBytes) : messageBytes,
+            ),
             abortSignal,
         );
+    }
+
+    /**
+     * Namespaced so the same bytes submitted for signing cannot collide with an
+     * earlier auto create that did broadcast them.
+     */
+    private namespaceManualIdempotencyInput(messageBytes: Uint8Array): Uint8Array {
+        utf8Encoder ||= getUtf8Encoder();
+        const namespace = utf8Encoder.encode(`fordefi:solana:manual:${this.chain!}:${this.vaultId}:`);
+        const namespaced = new Uint8Array(namespace.length + messageBytes.length);
+        namespaced.set(namespace);
+        namespaced.set(messageBytes, namespace.length);
+        return namespaced;
     }
 
     /**

--- a/typescript/packages/fordefi/src/index.ts
+++ b/typescript/packages/fordefi/src/index.ts
@@ -1,6 +1,7 @@
 export { createFordefiSigner } from './fordefi-signer.js';
 export type {
     FordefiBlackBoxSigner,
+    FordefiNativeManualSigner,
     FordefiNativeSigner,
     FordefiRequestSigner,
     FordefiSignerConfig,
@@ -9,6 +10,7 @@ export type {
     FordefiBlackBoxSignatureRequest,
     FordefiCreateTransactionResponse,
     FordefiErrorResponse,
+    FordefiPushMode,
     FordefiSolanaFee,
     FordefiSolanaMessageRequest,
     FordefiSolanaTransactionRequest,
@@ -20,6 +22,7 @@ export {
     assertIsSolanaSigner,
     assertIsSolanaTransactionSigner,
     isSolanaMessageSigner,
+    isSolanaModifyingSigner,
     isSolanaSendingSigner,
     isSolanaSigner,
     isSolanaTransactionSigner,

--- a/typescript/packages/fordefi/src/types.ts
+++ b/typescript/packages/fordefi/src/types.ts
@@ -30,17 +30,26 @@ export type FordefiSolanaFee =
     | { priority_level: 'high' | 'low' | 'medium'; type: 'priority' };
 
 /**
- * Request body for native Solana transaction signing via
- * `solana_serialized_transaction_message` with `push_mode: 'auto'`.
+ * Whether Fordefi broadcasts a native Solana transaction after signing it.
  *
- * Fordefi signs the serialized transaction message and pushes it on-chain.
+ * `auto` rewrites, signs and broadcasts; `manual` rewrites and signs, leaving
+ * the broadcast to the caller.
+ */
+export type FordefiPushMode = 'auto' | 'manual';
+
+/**
+ * Request body for native Solana transaction signing via
+ * `solana_serialized_transaction_message`.
+ *
+ * Fordefi signs the serialized transaction message and either pushes it
+ * on-chain or returns it for the caller to broadcast, per `details.push_mode`.
  */
 export interface FordefiSolanaTransactionRequest {
     details: {
         chain: SolanaChainUniqueId;
         data: string;
         fee?: FordefiSolanaFee;
-        push_mode: 'auto';
+        push_mode: FordefiPushMode;
         type: 'solana_serialized_transaction_message';
     };
     sign_mode: 'auto';

--- a/typescript/packages/keychain/src/create-keychain-signer.ts
+++ b/typescript/packages/keychain/src/create-keychain-signer.ts
@@ -6,7 +6,12 @@ import type {
 } from '@solana/keychain-core';
 import { SignerErrorCode, throwSignerError } from '@solana/keychain-core';
 import type { CrossmintSignerConfig } from '@solana/keychain-crossmint';
-import type { FordefiNativeSigner, FordefiSignerConfig, SolanaChainUniqueId } from '@solana/keychain-fordefi';
+import type {
+    FordefiNativeManualSigner,
+    FordefiNativeSigner,
+    FordefiSignerConfig,
+    SolanaChainUniqueId,
+} from '@solana/keychain-fordefi';
 import type { UtilaSignerConfig } from '@solana/keychain-utila';
 
 import type { KeychainSignerConfig } from './types.js';
@@ -37,7 +42,10 @@ export function createKeychainSigner(
     config: CrossmintSignerConfig & { backend: 'crossmint' },
 ): Promise<SolanaSendingSigner>;
 export function createKeychainSigner(
-    config: FordefiSignerConfig & { backend: 'fordefi'; chain: SolanaChainUniqueId },
+    config: FordefiSignerConfig & { backend: 'fordefi'; chain: SolanaChainUniqueId; pushMode: 'manual' },
+): Promise<FordefiNativeManualSigner>;
+export function createKeychainSigner(
+    config: FordefiSignerConfig & { backend: 'fordefi'; chain: SolanaChainUniqueId; pushMode?: 'auto' },
 ): Promise<FordefiNativeSigner>;
 export function createKeychainSigner(
     config: UtilaSignerConfig & { backend: 'utila' },

--- a/typescript/packages/keychain/src/index.ts
+++ b/typescript/packages/keychain/src/index.ts
@@ -9,7 +9,12 @@ export type { CdpSignerConfig } from '@solana/keychain-cdp';
 export type { CrossmintSignerConfig } from '@solana/keychain-crossmint';
 export type { DfnsSignerConfig } from '@solana/keychain-dfns';
 export type { FireblocksSignerConfig } from '@solana/keychain-fireblocks';
-export type { FordefiBlackBoxSigner, FordefiNativeSigner, FordefiSignerConfig } from '@solana/keychain-fordefi';
+export type {
+    FordefiBlackBoxSigner,
+    FordefiNativeManualSigner,
+    FordefiNativeSigner,
+    FordefiSignerConfig,
+} from '@solana/keychain-fordefi';
 export type { GcpKmsSignerConfig } from '@solana/keychain-gcp-kms';
 export type { MemorySignerConfig } from '@solana/keychain-memory';
 export type { OpenfortSignerConfig } from '@solana/keychain-openfort';

--- a/typescript/packages/kit-plugin/src/keychain-plugin.ts
+++ b/typescript/packages/kit-plugin/src/keychain-plugin.ts
@@ -9,12 +9,11 @@ import { extendClient } from '@solana/kit';
 
 /**
  * Backend configurations these plugins accept: every keychain backend except
- * the managed-broadcast ones — Crossmint, and Fordefi in native mode (`chain`
- * set). Those backends rewrite and broadcast transactions server-side, so
- * they expose `signAndSendTransactions` and no `signTransactions`, and cannot
- * serve as a client `payer` or `identity`: client send flows build, sign, and
- * broadcast themselves, and Kit routes a sending signer only through
- * `signAndSendTransactionMessageWithSigners()`. Create those signers with
+ * Crossmint and Fordefi in native mode (`chain` set). Those backends rewrite
+ * the transaction server-side, so they expose `signAndSendTransactions` or
+ * `modifyAndSignTransactions` and no `signTransactions`, and cannot serve as a
+ * client `payer` or `identity`: client send flows build, sign, and broadcast
+ * themselves against the message they compiled. Create those signers with
  * `createKeychainSigner()` and use that function directly instead.
  */
 export type KeychainKitPluginConfig =
@@ -22,17 +21,17 @@ export type KeychainKitPluginConfig =
     | (FordefiSignerConfig & { backend: 'fordefi'; chain?: undefined });
 
 /**
- * The managed-broadcast exclusion above only protects TypeScript callers, so
- * the config is also rejected at runtime — before `createKeychainSigner`
- * runs, since the excluded backends authenticate against their provider
- * during construction. The signer-shape assertion afterwards is the backstop
- * for any future backend whose factory returns a sending signer.
+ * The exclusion above only protects TypeScript callers, so the config is also
+ * rejected at runtime, before `createKeychainSigner` runs, since the excluded
+ * backends authenticate against their provider during construction. The
+ * signer-shape assertion afterwards is the backstop for any future backend
+ * whose factory returns a signer that is not a partial signer.
  */
 async function createPartialSigner(config: KeychainKitPluginConfig) {
     const { backend } = config as KeychainSignerConfig;
     if (backend === 'crossmint' || (backend === 'fordefi' && (config as { chain?: unknown }).chain !== undefined)) {
         throwSignerError(SignerErrorCode.CONFIG_ERROR, {
-            message: `The '${backend}' backend broadcasts transactions server-side and cannot serve as a Kit client payer/identity. Create it with createKeychainSigner() and use signAndSendTransaction() instead.`,
+            message: `The '${backend}' backend rewrites transactions server-side and cannot serve as a Kit client payer/identity. Create it with createKeychainSigner() and use signAndSendTransaction() instead.`,
         });
     }
     const signer = await createKeychainSigner(config);

--- a/typescript/pnpm-lock.yaml
+++ b/typescript/pnpm-lock.yaml
@@ -274,6 +274,9 @@ importers:
         specifier: workspace:*
         version: link:../core
     devDependencies:
+      '@solana-program/system':
+        specifier: ^0.13.0
+        version: 0.13.0(@solana/kit@8.0.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10))
       '@solana/addresses':
         specifier: 8.0.0
         version: 8.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
@@ -286,7 +289,13 @@ importers:
       '@solana/keys':
         specifier: 8.0.0
         version: 8.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/kit':
+        specifier: 8.0.0
+        version: 8.0.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@solana/signers':
+        specifier: 8.0.0
+        version: 8.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/transaction-messages':
         specifier: 8.0.0
         version: 8.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/transactions':


### PR DESCRIPTION
Adds `FordefiNativeManualSigner`, the first `ModifyingSigner` implementor.

In manual mode Fordefi rewrites the recent blockhash and the Compute Budget fee instructions, then signs **without** broadcasting, so the caller broadcasts. Following the trusted-provider model, the rewrite is not diffed against what was submitted: the returned signature covers Fordefi's bytes, not the caller's. What is enforced locally are the preconditions and the signature binding.

- The configured vault must be the transaction fee payer, and the transaction must carry no signatures yet (Fordefi's rewrite would silently void them). Both are checked before submitting.
- The returned signature is ed25519-verified against the rewritten message bytes at the vault's required-signer position, located by account position rather than assumed to be slot zero.
- The caller's transaction is never mutated; the rewritten one comes back as `SignedTransaction.transaction`.
- The create carries an `x-idempotence-id` under a `fordefi:solana:manual:<chain>:<vault>:` namespace, so a manual submit can never dedupe onto an auto create that did broadcast the same bytes.

## Modes and entry points

`create_fordefi_signer` dispatches on `config.chain` and `config.push_mode`, and each type rejects a config meant for another.

| Config | Signer | Capability | Entry point |
| --- | --- | --- | --- |
| no `chain` | `FordefiBlackBoxSigner` | `TransactionSigner` | `sign_transaction` |
| `chain`, `push_mode` unset or `"auto"` | `FordefiNativeAutoSigner` | `SendingSigner` | `sign_and_send_transaction` |
| `chain`, `push_mode="manual"` | `FordefiNativeManualSigner` | `ModifyingSigner` | `modify_and_sign_transaction` |

`core.sign_and_send_transaction` now routes a `ModifyingSigner` through `modify_and_sign_transaction` plus the caller-supplied send function.

## Breaking change

`SignedTransaction` gains a required `transaction` field carrying the authoritative signed transaction. solders messages are read-only, so a modifying signer cannot rewrite the caller's object in place the way the `ModifyingSigner` docstring on the base branch assumed; callers continue from `SignedTransaction.transaction`. `classify_signed_transaction` already received the transaction, so no backend needed new plumbing.

Also adds `core.extract_and_verify_rewritten_transaction`, the rewritten-message counterpart of `extract_and_verify_returned_signature`, sharing the signer-position lookup.

## Provenance

This is the Python counterpart of #279. Credit for the feature is entirely @hvbr1s'.

## Verification

- `just py-test`: 541 passed, 37 deselected (517 before).
- `just py-fmt`: ruff format clean, ruff check clean, mypy strict clean (75 source files).
- Shared docs (`CLAUDE.md`, `docs/SECURITY_MODEL.md`, `docs/ADDING_SIGNERS.md`) deliberately untouched; the Rust PR owns them.
