### PR TITLE
docs: add a contributing guide, trim CLAUDE.md, fix the release skills

### DIFF
--- a/.claude/skills/complete-release/SKILL.md
+++ b/.claude/skills/complete-release/SKILL.md
@@ -2,8 +2,9 @@
 name: complete-release
 description: >
   Finalize a mainline solana-keychain release after the PR is approved: approve, squash-merge, and
-  trigger both publish workflows from main via gh CLI. Use when asked to "finalize release",
-  "merge release PR", "complete release", "publish packages", or "approve and merge release".
+  trigger the publish workflows for the languages in the release from main via gh CLI. Use when
+  asked to "finalize release", "merge release PR", "complete release", "publish packages", or
+  "approve and merge release".
 ---
 
 # Complete Release Skill
@@ -56,15 +57,15 @@ Wait for merge to complete before proceeding.
 
 Check which paths the merged PR touched, then trigger only the relevant workflow(s):
 
+Each language publishes through its own workflow. Trigger only the ones whose tree the release touched.
+
 ```bash
 # Get the files changed by the merged PR
 FILES=$(gh pr view <PR_NUMBER> --json files --jq '.files[].path')
 
-CHANGED_RUST=$(echo "$FILES" | grep -q "^rust/" && echo "yes" || echo "no")
-CHANGED_TS=$(echo "$FILES" | grep -q "^typescript/" && echo "yes" || echo "no")
-
-echo "Rust changed: $CHANGED_RUST"
-echo "TypeScript changed: $CHANGED_TS"
+for lang in rust typescript python go; do
+  echo "$lang changed: $(echo "$FILES" | grep -q "^${lang}/" && echo yes || echo no)"
+done
 ```
 
 If Rust changed (`rust/Cargo.toml`, `rust/CHANGELOG.md`, etc.):
@@ -88,20 +89,41 @@ gh workflow run "Publish TypeScript Packages (Manual)" \
   -f create-github-release=true
 ```
 
+If Python changed (`python/pyproject.toml`, `python/CHANGELOG.md`, etc.):
+
+```bash
+gh workflow run "Publish Python Package (Manual)" \
+  --repo solana-foundation/solana-keychain \
+  --ref main \
+  -f publish-to-pypi=true \
+  -f create-github-release=true
+```
+
+If Go changed. Unlike the others, this workflow takes the version explicitly, without a leading `v`, because Go modules carry no version file to read it from:
+
+```bash
+gh workflow run "Publish Go Modules (Manual)" \
+  --repo solana-foundation/solana-keychain \
+  --ref main \
+  -f version=A.B.C \
+  -f create-github-release=true
+```
+
 ## Step 5: Verify workflows started
 
 Only check workflows that were triggered:
 
 ```bash
-gh run list --workflow="Publish Rust Crate" --limit 1
-gh run list --workflow="Publish TypeScript Packages (Manual)" --limit 1
+gh run list --workflow="<workflow name>" --limit 1
 ```
 
 Each triggered workflow should show `queued` or `in_progress`.
 
 ## Verification
 
-Once workflows complete:
+Once workflows complete, for each language published:
 
-- If Rust was published: confirm `vX.Y.Z` tag exists on GitHub and crates.io shows the new version
-- If TypeScript was published: confirm `ts-keychain-vA.B.C` tag exists on GitHub and `@solana/keychain` on npm shows the new version
+- Rust: `vX.Y.Z` tag exists on GitHub and crates.io shows the new version
+- TypeScript: `ts-keychain-vA.B.C` tag exists on GitHub and `@solana/keychain` on npm shows the new version
+- Python: `solana-keychain` on PyPI shows the new version
+- Go: the per-module tags exist and `go get` resolves the new version

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,9 +1,10 @@
 ---
 name: release
 description: >
-  Guide for releasing a new version of solana-keychain (Rust and/or TypeScript).
+  Guide for releasing a new version of solana-keychain (Rust, TypeScript, Python and/or Go).
   Use when asked to "prepare a release", "bump the version", "release Rust", "release TypeScript",
-  "publish a new version", or "cut a release". Covers the PR-based release flow end-to-end.
+  "release Python", "release Go", "publish a new version", or "cut a release". Covers the PR-based
+  release flow end-to-end.
 ---
 
 # Release Skill
@@ -15,22 +16,16 @@ Prepare and publish a new release of solana-keychain via a PR-based flow.
 - Mainline release: prepare release changes, open PR to `main`, merge, then publish from `main`.
 - Hotfix release: create `hotfix/*` from deployed tag, prepare release on `hotfix/*`, publish from `hotfix/*`, then merge back to `main`.
 
-## Prerequisites
+Needs `cargo-edit` (for `cargo set-version`) and `git-cliff`, both `cargo install`.
 
-| Tool | Install |
-|------|---------|
-| `cargo-edit` (`cargo set-version`) | `cargo install cargo-edit` |
-| `git-cliff` | `cargo install git-cliff` |
-| `pnpm` | `npm install -g pnpm` |
-| `gh` CLI | `brew install gh` |
-| `jq` | `brew install jq` |
+## Where versions live
 
-## Current Versions Reference
-
-| Artifact | Version file | Field |
-|----------|-------------|-------|
-| Rust crate | `rust/Cargo.toml` | `version` |
-| TypeScript packages | `typescript/packages/keychain/package.json` | `version` |
+| Artifact | Version file |
+|----------|-------------|
+| Rust crate | `rust/Cargo.toml` |
+| TypeScript packages | every `typescript/packages/*/package.json` plus `typescript/package.json` |
+| Python package | `python/pyproject.toml` |
+| Go modules | tags only; `just go-release-prep <version>` rewrites the module replace directives |
 
 ---
 
@@ -48,7 +43,7 @@ git pull
 git status  # must be clean before proceeding
 ```
 
-Also check whether the release branch already exists — if so, skip to Step 6:
+Also check whether the release branch already exists. If so, skip to Step 7:
 
 ```bash
 git branch -a | grep release
@@ -85,7 +80,7 @@ Review the output: `cat rust/CHANGELOG.md | head -30`
 
 ## Step 4: Update Cargo.lock and commit Rust changes
 
-This MUST happen before the TS release — `just release-ts` checks for a clean working tree and will fail if `Cargo.lock` is dirty.
+Commit this before touching the other languages. `Cargo.lock` moves whenever the crate version does, and a dirty lockfile fails the clean-working-tree check in `just release-ts` if anyone falls back to it.
 
 ```bash
 cd rust && cargo update --workspace && cd ..
@@ -97,31 +92,58 @@ git commit -m "chore: bump rust version to vX.Y.Z"
 
 ## Step 5: Bump TypeScript versions
 
+Derive the package list from the directory rather than hardcoding it: the set grows with every new backend, and a stale list silently skips bumping one.
+
 ```bash
 cd typescript
-for pkg in core aws-kms cdp dfns fireblocks gcp-kms memory openfort para privy turnkey utila vault keychain kit-plugin test-utils crossmint; do
-  cd packages/${pkg} && npm version "A.B.C" --no-git-tag-version && cd ../..
+for dir in packages/*/; do
+  (cd "$dir" && npm version "A.B.C" --no-git-tag-version)
 done
 npm version "A.B.C" --no-git-tag-version
 cd ..
 ```
 
+Confirm every package moved before continuing:
+
+```bash
+grep -h '"version"' typescript/package.json typescript/packages/*/package.json | sort -u
+```
+
 ---
 
-## Step 6: Create release branch, commit all changes, push
+## Step 6: Bump Python and Go, if they are in this release
+
+Release only the languages whose code changed; each publishes through its own workflow.
+
+Python, if `python/` changed:
+
+```bash
+# python/pyproject.toml -> version = "A.B.C"
+# add the release section to python/CHANGELOG.md
+```
+
+Go, if `go/` changed. Go modules carry no version file; the recipe rewrites each module's replace directives so the tagged modules resolve against each other:
+
+```bash
+just go-release-prep A.B.C
+```
+
+## Step 7: Create release branch, commit all changes, push
 
 ```bash
 git checkout -b chore/release-rust-vX.Y.Z-ts-vA.B.C
-git add typescript/
+git add -A
 git commit -m "chore: release rust vX.Y.Z and ts-keychain vA.B.C"
 git push -u origin chore/release-rust-vX.Y.Z-ts-vA.B.C
 ```
+
+Name the branch and the commit after the languages actually in the release.
 
 If the branch already existed from a previous session, switch to it and verify it already has the right state before opening the PR.
 
 ---
 
-## Step 7: Open PR to main
+## Step 8: Open PR to main
 
 ```bash
 gh pr create \
@@ -130,8 +152,12 @@ gh pr create \
   --body "$(cat <<'EOF'
 ## Release
 
-- Rust \`solana-keychain\` → vX.Y.Z ([CHANGELOG](rust/CHANGELOG.md))
-- TypeScript \`@solana/keychain\` and packages → vA.B.C
+List only the languages in this release:
+
+- Rust \`solana-keychain\` to vX.Y.Z ([CHANGELOG](rust/CHANGELOG.md))
+- TypeScript \`@solana/keychain\` and packages to vA.B.C
+- Python \`solana-keychain\` to vA.B.C ([CHANGELOG](python/CHANGELOG.md))
+- Go modules to vA.B.C
 
 ## Merge
 
@@ -148,12 +174,8 @@ For urgent fixes to a deployed stable version:
 
 ```bash
 just hotfix <fix-name>   # creates hotfix/<fix-name> from latest stable tag
-# apply fixes on hotfix/* and run release prep on hotfix/*
-just release             # required for Rust publish
-just release-ts          # if TypeScript packages changed
-# commit and push hotfix/*
-# publish from hotfix/* before merge-back
-# then open PR to main and merge hotfix back
 ```
 
-Hotfix patch releases are published from `hotfix/*` before merge-back to `main`.
+Apply the fix on `hotfix/*`, then run the same version-bump steps above on that branch. `just release` / `just release-ts` are still off limits here for the same TTY reason: use Steps 2 through 5 manually.
+
+Publish from `hotfix/*` before merging back, then open a PR to `main` and merge the hotfix back.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,18 +1,15 @@
 # CLAUDE.md
 
-One `SolanaSigner` contract over 14 backends in Rust, TypeScript, Python and Go, kept at cross-language parity: Memory, Vault, Privy, Turnkey, AWS KMS, Fireblocks, GCP KMS, Dfns, Crossmint, CDP, Para, Openfort, Utila, Fordefi.
-
-Layout: `rust/` (feature-gated crate), `typescript/` (pnpm monorepo, one package per backend plus `core` and the `keychain` umbrella), `python/` (single `solana-keychain` package, src layout), `go/` (one module per backend plus `core`, no umbrella). Adding a backend: [docs/ADDING_SIGNERS.md](docs/ADDING_SIGNERS.md).
+One `SolanaSigner` contract over 14 backends in Rust, TypeScript, Python and Go, kept at cross-language parity. Adding a backend: [docs/ADDING_SIGNERS.md](docs/ADDING_SIGNERS.md).
 
 ## Commands
 
-Always use `just`, never raw `cargo`/`pnpm`/`pytest`/`go test`: the recipes encode flags those get wrong. `just` with no args lists every recipe.
+Always use `just`, never raw `cargo`/`pnpm`/`pytest`/`go test`: the recipes encode flags those get wrong.
 
-- `just build` / `test` / `fmt` / `test-integration` cover all four languages. `just <rust|ts|py|go>-*` scopes to one.
 - `just rust-test` runs the `sdk-v2`, `sdk-v3` and `sdk-v4` matrices. `cargo test --all-features` fails: the SDK features are mutually exclusive.
 - `just ts-treeshake` after touching TS exports; every package and the umbrella must stay tree-shakable.
 - Integration recipes spawn their own local `vault server -dev` and load `.env`. Never start Vault or pass secrets yourself.
-- Releases go through the [`release`](.claude/skills/release/SKILL.md) and [`complete-release`](.claude/skills/complete-release/SKILL.md) skills; CI wiring for a forked backend PR through [`add-signer-ci`](.claude/skills/add-signer-ci/SKILL.md). Check version consistency across **all** crates and packages.
+- Releasing: check version consistency across **all** crates and packages.
 
 ## Security standing
 
@@ -25,14 +22,14 @@ Consumer-facing summary in [docs/SECURITY_MODEL.md](docs/SECURITY_MODEL.md); kee
 - **Redirects always rejected**, timeouts always set, HTTPS enforced on configured base URLs. Two carve-outs: Vault allows plain-HTTP loopback for `vault server -dev`, and the KMS backends use their vendor SDK's transport. Signing before `init()` fails rather than using the zero address.
 - **Pinned wire format.** Golden vectors freeze the serialized bytes; never regenerate them to make a suite pass.
 - Rust zeroizes intermediate key buffers. Go and Python cannot: treat the whole process memory as sensitive with local-key backends.
-- Audit covers Rust and TypeScript through one commit; Python and Go are entirely unaudited. See [audits/AUDIT_STATUS.md](audits/AUDIT_STATUS.md).
+- Audit coverage is uneven across the four languages and moves every release. [audits/AUDIT_STATUS.md](audits/AUDIT_STATUS.md) is the source of truth.
 
 ## Cross-language gotchas
 
 - **`init()` before use** for Privy, Fireblocks, Dfns, Crossmint, Para, Openfort. The `Signer::from_*` (Rust) and `await createXSigner(...)` / `create_keychain_signer(...)` factories do it for you; direct construction skips it.
-- **Rust capability is in the type.** `SolanaSigner` is the base (pubkey, sign_message, is_available); a backend implements exactly one of `TransactionSigner`, `ModifyingSigner` or `SendingSigner`. The umbrella `Signer` enum implements only the base trait; capabilities are reached through `as_transaction_signer()` / `as_sending_signer()` (`None` when absent) or its own variant-routing `sign_and_send`. Fordefi is two types (`FordefiBlackBoxSigner`, `FordefiNativeAutoSigner`), picked by `config.chain`. TS mirrors this: `SolanaSigner` is the union `SolanaTransactionSigner | SolanaModifyingSigner | SolanaSendingSigner` (narrow with the `isSolana*Signer` guards), `SolanaMessageSigner` is orthogonal, and Utila is transaction-only with no `signMessages` method.
-- **Go capability is in the interface.** `core.SolanaSigner` is the base; `core.TransactionSigner`, `core.ModifyingSigner` and `core.SendingSigner` embed it and add the one method. Capability is reached by type assertion, so a backend that cannot sign a transaction must carry no `SignTransaction` method at all. Fordefi is `fordefi.BlackBoxSigner` / `fordefi.NativeAutoSigner`, picked by `Config.Chain`.
-- **Crossmint is sending-only.** `sign_and_send_transaction` / `signAndSendTransactions` only; the sign-only entry point fails, and `signMessages` is unsupported. In Rust it implements `SendingSigner` and no `TransactionSigner`, and in Go `core.SendingSigner` with no `SignTransaction` method. In TS it is a `SolanaSendingSigner` and deliberately exposes no `signTransactions` or `signMessages`, because Kit classifies signers by duck-typed method presence, so it is excluded from `@solana/keychain-kit-plugin` at the type level.
+- **Capability is in the type, and the umbrella hides it.** A backend implements exactly one of the transaction, modifying or sending capability traits. The Rust umbrella `Signer` enum implements only the base trait: capabilities are reached through `as_transaction_signer()` / `as_sending_signer()`, which return `None` when absent, or through its own variant-routing `sign_and_send`. In TS, narrow with the `isSolana*Signer` guards; `SolanaMessageSigner` is orthogonal. Fordefi is two types (`FordefiBlackBoxSigner`, `FordefiNativeAutoSigner`), picked by `config.chain`.
+- **Go capability is by type assertion**, so a backend that cannot sign a transaction must carry no `SignTransaction` method at all. Fordefi is `fordefi.BlackBoxSigner` / `fordefi.NativeAutoSigner`, picked by `Config.Chain`.
+- **Crossmint is sending-only** and Utila is transaction-only, and in TS each must expose *no* method for what it does not support rather than a throwing one: Kit classifies signers by duck-typed method presence, so a stub would misclassify them. This is why Crossmint is excluded from `@solana/keychain-kit-plugin` at the type level.
 - **CDP** accepts UTF-8 message payloads only.
 - **Turnkey** response `r,s` must be left-padded to 32 bytes each before concatenation.
 - **GCP KMS** uses PureEdDSA with `EC_SIGN_ED25519`.
@@ -43,7 +40,3 @@ Consumer-facing summary in [docs/SECURITY_MODEL.md](docs/SECURITY_MODEL.md); kee
 - **Python extras:** the root `__init__.py` must never eagerly import a backend whose deps sit behind an optional extra, and such a backend must raise "install `solana-keychain[<extra>]`". New backends go in `keychain.py`'s `_BACKENDS` table.
 - **Adding a backend to TS** touches the umbrella in 7 places (including the treeshake script) plus `typescript-ci.yml` and `typescript-publish.yml`.
 - **No Go umbrella on purpose:** Go does not dead-code-eliminate across a runtime dispatch switch, so an umbrella would force every backend SDK into all consumers' builds.
-
-## Branches
-
-`main` is the integration branch (audited plus unaudited). Topic branches are `feat/*`, `fix/*`, `chore/*` off `main`; urgent fixes are `hotfix/*` off a deployed stable tag via `just hotfix`. `just branch-info` prints the full guidance.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,138 @@
+# Contributing
+
+Thanks for contributing to `solana-keychain`.
+
+This library holds signing keys and talks to production key-management services, so the bar for changes is higher than for most repositories. Read the [Making a change](#making-a-change) and [Cross-language parity](#cross-language-parity) sections before you start writing code.
+
+## Before you start
+
+- Search existing issues and pull requests before opening a new one.
+- For substantial changes, open an issue or start a discussion first so maintainers can confirm the approach. Small PRs are preferred.
+- Do not include secrets, private keys, seed phrases, API keys, or production credentials in issues, pull requests, commits, logs, or screenshots. Integration tests read credentials from a local `.env` that is gitignored: keep it that way, and never paste its contents into a PR or an issue.
+- All commits into a Solana Foundation repository require [commit signature verification](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) to be enabled. Your PRs will not be merged without this.
+
+## Security vulnerabilities
+
+Do not report security vulnerabilities in public issues. Follow this repository's [security policy](./SECURITY.md).
+
+Parts of this codebase are covered by a third-party audit. Audit status, the audited-through commit, and the current unaudited delta are tracked in [audits/AUDIT_STATUS.md](audits/AUDIT_STATUS.md). If your change touches audited code, say so in the PR description.
+
+## Development setup
+
+Use `just`. The recipes encode flags that are easy to get wrong by hand: `just rust-test` runs the `sdk-v2`, `sdk-v3`, and `sdk-v4` matrices, whereas `cargo test --all-features` fails outright because the SDK features are mutually exclusive.
+
+```sh
+just build              # all four languages
+just test               # unit tests, all four languages
+just fmt                # format and lint, all four languages
+just test-integration   # spins up a local Vault, runs integration tests
+just test-all           # test + test-integration
+```
+
+Run `just` with no arguments to list every recipe, including the per-language ones (`rust-*`, `ts-*`, `py-*`, `go-*`).
+
+Integration recipes spawn a local `vault server -dev` and load `.env` from the repository root themselves. Do not start Vault yourself or pass secrets on the command line.
+
+Use the toolchain versions checked into the repository. Do not bump the Rust toolchain, the Go version in `go.mod`, `pnpm`, the Solana SDK majors, or the Python dependency pins as an incidental part of another change: each of those has cross-language consequences and belongs in its own PR.
+
+## Making a change
+
+Keep changes focused. A pull request should solve one problem and include the tests, documentation, and changelog entries needed to keep the repository usable.
+
+Before opening a pull request:
+
+- Format, lint, build, and test the affected code with `just fmt`, `just build`, and `just test`.
+- Add or update tests when behavior changes. Unit tests must not make live API calls: mock HTTP with `wiremock` (Rust), `respx` (Python), `httptest` (Go), or the package's fetch mock (TypeScript).
+- Update documentation, examples, and the relevant `CHANGELOG.md` when they are part of the user-facing contract.
+- Explain any new dependency and why the existing dependency set is insufficient. A signing library pays for every transitive dependency it adds.
+
+### Cross-language parity
+
+`solana-keychain` ships one `SolanaSigner` contract over 14 backends in Rust, TypeScript, Python, and Go. A behavior change in one language is a bug in the other three until it lands there too.
+
+If your change alters signing behavior, error codes, validation, or the wire format, either implement it across all four languages in the same PR, or open tracking issues for the rest and say so explicitly in the PR description. Do not let the implementations drift silently.
+
+The golden wire-format vectors (for example `python/tests/test_parity.py`) exist to catch exactly this. Never regenerate them to make a failing suite pass: a changed vector means the serialization changed, which is the thing the test is there to notice.
+
+### Security-sensitive changes
+
+This library sits on a trust boundary. [docs/SECURITY_MODEL.md](docs/SECURITY_MODEL.md) states what Keychain does and does not guarantee; keep it in sync when a change alters the signing or sending shapes. When your change touches one of the following, document the reasoning in the PR:
+
+- Signature verification and public-key binding: anything deciding whether a provider-returned signature belongs to the key you asked to sign with, and at the position you asked for.
+- Transaction serialization, or the capability a backend exposes (transaction-signing, modifying, or sending).
+- Broadcast-managed backends, where a failure does not mean nothing landed.
+- HTTPS enforcement, redirect handling, timeouts, or credential handling in a remote signer.
+- Error messages and their redaction. Messages, `Debug`/`repr`, and sanitized remote bodies are redacted deliberately so key material and raw provider responses cannot leak through logs: keep them generic and let callers match on stable codes.
+
+### Adding a signer backend
+
+Adding a new backend touches Rust, TypeScript, Python, Go, the TypeScript umbrella, and CI. [docs/ADDING_SIGNERS.md](docs/ADDING_SIGNERS.md) has code templates and checklists for Rust, TypeScript, and Python. Go has no written guide yet: use an existing backend under `go/signers/` as the pattern, and see [go/README.md](go/README.md) for the package layout. Go deliberately has no umbrella package, so there is no dispatcher to update there.
+
+Open an issue first. New backends need a maintainer-side CI preparation step, handled through the [`add-signer-ci`](.claude/skills/add-signer-ci/SKILL.md) skill, before your PR can run its integration tests.
+
+## Pull requests
+
+Write a clear title and description explaining the problem, the approach, and how you tested it. Link related issues and call out behavior changes, compatibility concerns, or follow-up work. See the [AI use](#ai-use) section for how to disclose AI use in your PRs.
+
+Use [Conventional Commits](https://www.conventionalcommits.org/) for commit and PR titles, scoped by backend or language where it helps (`fix(turnkey):`, `feat(python):`).
+
+Branch and target rules:
+
+- Branch from `main` using `feat/*`, `fix/*`, or `chore/*`. Urgent fixes to a released version branch from the stable tag as `hotfix/*`.
+- Target `main`. The `release/*` flow is deprecated and CI rejects PRs from those branches.
+- `just branch-info` prints the full guidance.
+
+Review and CI:
+
+- [CODEOWNERS](.github/CODEOWNERS) assigns reviewers automatically; Rust and TypeScript directories each have a designated owner.
+- By default, [Greptile](https://www.greptile.com) is enabled on all Solana Foundation repositories. Before maintainers review, all Greptile comments must be resolved with either a code fix or an explanation of why no change is needed.
+- Once CI is approved to run by maintainers, all CI errors must be addressed before the PR will be merged.
+- **Pull requests from forks** additionally require a live-test gate. Integration tests against real signing providers cannot run with fork credentials, so a maintainer runs them manually and posts a marker comment tied to your head commit. Pushing new commits invalidates that marker and the gate must be re-run: batch your changes rather than force-pushing repeatedly once a maintainer has started.
+
+Maintainers may ask you to rebase, split a broad change, add tests, or revise documentation before merging.
+
+## AI use
+
+You may use AI-assisted tools, but you should review the generated code, understand its behavior, and run the same checks expected of any other contribution.
+
+If you are building with AI on Solana, check out the [Solana Dev Skill](https://github.com/solana-foundation/solana-dev-skill) or the [Solana MCP](https://mcp.solana.com/) to aid in your work.
+
+Ensure that the generated code adheres to the project's coding standards and best practices. Maintainers can close PRs if they appear to be low-effort AI slop. In particular, audit your changes for the following AI code smells that increase maintenance burden:
+
+- Comments that explain why the _previous_ behavior was wrong and the new behavior is correct. This can be helpful context for reviewers as a GitHub comment in the review, but we do not need a history of every code change living in the codebase.
+- Large blocks of comments with high density of technical jargon; comments should be distilled to clearly explain _why_ this code is doing something (if it's not obvious), not _what_ (the code should speak for itself).
+- Drive-by refactoring of code that is not relevant to the actual change being made.
+
+Two more that matter specifically here:
+
+- **Plausible-looking cryptography.** Assistants will happily produce signature handling, key derivation, or padding logic that compiles, passes a happy-path test, and is wrong. Anything touching signatures or key material needs you to have verified it against the provider's documentation yourself.
+- **Silently broken parity.** Applying a change to one language and letting the assistant "port" it to the other three without running each suite is how the implementations drift. Run `just test` and the per-language recipes for every language you touched.
+
+### Repository context for assistants
+
+This repository ships configuration that makes AI-assisted work go better, and you are welcome to use it:
+
+- [CLAUDE.md](CLAUDE.md) carries the commands, the security standing, and the cross-language gotchas that the code alone does not teach.
+- [.claude/skills/](.claude/skills/) contains guides for the repository's multi-step workflows: `add-signer-ci` for wiring CI for a forked backend PR, `release` and `complete-release` for cutting a release.
+
+Keep these current. If you learn something during your change that the next contributor would need (a failure mode, a non-obvious constraint), a line in the relevant `CLAUDE.md` is worth more than a comment buried in the diff.
+
+### Disclosure
+
+It can be helpful to note the extent to which AI was used in the change. For example, adding
+
+> I wrote all of the code for this feature, and had Claude update the documentation and create tests accordingly
+
+or
+
+> I architected the change and handed all implementation over to Codex
+
+to the pull request description can be helpful context for reviewers.
+
+### Communication
+
+If maintainers have suggested changes, feedback, or questions about your code, you should not be copy/pasting the questions to an LLM and copy/pasting the response. You being able to distill the information that AI produces is what makes your contribution valuable.
+
+## License
+
+By contributing, you agree that your contributions are licensed under the project's [LICENSE](./LICENSE).


### PR DESCRIPTION
## Summary

- Add `CONTRIBUTING.md`. The repo had none; `README.md` offered only "open an issue or submit a pull request". Covers setup through `just`, cross-language parity, security-sensitive change categories, branch and target rules, review and CI expectations including the fork live-test gate, and expectations for AI-assisted contributions.
- Trim `CLAUDE.md` to repo-specific gotchas, 7.3k to 5.7k characters. Removes the directory layout, the recipe inventory `just --list` prints, the branch rules `just branch-info` prints, and the audit detail `AUDIT_STATUS.md` owns. Every gotcha and the whole security standing section are kept.
- Fix three defects in the release skills.

## Release skill fixes

- **`release` skipped a package.** The TypeScript bump iterated a hardcoded list of 17 packages; `typescript/packages/` holds 18. A release today would silently leave `@solana/keychain-fordefi` unbumped. Now derived from the directory, with a verification step.
- **Python and Go were missing.** Both have their own publish workflow ("Publish Python Package (Manual)", "Publish Go Modules (Manual)") and `just go-release-prep`, but neither skill mentioned them, so a four-language release shipped two. Added to `release` as a bump step and to `complete-release` as dispatch targets, each triggered only when its tree changed.
- **The hotfix section contradicted the file.** It instructed the reader to run `just release` / `just release-ts`, which the same document forbids because both need a TTY.

## Notes

- Documentation only. No source, test, or CI changes.
- `add-signer-ci` deliberately left alone: it is already tight, and its Phase 1 / Phase 2 rigidity is load-bearing, since mixing them breaks CI on `main`.

## Test Plan

- `just fmt` pre-commit hook: no files to check (docs only).
- Every relative link in `CLAUDE.md` and `CONTRIBUTING.md` resolves against the current tree.
- Skill frontmatter parses; `release` step cross-references match after renumbering.
