### PR TITLE
docs: streamline release guidance and remove stale migration docs

### DIFF
--- a/typescript/packages/aws-kms/src/__tests__/aws-kms-signer.test.ts
+++ b/typescript/packages/aws-kms/src/__tests__/aws-kms-signer.test.ts
@@ -10,11 +10,9 @@ vi.mock('@solana/keychain-core', async importOriginal => {
     return { ...mod, assertSignatureValid: vi.fn() };
 });
 
-// Mock AWS SDK
 const mockSend = vi.fn();
 
 vi.mock('@aws-sdk/client-kms', () => {
-    // Create proper constructor mock classes
     class MockKMSClient {
         send = mockSend;
     }

--- a/typescript/packages/cdp/src/__tests__/cdp-signer.test.ts
+++ b/typescript/packages/cdp/src/__tests__/cdp-signer.test.ts
@@ -40,8 +40,6 @@ vi.mock('@solana/keychain-core', async importOriginal => {
 import { createCdpSigner } from '../cdp-signer.js';
 import type { CdpSignerConfig } from '../types.js';
 
-// --- Valid test credentials ---
-
 // Generate a real Ed25519 keypair so that createKeyPairFromBytes seed↔pubkey validation passes.
 // Ed25519 PKCS#8 DER: 16-byte header + 32-byte seed
 // Ed25519 SPKI DER:   12-byte header + 32-byte public key
@@ -79,7 +77,6 @@ const TEST_CDP_WALLET_SECRET = Buffer.from([
     0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01,
 ]).toString('base64');
 
-// Mock global fetch
 const mockFetch = vi.fn();
 vi.stubGlobal('fetch', mockFetch);
 
@@ -99,7 +96,6 @@ const createMockTransaction = (): Transaction & TransactionWithinSizeLimit & Tra
     return {} as Transaction & TransactionWithinSizeLimit & TransactionWithLifetime;
 };
 
-// A valid base58 Solana address for tests
 const TEST_ADDRESS = '7EcDhSYGxXyscszYEp35KHN8vvw3svAuLKTzXwCFLtV';
 
 function makeConfig(overrides?: Partial<CdpSignerConfig>): CdpSignerConfig {
@@ -208,7 +204,6 @@ describe('CdpSigner', () => {
 
     describe('signMessages', () => {
         it('signs a message and returns a signature dictionary', async () => {
-            // Base58-encoded 64-byte signature
             const base58Sig = '5LfnqEfGPFBaHHeQBiNkgQ2EPy4FkVLKE7cjMYc7gv6EjE8Vs5gqaXcZHjpxr3yj5TMt7j3JdJPkXfnwXxXiNAh';
             mockFetch.mockResolvedValue(new Response(JSON.stringify({ signature: base58Sig }), { status: 200 }));
 

--- a/typescript/packages/cdp/src/cdp-signer.ts
+++ b/typescript/packages/cdp/src/cdp-signer.ts
@@ -44,8 +44,6 @@ export async function createCdpSigner<TAddress extends string = string>(
     return await CdpSigner.create(config);
 }
 
-// --- Module-level constants ---
-
 const CDP_DEFAULT_BASE_URL = 'https://api.cdp.coinbase.com';
 const CDP_BASE_PATH = '/platform/v2/solana/accounts';
 const JWT_TTL_SECS = 120;
@@ -146,8 +144,6 @@ async function createWalletJwt(
     return await signJwt(header, payload, walletKey, 'ES256');
 }
 
-// --- Key loading ---
-
 /**
  * Load the Ed25519 CDP API key from a base64-encoded 64-byte secret (seed || pubkey).
  *
@@ -160,9 +156,6 @@ async function loadApiKey(cdpApiKeySecret: string): Promise<CryptoKey> {
     try {
         base64Encoder ||= getBase64Encoder();
         const bytes = base64Encoder.encode(cdpApiKeySecret);
-        // createKeyPairFromBytes validates:
-        //   - input is exactly 64 bytes (seed || pubkey)
-        //   - the public key bytes match the seed (signs test data and verifies)
         keyPair = await createKeyPairFromBytes(bytes);
     } catch (error) {
         throwSignerError(SignerErrorCode.CONFIG_ERROR, {

--- a/typescript/packages/core/src/__tests__/assert-signature-valid.test.ts
+++ b/typescript/packages/core/src/__tests__/assert-signature-valid.test.ts
@@ -28,7 +28,6 @@ describe('assertSignatureValid', () => {
         const data = new Uint8Array([1, 2, 3, 4]);
         const signature = await kp.sign(data);
 
-        // Corrupt the first byte
         const corrupted = new Uint8Array(signature);
         corrupted[0] ^= 0xff;
 

--- a/typescript/packages/crossmint/src/__tests__/crossmint-signer.test.ts
+++ b/typescript/packages/crossmint/src/__tests__/crossmint-signer.test.ts
@@ -272,14 +272,12 @@ describe('CrossmintSigner', () => {
         it('signs sequentially and stops creating transactions after a failure', async () => {
             vi.mocked(fetch)
                 .mockResolvedValueOnce(mockWalletResponse()) // create()
-                // tx 0: create -> success
                 .mockResolvedValueOnce(
                     new Response(
                         JSON.stringify({ id: 'tx-0', status: 'success', onChain: { txId: MOCK_SIGNATURE_B58 } }),
                         { status: 201 },
                     ),
                 )
-                // tx 1: create -> 500 (fails the batch)
                 .mockResolvedValueOnce(new Response(JSON.stringify({ message: 'boom' }), { status: 500 }))
                 // tx 2: should NEVER be created (would only be reached under concurrent Promise.all)
                 .mockResolvedValueOnce(
@@ -1035,7 +1033,6 @@ describe('CrossmintSigner', () => {
                         { status: 201 },
                     ),
                 )
-                // approvals POST response -> success
                 .mockResolvedValueOnce(
                     new Response(
                         JSON.stringify({

--- a/typescript/packages/dfns/src/__tests__/dfns-signer.test.ts
+++ b/typescript/packages/dfns/src/__tests__/dfns-signer.test.ts
@@ -172,7 +172,6 @@ describe('DfnsSigner', () => {
             mockWalletFetch();
             const signer = await createDfnsSigner(defaultConfig);
 
-            // The auth flow init request fails with network error
             mockFetch.mockRejectedValueOnce(new Error('Network timeout'));
 
             await expect(

--- a/typescript/packages/dfns/src/auth.ts
+++ b/typescript/packages/dfns/src/auth.ts
@@ -213,7 +213,6 @@ async function importWithWebCrypto(
             privateKey = await subtle.importKey('pkcs8', privateKeyDer, attempt.importAlgorithm, false, ['sign']);
             await subtle.sign(attempt.signAlgorithm, privateKey, toArrayBuffer(getProbePayload()));
         } catch {
-            // Try the next key algorithm.
             continue;
         }
         return {

--- a/typescript/packages/dfns/src/dfns-signer.ts
+++ b/typescript/packages/dfns/src/dfns-signer.ts
@@ -300,9 +300,6 @@ class DfnsSigner<TAddress extends string = string>
         }
     }
 
-    /**
-     * Send a signature request to the Dfns Keys API
-     */
     private async sendSignatureRequest(
         request: GenerateSignatureRequest,
         abortSignal?: AbortSignal,
@@ -363,9 +360,6 @@ class DfnsSigner<TAddress extends string = string>
     }
 }
 
-/**
- * Fetch wallet details from Dfns
- */
 async function fetchWallet(apiBaseUrl: string, authToken: string, walletId: string): Promise<GetWalletResponse> {
     const rawWalletResponse = await fetchSignerJson<unknown>({
         init: {

--- a/typescript/packages/fireblocks/src/__tests__/fireblocks-signer.test.ts
+++ b/typescript/packages/fireblocks/src/__tests__/fireblocks-signer.test.ts
@@ -33,7 +33,6 @@ vi.mock('@solana/keychain-core', async importOriginal => {
     };
 });
 
-// Mock fetch globally
 global.fetch = vi.fn();
 
 const mockFetch = global.fetch as ReturnType<typeof vi.fn>;
@@ -375,7 +374,6 @@ describe('createFireblocksSigner', () => {
         it('should throw HTTP_ERROR when fetch fails during signing request', async () => {
             const keyPair = await generateKeyPairSigner();
 
-            // Mock init fetch (success)
             mockFetch.mockResolvedValueOnce({
                 ok: true,
                 json: async () => ({ addresses: [{ address: keyPair.address }] }),
@@ -387,7 +385,6 @@ describe('createFireblocksSigner', () => {
                 vaultAccountId: TEST_VAULT_ACCOUNT_ID,
             });
 
-            // Mock signing request to fail with network error
             mockFetch.mockRejectedValueOnce(new Error('Network timeout'));
 
             const message = {
@@ -403,19 +400,16 @@ describe('createFireblocksSigner', () => {
         it('should sign a message successfully', async () => {
             const keyPair = await generateKeyPairSigner();
 
-            // Mock init fetch
             mockFetch.mockResolvedValueOnce({
                 ok: true,
                 json: async () => ({ addresses: [{ address: keyPair.address }] }),
             });
 
-            // Mock create transaction
             mockFetch.mockResolvedValueOnce({
                 ok: true,
                 json: async () => ({ id: 'tx-123', status: 'SUBMITTED' }),
             });
 
-            // Mock poll for completion
             mockFetch.mockResolvedValueOnce({
                 ok: true,
                 json: async () => ({
@@ -450,19 +444,16 @@ describe('createFireblocksSigner', () => {
         it('should throw error on transaction failure', async () => {
             const keyPair = await generateKeyPairSigner();
 
-            // Mock init fetch
             mockFetch.mockResolvedValueOnce({
                 ok: true,
                 json: async () => ({ addresses: [{ address: keyPair.address }] }),
             });
 
-            // Mock create transaction
             mockFetch.mockResolvedValueOnce({
                 ok: true,
                 json: async () => ({ id: 'tx-123', status: 'SUBMITTED' }),
             });
 
-            // Mock poll returning FAILED status
             mockFetch.mockResolvedValueOnce({
                 ok: true,
                 json: async () => ({
@@ -488,19 +479,16 @@ describe('createFireblocksSigner', () => {
         it('should throw error on invalid signature length', async () => {
             const keyPair = await generateKeyPairSigner();
 
-            // Mock init fetch
             mockFetch.mockResolvedValueOnce({
                 ok: true,
                 json: async () => ({ addresses: [{ address: keyPair.address }] }),
             });
 
-            // Mock create transaction
             mockFetch.mockResolvedValueOnce({
                 ok: true,
                 json: async () => ({ id: 'tx-123', status: 'SUBMITTED' }),
             });
 
-            // Mock poll with wrong signature length
             mockFetch.mockResolvedValueOnce({
                 ok: true,
                 json: async () => ({
@@ -535,19 +523,16 @@ describe('createFireblocksSigner', () => {
         it('should sign a transaction successfully with RAW signing', async () => {
             const keyPair = await generateKeyPairSigner();
 
-            // Mock init fetch
             mockFetch.mockResolvedValueOnce({
                 ok: true,
                 json: async () => ({ addresses: [{ address: keyPair.address }] }),
             });
 
-            // Mock create transaction
             mockFetch.mockResolvedValueOnce({
                 ok: true,
                 json: async () => ({ id: 'tx-123', status: 'SUBMITTED' }),
             });
 
-            // Mock poll for completion
             mockFetch.mockResolvedValueOnce({
                 ok: true,
                 json: async () => ({
@@ -583,19 +568,16 @@ describe('createFireblocksSigner', () => {
         it('should throw when COMPLETED response has no signedMessages', async () => {
             const keyPair = await generateKeyPairSigner();
 
-            // Mock init fetch
             mockFetch.mockResolvedValueOnce({
                 ok: true,
                 json: async () => ({ addresses: [{ address: keyPair.address }] }),
             });
 
-            // Mock create transaction
             mockFetch.mockResolvedValueOnce({
                 ok: true,
                 json: async () => ({ id: 'tx-123', status: 'SUBMITTED' }),
             });
 
-            // Mock poll for completion with no signedMessages
             mockFetch.mockResolvedValueOnce({
                 ok: true,
                 json: async () => ({

--- a/typescript/packages/fireblocks/src/fireblocks-signer.ts
+++ b/typescript/packages/fireblocks/src/fireblocks-signer.ts
@@ -158,9 +158,6 @@ class FireblocksSigner<TAddress extends string = string>
         return this._address;
     }
 
-    /**
-     * Initialize the signer by fetching the public key from Fireblocks
-     */
     private async init(): Promise<void> {
         if (this.initialized) {
             return;
@@ -183,9 +180,6 @@ class FireblocksSigner<TAddress extends string = string>
         return this.privateKeyPromise;
     }
 
-    /**
-     * Fetch the public key from Fireblocks API
-     */
     private async fetchPublicKey(): Promise<Address> {
         const uri = `/v1/vault/accounts/${encodeURIComponent(this.vaultAccountId)}/${encodeURIComponent(this.assetId)}/addresses_paginated`;
         const addressesResponse = await this.request<VaultAddressesResponse>('GET', uri);
@@ -228,9 +222,6 @@ class FireblocksSigner<TAddress extends string = string>
         });
     }
 
-    /**
-     * Make an authenticated request to Fireblocks API
-     */
     private async request<T>(method: string, uri: string, body?: unknown, abortSignal?: AbortSignal): Promise<T> {
         const bodyStr = body ? JSON.stringify(body) : '';
         const token = await createJwt(this.apiKey, await this.getPrivateKey(), uri, bodyStr);
@@ -251,9 +242,6 @@ class FireblocksSigner<TAddress extends string = string>
         });
     }
 
-    /**
-     * Sign raw bytes using Fireblocks RAW operation
-     */
     private async signRawBytes(messageBytes: Uint8Array, abortSignal?: AbortSignal): Promise<SignatureBytes> {
         base16Decoder ||= getBase16Decoder();
         const hexContent = base16Decoder.decode(messageBytes);
@@ -481,9 +469,6 @@ class FireblocksSigner<TAddress extends string = string>
         }
     }
 
-    /**
-     * Ensure the signer has been initialized
-     */
     private ensureInitialized(): void {
         if (!this.initialized) {
             throwSignerError(SignerErrorCode.SIGNER_NOT_INITIALIZED, {

--- a/typescript/packages/fireblocks/src/jwt.ts
+++ b/typescript/packages/fireblocks/src/jwt.ts
@@ -69,9 +69,6 @@ export async function createJwt(apiKey: string, privateKey: CryptoKey, uri: stri
     }
 }
 
-/**
- * Compute SHA256 hash and return as hex string
- */
 async function sha256Hex(data: string): Promise<string> {
     const dataBuffer = new TextEncoder().encode(data);
     const hashBuffer = await crypto.subtle.digest('SHA-256', dataBuffer);

--- a/typescript/packages/fordefi/src/__tests__/fordefi-signer.test.ts
+++ b/typescript/packages/fordefi/src/__tests__/fordefi-signer.test.ts
@@ -34,12 +34,10 @@ vi.mock('@solana/keychain-core', async importOriginal => {
 import { createFordefiSigner, type FordefiSignerConfig } from '../fordefi-signer.js';
 import type { SolanaChainUniqueId } from '../types.js';
 
-// Mock fetch globally
 global.fetch = vi.fn();
 
 const MOCK_ADDRESS = '11111111111111111111111111111111';
 
-// Generate a real P-256 key pair for tests
 const { privateKey: testPrivateKey } = generateKeyPairSync('ec', { namedCurve: 'prime256v1' });
 const TEST_PEM = testPrivateKey.export({ type: 'sec1', format: 'pem' }) as string;
 
@@ -183,7 +181,6 @@ describe('createFordefiSigner', () => {
     });
 
     describe('custom requestSigner', () => {
-        // Config using a custom request signer instead of a PEM key.
         const customConfig: FordefiSignerConfig & { chain?: undefined; pushMode?: undefined } = {
             accessToken: 'test-token',
             apiBaseUrl: 'https://api.test.fordefi.com',
@@ -252,7 +249,6 @@ describe('createFordefiSigner', () => {
             expect(results).toHaveLength(1);
             expect(results[0]).toHaveProperty(MOCK_ADDRESS);
 
-            // Verify POST was called with black_box_signature format (call #1)
             expect(fetch).toHaveBeenCalledTimes(2);
             const call = vi.mocked(fetch).mock.calls[0]!;
             expect(call[0]).toBe('https://api.test.fordefi.com/api/v1/transactions');
@@ -359,7 +355,6 @@ describe('createFordefiSigner', () => {
             const results = await signer.signMessages([{ content: new Uint8Array(32), signatures: {} }]);
             expect(results).toHaveLength(1);
 
-            // Verify request body uses the black_box_signature schema (call #1)
             expect(fetch).toHaveBeenCalledTimes(2);
             const call = vi.mocked(fetch).mock.calls[0]!;
             expect(call[0]).toBe('https://api.test.fordefi.com/api/v1/transactions');
@@ -457,7 +452,6 @@ describe('createFordefiSigner', () => {
                     }),
                 );
 
-                // Verify POST body uses solana_transaction type
                 const call = vi.mocked(fetch).mock.calls[0]!;
                 const postOpts = call[1] as RequestInit;
                 const body = JSON.parse(postOpts.body as string);
@@ -933,7 +927,6 @@ describe('createFordefiSigner', () => {
             const results = await signer.signMessages([{ content: new Uint8Array(32), signatures: {} }]);
             expect(results).toHaveLength(1);
 
-            // Verify POST body uses solana_message type
             const call = vi.mocked(fetch).mock.calls[0]!;
             const postOpts = call[1] as RequestInit;
             const body = JSON.parse(postOpts.body as string);

--- a/typescript/packages/fordefi/src/fordefi-signer.ts
+++ b/typescript/packages/fordefi/src/fordefi-signer.ts
@@ -806,9 +806,6 @@ class FordefiSigner<TAddress extends string = string> implements SolanaMessageSi
         return createResponse.id;
     }
 
-    /**
-     * Submit a black_box_signature request for raw EdDSA signing.
-     */
     private async submitBlackBoxSignature(base64Data: string, abortSignal?: AbortSignal): Promise<string> {
         const requestBody: FordefiBlackBoxSignatureRequest = {
             details: {
@@ -869,9 +866,6 @@ class FordefiSigner<TAddress extends string = string> implements SolanaMessageSi
         return namespaced;
     }
 
-    /**
-     * Submit a native Solana personal message for signing.
-     */
     private async submitSolanaMessage(base64Data: string, abortSignal?: AbortSignal): Promise<string> {
         const requestBody: FordefiSolanaMessageRequest = {
             details: {
@@ -965,9 +959,6 @@ class FordefiSigner<TAddress extends string = string> implements SolanaMessageSi
         });
     }
 
-    /**
-     * Extract the base64-encoded signature from a poll result.
-     */
     private extractSignatureData(result: FordefiTransactionStatusResponse): string {
         const sigData = result.signatures?.[0]?.data;
         if (!sigData) {
@@ -987,9 +978,6 @@ class FordefiSigner<TAddress extends string = string> implements SolanaMessageSi
         return await this.requestSigner.signRequest(payload);
     }
 
-    /**
-     * Make an authenticated request to the Fordefi API.
-     */
     private async request<T>(
         method: 'GET' | 'POST',
         apiPath: string,

--- a/typescript/packages/keychain/src/__tests__/create-keychain-signer.test.ts
+++ b/typescript/packages/keychain/src/__tests__/create-keychain-signer.test.ts
@@ -17,7 +17,6 @@ function makeMockSigner(address: Address = TEST_ADDRESS): SolanaSigner {
     } as unknown as SolanaSigner;
 }
 
-// Mock all backend factories
 vi.mock('@solana/keychain-aws-kms', () => ({ createAwsKmsSigner: vi.fn() }));
 vi.mock('@solana/keychain-cdp', () => ({ createCdpSigner: vi.fn() }));
 vi.mock('@solana/keychain-crossmint', () => ({ createCrossmintSigner: vi.fn() }));

--- a/typescript/packages/openfort/src/__tests__/openfort-signer.test.ts
+++ b/typescript/packages/openfort/src/__tests__/openfort-signer.test.ts
@@ -23,8 +23,6 @@ vi.mock('@solana/keychain-core', async importOriginal => {
 import { createOpenfortSigner } from '../openfort-signer.js';
 import type { OpenfortSignerConfig } from '../types.js';
 
-// --- Test fixtures ---
-
 // Valid P-256 PKCS#8 DER (scalar [0x01;32], in [1, n-1]) — base64-encoded.
 // This is the bare single-line form an operator pastes into an env var.
 const TEST_WALLET_SECRET_BASE64 = Buffer.from([
@@ -45,7 +43,6 @@ const TEST_SECRET_KEY = 'sk_test_secret';
 // 64-byte signature, hex-encoded with 0x prefix.
 const TEST_SIGNATURE_HEX = `0x${'ab'.repeat(64)}`;
 
-// Mock global fetch.
 const mockFetch = vi.fn();
 vi.stubGlobal('fetch', mockFetch);
 

--- a/typescript/packages/openfort/src/openfort-signer.ts
+++ b/typescript/packages/openfort/src/openfort-signer.ts
@@ -270,8 +270,6 @@ class OpenfortSigner<TAddress extends string = string>
     }
 }
 
-// --- JWT construction (ES256, signed with the wallet secret) ---
-
 function sortJson(value: unknown): unknown {
     if (value === null || typeof value !== 'object') return value;
     if (Array.isArray(value)) return (value as unknown[]).map(sortJson);
@@ -319,8 +317,6 @@ async function createWalletJwt(
     );
     return `${signingInput}.${base64UrlDecoder(new Uint8Array(sigBuffer))}`;
 }
-
-// --- Key + URL helpers ---
 
 /**
  * Decode a P-256 PKCS#8 private key into a Web Crypto `CryptoKey`. Accepts

--- a/typescript/packages/para/src/__tests__/para-signer.test.ts
+++ b/typescript/packages/para/src/__tests__/para-signer.test.ts
@@ -20,7 +20,6 @@ vi.mock('@solana/keychain-core', async importOriginal => {
 
 import { createParaSigner } from '../para-signer.js';
 
-// Mock fetch globally
 global.fetch = vi.fn();
 
 // Valid 64-byte Ed25519 signature as 128 hex chars
@@ -419,7 +418,6 @@ describe('ParaSigner', () => {
 
             await signer.signMessages(messages);
 
-            // First message has no delay, second has 100ms, third has 200ms
             expect(delaySpy).toHaveBeenCalledTimes(2);
             expect(delaySpy).toHaveBeenNthCalledWith(1, expect.any(Function), 100);
             expect(delaySpy).toHaveBeenNthCalledWith(2, expect.any(Function), 200);

--- a/typescript/packages/para/src/para-signer.ts
+++ b/typescript/packages/para/src/para-signer.ts
@@ -219,9 +219,6 @@ class ParaSigner<TAddress extends string = string>
         );
     }
 
-    /**
-     * Sign raw bytes via Para's /sign-raw endpoint
-     */
     private async signBytes(data: ArrayLike<number>, abortSignal?: AbortSignal): Promise<SignatureBytes> {
         const bytes = data instanceof Uint8Array ? data : new Uint8Array(Array.from(data));
         const hexData = getBase16Decoder().decode(bytes);
@@ -255,9 +252,6 @@ class ParaSigner<TAddress extends string = string>
         return this.decodeHexSignature(signResponse.signature);
     }
 
-    /**
-     * Decode a hex-encoded Ed25519 signature to SignatureBytes
-     */
     private decodeHexSignature(hexSignature: string): SignatureBytes {
         const cleaned = hexSignature.startsWith('0x') ? hexSignature.slice(2) : hexSignature;
 

--- a/typescript/packages/test-utils/src/integration-test-runner.ts
+++ b/typescript/packages/test-utils/src/integration-test-runner.ts
@@ -60,8 +60,8 @@ export async function runSignerIntegrationTest<T extends TestSigner>(
         console.log(`Address: ${truncateAddress(signer.address)}`);
     }
 
-    // Setup test environment. The recipient is funded by the test transfer itself,
-    // so only the signer needs an airdrop here.
+    // The recipient is funded by the test transfer itself, so only the signer
+    // needs an airdrop here.
     const recipientAddress = config.recipientAddress ?? (await generateKeyPairSigner()).address;
 
     airdropLamports(litesvm, signer.address, opts.airdropAmount);
@@ -80,9 +80,6 @@ export async function runSignerIntegrationTest<T extends TestSigner>(
     }
 }
 
-/**
- * Validates that required environment variables are present
- */
 function validateEnvironment(requiredVars: string[]): void {
     const missing = requiredVars.filter(v => !process.env[v]);
 
@@ -94,9 +91,6 @@ function validateEnvironment(requiredVars: string[]): void {
     }
 }
 
-/**
- * Runs a specific test scenario
- */
 async function runScenario<T extends TestSigner>(scenario: TestScenario, context: TestContext<T>): Promise<void> {
     switch (scenario) {
         case 'signTransaction':

--- a/typescript/packages/turnkey/src/__tests__/stamper.test.ts
+++ b/typescript/packages/turnkey/src/__tests__/stamper.test.ts
@@ -4,9 +4,6 @@ import { describe, expect, test } from 'vitest';
 
 import { ApiKeyStamper } from '../stamper.js';
 
-/**
- * Test fixture with P256 key pair
- */
 function getTestKeys() {
     const privateKey = 'c9afa9d845ba75166b5c215767b1d6934e50c3db36e89b127b8a622b120f6721';
 
@@ -87,7 +84,6 @@ describe('ApiKeyStamper', () => {
         expect(decodedStamp.publicKey).toBe(publicKey);
         expect(decodedStamp.scheme).toBe('SIGNATURE_SCHEME_TK_API_P256');
 
-        // Verify signature is a valid DER hex string
         expect(decodedStamp.signature).toMatch(/^30[0-9a-f]+$/);
         expect(decodedStamp.signature.length).toBeGreaterThan(0);
     });

--- a/typescript/packages/turnkey/src/__tests__/turnkey-signer.test.ts
+++ b/typescript/packages/turnkey/src/__tests__/turnkey-signer.test.ts
@@ -43,7 +43,6 @@ global.fetch = vi.fn();
 const MOCK_B64_WIRE_TX =
     'Af1fCRSrZ9ASprap8D3ZLPsbzeCs6uihvj/jfjm3UrAY72by5zKMRd7YAIbJCl9gyRHQbw+xdklET2ZNmZi3iA2AAQABAurnRuGN5bfL2osZZMdGlvL1qz8k0GbdLhiP1fICgkmsBUpTWpkpIQZNJOhxYNo4fHw1td28kruB5B+oQEEFRI1NhzEgE0w/YfwaeZi2Ns/mLoZvq2Sx5NVQg7Am7wrjGwEBAAxIZWxsbywgUHJpdnkA' as Base64EncodedWireTransaction;
 
-// Mock the transaction encoding function
 vi.mock('@solana/transactions', async () => {
     const actual = await vi.importActual<typeof import('@solana/transactions')>('@solana/transactions');
     return {
@@ -52,7 +51,6 @@ vi.mock('@solana/transactions', async () => {
     };
 });
 
-// Helper to create a mock transaction without needing real transaction building
 const createMockTransaction = (): Transaction & TransactionWithinSizeLimit & TransactionWithLifetime => {
     return {} as Transaction & TransactionWithinSizeLimit & TransactionWithLifetime;
 };
@@ -237,7 +235,6 @@ describe('createTurnkeySigner', () => {
             const messageContent = new Uint8Array([1, 2, 3, 4]);
             const signature = await signBytes(keyPair.privateKey, messageContent);
 
-            // Split signature into r and s (32 bytes each)
             const r = Buffer.from(signature.slice(0, 32)).toString('hex');
             const s = Buffer.from(signature.slice(32, 64)).toString('hex');
 
@@ -260,7 +257,6 @@ describe('createTurnkeySigner', () => {
 
             const signer = createTurnkeySigner(config);
 
-            // Create undersized components (less than 32 bytes)
             const r = '1234abcd'; // 4 bytes
             const s = '5678ef90'; // 4 bytes
 
@@ -272,7 +268,6 @@ describe('createTurnkeySigner', () => {
             expect(sigDict).toBeTruthy();
             expect(sigDict?.[signer.address]).toBeTruthy();
 
-            // Signature should be 64 bytes (r and s padded to 32 each)
             const signatureBytes = sigDict?.[signer.address];
             expect(signatureBytes?.length).toBe(64);
         });
@@ -287,7 +282,6 @@ describe('createTurnkeySigner', () => {
 
             const signer = createTurnkeySigner(config);
 
-            // Create oversized r component (> 32 bytes)
             const r = Buffer.alloc(33, 0xff).toString('hex');
             const s = Buffer.alloc(32, 0x01).toString('hex');
 
@@ -311,7 +305,6 @@ describe('createTurnkeySigner', () => {
 
             const signer = createTurnkeySigner(config);
 
-            // Create oversized s component (> 32 bytes)
             const r = Buffer.alloc(32, 0x01).toString('hex');
             const s = Buffer.alloc(33, 0xff).toString('hex');
 

--- a/typescript/packages/turnkey/src/stamper.ts
+++ b/typescript/packages/turnkey/src/stamper.ts
@@ -105,7 +105,6 @@ export class ApiKeyStamper {
                 signature: signatureHex,
             };
 
-            // Encode as base64url (RFC 4648 §5)
             const stampJson = JSON.stringify(stamp);
             const stampBase64url = base64UrlDecoder(new TextEncoder().encode(stampJson));
 

--- a/typescript/packages/turnkey/src/turnkey-signer.ts
+++ b/typescript/packages/turnkey/src/turnkey-signer.ts
@@ -135,10 +135,7 @@ class TurnkeySigner<TAddress extends string = string>
         }
     }
 
-    /**
-     * Pad signature component to exactly 32 bytes
-     * Components from Turnkey may be shorter than 32 bytes and need left-padding with zeros
-     */
+    /** Components from Turnkey may be shorter than 32 bytes and need left-padding with zeros. */
     private padSignatureComponent(hex: string): Uint8Array {
         if (hex.length % 2 !== 0) {
             throwSignerError(SignerErrorCode.REMOTE_API_ERROR, {
@@ -154,7 +151,6 @@ class TurnkeySigner<TAddress extends string = string>
             });
         }
 
-        // Create 32-byte array and right-align the component (left-pad with zeros)
         const padded = new Uint8Array(32);
         padded.set(bytes, 32 - bytes.length);
         return padded;

--- a/typescript/packages/vault/src/__tests__/vault-signer.test.ts
+++ b/typescript/packages/vault/src/__tests__/vault-signer.test.ts
@@ -18,7 +18,6 @@ vi.mock('@solana/keychain-core', async importOriginal => {
     };
 });
 
-// Mock fetch globally
 global.fetch = vi.fn();
 
 describe('createVaultSigner', () => {
@@ -422,7 +421,6 @@ describe('createVaultSigner', () => {
 
             await signer.signMessages(messages);
 
-            // First message should not have delay, subsequent ones should
             expect(delaySpy).toHaveBeenCalledTimes(2);
             expect(delaySpy).toHaveBeenNthCalledWith(1, expect.any(Function), 100);
             expect(delaySpy).toHaveBeenNthCalledWith(2, expect.any(Function), 200);
@@ -448,7 +446,6 @@ describe('createVaultSigner', () => {
 
             const signer = createVaultSigner(mockConfig);
 
-            // Create a mock transaction - this is simplified
             const mockTransaction = {
                 '"__transactionSize:@solana/kit"': 100,
                 lifetimeConstraint: { blockhash: 'test', lastValidBlockHeight: 100n },

--- a/typescript/packages/vault/src/vault-signer.ts
+++ b/typescript/packages/vault/src/vault-signer.ts
@@ -138,9 +138,6 @@ class VaultSigner<TAddress extends string = string>
         return sigBytes as SignatureBytes;
     }
 
-    /**
-     * Sign data using Vault's transit engine
-     */
     private async signWithVault(base64Data: string, abortSignal?: AbortSignal): Promise<SignatureBytes> {
         const url = `${this.vaultAddr}/v1/transit/sign/${encodeURIComponent(this.keyName)}`;
 
@@ -171,9 +168,6 @@ class VaultSigner<TAddress extends string = string>
         return this.extractSignatureFromVaultFormat(signResponse.data.signature);
     }
 
-    /**
-     * Sign message bytes using Vault
-     */
     private async signMessageBytes(
         messageBytes: ArrayLike<number>,
         abortSignal?: AbortSignal,


### PR DESCRIPTION
## Summary

- Simplify release and completion skills around changelogs and publishing workflows
- Add Rust changelog generation configuration and update release metadata
- Remove the obsolete v2 migration guide and unnecessary TypeScript comments
- Refresh cross-language dependency versions and release workflow documentation

## Testing

- Not run; documentation, configuration, dependency metadata, and workflow changes only