### PR TITLE
style(rust): apply cargo fmt to gcp_kms availability check

### DIFF
--- a/rust/src/gcp_kms/mod.rs
+++ b/rust/src/gcp_kms/mod.rs
@@ -137,9 +137,7 @@ impl GcpKmsSigner {
             .await;
 
         match result {
-            Ok(public_key) => {
-                public_key.algorithm == CryptoKeyVersionAlgorithm::EcSignEd25519
-            }
+            Ok(public_key) => public_key.algorithm == CryptoKeyVersionAlgorithm::EcSignEd25519,
             Err(_e) => {
                 #[cfg(feature = "unsafe-debug")]
                 log::error!("GCP KMS availability check failed: {_e:?}");


### PR DESCRIPTION
`cargo fmt --all -- --check` fails on main: the comment-removal pass left a match arm as a block that rustfmt collapses to a single line. Formatting only, no behavior change.